### PR TITLE
Update podspec to v0.4.1 for core v1.11.0

### DIFF
--- a/SwiftGRPC.podspec
+++ b/SwiftGRPC.podspec
@@ -29,7 +29,7 @@
 
 Pod::Spec.new do |s|
   s.name = 'SwiftGRPC'
-  s.version = '0.4.0'
+  s.version = '0.4.1'
   s.license  = 'New BSD'
   s.summary = 'Swift gRPC code generator plugin and runtime library'
   s.homepage = 'http://www.grpc.io'
@@ -45,7 +45,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Sources/SwiftGRPC/*.swift', 'Sources/SwiftGRPC/**/*.swift', 'Sources/CgRPC/shim/*.[ch]'
   s.public_header_files = 'Sources/CgRPC/shim/cgrpc.h'
 
-  s.dependency 'gRPC-Core', '~> 1.11.0-pre2'
+  s.dependency 'gRPC-Core', '~> 1.11.0'
   s.dependency 'BoringSSL', '~> 10.0'
   s.dependency 'SwiftProtobuf', '~> 1.0.3'
 end


### PR DESCRIPTION
Google has released v1.11.0 of gRPC core. We can now move off of the pre-release and bump the podspec version.