### PR TITLE
Explicitly specify protoc plugin in Plugin test target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ project.xcworkspace
 xcuserdata
 .build
 third_party/**
+Plugin/Packages/**
+Plugin/protoc-*

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ xcuserdata
 third_party/**
 Plugin/Packages/**
 Plugin/protoc-*
+Plugin/swiftgrpc.log
+Plugin/echo.*.swift

--- a/Plugin/Makefile
+++ b/Plugin/Makefile
@@ -9,7 +9,7 @@ build:  clear
 	cp .build/debug/protoc-gen-swift .
 
 test:	build
-	protoc ../Examples/Echo/echo.proto --proto_path=../Examples/Echo --swiftgrpc_out=. 
+	protoc ../Examples/Echo/echo.proto --proto_path=../Examples/Echo --plugin=./protoc-gen-swiftgrpc --swiftgrpc_out=. 
 	diff echo.client.pb.swift ../Examples/Echo/Generated/echo.client.pb.swift
 	diff echo.server.pb.swift ../Examples/Echo/Generated/echo.server.pb.swift
 

--- a/Plugin/README.md
+++ b/Plugin/README.md
@@ -6,11 +6,15 @@ the Protocol Buffer Compiler.
 It is built with the Swift Package Manager and the included
 Makefile. The resulting binary is named `protoc-gen-swiftgrpc`
 and can be called from `protoc` by adding the `--swiftgrpc_out`
-command-line option. For example, here's an invocation from
-the Makefile:
+command-line option and `--plugin` option. For example, here's an
+invocation from the Makefile:
 
-	protoc ../Examples/Echo/echo.proto --proto_path=../Examples/Echo --swiftgrpc_out=. 
+		protoc ../Examples/Echo/echo.proto --proto_path=../Examples/Echo --plugin=./protoc-gen-swiftgrpc --swiftgrpc_out=.
 
 The plugin uses template files in the [Templates](Templates) directory. 
 These files are compiled into the `protoc-gen-swiftgrpc` plugin executable.
 
+The Swift gRPC plugin can be installed by placing the
+`protoc-gen-swiftgrpc` binary into one of the directories in your
+path.  Specifying `--swiftgrpc_out` to `protoc` will automatically
+search the `PATH` environment variable for this binary.


### PR DESCRIPTION
This change explicitly specifies the swift grpc ptotoc plugin in the
`Plugin` directory, so users without `.` in the path can run the test
target.

Also add some build artifacts from the Plugin directory to .gitignore.