### PR TITLE
Changed String init to use Linux friendly implementation

### DIFF
--- a/Examples/Echo/Generated/echo.server.pb.swift
+++ b/Examples/Echo/Generated/echo.server.pb.swift
@@ -274,8 +274,8 @@ public class Echo_EchoServer {
     self.address = address
     self.provider = provider
     guard
-      let certificate = try? String(contentsOf: certificateURL),
-      let key = try? String(contentsOf: keyURL)
+      let certificate = try? String(contentsOf: certificateURL, encoding: .utf8),
+      let key = try? String(contentsOf: keyURL, encoding: .utf8)
       else {
         return nil
     }

--- a/Plugin/Templates/server.pb.swift
+++ b/Plugin/Templates/server.pb.swift
@@ -121,8 +121,8 @@ public class {{ .|server:protoFile,service }} {
     self.address = address
     self.provider = provider
     guard
-      let certificate = try? String(contentsOf: certificateURL),
-      let key = try? String(contentsOf: keyURL)
+      let certificate = try? String(contentsOf: certificateURL, encoding: .utf8),
+      let key = try? String(contentsOf: keyURL, encoding: .utf8)
       else {
         return nil
     }


### PR DESCRIPTION
Couldn't start Echo server with ssl on linux due to String init method not being implemented yet. I'd get the following crash.

```
.build/debug/Echo serve -ssl
[".build/debug/Echo", "serve", "-ssl"]
Starting secure server
fatal error: init(contentsOf:usedEncoding:) is not yet implemented: file Foundation/NSString.swift, line 1251
Illegal instruction
```
Looks like the linux version of `NSString.init(contentsOfFile:)` hasn't been implemented yet. Looks like [internally](https://github.com/apple/swift-corelibs-foundation/blob/master/Foundation/NSStringAPI.swift#L796) it calls `NSString.init(contentsOfFile:encoding:)` though, so I swapped the call.

http://stackoverflow.com/questions/41317986/string-initcontentsoffile-replacement-for-linux