### PR TITLE
Fix SwiftGRPC.podspec

### DIFF
--- a/SwiftGRPC.podspec
+++ b/SwiftGRPC.podspec
@@ -45,7 +45,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Sources/SwiftGRPC/*.swift', 'Sources/SwiftGRPC/**/*.swift', 'Sources/CgRPC/shim/*.[ch]'
   s.public_header_files = 'Sources/CgRPC/shim/cgrpc.h'
 
-  s.dependency 'gRPC-Core', '~> 1.9.1'
-  s.dependency 'BoringSSL', '~> 9.1'
-  s.dependency 'SwiftProtobuf', '~> 1.0.2'
+  s.dependency 'gRPC-Core', '~> 1.11.0-pre2'
+  s.dependency 'BoringSSL', '~> 10.0'
+  s.dependency 'SwiftProtobuf', '~> 1.0.3'
 end


### PR DESCRIPTION
The existing podspec is broken with `inttypes.h` errors. Updating the dependencies resolves the issue.

Fix #111
Fix #11 
Fix #45