### PR TITLE
Remove a few occasions of implicitly unwrapped optionals/explicit optional unwrapping

### DIFF
--- a/Sources/gRPC/Call.swift
+++ b/Sources/gRPC/Call.swift
@@ -296,7 +296,7 @@ public class Call {
 
   // Receive a message over a streaming connection.
   /// - Throws: `CallError` if fails to call.
-  public func receiveMessage(callback: @escaping ((Data!) throws -> Void)) throws {
+  public func receiveMessage(callback: @escaping (Data?) throws -> Void) throws {
     try perform(OperationGroup(call: self, operations: [.receiveMessage]) { operationGroup in
       if operationGroup.success {
         if let messageBuffer = operationGroup.receivedMessage() {

--- a/Sources/gRPC/Handler.swift
+++ b/Sources/gRPC/Handler.swift
@@ -38,24 +38,23 @@ public class Handler {
 
   /// The host name sent with the request
   public lazy var host: String? = {
-    guard let string = cgrpc_handler_copy_host(self.underlyingHandler)
-      else { return nil }
+    // We actually know that this method will never return nil,
+    // so we can forcibly unwrap the result. (Also below.)
+    let string = cgrpc_handler_copy_host(self.underlyingHandler)!
     defer { cgrpc_free_copied_string(string) }
     return String(cString: string, encoding: .utf8)
   }()
 
   /// The method name sent with the request
   public lazy var method: String? = {
-    guard let string = cgrpc_handler_copy_method(self.underlyingHandler)
-      else { return nil }
+    let string = cgrpc_handler_copy_method(self.underlyingHandler)!
     defer { cgrpc_free_copied_string(string) }
     return String(cString: string, encoding: .utf8)
   }()
 
   /// The caller address associated with the request
   public lazy var caller: String? = {
-    guard let string = cgrpc_handler_call_peer(self.underlyingHandler)
-      else { return nil }
+    let string = cgrpc_handler_call_peer(self.underlyingHandler)!
     defer { cgrpc_free_copied_string(string) }
     return String(cString: string, encoding: .utf8)
   }()

--- a/Sources/gRPC/Handler.swift
+++ b/Sources/gRPC/Handler.swift
@@ -37,33 +37,27 @@ public class Handler {
   }()
 
   /// The host name sent with the request
-  public lazy var host: String = {
-    if let string = cgrpc_handler_copy_host(self.underlyingHandler) {
-      defer {
-        cgrpc_free_copied_string(string)
-      }
-      return String(cString: string, encoding: .utf8)!
-    } else {
-      return ""
-    }
+  public lazy var host: String? = {
+    guard let string = cgrpc_handler_copy_host(self.underlyingHandler)
+      else { return nil }
+    defer { cgrpc_free_copied_string(string) }
+    return String(cString: string, encoding: .utf8)
   }()
 
   /// The method name sent with the request
-  public lazy var method: String = {
-    if let string = cgrpc_handler_copy_method(self.underlyingHandler) {
-      defer {
-        cgrpc_free_copied_string(string)
-      }
-      return String(cString: string, encoding: .utf8)!
-    } else {
-      return ""
-    }
+  public lazy var method: String? = {
+    guard let string = cgrpc_handler_copy_method(self.underlyingHandler)
+      else { return nil }
+    defer { cgrpc_free_copied_string(string) }
+    return String(cString: string, encoding: .utf8)
   }()
 
   /// The caller address associated with the request
-  public lazy var caller: String = {
-    String(cString: cgrpc_handler_call_peer(self.underlyingHandler),
-           encoding: .utf8)!
+  public lazy var caller: String? = {
+    guard let string = cgrpc_handler_call_peer(self.underlyingHandler)
+      else { return nil }
+    defer { cgrpc_free_copied_string(string) }
+    return String(cString: string, encoding: .utf8)
   }()
 
   /// Initializes a Handler

--- a/Sources/gRPC/OperationGroup.swift
+++ b/Sources/gRPC/OperationGroup.swift
@@ -164,8 +164,8 @@ class OperationGroup {
     for (i, operation) in operations.enumerated() {
       switch operation {
       case .receiveStatusOnClient:
-        guard let string = cgrpc_observer_recv_status_on_client_copy_status_details(underlyingObservers[i])
-          else { return nil }
+        // We actually know that this method will never return nil, so we can forcibly the result. (Also below.)
+        let string = cgrpc_observer_recv_status_on_client_copy_status_details(underlyingObservers[i])!
         defer { cgrpc_free_copied_string(string) }
         return String(cString: string, encoding: String.Encoding.utf8)
       default:

--- a/Sources/gRPC/OperationGroup.swift
+++ b/Sources/gRPC/OperationGroup.swift
@@ -164,14 +164,10 @@ class OperationGroup {
     for (i, operation) in operations.enumerated() {
       switch operation {
       case .receiveStatusOnClient:
-        if let string = cgrpc_observer_recv_status_on_client_copy_status_details(underlyingObservers[i]) {
-          defer {
-            cgrpc_free_copied_string(string)
-          }
-          return String(cString: string, encoding: String.Encoding.utf8)!
-        } else {
-          return nil
-        }
+        guard let string = cgrpc_observer_recv_status_on_client_copy_status_details(underlyingObservers[i])
+          else { return nil }
+        defer { cgrpc_free_copied_string(string) }
+        return String(cString: string, encoding: String.Encoding.utf8)
       default:
         continue
       }

--- a/Sources/gRPC/gRPC.swift
+++ b/Sources/gRPC/gRPC.swift
@@ -31,15 +31,15 @@ public func shutdown() {
 /// Returns version of underlying gRPC library
 ///
 /// Returns: gRPC version string
-public func version() -> String {
-  return String(cString: grpc_version_string(), encoding: String.Encoding.utf8)!
+public func version() -> String? {
+  return String(cString: grpc_version_string(), encoding: String.Encoding.utf8)
 }
 
 /// Returns name associated with gRPC version
 ///
 /// Returns: gRPC version name
-public func gStandsFor() -> String {
-  return String(cString: grpc_g_stands_for(), encoding: String.Encoding.utf8)!
+public func gStandsFor() -> String? {
+  return String(cString: grpc_g_stands_for(), encoding: String.Encoding.utf8)
 }
 
 /// Status codes for gRPC operations (replicated from status_code_enum.h)

--- a/Tests/gRPCTests/GRPCTests.swift
+++ b/Tests/gRPCTests/GRPCTests.swift
@@ -68,7 +68,7 @@ func runTest(useSSL: Bool) {
   let serverRunningSemaphore = DispatchSemaphore(value: 0)
 
   // create the server
-  var server: gRPC.Server!
+  let server: gRPC.Server
   if useSSL {
     let certificateURL = URL(fileURLWithPath: "Tests/ssl.crt")
     let keyURL = URL(fileURLWithPath: "Tests/ssl.key")
@@ -120,7 +120,7 @@ func verify_metadata(_ metadata: Metadata, expected: [String: String]) {
 
 func runClient(useSSL: Bool) throws {
   let message = clientText.data(using: .utf8)
-  var channel: gRPC.Channel!
+  let channel: gRPC.Channel
 
   if useSSL {
     let certificateURL = URL(fileURLWithPath: "Tests/ssl.crt")
@@ -147,8 +147,8 @@ func runClient(useSSL: Bool) throws {
       XCTAssertEqual(response.statusCode, statusCode)
       XCTAssertEqual(response.statusMessage, statusMessage)
       // verify the message from the server
-      let resultData = response.resultData
-      let messageString = String(data: resultData!, encoding: .utf8)
+      let resultData = response.resultData!
+      let messageString = String(data: resultData, encoding: .utf8)
       XCTAssertEqual(messageString, serverText)
       // verify the initial metadata from the server
       let initialMetadata = response.initialMetadata!


### PR DESCRIPTION
In the unlikely case that these unwraps fail, I think it is still better to return nil and have the library's clients deal with it than crash.