### PR TITLE
Package check should be optional for files without services

### DIFF
--- a/Plugin/Sources/protoc-gen-swiftgrpc/main.swift
+++ b/Plugin/Sources/protoc-gen-swiftgrpc/main.swift
@@ -66,13 +66,6 @@ func main() throws {
 
     let file = FileDescriptor(proto:protoFile)
 
-    // a package declaration is required
-    let package = file.package
-    guard package != "" else {
-      print("ERROR: no package for \(file.name)")
-      continue
-    }
-
     // log info about the service
     log += "File \(file.name)\n"
     for service in file.service {
@@ -87,7 +80,13 @@ func main() throws {
     }
 
     if file.service.count > 0 {
-
+      // a package declaration is required for file containing service(s)
+      let package = file.package
+      guard package != ""  else {
+        print("ERROR: no package for \(file.name)")
+        continue
+      }
+      
       // generate separate implementation files for client and server
       let context : [String:Any] = ["file": file, "access": options.visibility.sourceSnippet]
 


### PR DESCRIPTION
Package check should be optional for files without services, which makes it easier to work with existing / legacy model protobuf files. 

Reference: https://developers.google.com/protocol-buffers/docs/proto#packages