### PR TITLE
Improve the example tests

### DIFF
--- a/Examples/Echo/EchoProvider.swift
+++ b/Examples/Echo/EchoProvider.swift
@@ -63,9 +63,9 @@ class EchoProvider: Echo_EchoProvider {
     while true {
       do {
         let request = try session.receive()
-        count += 1
         var response = Echo_EchoResponse()
         response.text = "Swift echo update (\(count)): \(request.text)"
+        count += 1
         let sem = DispatchSemaphore(value: 0)
         try session.send(response) { _ in sem.signal() }
         _ = sem.wait(timeout: DispatchTime.distantFuture)

--- a/Examples/Echo/PackageManager/Makefile
+++ b/Examples/Echo/PackageManager/Makefile
@@ -10,7 +10,7 @@ test:	all
 	./Echo collect | tee -a test.out
 	./Echo update | tee -a test.out
 	kill -9 `cat echo.pid`
-	diff test.out test.gold
+	diff -u test.out test.gold
 	
 project:
 	swift package generate-xcodeproj

--- a/Examples/Echo/PackageManager/test.gold
+++ b/Examples/Echo/PackageManager/test.gold
@@ -14,14 +14,14 @@ collect sending: 1
 collect sending: 2
 collect sending: 3
 collect received: Swift echo collect: Testing 1 2 3
-collect completed with status ok
+collect completed with code ok
 calling update
 update sending: Testing
 update sending: 1
 update sending: 2
 update sending: 3
-update received: Swift echo update (1): Testing
-update received: Swift echo update (2): 1
-update received: Swift echo update (3): 2
-update received: Swift echo update (4): 3
-update completed with status ok
+update received: Swift echo update (0): Testing
+update received: Swift echo update (1): 1
+update received: Swift echo update (2): 2
+update received: Swift echo update (3): 3
+update completed with code ok

--- a/Sources/gRPC/Call.swift
+++ b/Sources/gRPC/Call.swift
@@ -157,6 +157,8 @@ public class Call {
   /// A queue of pending messages to send over the call
   private var messageQueue: [(dataToSend: Data, completion: (Error?) -> Void)] = []
 
+  public let messageQueueEmpty = DispatchGroup()
+  
   /// True if a message write operation is underway
   private var writing: Bool
 
@@ -254,6 +256,7 @@ public class Call {
   /// Parameter data: the message data to send
   /// - Throws: `CallError` if fails to call. `CallWarning` if blocked.
   public func sendMessage(data: Data, completion: @escaping (Error?) -> Void) throws {
+    messageQueueEmpty.enter()
     try sendMutex.synchronize {
       if writing {
         if (Call.messageQueueMaxLength > 0) && // if max length is <= 0, consider it infinite
@@ -272,29 +275,28 @@ public class Call {
   private func sendWithoutBlocking(data: Data, completion: @escaping (Error?) -> Void) throws {
     try perform(OperationGroup(call: self,
                                operations: [.sendMessage(ByteBuffer(data: data))]) { operationGroup in
-        if operationGroup.success {
-          self.messageDispatchQueue.async {
-            self.sendMutex.synchronize {
-              // if there are messages pending, send the next one
-              if self.messageQueue.count > 0 {
-                let (nextMessage, nextCompletionHandler) = self.messageQueue.removeFirst()
-                do {
-                  try self.sendWithoutBlocking(data: nextMessage, completion: nextCompletionHandler)
-                } catch (let callError) {
-                  nextCompletionHandler(callError)
-                }
-              } else {
-                // otherwise, we are finished writing
-                self.writing = false
+        // TODO(timburks, danielalm): Is the `async` dispatch here needed, and/or should we call the completion handler
+        // and leave `messageQueueEmpty` in the `async` block as well?
+        self.messageDispatchQueue.async {
+          // Always enqueue the next message, even if sending this one failed. This ensures that all send completion
+          // handlers are called eventually.
+          self.sendMutex.synchronize {
+            // if there are messages pending, send the next one
+            if self.messageQueue.count > 0 {
+              let (nextMessage, nextCompletionHandler) = self.messageQueue.removeFirst()
+              do {
+                try self.sendWithoutBlocking(data: nextMessage, completion: nextCompletionHandler)
+              } catch (let callError) {
+                nextCompletionHandler(callError)
               }
+            } else {
+              // otherwise, we are finished writing
+              self.writing = false
             }
           }
-          completion(nil)
-        } else {
-          // if the event failed, shut down
-          self.writing = false
-          completion(CallError.unknown)
         }
+        completion(operationGroup.success ? nil : CallError.unknown)
+        self.messageQueueEmpty.leave()
     })
   }
 

--- a/Sources/gRPC/GenCodeSupport/ClientCall.swift
+++ b/Sources/gRPC/GenCodeSupport/ClientCall.swift
@@ -20,6 +20,9 @@ import SwiftProtobuf
 
 public protocol ClientCall: class {
   static var method: String { get }
+  
+  /// Cancel the call.
+  func cancel()
 }
 
 open class ClientCallBase: ClientCall {
@@ -31,4 +34,6 @@ open class ClientCallBase: ClientCall {
   public init(_ channel: Channel) {
     call = channel.makeCall(type(of: self).method)
   }
+  
+  public func cancel() { call.cancel() }
 }

--- a/Sources/gRPC/GenCodeSupport/ClientCallBidirectionalStreaming.swift
+++ b/Sources/gRPC/GenCodeSupport/ClientCallBidirectionalStreaming.swift
@@ -19,6 +19,8 @@ import Foundation
 import SwiftProtobuf
 
 public protocol ClientCallBidirectionalStreaming: ClientCall {
+  func waitForSendOperationsToFinish()
+  
   // TODO: Move the other, message type-dependent, methods into this protocol. At the moment, this is not possible,
   // as the protocol would then have an associated type requirement (and become pretty much unusable in the process).
 }
@@ -81,9 +83,9 @@ open class ClientCallBidirectionalStreamingBase<InputType: Message, OutputType: 
     }
     _ = sem.wait(timeout: DispatchTime.distantFuture)
   }
-
-  public func cancel() {
-    call.cancel()
+  
+  public func waitForSendOperationsToFinish() {
+    call.messageQueueEmpty.wait()
   }
 }
 
@@ -122,6 +124,8 @@ open class ClientCallBidirectionalStreamingTestStub<InputType: Message, OutputTy
   open func closeSend(completion: (() -> Void)?) throws { completion?() }
 
   open func closeSend() throws {}
+
+  open func waitForSendOperationsToFinish() {}
 
   open func cancel() {}
 }

--- a/Sources/gRPC/GenCodeSupport/ClientCallClientStreaming.swift
+++ b/Sources/gRPC/GenCodeSupport/ClientCallClientStreaming.swift
@@ -19,8 +19,7 @@ import Foundation
 import SwiftProtobuf
 
 public protocol ClientCallClientStreaming: ClientCall {
-  /// Cancel the call.
-  func cancel()
+  func waitForSendOperationsToFinish()
 
   // TODO: Move the other, message type-dependent, methods into this protocol. At the moment, this is not possible,
   // as the protocol would then have an associated type requirement (and become pretty much unusable in the process).
@@ -73,8 +72,8 @@ open class ClientCallClientStreamingBase<InputType: Message, OutputType: Message
     return returnResponse
   }
 
-  public func cancel() {
-    call.cancel()
+  public func waitForSendOperationsToFinish() {
+    call.messageQueueEmpty.wait()
   }
 }
 
@@ -100,5 +99,7 @@ open class ClientCallClientStreamingTestStub<InputType: Message, OutputType: Mes
     return output!
   }
 
+  open func waitForSendOperationsToFinish() {}
+  
   open func cancel() {}
 }

--- a/Sources/gRPC/GenCodeSupport/ClientCallServerStreaming.swift
+++ b/Sources/gRPC/GenCodeSupport/ClientCallServerStreaming.swift
@@ -19,9 +19,6 @@ import Foundation
 import SwiftProtobuf
 
 public protocol ClientCallServerStreaming: ClientCall {
-  /// Cancel the call.
-  func cancel()
-
   // TODO: Move the other, message type-dependent, methods into this protocol. At the moment, this is not possible,
   // as the protocol would then have an associated type requirement (and become pretty much unusable in the process).
 }
@@ -69,10 +66,6 @@ open class ClientCallServerStreamingBase<InputType: Message, OutputType: Message
       throw returnError
     }
     return returnResponse
-  }
-
-  public func cancel() {
-    call.cancel()
   }
 }
 

--- a/Sources/gRPC/GenCodeSupport/ClientCallUnary.swift
+++ b/Sources/gRPC/GenCodeSupport/ClientCallUnary.swift
@@ -18,10 +18,7 @@ import Dispatch
 import Foundation
 import SwiftProtobuf
 
-public protocol ClientCallUnary: ClientCall {
-  /// Cancel the call.
-  func cancel()
-}
+public protocol ClientCallUnary: ClientCall {}
 
 open class ClientCallUnaryBase<InputType: Message, OutputType: Message>: ClientCallBase, ClientCallUnary {
   /// Run the call. Blocks until the reply is received.
@@ -58,9 +55,5 @@ open class ClientCallUnaryBase<InputType: Message, OutputType: Message>: ClientC
       }
     }
     return self
-  }
-
-  public func cancel() {
-    call.cancel()
   }
 }


### PR DESCRIPTION
Namely:
- Change the responses for `update` calls to use zero-based indexing, like with `expand`
- Make all calls print `... completed with CODE ...` instead of having some print `with STATUS ...`
- Add a `waitForSendOperationsToFinish` method and use that instead of polling and comparing send counts
- Use a more human-readable unified diff for the differences between `test.gold` and the actual test output
- Move the `cancel` method into `ClientCall` (not 100% related, but it would be fairly ugly to extract that into a separate PR.