### PR TITLE
Make CI verify that runtime library+generated code are matching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ Plugin/Sources/protoc-gen-swiftgrpc/templates.swift
 Plugin/protoc-*
 Plugin/swiftgrpc.log
 Plugin/echo.*.swift
+ExampleTests/Generated
 SwiftGRPC.xcodeproj
 Package.resolved

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,3 +43,5 @@ script:
   - make test
   - cd Plugin
   - make test
+  - cd ../ExampleTests
+  - make

--- a/ExampleTests/Makefile
+++ b/ExampleTests/Makefile
@@ -1,0 +1,11 @@
+
+all:
+	swift build -c release
+
+project:
+	swift package generate-xcodeproj
+
+clean :
+	rm -rf Packages googleapis .build
+	rm -f Package.pins
+	rm -rf Package.resolved ExampleTests.xcodeproj ExampleTests

--- a/ExampleTests/Package.swift
+++ b/ExampleTests/Package.swift
@@ -1,0 +1,34 @@
+// swift-tools-version:4.0
+
+/*
+ * Copyright 2017, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import PackageDescription
+
+let package = Package(
+  name: "ExampleTests",
+  dependencies: [
+    .package(url: "../", .branch("HEAD")),
+    .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.0.2"),
+    .package(url: "https://github.com/kylef/Commander.git", from: "0.8.0")
+  ],
+  targets: [
+    .target(name: "Echo",
+            dependencies: [
+              "SwiftGRPC",
+              "SwiftProtobuf",
+              "Commander"
+            ])
+  ])

--- a/ExampleTests/Sources/Echo
+++ b/ExampleTests/Sources/Echo
@@ -1,0 +1,1 @@
+../../Examples/Echo/PackageManager/Sources/


### PR DESCRIPTION
Add an "ExampleTests" directory to let Travis verify that the latest combination of runtime library+generated code are matching (i.e. don't produce any build errors), and that the examples are compiling (currently covers only the default example).
I'm not 100% sure yet whether this works as expected, but I figured it would make sense to start by sending a pull request and see what Travis makes out of this ;-)

This of course causes much more compilation work on CI than before, but I think it is worth it for the peace of mind that a commit doesn't break the generated code.

At the moment, running `swift build` in `ExampleTests` creates the file `ExampleTests/Generated/echo.grpc.swift`, and I have no idea why. **Any suggestions on where that might come from would be much appreciated :-)**

If this works well, we could also add the other examples in a similar fashion.