### PR TITLE
Make `gRPC.version` and `.gStandsFor` non-optional again, as those can safely be forcibly unwrapped

### DIFF
--- a/Sources/gRPC/gRPC.swift
+++ b/Sources/gRPC/gRPC.swift
@@ -34,15 +34,16 @@ public final class gRPC {
   /// Returns version of underlying gRPC library
   ///
   /// Returns: gRPC version string
-  public static var version: String? {
-    return String(cString: grpc_version_string(), encoding: String.Encoding.utf8)
+  public static var version: String {
+    // These two should always be valid UTF-8 strings, so we can forcibly unwrap them.
+    return String(cString: grpc_version_string(), encoding: String.Encoding.utf8)!
   }
   
   /// Returns name associated with gRPC version
   ///
   /// Returns: gRPC version name
-  public static var gStandsFor: String? {
-    return String(cString: grpc_g_stands_for(), encoding: String.Encoding.utf8)
+  public static var gStandsFor: String {
+    return String(cString: grpc_g_stands_for(), encoding: String.Encoding.utf8)!
   }
 }
 


### PR DESCRIPTION
Sorry, I was a bit too aggressive in making all the things optional.