### PR TITLE
make return completion when event is GRPC_QUEUE_SHUTDOWN at Completio…

### DIFF
--- a/Sources/gRPC/CompletionQueue.swift
+++ b/Sources/gRPC/CompletionQueue.swift
@@ -125,8 +125,19 @@ internal class CompletionQueue {
           }
           break
         case GRPC_QUEUE_SHUTDOWN:
-          running = false
-          break
+            running = false
+            do {
+                for operationGroup in self.operationGroups.values {
+                    operationGroup.success = false
+                    try operationGroup.completion(operationGroup)
+                }
+            } catch (let callError) {
+                print("CompletionQueue runToCompletion: grpc error \(callError)")
+            }
+            self.operationGroupsMutex.lock()
+            self.operationGroups = [:]
+            self.operationGroupsMutex.unlock()
+            break
         case GRPC_QUEUE_TIMEOUT:
           break
         default:


### PR DESCRIPTION
## Description
when we call method with completion and it fails, completion does not return anything
because completion does not call in case of GRPC_QUEUE_SHUTDOWN.

## Related Issue
This fix may be related to #92 