### PR TITLE
Add DerivedData/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 project.xcworkspace
 xcuserdata
+DerivedData/
 .build
 /protoc-gen-swift
 /protoc-gen-swiftgrpc


### PR DESCRIPTION
For developers with `Locations > DerivedData` set to "Relative", this ignores a lot of the noise that Xcode adds when generating/opening the project.