### PR TITLE
Add some free methods as static members to a `gRPC` class instead

### DIFF
--- a/Sources/gRPC/gRPC.swift
+++ b/Sources/gRPC/gRPC.swift
@@ -18,7 +18,6 @@
 #endif
 import Foundation // for String.Encoding
 
-<<<<<<< HEAD
 public final class gRPC {
   private init() { }  // Static members only.
   

--- a/Sources/gRPC/gRPC.swift
+++ b/Sources/gRPC/gRPC.swift
@@ -18,28 +18,32 @@
 #endif
 import Foundation // for String.Encoding
 
-/// Initializes gRPC system
-public func initialize() {
-  grpc_init()
-}
-
-/// Shuts down gRPC system
-public func shutdown() {
-  grpc_shutdown()
-}
-
-/// Returns version of underlying gRPC library
-///
-/// Returns: gRPC version string
-public func version() -> String {
-  return String(cString: grpc_version_string(), encoding: String.Encoding.utf8)!
-}
-
-/// Returns name associated with gRPC version
-///
-/// Returns: gRPC version name
-public func gStandsFor() -> String {
-  return String(cString: grpc_g_stands_for(), encoding: String.Encoding.utf8)!
+public final class gRPC {
+  private init() { }  // Static members only.
+  
+  /// Initializes gRPC system
+  public static func initialize() {
+    grpc_init()
+  }
+  
+  /// Shuts down gRPC system
+  public static func shutdown() {
+    grpc_shutdown()
+  }
+  
+  /// Returns version of underlying gRPC library
+  ///
+  /// Returns: gRPC version string
+  public static var version: String {
+    return String(cString: grpc_version_string(), encoding: String.Encoding.utf8)!
+  }
+  
+  /// Returns name associated with gRPC version
+  ///
+  /// Returns: gRPC version name
+  public static var gStandsFor: String {
+    return String(cString: grpc_g_stands_for(), encoding: String.Encoding.utf8)!
+  }
 }
 
 /// Status codes for gRPC operations (replicated from status_code_enum.h)

--- a/Tests/gRPCTests/GRPCTests.swift
+++ b/Tests/gRPCTests/GRPCTests.swift
@@ -68,7 +68,7 @@ func runTest(useSSL: Bool) {
   let serverRunningSemaphore = DispatchSemaphore(value: 0)
 
   // create the server
-  var server: gRPC.Server!
+  var server: Server!
   if useSSL {
     let certificateURL = URL(fileURLWithPath: "Tests/ssl.crt")
     let keyURL = URL(fileURLWithPath: "Tests/ssl.key")
@@ -78,11 +78,11 @@ func runTest(useSSL: Bool) {
     else {
       return
     }
-    server = gRPC.Server(address: address,
-                         key: key,
-                         certs: certificate)
+    server = Server(address: address,
+                    key: key,
+                    certs: certificate)
   } else {
-    server = gRPC.Server(address: address)
+    server = Server(address: address)
   }
 
   // start the server
@@ -120,7 +120,7 @@ func verify_metadata(_ metadata: Metadata, expected: [String: String]) {
 
 func runClient(useSSL: Bool) throws {
   let message = clientText.data(using: .utf8)
-  var channel: gRPC.Channel!
+  var channel: Channel!
 
   if useSSL {
     let certificateURL = URL(fileURLWithPath: "Tests/ssl.crt")
@@ -130,9 +130,9 @@ func runClient(useSSL: Bool) throws {
       return
     }
     let host = "example.com"
-    channel = gRPC.Channel(address: address, certificates: certificates, host: host)
+    channel = Channel(address: address, certificates: certificates, host: host)
   } else {
-    channel = gRPC.Channel(address: address, secure: false)
+    channel = Channel(address: address, secure: false)
   }
 
   channel.host = host
@@ -164,7 +164,7 @@ func runClient(useSSL: Bool) throws {
   }
 }
 
-func runServer(server: gRPC.Server) throws {
+func runServer(server: Server) throws {
   var requestCount = 0
   let sem = DispatchSemaphore(value: 0)
   server.run { requestHandler in


### PR DESCRIPTION
Add the free methods `initialize`, `shutdown`, `version` and `gStandsFor` as static members to a `gRPC` class, to avoid namespace collision.

I figured this might help avoid confusion what a call to e.g. `initialize()` stands for, but YMMV. Feel free to reject if you think this is not a good idea.