### PR TITLE
Fix a similar set of warnings in the vendored gRPC code

### DIFF
--- a/Sources/CgRPC/include/grpc/census.h
+++ b/Sources/CgRPC/include/grpc/census.h
@@ -414,7 +414,7 @@ CENSUSAPI int census_trace_scan_start(int consume);
 CENSUSAPI int census_get_trace_record(census_trace_record *trace_record);
 
 /** End a scan previously started by census_trace_scan_start() */
-CENSUSAPI void census_trace_scan_end();
+CENSUSAPI void census_trace_scan_end(void);
 
 /** Core stats collection API's. The following concepts are used:
    * Resource: Users record measurements for a single resource. Examples

--- a/Sources/CgRPC/include/grpc/grpc_security.h
+++ b/Sources/CgRPC/include/grpc/grpc_security.h
@@ -185,7 +185,7 @@ GRPCAPI grpc_call_credentials *grpc_composite_call_credentials_create(
 GRPCAPI grpc_call_credentials *grpc_google_compute_engine_credentials_create(
     void *reserved);
 
-GRPCAPI gpr_timespec grpc_max_auth_token_lifetime();
+GRPCAPI gpr_timespec grpc_max_auth_token_lifetime(void);
 
 /** Creates a JWT credentials object. May return NULL if the input is invalid.
    - json_key is the JSON key string containing the client's private key.

--- a/Sources/CgRPC/include/grpc/impl/codegen/fork.h
+++ b/Sources/CgRPC/include/grpc/impl/codegen/fork.h
@@ -37,12 +37,12 @@
  * }
  */
 
-void grpc_prefork();
+void grpc_prefork(void);
 
-void grpc_postfork_parent();
+void grpc_postfork_parent(void);
 
-void grpc_postfork_child();
+void grpc_postfork_child(void);
 
-void grpc_fork_handlers_auto_register();
+void grpc_fork_handlers_auto_register(void);
 
 #endif /* GRPC_IMPL_CODEGEN_FORK_H */

--- a/Sources/CgRPC/include/grpc/support/alloc.h
+++ b/Sources/CgRPC/include/grpc/support/alloc.h
@@ -58,7 +58,7 @@ GPRAPI void gpr_free_aligned(void *ptr);
 GPRAPI void gpr_set_allocation_functions(gpr_allocation_functions functions);
 
 /** Return the family of allocation functions currently in effect. */
-GPRAPI gpr_allocation_functions gpr_get_allocation_functions();
+GPRAPI gpr_allocation_functions gpr_get_allocation_functions(void);
 
 #ifdef __cplusplus
 }

--- a/Sources/CgRPC/include/grpc/support/log.h
+++ b/Sources/CgRPC/include/grpc/support/log.h
@@ -68,7 +68,7 @@ GPRAPI void gpr_log_message(const char *file, int line,
 /** Set global log verbosity */
 GPRAPI void gpr_set_log_verbosity(gpr_log_severity min_severity_to_print);
 
-GPRAPI void gpr_log_verbosity_init();
+GPRAPI void gpr_log_verbosity_init(void);
 
 /** Log overrides: applications can use this API to intercept logging calls
    and use their own implementations */

--- a/Sources/CgRPC/include/grpc/support/subprocess.h
+++ b/Sources/CgRPC/include/grpc/support/subprocess.h
@@ -28,7 +28,7 @@ extern "C" {
 typedef struct gpr_subprocess gpr_subprocess;
 
 /** .exe on windows, empty on unices */
-GPRAPI const char *gpr_subprocess_binary_extension();
+GPRAPI const char *gpr_subprocess_binary_extension(void);
 
 GPRAPI gpr_subprocess *gpr_subprocess_create(int argc, const char **argv);
 /** if subprocess has not been joined, kill it */

--- a/Sources/CgRPC/src/core/ext/census/base_resources.h
+++ b/Sources/CgRPC/src/core/ext/census/base_resources.h
@@ -19,6 +19,6 @@
 #define GRPC_CORE_EXT_CENSUS_BASE_RESOURCES_H
 
 /* Define all base resources. This should be called by census initialization. */
-void define_base_resources();
+void define_base_resources(void);
 
 #endif /* GRPC_CORE_EXT_CENSUS_BASE_RESOURCES_H */

--- a/Sources/CgRPC/src/core/ext/filters/client_channel/http_connect_handshaker.h
+++ b/Sources/CgRPC/src/core/ext/filters/client_channel/http_connect_handshaker.h
@@ -29,6 +29,6 @@
 #define GRPC_ARG_HTTP_CONNECT_HEADERS "grpc.http_connect_headers"
 
 /// Registers handshaker factory.
-void grpc_http_connect_register_handshaker_factory();
+void grpc_http_connect_register_handshaker_factory(void);
 
 #endif /* GRPC_CORE_EXT_FILTERS_CLIENT_CHANNEL_HTTP_CONNECT_HANDSHAKER_H */

--- a/Sources/CgRPC/src/core/ext/filters/client_channel/http_proxy.h
+++ b/Sources/CgRPC/src/core/ext/filters/client_channel/http_proxy.h
@@ -19,6 +19,6 @@
 #ifndef GRPC_CORE_EXT_FILTERS_CLIENT_CHANNEL_HTTP_PROXY_H
 #define GRPC_CORE_EXT_FILTERS_CLIENT_CHANNEL_HTTP_PROXY_H
 
-void grpc_register_http_proxy_mapper();
+void grpc_register_http_proxy_mapper(void);
 
 #endif /* GRPC_CORE_EXT_FILTERS_CLIENT_CHANNEL_HTTP_PROXY_H */

--- a/Sources/CgRPC/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.h
+++ b/Sources/CgRPC/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.h
@@ -24,6 +24,6 @@
 /** Returns a load balancing factory for the glb policy, which tries to connect
  * to a load balancing server to decide the next successfully connected
  * subchannel to pick. */
-grpc_lb_policy_factory *grpc_glb_lb_factory_create();
+grpc_lb_policy_factory *grpc_glb_lb_factory_create(void);
 
 #endif /* GRPC_CORE_EXT_FILTERS_CLIENT_CHANNEL_LB_POLICY_GRPCLB_GRPCLB_H */

--- a/Sources/CgRPC/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_client_stats.h
+++ b/Sources/CgRPC/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_client_stats.h
@@ -35,7 +35,7 @@ typedef struct {
   size_t num_entries;
 } grpc_grpclb_dropped_call_counts;
 
-grpc_grpclb_client_stats* grpc_grpclb_client_stats_create();
+grpc_grpclb_client_stats* grpc_grpclb_client_stats_create(void);
 grpc_grpclb_client_stats* grpc_grpclb_client_stats_ref(
     grpc_grpclb_client_stats* client_stats);
 void grpc_grpclb_client_stats_unref(grpc_grpclb_client_stats* client_stats);

--- a/Sources/CgRPC/src/core/ext/filters/client_channel/proxy_mapper_registry.h
+++ b/Sources/CgRPC/src/core/ext/filters/client_channel/proxy_mapper_registry.h
@@ -21,8 +21,8 @@
 
 #include "src/core/ext/filters/client_channel/proxy_mapper.h"
 
-void grpc_proxy_mapper_registry_init();
-void grpc_proxy_mapper_registry_shutdown();
+void grpc_proxy_mapper_registry_init(void);
+void grpc_proxy_mapper_registry_shutdown(void);
 
 /// Registers a new proxy mapper.  Takes ownership.
 /// If \a at_start is true, the new mapper will be at the beginning of

--- a/Sources/CgRPC/src/core/ext/filters/client_channel/resolver/fake/fake_resolver.h
+++ b/Sources/CgRPC/src/core/ext/filters/client_channel/resolver/fake/fake_resolver.h
@@ -24,7 +24,7 @@
 #define GRPC_ARG_FAKE_RESOLVER_RESPONSE_GENERATOR \
   "grpc.fake_resolver.response_generator"
 
-void grpc_resolver_fake_init();
+void grpc_resolver_fake_init(void);
 
 // Instances of \a grpc_fake_resolver_response_generator are passed to the
 // fake resolver in a channel argument (see \a
@@ -34,7 +34,7 @@ void grpc_resolver_fake_init();
 typedef struct grpc_fake_resolver_response_generator
     grpc_fake_resolver_response_generator;
 grpc_fake_resolver_response_generator*
-grpc_fake_resolver_response_generator_create();
+grpc_fake_resolver_response_generator_create(void);
 
 // Instruct the fake resolver associated with the \a response_generator instance
 // to trigger a new resolution for \a uri and \a args.

--- a/Sources/CgRPC/src/core/ext/filters/client_channel/resolver_registry.h
+++ b/Sources/CgRPC/src/core/ext/filters/client_channel/resolver_registry.h
@@ -22,7 +22,7 @@
 #include "src/core/ext/filters/client_channel/resolver_factory.h"
 #include "src/core/lib/iomgr/pollset_set.h"
 
-void grpc_resolver_registry_init();
+void grpc_resolver_registry_init(void);
 void grpc_resolver_registry_shutdown(void);
 
 /** Set the default URI prefix to \a default_prefix. */

--- a/Sources/CgRPC/src/core/ext/filters/client_channel/retry_throttle.h
+++ b/Sources/CgRPC/src/core/ext/filters/client_channel/retry_throttle.h
@@ -37,9 +37,9 @@ void grpc_server_retry_throttle_data_unref(
     grpc_server_retry_throttle_data* throttle_data);
 
 /// Initializes global map of failure data for each server name.
-void grpc_retry_throttle_map_init();
+void grpc_retry_throttle_map_init(void);
 /// Shuts down global map of failure data for each server name.
-void grpc_retry_throttle_map_shutdown();
+void grpc_retry_throttle_map_shutdown(void);
 
 /// Returns a reference to the failure data for \a server_name, creating
 /// a new entry if needed.

--- a/Sources/CgRPC/src/core/ext/filters/load_reporting/server_load_reporting_plugin.h
+++ b/Sources/CgRPC/src/core/ext/filters/load_reporting/server_load_reporting_plugin.h
@@ -53,7 +53,7 @@ typedef struct grpc_load_reporting_call_data {
 } grpc_load_reporting_call_data;
 
 /** Return a \a grpc_arg enabling load reporting */
-grpc_arg grpc_load_reporting_enable_arg();
+grpc_arg grpc_load_reporting_enable_arg(void);
 
 #endif /* GRPC_CORE_EXT_FILTERS_LOAD_REPORTING_SERVER_LOAD_REPORTING_PLUGIN_H \
           */

--- a/Sources/CgRPC/src/core/ext/transport/chttp2/client/chttp2_connector.h
+++ b/Sources/CgRPC/src/core/ext/transport/chttp2/client/chttp2_connector.h
@@ -21,6 +21,6 @@
 
 #include "src/core/ext/filters/client_channel/connector.h"
 
-grpc_connector* grpc_chttp2_connector_create();
+grpc_connector* grpc_chttp2_connector_create(void);
 
 #endif /* GRPC_CORE_EXT_TRANSPORT_CHTTP2_CLIENT_CHTTP2_CONNECTOR_H */

--- a/Sources/CgRPC/src/core/lib/channel/handshaker.h
+++ b/Sources/CgRPC/src/core/lib/channel/handshaker.h
@@ -111,7 +111,7 @@ void grpc_handshaker_do_handshake(grpc_exec_ctx* exec_ctx,
 typedef struct grpc_handshake_manager grpc_handshake_manager;
 
 /// Creates a new handshake manager.  Caller takes ownership.
-grpc_handshake_manager* grpc_handshake_manager_create();
+grpc_handshake_manager* grpc_handshake_manager_create(void);
 
 /// Adds a handshaker to the handshake manager.
 /// Takes ownership of \a handshaker.

--- a/Sources/CgRPC/src/core/lib/channel/handshaker_registry.h
+++ b/Sources/CgRPC/src/core/lib/channel/handshaker_registry.h
@@ -30,7 +30,7 @@ typedef enum {
   NUM_HANDSHAKER_TYPES,  // Must be last.
 } grpc_handshaker_type;
 
-void grpc_handshaker_factory_registry_init();
+void grpc_handshaker_factory_registry_init(void);
 void grpc_handshaker_factory_registry_shutdown(grpc_exec_ctx* exec_ctx);
 
 /// Registers a new handshaker factory.  Takes ownership.

--- a/Sources/CgRPC/src/core/lib/iomgr/ev_posix.h
+++ b/Sources/CgRPC/src/core/lib/iomgr/ev_posix.h
@@ -86,7 +86,7 @@ void grpc_event_engine_init(void);
 void grpc_event_engine_shutdown(void);
 
 /* Return the name of the poll strategy */
-const char *grpc_get_poll_strategy_name();
+const char *grpc_get_poll_strategy_name(void);
 
 /* Create a wrapped file descriptor.
    Requires fd is a non-blocking file descriptor.
@@ -156,6 +156,6 @@ extern grpc_poll_function_type grpc_poll_function;
 /* WARNING: The following two functions should be used for testing purposes
  * ONLY */
 void grpc_set_event_engine_test_only(const grpc_event_engine_vtable *);
-const grpc_event_engine_vtable *grpc_get_event_engine_test_only();
+const grpc_event_engine_vtable *grpc_get_event_engine_test_only(void);
 
 #endif /* GRPC_CORE_LIB_IOMGR_EV_POSIX_H */

--- a/Sources/CgRPC/src/core/lib/iomgr/executor.h
+++ b/Sources/CgRPC/src/core/lib/iomgr/executor.h
@@ -39,7 +39,7 @@ grpc_closure_scheduler *grpc_executor_scheduler(grpc_executor_job_length);
 void grpc_executor_shutdown(grpc_exec_ctx *exec_ctx);
 
 /** Is the executor multi-threaded? */
-bool grpc_executor_is_threaded();
+bool grpc_executor_is_threaded(void);
 
 /* enable/disable threading - must be called after grpc_executor_init and before
    grpc_executor_shutdown */

--- a/Sources/CgRPC/src/core/lib/iomgr/network_status_tracker.h
+++ b/Sources/CgRPC/src/core/lib/iomgr/network_status_tracker.h
@@ -25,6 +25,6 @@ void grpc_network_status_shutdown(void);
 
 void grpc_network_status_register_endpoint(grpc_endpoint *ep);
 void grpc_network_status_unregister_endpoint(grpc_endpoint *ep);
-void grpc_network_status_shutdown_all_endpoints();
+void grpc_network_status_shutdown_all_endpoints(void);
 
 #endif /* GRPC_CORE_LIB_IOMGR_NETWORK_STATUS_TRACKER_H */

--- a/Sources/CgRPC/src/core/lib/security/transport/security_handshaker.h
+++ b/Sources/CgRPC/src/core/lib/security/transport/security_handshaker.h
@@ -29,6 +29,6 @@ grpc_handshaker *grpc_security_handshaker_create(
     grpc_security_connector *connector);
 
 /// Registers security handshaker factories.
-void grpc_security_register_handshaker_factories();
+void grpc_security_register_handshaker_factories(void);
 
 #endif /* GRPC_CORE_LIB_SECURITY_TRANSPORT_SECURITY_HANDSHAKER_H */

--- a/Sources/CgRPC/src/core/lib/support/block_annotate.h
+++ b/Sources/CgRPC/src/core/lib/support/block_annotate.h
@@ -23,8 +23,8 @@
 extern "C" {
 #endif
 
-void gpr_thd_start_blocking_region();
-void gpr_thd_end_blocking_region();
+void gpr_thd_start_blocking_region(void);
+void gpr_thd_end_blocking_region(void);
 
 #ifdef __cplusplus
 }

--- a/Sources/CgRPC/src/core/lib/support/thd_internal.h
+++ b/Sources/CgRPC/src/core/lib/support/thd_internal.h
@@ -22,7 +22,7 @@
 #include <grpc/support/time.h>
 
 /* Internal interfaces between modules within the gpr support library.  */
-void gpr_thd_init();
+void gpr_thd_init(void);
 
 /* Wait for all outstanding threads to finish, up to deadline */
 int gpr_await_threads(gpr_timespec deadline);

--- a/Sources/CgRPC/src/core/lib/support/thd_posix.c
+++ b/Sources/CgRPC/src/core/lib/support/thd_posix.c
@@ -43,8 +43,8 @@ struct thd_arg {
   void *arg;               /* argument to a thread */
 };
 
-static void inc_thd_count();
-static void dec_thd_count();
+static void inc_thd_count(void);
+static void dec_thd_count(void);
 
 /* Body of every thread started via gpr_thd_new. */
 static void *thread_body(void *v) {

--- a/Sources/CgRPC/src/core/lib/surface/init.c
+++ b/Sources/CgRPC/src/core/lib/surface/init.c
@@ -102,8 +102,8 @@ static void register_builtin_channel_init() {
 }
 
 typedef struct grpc_plugin {
-  void (*init)();
-  void (*destroy)();
+  void (*init)(void);
+  void (*destroy)(void);
 } grpc_plugin;
 
 static grpc_plugin g_all_of_the_plugins[MAX_PLUGINS];

--- a/Sources/CgRPC/src/core/tsi/transport_security_interface.h
+++ b/Sources/CgRPC/src/core/tsi/transport_security_interface.h
@@ -448,10 +448,10 @@ void tsi_handshaker_destroy(tsi_handshaker *self);
 
 /* This method initializes the necessary shared objects used for tsi
    implementation.  */
-void tsi_init();
+void tsi_init(void);
 
 /* This method destroys the shared objects created by tsi_init.  */
-void tsi_destroy();
+void tsi_destroy(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
See https://github.com/grpc/grpc-swift/pull/126 for details. If you'd rather not have manual changes like this to the vendored code, no objections. In that case, I'd just suggest leaving them in there until we are able to get rid of the vendored code completely, then fix them upstream in gRPC if still necessary.