### PR TITLE
Support for Protocol Buffers Well-Known Types

### DIFF
--- a/Plugin/Templates/client.pb.swift
+++ b/Plugin/Templates/client.pb.swift
@@ -24,6 +24,7 @@
 import Foundation
 import Dispatch
 import gRPC
+import SwiftProtobuf
 //-{% for service in file.service %}
 
 /// Type for errors thrown from generated client code.

--- a/Plugin/Templates/server.pb.swift
+++ b/Plugin/Templates/server.pb.swift
@@ -24,6 +24,7 @@
 import Foundation
 import Dispatch
 import gRPC
+import SwiftProtobuf
 //-{% for service in file.service %}
 
 /// Type for errors thrown from generated server code.


### PR DESCRIPTION
My protobufs are using the [well-known types provided by Google](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf). I couldn't compile without adding `import SwiftProtobuf` to the `client.pb.swift` and `server.pb.swift` templates. This was not an issue for the Swift files generated by the `protoc-gen-swift` plugin, which handles this case as follows: https://github.com/apple/swift-protobuf/blob/master/Sources/protoc-gen-swift/FileGenerator.swift#L88