### PR TITLE
Fix a few problems found running "pod spec lint".

### DIFF
--- a/Sources/CgRPC/shim/call.c
+++ b/Sources/CgRPC/shim/call.c
@@ -27,7 +27,7 @@ void cgrpc_call_destroy(cgrpc_call *call) {
   free(call);
 }
 
-grpc_call_error cgrpc_call_perform(cgrpc_call *call, cgrpc_operations *operations, int64_t tag) {
+grpc_call_error cgrpc_call_perform(cgrpc_call *call, cgrpc_operations *operations, void *tag) {
   grpc_call_error error = grpc_call_start_batch(call->call,
                                                 operations->ops,
                                                 operations->ops_count,

--- a/Sources/CgRPC/shim/cgrpc.h
+++ b/Sources/CgRPC/shim/cgrpc.h
@@ -172,14 +172,14 @@ cgrpc_completion_queue *cgrpc_handler_get_completion_queue(cgrpc_handler *h);
 
 grpc_call_error cgrpc_handler_request_call(cgrpc_handler *h,
                                            cgrpc_metadata_array *metadata,
-                                           long tag);
+                                           void *tag);
 char *cgrpc_handler_copy_host(cgrpc_handler *h);
 char *cgrpc_handler_copy_method(cgrpc_handler *h);
 char *cgrpc_handler_call_peer(cgrpc_handler *h);
 
 // call support
 void cgrpc_call_destroy(cgrpc_call *call);
-grpc_call_error cgrpc_call_perform(cgrpc_call *call, cgrpc_operations *operations, int64_t tag);
+grpc_call_error cgrpc_call_perform(cgrpc_call *call, cgrpc_operations *operations, void *tag);
 void cgrpc_call_cancel(cgrpc_call *call);
 
 // operations
@@ -209,7 +209,7 @@ cgrpc_byte_buffer *cgrpc_byte_buffer_create_by_copying_data(const void *source, 
 const void *cgrpc_byte_buffer_copy_data(cgrpc_byte_buffer *bb, size_t *length);
 
 // event support
-int64_t cgrpc_event_tag(grpc_event ev);
+void *cgrpc_event_tag(grpc_event ev);
 
 // observers
 

--- a/Sources/CgRPC/shim/event.c
+++ b/Sources/CgRPC/shim/event.c
@@ -16,6 +16,6 @@
 #include "internal.h"
 #include "cgrpc.h"
 
-int64_t cgrpc_event_tag(grpc_event ev) {
-  return (int64_t) ev.tag;
+void *cgrpc_event_tag(grpc_event ev) {
+  return ev.tag;
 }

--- a/Sources/CgRPC/shim/handler.c
+++ b/Sources/CgRPC/shim/handler.c
@@ -77,7 +77,7 @@ cgrpc_completion_queue *cgrpc_handler_get_completion_queue(cgrpc_handler *h) {
 
 grpc_call_error cgrpc_handler_request_call(cgrpc_handler *h,
                                            cgrpc_metadata_array *metadata,
-                                           long tag) {
+                                           void *tag) {
   if (h->server_call != NULL) {
     return GRPC_CALL_OK;
   }

--- a/Sources/CgRPC/shim/internal.c
+++ b/Sources/CgRPC/shim/internal.c
@@ -19,7 +19,7 @@
 #include <stdio.h>
 #include <assert.h>
 
-void *cgrpc_create_tag(intptr_t t) { return (void *)t; }
+void *cgrpc_create_tag(void *t) { return t; }
 
 gpr_timespec cgrpc_deadline_in_seconds_from_now(float seconds) {
   return gpr_time_add(gpr_now(GPR_CLOCK_MONOTONIC),

--- a/Sources/CgRPC/shim/internal.h
+++ b/Sources/CgRPC/shim/internal.h
@@ -105,7 +105,7 @@ typedef struct {
 } cgrpc_observer_recv_close_on_server;
 
 // internal utilities
-void *cgrpc_create_tag(intptr_t t);
+void *cgrpc_create_tag(void *t);
 gpr_timespec cgrpc_deadline_in_seconds_from_now(float seconds);
 
 void cgrpc_observer_apply(cgrpc_observer *observer, grpc_op *op);

--- a/Sources/SwiftGRPC/Core/Call.swift
+++ b/Sources/SwiftGRPC/Core/Call.swift
@@ -88,7 +88,7 @@ public class Call {
       Call.callMutex.lock()
       // We need to do the perform *inside* the `completionQueue.register` call, to ensure that the queue can't get
       // shutdown in between registering the operation group and calling `cgrpc_call_perform`.
-      let error = cgrpc_call_perform(underlyingCall, operations.underlyingOperations, operations.tag)
+      let error = cgrpc_call_perform(underlyingCall, operations.underlyingOperations, UnsafeMutableRawPointer(bitPattern:operations.tag))
       Call.callMutex.unlock()
       if error != GRPC_CALL_OK {
         throw CallError.callError(grpcCallError: error)

--- a/Sources/SwiftGRPC/Core/CompletionQueue.swift
+++ b/Sources/SwiftGRPC/Core/CompletionQueue.swift
@@ -49,7 +49,7 @@ struct CompletionQueueEvent {
   init(_ event: grpc_event) {
     type = CompletionType.completionType(event.type)
     success = event.success
-    tag = Int(bitPattern:cgrpc_event_tag(event))
+    tag = Int(bitPattern: cgrpc_event_tag(event))
   }
 }
 

--- a/Sources/SwiftGRPC/Core/CompletionQueue.swift
+++ b/Sources/SwiftGRPC/Core/CompletionQueue.swift
@@ -44,12 +44,12 @@ enum CompletionType {
 struct CompletionQueueEvent {
   let type: CompletionType
   let success: Int32
-  let tag: Int64
+  let tag: Int
 
   init(_ event: grpc_event) {
     type = CompletionType.completionType(event.type)
     success = event.success
-    tag = cgrpc_event_tag(event)
+    tag = Int(bitPattern:cgrpc_event_tag(event))
   }
 }
 
@@ -62,7 +62,7 @@ class CompletionQueue {
   private let underlyingCompletionQueue: UnsafeMutableRawPointer
 
   /// Operation groups that are awaiting completion, keyed by tag
-  private var operationGroups: [Int64: OperationGroup] = [:]
+  private var operationGroups: [Int: OperationGroup] = [:]
 
   /// Mutex for synchronizing access to operationGroups
   private let operationGroupsMutex: Mutex = Mutex()
@@ -118,7 +118,7 @@ class CompletionQueue {
         let event = cgrpc_completion_queue_get_next_event(self.underlyingCompletionQueue, 600)
         switch event.type {
         case GRPC_OP_COMPLETE:
-          let tag = cgrpc_event_tag(event)
+          let tag = Int(bitPattern:cgrpc_event_tag(event))
           self.operationGroupsMutex.lock()
           let operationGroup = self.operationGroups[tag]
           self.operationGroupsMutex.unlock()

--- a/Sources/SwiftGRPC/Core/Handler.swift
+++ b/Sources/SwiftGRPC/Core/Handler.swift
@@ -81,7 +81,7 @@ public class Handler {
   /// Fills the handler properties with information about the received request
   ///
   func requestCall(tag: Int) throws {
-    let error = cgrpc_handler_request_call(underlyingHandler, requestMetadata.underlyingArray, UnsafeMutableRawPointer(bitPattern:tag))
+    let error = cgrpc_handler_request_call(underlyingHandler, requestMetadata.underlyingArray, UnsafeMutableRawPointer(bitPattern: tag))
     if error != GRPC_CALL_OK {
       throw CallError.callError(grpcCallError: error)
     }

--- a/Sources/SwiftGRPC/Core/Handler.swift
+++ b/Sources/SwiftGRPC/Core/Handler.swift
@@ -81,7 +81,7 @@ public class Handler {
   /// Fills the handler properties with information about the received request
   ///
   func requestCall(tag: Int) throws {
-    let error = cgrpc_handler_request_call(underlyingHandler, requestMetadata.underlyingArray, tag)
+    let error = cgrpc_handler_request_call(underlyingHandler, requestMetadata.underlyingArray, UnsafeMutableRawPointer(bitPattern:tag))
     if error != GRPC_CALL_OK {
       throw CallError.callError(grpcCallError: error)
     }

--- a/Sources/SwiftGRPC/Core/OperationGroup.swift
+++ b/Sources/SwiftGRPC/Core/OperationGroup.swift
@@ -23,10 +23,10 @@ class OperationGroup {
   static let tagMutex = Mutex()
 
   /// Used to generate unique tags for OperationGroups
-  private static var nextTag: Int64 = 1
+  private static var nextTag: Int = 1
 
   /// Automatically-assigned tag that is used by the completion queue that watches this group.
-  let tag: Int64
+  let tag: Int
 
   /// The call associated with the operation group. Retained while the operations are running.
   // FIXME(danielalm): Is this property needed?

--- a/SwiftGRPC.podspec
+++ b/SwiftGRPC.podspec
@@ -1,46 +1,40 @@
-# Copyright 2015, Google Inc.
-# All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are
-# met:
-#
-#     * Redistributions of source code must retain the above copyright
-# notice, this list of conditions and the following disclaimer.
-#     * Redistributions in binary form must reproduce the above
-# copyright notice, this list of conditions and the following disclaimer
-# in the documentation and/or other materials provided with the
-# distribution.
-#     * Neither the name of Google Inc. nor the names of its
-# contributors may be used to endorse or promote products derived from
-# this software without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# Copyright 2018, gRPC Authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#   http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 Pod::Spec.new do |s|
   s.name = 'SwiftGRPC'
   s.version = '0.4.1'
-  s.license  = 'New BSD'
+  s.license     = { :type => 'Apache License, Version 2.0',
+                    :text => <<-LICENSE
+                      Copyright 2018, gRPC Authors. All rights reserved.
+                      Licensed under the Apache License, Version 2.0 (the "License");
+                      you may not use this file except in compliance with the License.
+                      You may obtain a copy of the License at
+                        http://www.apache.org/licenses/LICENSE-2.0
+                      Unless required by applicable law or agreed to in writing, software
+                      distributed under the License is distributed on an "AS IS" BASIS,
+                      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                      See the License for the specific language governing permissions and
+                      limitations under the License.
+                    LICENSE
+                  }
+
   s.summary = 'Swift gRPC code generator plugin and runtime library'
   s.homepage = 'http://www.grpc.io'
   s.authors  = { 'The gRPC contributors' => 'grpc-packages@google.com' }
   s.source = { :git => 'https://github.com/grpc/grpc-swift.git', :tag => s.version }
 
   s.requires_arc = true
-  #s.ios.deployment_target = '8.0'
-  #s.osx.deployment_target = '10.9'
-  #s.tvos.deployment_target = '9.0'
-  #s.watchos.deployment_target = '2.0'
+  s.ios.deployment_target = '8.0'
+  s.osx.deployment_target = '10.10'
 
   s.source_files = 'Sources/SwiftGRPC/*.swift', 'Sources/SwiftGRPC/**/*.swift', 'Sources/CgRPC/shim/*.[ch]'
   s.public_header_files = 'Sources/CgRPC/shim/cgrpc.h'

--- a/SwiftGRPC.podspec
+++ b/SwiftGRPC.podspec
@@ -11,7 +11,7 @@
 
 Pod::Spec.new do |s|
   s.name = 'SwiftGRPC'
-  s.version = '0.4.1'
+  s.version = '0.4.2'
   s.license     = { :type => 'Apache License, Version 2.0',
                     :text => <<-LICENSE
                       Copyright 2018, gRPC Authors. All rights reserved.
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
                   }
 
   s.summary = 'Swift gRPC code generator plugin and runtime library'
-  s.homepage = 'http://www.grpc.io'
+  s.homepage = 'https://www.grpc.io'
   s.authors  = { 'The gRPC contributors' => 'grpc-packages@google.com' }
   s.source = { :git => 'https://github.com/grpc/grpc-swift.git', :tag => s.version }
 


### PR DESCRIPTION
This includes updating the minimum supported iOS and OSX versions
to match gRPC and a fix for a compiler warning found by the linter.

The compiler warning was due to careless conversion of grpc event tags
from void * to various integer types that were 64 bit but inappropriate
for 32 bit architectures. The change now directly exposes void * tags
from the shim layer and converts them from UnsafeMutableRawPointers
to Int (and back) in SwiftGRPC/Core.