### PR TITLE
Create a first version of a Podspec that seems to be working

### DIFF
--- a/SwiftGRPC.podspec
+++ b/SwiftGRPC.podspec
@@ -29,7 +29,7 @@
 
 Pod::Spec.new do |s|
   s.name = 'SwiftGRPC'
-  s.version = '0.1.0'
+  s.version = '0.3.3'
   s.license  = 'New BSD'
   s.summary = 'Swift gRPC code generator plugin and runtime library'
   s.homepage = 'http://www.grpc.io'
@@ -42,7 +42,9 @@ Pod::Spec.new do |s|
   #s.tvos.deployment_target = '9.0'
   #s.watchos.deployment_target = '2.0'
 
-  s.source_files = 'Sources/**/*.swift', 'Sources/**/*.[ch]'
+  s.source_files = 'Sources/**/*.swift', 'Sources/CgRPC/shim/*.[ch]'
+  s.public_header_files = 'Sources/CgRPC/shim/cgrpc.h'
 
-  s.dependency 'gRPC-Core', '~> 1.0.1'
+  s.dependency 'gRPC-Core', '~> 1.9.1'
+  s.dependency 'BoringSSL', '~> 9.1'
 end


### PR DESCRIPTION
At least for me, this Podspec is working. Also, as long as the podspec is called `Podspec-incomplete.swift`, running `pod install` fails right away, so I think using the proper name makes sense already, for those who'd like to try it out. See https://github.com/grpc/grpc-swift/issues/111#issuecomment-366733622 on how to use the Podspec for now.

What still needs to be done, though, is changing the resulting module name, while currently the generated code imports `gRPC` (also see https://github.com/grpc/grpc-swift/issues/111#issuecomment-366733622). I would actually suggest always using `SwiftGRPC` as the name for this project's module, instead of `gRPC`, to avoid confusion with `gRPC-Core` (which gets built as `gRPC` as well). WDYT?