### PR TITLE
Make most completion blocks optional, so that clients don't need to pass them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,6 @@ Plugin/Sources/protoc-gen-swiftgrpc/templates.swift
 Plugin/protoc-*
 Plugin/swiftgrpc.log
 Plugin/echo.*.swift
-ExampleTests/Generated
+Examples/Echo/PackageManager/Echo
 SwiftGRPC.xcodeproj
 Package.resolved

--- a/Examples/Echo/EchoProvider.swift
+++ b/Examples/Echo/EchoProvider.swift
@@ -32,7 +32,7 @@ class EchoProvider: Echo_EchoProvider {
       var response = Echo_EchoResponse()
       response.text = "Swift echo expand (\(i)): \(part)"
       let sem = DispatchSemaphore(value: 0)
-      try session.send(response) { sem.signal() }
+      try session.send(response) { _ in sem.signal() }
       _ = sem.wait(timeout: DispatchTime.distantFuture)
       i += 1
       sleep(1)
@@ -67,7 +67,7 @@ class EchoProvider: Echo_EchoProvider {
         var response = Echo_EchoResponse()
         response.text = "Swift echo update (\(count)): \(request.text)"
         let sem = DispatchSemaphore(value: 0)
-        try session.send(response) { sem.signal() }
+        try session.send(response) { _ in sem.signal() }
         _ = sem.wait(timeout: DispatchTime.distantFuture)
       } catch Echo_EchoServerError.endOfStream {
         break

--- a/Examples/Echo/Generated/echo.grpc.swift
+++ b/Examples/Echo/Generated/echo.grpc.swift
@@ -169,6 +169,21 @@ fileprivate final class Echo_EchoExpandCallImpl: Echo_EchoExpandCall {
   }
 }
 
+/// Simple fake implementation of Echo_EchoExpandCall that returns a previously-defined set of results.
+class Echo_EchoExpandCallTestStub: Echo_EchoExpandCall {
+  var outputs: [Echo_EchoResponse] = []
+  
+  func receive(completion:@escaping (Echo_EchoResponse?, Echo_EchoClientError?)->()) throws {
+    if let output = outputs.first {
+      outputs.removeFirst()
+      completion(output, nil)
+    } else {
+      completion(nil, Echo_EchoClientError.endOfStream)
+    }
+  }
+
+  func cancel() { }
+}
 
 /// Collect (Client Streaming)
 internal protocol Echo_EchoCollectCall {
@@ -247,6 +262,22 @@ fileprivate final class Echo_EchoCollectCallImpl: Echo_EchoCollectCall {
   }
 }
 
+/// Simple fake implementation of Echo_EchoCollectCall
+/// stores sent values for later verification and finall returns a previously-defined result.
+class Echo_EchoCollectCallTestStub: Echo_EchoCollectCall {
+  var inputs: [Echo_EchoRequest] = []
+  var output: Echo_EchoResponse?
+
+  func send(_ message:Echo_EchoRequest, errorHandler:@escaping (Error)->()) throws {
+    inputs.append(message)
+  }
+  
+  func closeAndReceive(completion:@escaping (Echo_EchoResponse?, Echo_EchoClientError?)->()) throws {
+    completion(output!, nil)
+  }
+
+  func cancel() { }
+}
 
 /// Update (Bidirectional Streaming)
 internal protocol Echo_EchoUpdateCall {
@@ -340,6 +371,29 @@ fileprivate final class Echo_EchoUpdateCallImpl: Echo_EchoUpdateCall {
   }
 }
 
+/// Simple fake implementation of Echo_EchoUpdateCall that returns a previously-defined set of results
+/// and stores sent values for later verification.
+class Echo_EchoUpdateCallTestStub: Echo_EchoUpdateCall {
+  var inputs: [Echo_EchoRequest] = []
+  var outputs: [Echo_EchoResponse] = []
+  
+  func receive(completion:@escaping (Echo_EchoResponse?, Echo_EchoClientError?)->()) throws {
+    if let output = outputs.first {
+      outputs.removeFirst()
+      completion(output, nil)
+    } else {
+      completion(nil, Echo_EchoClientError.endOfStream)
+    }
+  }
+
+  func send(_ message:Echo_EchoRequest, errorHandler:@escaping (Error)->()) throws {
+    inputs.append(message)
+  }
+
+  func closeSend(completion: (()->())?) throws { completion?() }
+
+  func cancel() { }
+}
 
 
 /// Instantiate Echo_EchoServiceImpl, then call methods of this protocol to make API calls.
@@ -465,6 +519,51 @@ internal final class Echo_EchoServiceClient: Echo_EchoService {
 
 }
 
+/// Simple fake implementation of Echo_EchoService that returns a previously-defined set of results
+/// and stores request values passed into it for later verification.
+/// Note: completion blocks are NOT called with this default implementation, and asynchronous unary calls are NOT implemented!
+class Echo_EchoServiceTestStub: Echo_EchoService {
+  var channel: Channel { fatalError("not implemented") }
+  var metadata = Metadata()
+  var host = ""
+  var timeout: TimeInterval = 0
+  
+  var getRequests: [Echo_EchoRequest] = []
+  var getResponses: [Echo_EchoResponse] = []
+  func get(_ request: Echo_EchoRequest) throws -> Echo_EchoResponse {
+    getRequests.append(request)
+    defer { getResponses.removeFirst() }
+    return getResponses.first!
+  }
+  func get(_ request: Echo_EchoRequest,
+                  completion: @escaping (Echo_EchoResponse?, CallResult)->()) throws -> Echo_EchoGetCall {
+    fatalError("not implemented")
+  }
+
+  var expandRequests: [Echo_EchoRequest] = []
+  var expandCalls: [Echo_EchoExpandCall] = []
+  func expand(_ request: Echo_EchoRequest, completion: ((CallResult)->())?)
+    throws -> Echo_EchoExpandCall {
+      expandRequests.append(request)
+      defer { expandCalls.removeFirst() }
+      return expandCalls.first!
+  }
+
+  var collectCalls: [Echo_EchoCollectCall] = []
+  func collect(completion: ((CallResult)->())?)
+    throws -> Echo_EchoCollectCall {
+      defer { collectCalls.removeFirst() }
+      return collectCalls.first!
+  }
+
+  var updateCalls: [Echo_EchoUpdateCall] = []
+  func update(completion: ((CallResult)->())?)
+    throws -> Echo_EchoUpdateCall {
+      defer { updateCalls.removeFirst() }
+      return updateCalls.first!
+  }
+
+}
 
 
 
@@ -505,6 +604,14 @@ fileprivate class Echo_EchoSessionImpl: Echo_EchoSession {
   }
 }
 
+class Echo_EchoSessionTestStub: Echo_EchoSession {
+  var requestMetadata = Metadata()
+
+  var statusCode = StatusCode.ok
+  var statusMessage = "OK"
+  var initialMetadata = Metadata()
+  var trailingMetadata = Metadata()
+}
 
 // Get (Unary Streaming)
 internal protocol Echo_EchoGetSession : Echo_EchoSession { }
@@ -533,6 +640,8 @@ fileprivate final class Echo_EchoGetSessionImpl : Echo_EchoSessionImpl, Echo_Ech
   }
 }
 
+/// Trivial fake implementation of Echo_EchoGetSession.
+class Echo_EchoGetSessionTestStub : Echo_EchoSessionTestStub, Echo_EchoGetSession { }
 
 // Expand (Server Streaming)
 internal protocol Echo_EchoExpandSession : Echo_EchoSession {
@@ -580,6 +689,17 @@ fileprivate final class Echo_EchoExpandSessionImpl : Echo_EchoSessionImpl, Echo_
   }
 }
 
+/// Simple fake implementation of Echo_EchoExpandSession that returns a previously-defined set of results
+/// and stores sent values for later verification.
+class Echo_EchoExpandSessionTestStub : Echo_EchoSessionTestStub, Echo_EchoExpandSession {
+  var outputs: [Echo_EchoResponse] = []
+
+  func send(_ response: Echo_EchoResponse, completion: ((Bool)->())?) throws {
+    outputs.append(response)
+  }
+
+  func close() throws { }
+}
 
 // Collect (Client Streaming)
 internal protocol Echo_EchoCollectSession : Echo_EchoSession {
@@ -636,6 +756,27 @@ fileprivate final class Echo_EchoCollectSessionImpl : Echo_EchoSessionImpl, Echo
   }
 }
 
+/// Simple fake implementation of Echo_EchoCollectSession that returns a previously-defined set of results
+/// and stores sent values for later verification.
+class Echo_EchoCollectSessionTestStub: Echo_EchoSessionTestStub, Echo_EchoCollectSession {
+  var inputs: [Echo_EchoRequest] = []
+  var output: Echo_EchoResponse?
+
+  func receive() throws -> Echo_EchoRequest {
+    if let input = inputs.first {
+      inputs.removeFirst()
+      return input
+    } else {
+      throw Echo_EchoClientError.endOfStream
+    }
+  }
+
+  func sendAndClose(_ response: Echo_EchoResponse) throws {
+    output = response
+  }
+
+  func close() throws { }
+}
 
 // Update (Bidirectional Streaming)
 internal protocol Echo_EchoUpdateSession : Echo_EchoSession {
@@ -705,6 +846,27 @@ fileprivate final class Echo_EchoUpdateSessionImpl : Echo_EchoSessionImpl, Echo_
   }
 }
 
+/// Simple fake implementation of Echo_EchoUpdateSession that returns a previously-defined set of results
+/// and stores sent values for later verification.
+class Echo_EchoUpdateSessionTestStub : Echo_EchoSessionTestStub, Echo_EchoUpdateSession {
+  var inputs: [Echo_EchoRequest] = []
+  var outputs: [Echo_EchoResponse] = []
+
+  func receive() throws -> Echo_EchoRequest {
+    if let input = inputs.first {
+      inputs.removeFirst()
+      return input
+    } else {
+      throw Echo_EchoClientError.endOfStream
+    }
+  }
+
+  func send(_ response: Echo_EchoResponse, completion: ((Bool)->())?) throws {
+    outputs.append(response)
+  }
+
+  func close() throws { }
+}
 
 
 /// Main server for generated service

--- a/Examples/Echo/Generated/echo.grpc.swift
+++ b/Examples/Echo/Generated/echo.grpc.swift
@@ -215,7 +215,7 @@ fileprivate final class Echo_EchoCollectCallImpl: Echo_EchoCollectCall {
   }
 
   /// Call this to start a call. Nonblocking.
-  func start(metadata:Metadata, completion: (CallResult)->()?)
+  func start(metadata:Metadata, completion: ((CallResult)->())?)
     throws -> Echo_EchoCollectCall {
       try self.call.start(.clientStreaming, metadata:metadata, completion:completion)
       return self
@@ -366,19 +366,19 @@ internal protocol Echo_EchoService {
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  func expand(_ request: Echo_EchoRequest, completion: @escaping (CallResult)->())
+  func expand(_ request: Echo_EchoRequest, completion: ((CallResult)->())?)
     throws -> Echo_EchoExpandCall
 
   /// Asynchronous. Client-streaming.
   /// Use methods on the returned object to stream messages and
   /// to close the connection and wait for a final response.
-  func collect(completion: @escaping (CallResult)->())
+  func collect(completion: ((CallResult)->())?)
     throws -> Echo_EchoCollectCall
 
   /// Asynchronous. Bidirectional-streaming.
   /// Use methods on the returned object to stream messages,
   /// to wait for replies, and to close the connection.
-  func update(completion: @escaping (CallResult)->())
+  func update(completion: ((CallResult)->())?)
     throws -> Echo_EchoUpdateCall
 
 }

--- a/Examples/Echo/Generated/echo.grpc.swift
+++ b/Examples/Echo/Generated/echo.grpc.swift
@@ -350,7 +350,7 @@ internal final class Echo_EchoService {
   }
   /// Asynchronous. Unary.
   internal func get(_ request: Echo_EchoRequest,
-                  completion: @escaping ((Echo_EchoResponse?, CallResult)->()))
+                  completion: @escaping (Echo_EchoResponse?, CallResult)->())
     throws
     -> Echo_EchoGetCall {
       return try Echo_EchoGetCall(channel).start(request:request,

--- a/Examples/Simple/PackageManager/main.swift
+++ b/Examples/Simple/PackageManager/main.swift
@@ -115,7 +115,7 @@ func server() throws {
     }
   }
 
-  server.onCompletion {
+  server.onCompletion = {
     print("Server Stopped")
   }
 

--- a/Plugin/Makefile
+++ b/Plugin/Makefile
@@ -9,7 +9,7 @@ build:  clear
 	cp .build/debug/protoc-gen-swift .
 
 test:	build
-	protoc ../Examples/Echo/echo.proto --proto_path=../Examples/Echo --plugin=./protoc-gen-swiftgrpc --swiftgrpc_out=. --swift_out=.
+	protoc ../Examples/Echo/echo.proto --proto_path=../Examples/Echo --plugin=./protoc-gen-swiftgrpc --swiftgrpc_out=. --swift_out=. --swiftgrpc_opt=TestStubs=true
 	diff echo.grpc.swift ../Examples/Echo/Generated/echo.grpc.swift
 
 deploy:

--- a/Plugin/Templates/client-call-bidistreaming.swift
+++ b/Plugin/Templates/client-call-bidistreaming.swift
@@ -8,7 +8,7 @@
   }
 
   /// Call this to start a call. Nonblocking.
-  fileprivate func start(metadata:Metadata, completion:@escaping (CallResult)->())
+  fileprivate func start(metadata:Metadata, completion: ((CallResult)->())?)
     throws -> {{ .|call:file,service,method }} {
       try self.call.start(.bidiStreaming, metadata:metadata, completion:completion)
       return self
@@ -66,10 +66,8 @@
   }
 
   /// Call this to close the sending connection. Nonblocking.
-  {{ access }} func closeSend(completion:@escaping ()->()) throws {
-    try call.close() {
-      completion()
-    }
+  {{ access }} func closeSend(completion: (()->())?) throws {
+	try call.close(completion: completion)
   }
 
   /// Cancel the call.

--- a/Plugin/Templates/client-call-clientstreaming.swift
+++ b/Plugin/Templates/client-call-clientstreaming.swift
@@ -43,7 +43,7 @@ fileprivate final class {{ .|call:file,service,method }}Impl: {{ .|call:file,ser
   }
 
   /// Call this to start a call. Nonblocking.
-  func start(metadata:Metadata, completion: (CallResult)->()?)
+  func start(metadata:Metadata, completion: ((CallResult)->())?)
     throws -> {{ .|call:file,service,method }} {
       try self.call.start(.clientStreaming, metadata:metadata, completion:completion)
       return self

--- a/Plugin/Templates/client-call-clientstreaming.swift
+++ b/Plugin/Templates/client-call-clientstreaming.swift
@@ -8,7 +8,7 @@
   }
 
   /// Call this to start a call. Nonblocking.
-  fileprivate func start(metadata:Metadata, completion:@escaping (CallResult)->())
+  fileprivate func start(metadata:Metadata, completion: ((CallResult)->())?)
     throws -> {{ .|call:file,service,method }} {
       try self.call.start(.clientStreaming, metadata:metadata, completion:completion)
       return self

--- a/Plugin/Templates/client-call-serverstreaming.swift
+++ b/Plugin/Templates/client-call-serverstreaming.swift
@@ -10,7 +10,7 @@
   /// Call this once with the message to send. Nonblocking.
   fileprivate func start(request: {{ method|input }},
                          metadata: Metadata,
-                         completion: @escaping (CallResult) -> ())
+                         completion: ((CallResult) -> ())?)
     throws -> {{ .|call:file,service,method }} {
       let requestData = try request.serializedData()
       try call.start(.serverStreaming,

--- a/Plugin/Templates/client-call-unary.swift
+++ b/Plugin/Templates/client-call-unary.swift
@@ -31,7 +31,7 @@
   /// - Throws: `BinaryEncodingError` if encoding fails. `CallError` if fails to call.
   fileprivate func start(request: {{ method|input }},
                          metadata: Metadata,
-                         completion: @escaping ({{ method|output }}?, CallResult)->())
+                         completion: @escaping (({{ method|output }}?, CallResult)->()))
     throws -> {{ .|call:file,service,method }} {
 
       let requestData = try request.serializedData()

--- a/Plugin/Templates/client.swift
+++ b/Plugin/Templates/client.swift
@@ -86,7 +86,7 @@
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  {{ access }} func {{ method|methodDescriptorName|lowercase }}(_ request: {{ method|input }}, completion: @escaping (CallResult)->())
+  {{ access }} func {{ method|methodDescriptorName|lowercase }}(_ request: {{ method|input }}, completion: ((CallResult)->())?)
     throws
     -> {{ .|call:file,service,method }} {
       return try {{ .|call:file,service,method }}(channel).start(request:request, metadata:metadata, completion:completion)
@@ -96,7 +96,7 @@
   /// Asynchronous. Client-streaming.
   /// Use methods on the returned object to stream messages and
   /// to close the connection and wait for a final response.
-  {{ access }} func {{ method|methodDescriptorName|lowercase }}(completion: @escaping (CallResult)->())
+  {{ access }} func {{ method|methodDescriptorName|lowercase }}(completion: ((CallResult)->())?)
     throws
     -> {{ .|call:file,service,method }} {
       return try {{ .|call:file,service,method }}(channel).start(metadata:metadata, completion:completion)
@@ -106,7 +106,7 @@
   /// Asynchronous. Bidirectional-streaming.
   /// Use methods on the returned object to stream messages,
   /// to wait for replies, and to close the connection.
-  {{ access }} func {{ method|methodDescriptorName|lowercase }}(completion: @escaping (CallResult)->())
+  {{ access }} func {{ method|methodDescriptorName|lowercase }}(completion: ((CallResult)->())?)
     throws
     -> {{ .|call:file,service,method }} {
       return try {{ .|call:file,service,method }}(channel).start(metadata:metadata, completion:completion)

--- a/Plugin/Templates/client.swift
+++ b/Plugin/Templates/client.swift
@@ -49,21 +49,21 @@
   /// Asynchronous. Server-streaming.
   /// Send the initial message.
   /// Use methods on the returned object to get streamed responses.
-  func {{ method|methodDescriptorName|lowercase }}(_ request: {{ method|input }}, completion: @escaping (CallResult)->())
+  func {{ method|methodDescriptorName|lowercase }}(_ request: {{ method|input }}, completion: ((CallResult)->())?)
     throws -> {{ .|call:file,service,method }}
   //-{% endif %}
   //-{% if method|methodIsClientStreaming %}
   /// Asynchronous. Client-streaming.
   /// Use methods on the returned object to stream messages and
   /// to close the connection and wait for a final response.
-  func {{ method|methodDescriptorName|lowercase }}(completion: @escaping (CallResult)->())
+  func {{ method|methodDescriptorName|lowercase }}(completion: ((CallResult)->())?)
     throws -> {{ .|call:file,service,method }}
   //-{% endif %}
   //-{% if method|methodIsBidiStreaming %}
   /// Asynchronous. Bidirectional-streaming.
   /// Use methods on the returned object to stream messages,
   /// to wait for replies, and to close the connection.
-  func {{ method|methodDescriptorName|lowercase }}(completion: @escaping (CallResult)->())
+  func {{ method|methodDescriptorName|lowercase }}(completion: ((CallResult)->())?)
     throws -> {{ .|call:file,service,method }}
   //-{% endif %}
 
@@ -186,7 +186,7 @@ class {{ .|serviceclass:file,service }}TestStub: {{ .|serviceclass:file,service 
   //-{% if method|methodIsServerStreaming %}
   var {{ method|methodDescriptorName|lowercase }}Requests: [{{ method|input }}] = []
   var {{ method|methodDescriptorName|lowercase }}Calls: [{{ .|call:file,service,method }}] = []
-  func {{ method|methodDescriptorName|lowercase }}(_ request: {{ method|input }}, completion: @escaping (CallResult)->())
+  func {{ method|methodDescriptorName|lowercase }}(_ request: {{ method|input }}, completion: ((CallResult)->())?)
     throws -> {{ .|call:file,service,method }} {
       {{ method|methodDescriptorName|lowercase }}Requests.append(request)
       defer { {{ method|methodDescriptorName|lowercase }}Calls.removeFirst() }
@@ -195,7 +195,7 @@ class {{ .|serviceclass:file,service }}TestStub: {{ .|serviceclass:file,service 
   //-{% endif %}
   //-{% if method|methodIsClientStreaming %}
   var {{ method|methodDescriptorName|lowercase }}Calls: [{{ .|call:file,service,method }}] = []
-  func {{ method|methodDescriptorName|lowercase }}(completion: @escaping (CallResult)->())
+  func {{ method|methodDescriptorName|lowercase }}(completion: ((CallResult)->())?)
     throws -> {{ .|call:file,service,method }} {
       defer { {{ method|methodDescriptorName|lowercase }}Calls.removeFirst() }
       return {{ method|methodDescriptorName|lowercase }}Calls.first!
@@ -203,7 +203,7 @@ class {{ .|serviceclass:file,service }}TestStub: {{ .|serviceclass:file,service 
   //-{% endif %}
   //-{% if method|methodIsBidiStreaming %}
   var {{ method|methodDescriptorName|lowercase }}Calls: [{{ .|call:file,service,method }}] = []
-  func {{ method|methodDescriptorName|lowercase }}(completion: @escaping (CallResult)->())
+  func {{ method|methodDescriptorName|lowercase }}(completion: ((CallResult)->())?)
     throws -> {{ .|call:file,service,method }} {
       defer { {{ method|methodDescriptorName|lowercase }}Calls.removeFirst() }
       return {{ method|methodDescriptorName|lowercase }}Calls.first!

--- a/Plugin/Templates/server-session-bidistreaming.swift
+++ b/Plugin/Templates/server-session-bidistreaming.swift
@@ -82,7 +82,7 @@ class {{ .|session:file,service,method }}TestStub : {{ .|service:file,service }}
     }
   }
 
-  func send(_ response: {{ method|output }}, completion: @escaping ()->()) throws {
+  func send(_ response: {{ method|output }}, completion: ((Bool)->())?) throws {
     outputs.append(response)
   }
 

--- a/Plugin/Templates/server-session-clientstreaming.swift
+++ b/Plugin/Templates/server-session-clientstreaming.swift
@@ -35,7 +35,7 @@
 
   /// Run the session. Internal.
   fileprivate func run(queue:DispatchQueue) throws {
-    try self.handler.sendMetadata(initialMetadata:initialMetadata) {
+    try self.handler.sendMetadata(initialMetadata:initialMetadata) { _ in
       queue.async {
         do {
           try self.provider.{{ method|methodDescriptorName|lowercase }}(session:self)

--- a/Plugin/Templates/server-session-serverstreaming.swift
+++ b/Plugin/Templates/server-session-serverstreaming.swift
@@ -9,8 +9,8 @@
   }
 
   /// Send a message. Nonblocking.
-  {{ access }} func send(_ response: {{ method|output }}, completion: @escaping ()->()) throws {
-    try handler.sendResponse(message:response.serializedData()) {completion()}
+  {{ access }} func send(_ response: {{ method|output }}, completion: ((Bool)->())?) throws {
+	try handler.sendResponse(message:response.serializedData(), completion: completion)
   }
 
   /// Run the session. Internal.
@@ -27,7 +27,7 @@
               try self.handler.sendStatus(statusCode:self.statusCode,
                                           statusMessage:self.statusMessage,
                                           trailingMetadata:self.trailingMetadata,
-                                          completion:{})
+                                          completion:nil)
             } catch (let error) {
               print("error: \(error)")
             }

--- a/Plugin/Templates/server-session-serverstreaming.swift
+++ b/Plugin/Templates/server-session-serverstreaming.swift
@@ -50,7 +50,7 @@ fileprivate final class {{ .|session:file,service,method }}Impl : {{ .|service:f
 class {{ .|session:file,service,method }}TestStub : {{ .|service:file,service }}SessionTestStub, {{ .|session:file,service,method }} {
   var outputs: [{{ method|output }}] = []
 
-  func send(_ response: {{ method|output }}, completion: @escaping ()->()) throws {
+  func send(_ response: {{ method|output }}, completion: ((Bool)->())?) throws {
     outputs.append(response)
   }
 

--- a/Sources/gRPC/CompletionQueue.swift
+++ b/Sources/gRPC/CompletionQueue.swift
@@ -97,8 +97,8 @@ class CompletionQueue {
   ///
   /// - Parameter callbackQueue: a DispatchQueue to use to call the completion handler
   /// - Parameter completion: a completion handler that is called when the queue stops running
-  func runToCompletion(callbackQueue: DispatchQueue? = DispatchQueue.main,
-                                _ completion: @escaping () -> Void) {
+  func runToCompletion(callbackQueue: DispatchQueue = DispatchQueue.main,
+                       completion: (() -> Void)?) {
     // run the completion queue on a new background thread
     DispatchQueue.global().async {
       var running = true
@@ -114,7 +114,7 @@ class CompletionQueue {
             // call the operation group completion handler
             do {
               operationGroup.success = (event.success == 1)
-              try operationGroup.completion(operationGroup)
+              try operationGroup.completion?(operationGroup)
             } catch (let callError) {
               print("CompletionQueue runToCompletion: grpc error \(callError)")
             }
@@ -128,7 +128,7 @@ class CompletionQueue {
           do {
             for operationGroup in self.operationGroups.values {
               operationGroup.success = false
-              try operationGroup.completion(operationGroup)
+              try operationGroup.completion?(operationGroup)
             }
           } catch (let callError) {
             print("CompletionQueue runToCompletion: grpc error \(callError)")
@@ -143,7 +143,7 @@ class CompletionQueue {
           break
         }
       }
-      if let callbackQueue = callbackQueue {
+      if let completion = completion {
         callbackQueue.async {
           // when the queue stops running, call the queue completion handler
           completion()
@@ -154,7 +154,7 @@ class CompletionQueue {
 
   /// Runs a completion queue
   func run() {
-    runToCompletion(callbackQueue: nil) {}
+    runToCompletion(completion: nil)
   }
 
   /// Shuts down a completion queue

--- a/Sources/gRPC/OperationGroup.swift
+++ b/Sources/gRPC/OperationGroup.swift
@@ -41,7 +41,7 @@ class OperationGroup {
   var underlyingOperations: UnsafeMutableRawPointer?
 
   /// Completion handler that is called when the group completes
-  var completion: ((OperationGroup) throws -> Void)
+  let completion: ((OperationGroup) throws -> Void)?
 
   /// Indicates that the OperationGroup completed successfully
   var success: Bool = false
@@ -81,7 +81,7 @@ class OperationGroup {
   /// - Parameter operations: an array of operations
   init(call: Call,
        operations: [Operation],
-       completion: @escaping ((OperationGroup) throws -> Void)) {
+       completion: ((OperationGroup) throws -> Void)? = nil) {
     self.call = call
     self.operations = operations
     self.completion = completion

--- a/Sources/gRPC/Server.swift
+++ b/Sources/gRPC/Server.swift
@@ -34,7 +34,7 @@ public class Server {
   private var handlersMutex: Mutex = Mutex()
 
   /// Optional callback when server stops serving
-  private var onCompletion: (() -> Void)?
+  public var onCompletion: (() -> Void)?
 
   /// Initializes a Server
   ///
@@ -108,17 +108,11 @@ public class Server {
           running = false
         }
       }
-      if let onCompletion = self.onCompletion {
-        onCompletion()
-      }
+      self.onCompletion?()
     }
   }
 
   public func stop() {
     cgrpc_server_stop(underlyingServer)
-  }
-
-  public func onCompletion(completion: @escaping (() -> Void)) {
-    onCompletion = completion
   }
 }

--- a/Tests/gRPCTests/GRPCTests.swift
+++ b/Tests/gRPCTests/GRPCTests.swift
@@ -189,7 +189,7 @@ func runServer(server: gRPC.Server) throws {
       XCTFail("error \(error)")
     }
   }
-  server.onCompletion {
+  server.onCompletion = {
     // return from runServer()
     sem.signal()
   }


### PR DESCRIPTION
I've also changed several completion blocks to accept a boolean argument whether the corresponding operation was successful, instead of just never calling the completion block in case of errors.
In general, I think we should soon take a hard look at how errors are handled currently and ensure that no errors can lead to unexpected behavior (e.g. some blocks never getting called etc.), both in the client and server use-cases.