### PR TITLE
Two more minor warning fixes

### DIFF
--- a/Sources/CgRPC/shim/byte_buffer.c
+++ b/Sources/CgRPC/shim/byte_buffer.c
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <stdio.h>
-
 #include "internal.h"
 #include "cgrpc.h"
 

--- a/Sources/CgRPC/shim/cgrpc.h
+++ b/Sources/CgRPC/shim/cgrpc.h
@@ -16,7 +16,7 @@
 #ifndef cgrpc_h
 #define cgrpc_h
 
-#import <stdlib.h>
+#include <stdlib.h>
 
 // This file lists C functions and types used to build Swift gRPC support
 

--- a/Sources/CgRPC/shim/metadata.c
+++ b/Sources/CgRPC/shim/metadata.c
@@ -16,11 +16,11 @@
 
 #include <grpc/support/alloc.h>
 
+#include <stdlib.h>
+#include <string.h>
+
 #include "internal.h"
 #include "cgrpc.h"
-
-#include "stdlib.h"
-#include "string.h"
 
 cgrpc_metadata_array *cgrpc_metadata_array_create() {
   cgrpc_metadata_array *metadata = (cgrpc_metadata_array *) gpr_malloc(sizeof(cgrpc_metadata_array));

--- a/Sources/CgRPC/shim/observers.c
+++ b/Sources/CgRPC/shim/observers.c
@@ -236,7 +236,7 @@ long cgrpc_observer_recv_status_on_client_get_status(cgrpc_observer_recv_status_
 }
 
 char *cgrpc_observer_recv_status_on_client_copy_status_details(cgrpc_observer_recv_status_on_client *observer) {
-  int length = GRPC_SLICE_LENGTH(observer->server_details);
+  size_t length = GRPC_SLICE_LENGTH(observer->server_details);
   char *str = (char *) malloc(length + 1);
   memcpy(str, GRPC_SLICE_START_PTR(observer->server_details), length);
   str[length] = 0;


### PR DESCRIPTION
One about an integer conversion, and one about `memcpy` missing because we included `"string.h"` rather than `<string.h>`.

While at it, I also replaced one `#import` with an `#include` and removed another redundant `#include`.