### PR TITLE
Fix a few compiler warnings in the CgRPC shim

### DIFF
--- a/Sources/CgRPC/shim/cgrpc.h
+++ b/Sources/CgRPC/shim/cgrpc.h
@@ -105,13 +105,13 @@ typedef struct grpc_event {
 #endif
 
 // directly expose a few grpc library functions
-void grpc_init();
-void grpc_shutdown();
-const char *grpc_version_string();
-const char *grpc_g_stands_for();
+void grpc_init(void);
+void grpc_shutdown(void);
+const char *grpc_version_string(void);
+const char *grpc_g_stands_for(void);
 
 // helper
-void cgrpc_free_copied_string(const char *string);
+void cgrpc_free_copied_string(char *string);
 
 // channel support
 cgrpc_channel *cgrpc_channel_create(const char *address);
@@ -151,9 +151,9 @@ cgrpc_completion_queue *cgrpc_handler_get_completion_queue(cgrpc_handler *h);
 grpc_call_error cgrpc_handler_request_call(cgrpc_handler *h,
                                            cgrpc_metadata_array *metadata,
                                            long tag);
-const char *cgrpc_handler_copy_host(cgrpc_handler *h);
-const char *cgrpc_handler_copy_method(cgrpc_handler *h);
-const char *cgrpc_handler_call_peer(cgrpc_handler *h);
+char *cgrpc_handler_copy_host(cgrpc_handler *h);
+char *cgrpc_handler_copy_method(cgrpc_handler *h);
+char *cgrpc_handler_call_peer(cgrpc_handler *h);
 
 // call support
 void cgrpc_call_destroy(cgrpc_call *call);
@@ -161,22 +161,22 @@ grpc_call_error cgrpc_call_perform(cgrpc_call *call, cgrpc_operations *operation
 void cgrpc_call_cancel(cgrpc_call *call);
 
 // operations
-cgrpc_operations *cgrpc_operations_create();
+cgrpc_operations *cgrpc_operations_create(void);
 void cgrpc_operations_destroy(cgrpc_operations *operations);
 void cgrpc_operations_reserve_space_for_operations(cgrpc_operations *call, int max_operations);
 void cgrpc_operations_add_operation(cgrpc_operations *call, cgrpc_observer *observer);
 
 // metadata support
-cgrpc_metadata_array *cgrpc_metadata_array_create();
+cgrpc_metadata_array *cgrpc_metadata_array_create(void);
 void cgrpc_metadata_array_destroy(cgrpc_metadata_array *array);
 size_t cgrpc_metadata_array_get_count(cgrpc_metadata_array *array);
-const char *cgrpc_metadata_array_copy_key_at_index(cgrpc_metadata_array *array, size_t index);
-const char *cgrpc_metadata_array_copy_value_at_index(cgrpc_metadata_array *array, size_t index);
+char *cgrpc_metadata_array_copy_key_at_index(cgrpc_metadata_array *array, size_t index);
+char *cgrpc_metadata_array_copy_value_at_index(cgrpc_metadata_array *array, size_t index);
 void cgrpc_metadata_array_move_metadata(cgrpc_metadata_array *dest, cgrpc_metadata_array *src);
 void cgrpc_metadata_array_append_metadata(cgrpc_metadata_array *metadata, const char *key, const char *value);
 
 // mutex support
-cgrpc_mutex *cgrpc_mutex_create();
+cgrpc_mutex *cgrpc_mutex_create(void);
 void cgrpc_mutex_destroy(cgrpc_mutex *mu);
 void cgrpc_mutex_lock(cgrpc_mutex *mu);
 void cgrpc_mutex_unlock(cgrpc_mutex *mu);
@@ -193,13 +193,13 @@ int64_t cgrpc_event_tag(grpc_event ev);
 
 // constructors
 cgrpc_observer_send_initial_metadata   *cgrpc_observer_create_send_initial_metadata(cgrpc_metadata_array *metadata);
-cgrpc_observer_send_message            *cgrpc_observer_create_send_message();
-cgrpc_observer_send_close_from_client  *cgrpc_observer_create_send_close_from_client();
+cgrpc_observer_send_message            *cgrpc_observer_create_send_message(void);
+cgrpc_observer_send_close_from_client  *cgrpc_observer_create_send_close_from_client(void);
 cgrpc_observer_send_status_from_server *cgrpc_observer_create_send_status_from_server(cgrpc_metadata_array *metadata);
-cgrpc_observer_recv_initial_metadata   *cgrpc_observer_create_recv_initial_metadata();
-cgrpc_observer_recv_message            *cgrpc_observer_create_recv_message();
-cgrpc_observer_recv_status_on_client   *cgrpc_observer_create_recv_status_on_client();
-cgrpc_observer_recv_close_on_server    *cgrpc_observer_create_recv_close_on_server();
+cgrpc_observer_recv_initial_metadata   *cgrpc_observer_create_recv_initial_metadata(void);
+cgrpc_observer_recv_message            *cgrpc_observer_create_recv_message(void);
+cgrpc_observer_recv_status_on_client   *cgrpc_observer_create_recv_status_on_client(void);
+cgrpc_observer_recv_close_on_server    *cgrpc_observer_create_recv_close_on_server(void);
 
 // destructor
 void cgrpc_observer_destroy(cgrpc_observer *observer);
@@ -238,7 +238,7 @@ cgrpc_metadata_array *cgrpc_observer_recv_status_on_client_get_metadata
 long cgrpc_observer_recv_status_on_client_get_status
 (cgrpc_observer_recv_status_on_client *observer);
 
-const char *cgrpc_observer_recv_status_on_client_copy_status_details
+char *cgrpc_observer_recv_status_on_client_copy_status_details
 (cgrpc_observer_recv_status_on_client *observer);
 
 // GRPC_OP_RECV_CLOSE_ON_SERVER

--- a/Sources/CgRPC/shim/handler.c
+++ b/Sources/CgRPC/shim/handler.c
@@ -43,23 +43,23 @@ void cgrpc_handler_destroy(cgrpc_handler *h) {
   free(h);
 }
 
-const char *cgrpc_handler_copy_host(cgrpc_handler *h) {
-  int length = GRPC_SLICE_LENGTH(h->call_details.host);
+char *cgrpc_handler_copy_host(cgrpc_handler *h) {
+  size_t length = GRPC_SLICE_LENGTH(h->call_details.host);
   char *str = (char *) malloc(length + 1);
   memcpy(str, GRPC_SLICE_START_PTR(h->call_details.host), length);
   str[length] = 0;
   return str;
 }
 
-const char *cgrpc_handler_copy_method(cgrpc_handler *h) {
-  int length = GRPC_SLICE_LENGTH(h->call_details.method);
+char *cgrpc_handler_copy_method(cgrpc_handler *h) {
+  size_t length = GRPC_SLICE_LENGTH(h->call_details.method);
   char *str = (char *) malloc(length + 1);
   memcpy(str, GRPC_SLICE_START_PTR(h->call_details.method), length);
   str[length] = 0;
   return str;
 }
 
-const char *cgrpc_handler_call_peer(cgrpc_handler *h) {
+char *cgrpc_handler_call_peer(cgrpc_handler *h) {
   return grpc_call_get_peer(h->server_call);
 }
 

--- a/Sources/CgRPC/shim/internal.c
+++ b/Sources/CgRPC/shim/internal.c
@@ -26,6 +26,6 @@ gpr_timespec cgrpc_deadline_in_seconds_from_now(float seconds) {
                       gpr_time_from_millis((int64_t)(1e3 * seconds), GPR_TIMESPAN));
 }
 
-void cgrpc_free_copied_string(const char *string) {
+void cgrpc_free_copied_string(char *string) {
 	free(string);
 }

--- a/Sources/CgRPC/shim/metadata.c
+++ b/Sources/CgRPC/shim/metadata.c
@@ -33,23 +33,23 @@ size_t cgrpc_metadata_array_get_count(cgrpc_metadata_array *array) {
   return array->count;
 }
 
-const char *cgrpc_metadata_array_copy_key_at_index(cgrpc_metadata_array *array, size_t index) {
-  int length = GRPC_SLICE_LENGTH(array->metadata[index].key);
+char *cgrpc_metadata_array_copy_key_at_index(cgrpc_metadata_array *array, size_t index) {
+  size_t length = GRPC_SLICE_LENGTH(array->metadata[index].key);
   char *str = (char *) malloc(length + 1);
   memcpy(str, GRPC_SLICE_START_PTR(array->metadata[index].key), length);
   str[length] = 0;
   return str;
 }
 
-const char *cgrpc_metadata_array_copy_value_at_index(cgrpc_metadata_array *array, size_t index) {
-  int length = GRPC_SLICE_LENGTH(array->metadata[index].value);
+char *cgrpc_metadata_array_copy_value_at_index(cgrpc_metadata_array *array, size_t index) {
+  size_t length = GRPC_SLICE_LENGTH(array->metadata[index].value);
   char *str = (char *) malloc(length + 1);
   memcpy(str, GRPC_SLICE_START_PTR(array->metadata[index].value), length);
   str[length] = 0;
   return str;
 }
 
-int cgrpc_metadata_array_get_value_length_at_index(cgrpc_metadata_array *array, size_t index) {
+size_t cgrpc_metadata_array_get_value_length_at_index(cgrpc_metadata_array *array, size_t index) {
   return GRPC_SLICE_LENGTH(array->metadata[index].value);
   /*
   int length = GRPC_SLICE_LENGTH(array->metadata[index].value);

--- a/Sources/CgRPC/shim/observers.c
+++ b/Sources/CgRPC/shim/observers.c
@@ -235,7 +235,7 @@ long cgrpc_observer_recv_status_on_client_get_status(cgrpc_observer_recv_status_
   return observer->server_status;
 }
 
-const char *cgrpc_observer_recv_status_on_client_copy_status_details(cgrpc_observer_recv_status_on_client *observer) {
+char *cgrpc_observer_recv_status_on_client_copy_status_details(cgrpc_observer_recv_status_on_client *observer) {
   int length = GRPC_SLICE_LENGTH(observer->server_details);
   char *str = (char *) malloc(length + 1);
   memcpy(str, GRPC_SLICE_START_PTR(observer->server_details), length);


### PR DESCRIPTION
These warnings occur when enabling the following warnings in the project settings:

- Implicit Conversion to 32 Bit Type
- Strict Prototypes

As far as I know, those warnings are actually recommended by Apple to be turned on for new projects, and I think it doesn't hurt fixing them here. I was also warned about trying to free `const char *` pointers, so I changed the corresponding method signatures to accept/return non-const character arrays, as do the underlying gRPC calls.