### PR TITLE
Allows passing \'--swiftgrpc_opt=Visibility=Public\' to protoc to cha…

### DIFF
--- a/Plugin/Sources/protoc-gen-swiftgrpc/main.swift
+++ b/Plugin/Sources/protoc-gen-swiftgrpc/main.swift
@@ -56,7 +56,9 @@ func main() throws {
   // read plugin input
   let rawRequest = try Stdin.readall()
   let request = try Google_Protobuf_Compiler_CodeGeneratorRequest(serializedData: rawRequest)
-
+  
+  let options = try GeneratorOptions(parameter: request.parameter)
+  
   var generatedFileNames = Set<String>()
 
   // process each .proto file separately
@@ -87,7 +89,7 @@ func main() throws {
     if file.service.count > 0 {
 
       // generate separate implementation files for client and server
-      let context : [String:Any] = ["file": file, "access": "internal"]
+      let context : [String:Any] = ["file": file, "access": options.visibility.sourceSnippet]
 
       do {
         let clientFileName = package + ".client.pb.swift"

--- a/Plugin/Sources/protoc-gen-swiftgrpc/options.swift
+++ b/Plugin/Sources/protoc-gen-swiftgrpc/options.swift
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Foundation
+
+enum GenerationError: Error {
+  /// Raised when parsing the parameter string and found an unknown key
+  case unknownParameter(name: String)
+  /// Raised when a parameter was giving an invalid value
+  case invalidParameterValue(name: String, value: String)
+  
+  var localizedDescription: String {
+    switch self {
+    case .unknownParameter(let name):
+      return "Unknown generation parameter '\(name)'"
+    case .invalidParameterValue(let name, let value):
+      return "Unknown value for generation parameter '\(name)': '\(value)'"
+    }
+  }
+}
+
+class GeneratorOptions {
+  enum Visibility: String {
+    case Internal
+    case Public
+    
+    var sourceSnippet: String {
+      switch self {
+      case .Internal:
+        return "internal"
+      case .Public:
+        return "public"
+      }
+    }
+  }
+  
+  let visibility: Visibility
+  
+  init(parameter: String?) throws {
+    var visibility: Visibility = .Internal
+    
+    for pair in GeneratorOptions.parseParameter(string: parameter) {
+      switch pair.key {
+      case "Visibility":
+        if let value = Visibility(rawValue: pair.value) {
+          visibility = value
+        } else {
+          throw GenerationError.invalidParameterValue(name: pair.key,
+                                                      value: pair.value)
+        }
+      default:
+        throw GenerationError.unknownParameter(name: pair.key)
+      }
+    }
+    
+    self.visibility = visibility
+  }
+  
+  static func parseParameter(string: String?) -> [(key: String, value: String)] {
+    guard let string = string, string.characters.count > 0 else {
+      return []
+    }
+    let parts = string.components(separatedBy: ",")
+    
+    // Partitions the string into the section before the = and after the =
+    let result = parts.map { string -> (key: String, value: String) in
+      
+      // Finds the equal sign and exits early if none
+      guard let index = string.range(of: "=")?.lowerBound else {
+        return (string, "")
+      }
+      
+      // Creates key/value pair and trims whitespace
+      let key = string.substring(to: index)
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+      let value = string.substring(from: string.index(after: index))
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+      
+      return (key: key, value: value)
+    }
+    return result
+  }
+}
+
+
+
+


### PR DESCRIPTION
…nge the visibility of the generated code for use in projects using multiple modules.

Hello! I'm new to open-source, but hopefully I did this whole pull request thing properly. Let me know if there's anything I should do differently next time.

**What does this do?**

This PR adds the ability to change the access controls of the generated code when calling 'protoc' by passing options with '--swiftgrpc_opt='. The only option that this PR adds is 'Visibility'. Setting 'Visibility=Internal' or not specifying an option at all will produce code identical to before this PR. Setting 'Visibility=Public' will change 'access' in the context of the Stencil rendering to 'public' in order to change the access of generated code to 'public', which allows compiling and using the generated code in separate modules.

**Possible regressions**

If an invalid option is specified, code generation through the grpc-swift plugin will return an error. Previously, the option was simply ignored. Any workflow which relied on passing junk options will no longer function; however, I do not anticipate that being a meaningful regression. 

**Another gotcha**

As the functionality of this PR is intended to mirror the visibility options of the swift-protobuf plugin, the logic used to implement this feature in grpc-swift is basically identical to the logic from swift-protobuf. The 'options.swift' file is basically just a feature-stripped and slightly refactored version of the [GeneratorOptions.swift](https://github.com/apple/swift-protobuf/blob/master/Sources/protoc-gen-swift/GeneratorOptions.swift) file from protobuf-swift. The logic for actually changing the access controls was already in the Stencil templates, so the only code needed for this PR just allowed setting options. I'm not really sure if this is okay or not. Both projects appear to be licensed under Apache 2.0, but I don't understand code licensing very well. 