### PR TITLE
Fix conditional statement for Ubuntu

### DIFF
--- a/third_party/RUNME.sh
+++ b/third_party/RUNME.sh
@@ -16,9 +16,9 @@
 #
 printf "\033c"
 read -p "Would you like to download swift-protobuf / grpc [y/N]" CONDITION;
-if [ "$CONDITION" == "y" ] ; then
+if [ "$CONDITION" = "y" ] ; then
     read -p "Use last known stable swift-protobuf - 0.9.903 ? or  latest master ? [S/l]  " CONDITION;
-    if [ "$CONDITION" == "l" ] ; then
+    if [ "$CONDITION" = "l" ] ; then
         git clone https://github.com/apple/swift-protobuf.git
     else
         git clone -b 0.9.903 https://github.com/apple/swift-protobuf.git


### PR DESCRIPTION
Running on a clean Ubuntu 16.10 install, the current script will result in an error: `RUNME.sh: 19: [: y: unexpected operator`. This fixes it. I tested a similar command on Mac (outside of this repo) to ensure it still works, and had no problems.