### PR TITLE
Fix inconsistency in proto message naming convention

### DIFF
--- a/Plugin/Sources/protoc-gen-swiftgrpc/main.swift
+++ b/Plugin/Sources/protoc-gen-swiftgrpc/main.swift
@@ -52,18 +52,25 @@ extension String {
   }
 }
 
+// Transforms .some.package_name.FooBarRequest -> Some_PackageName_FooBarRequest
 func protoMessageName(_ name :String?) -> String {
   guard let name = name else {
     return ""
   }
-  let parts = name.undotted.components(separatedBy:"_")
-  var capitalizedParts : [String] = []
-  for part in parts {
-    if part != "" {
-      capitalizedParts.append(part.uppercasedFirst)
+
+  var parts : [String] = []
+  for dotComponent in name.components(separatedBy:".") {
+    var part = ""
+    if dotComponent == "" {
+      continue
     }
+    for underscoreComponent in dotComponent.components(separatedBy:"_") {
+      part.append(underscoreComponent.uppercasedFirst)
+    }
+    parts.append(part)
   }
-  return capitalizedParts.joined(separator:"_")
+
+  return parts.joined(separator:"_")
 }
 
 func pathName(_ arguments: [Any?]) throws -> String {


### PR DESCRIPTION
Here's a simple fix for #38 that is working for me as a workaround.

I acknowledge that my proposed patch here is a bit hacky, and I think it could use some unit testing. Moreover, I'm wondering if there's a way this library could pull in [some code](https://github.com/apple/swift-protobuf/blob/0.9.28/Sources/protoc-gen-swift/MessageGenerator.swift) from `swift-protobuf` and ensure that the exact same logic is used for handling Swifty naming conventions. Unfortunately, I don't have enough context in the projects to make such a change.

Thanks!