### PR TITLE
Make the test stubs thread safe.

### DIFF
--- a/Sources/SwiftGRPC/Runtime/ClientCallBidirectionalStreaming.swift
+++ b/Sources/SwiftGRPC/Runtime/ClientCallBidirectionalStreaming.swift
@@ -54,14 +54,18 @@ open class ClientCallBidirectionalStreamingBase<InputType: Message, OutputType: 
 open class ClientCallBidirectionalStreamingTestStub<InputType: Message, OutputType: Message>: ClientCallBidirectionalStreaming {
   open class var method: String { fatalError("needs to be overridden") }
 
+  open var lock = Mutex()
+  
   open var inputs: [InputType] = []
   open var outputs: [OutputType] = []
   
   public init() {}
 
   open func _receive(timeout: DispatchTime) throws -> OutputType? {
-    defer { if !outputs.isEmpty { outputs.removeFirst() } }
-    return outputs.first
+    return lock.synchronize {
+      defer { if !outputs.isEmpty { outputs.removeFirst() } }
+      return outputs.first
+    }
   }
   
   open func receive(completion: @escaping (ResultOrRPCError<OutputType?>) -> Void) throws {
@@ -69,11 +73,11 @@ open class ClientCallBidirectionalStreamingTestStub<InputType: Message, OutputTy
   }
 
   open func send(_ message: InputType, completion _: @escaping (Error?) -> Void) throws {
-    inputs.append(message)
+    lock.synchronize { inputs.append(message) }
   }
   
   open func _send(_ message: InputType, timeout: DispatchTime) throws {
-    inputs.append(message)
+    lock.synchronize { inputs.append(message) }
   }
 
   open func closeSend(completion: (() -> Void)?) throws { completion?() }

--- a/Sources/SwiftGRPC/Runtime/ClientCallClientStreaming.swift
+++ b/Sources/SwiftGRPC/Runtime/ClientCallClientStreaming.swift
@@ -67,17 +67,19 @@ open class ClientCallClientStreamingBase<InputType: Message, OutputType: Message
 open class ClientCallClientStreamingTestStub<InputType: Message, OutputType: Message>: ClientCallClientStreaming {
   open class var method: String { fatalError("needs to be overridden") }
 
+  open var lock = Mutex()
+  
   open var inputs: [InputType] = []
   open var output: OutputType?
   
   public init() {}
 
   open func send(_ message: InputType, completion _: @escaping (Error?) -> Void) throws {
-    inputs.append(message)
+    lock.synchronize { inputs.append(message) }
   }
   
   open func _send(_ message: InputType, timeout: DispatchTime) throws {
-    inputs.append(message)
+    lock.synchronize { inputs.append(message) }
   }
 
   open func closeAndReceive(completion: @escaping (ResultOrRPCError<OutputType>) -> Void) throws {

--- a/Sources/SwiftGRPC/Runtime/ClientCallServerStreaming.swift
+++ b/Sources/SwiftGRPC/Runtime/ClientCallServerStreaming.swift
@@ -41,13 +41,17 @@ open class ClientCallServerStreamingBase<InputType: Message, OutputType: Message
 open class ClientCallServerStreamingTestStub<OutputType: Message>: ClientCallServerStreaming {
   open class var method: String { fatalError("needs to be overridden") }
 
+  open var lock = Mutex()
+  
   open var outputs: [OutputType] = []
   
   public init() {}
   
   open func _receive(timeout: DispatchTime) throws -> OutputType? {
-    defer { if !outputs.isEmpty { outputs.removeFirst() } }
-    return outputs.first
+    return lock.synchronize {
+      defer { if !outputs.isEmpty { outputs.removeFirst() } }
+      return outputs.first
+    }
   }
   
   open func receive(completion: @escaping (ResultOrRPCError<OutputType?>) -> Void) throws {

--- a/Sources/SwiftGRPC/Runtime/ServerSessionServerStreaming.swift
+++ b/Sources/SwiftGRPC/Runtime/ServerSessionServerStreaming.swift
@@ -65,19 +65,21 @@ open class ServerSessionServerStreamingBase<InputType: Message, OutputType: Mess
 /// Simple fake implementation of ServerSessionServerStreaming that returns a previously-defined set of results
 /// and stores sent values for later verification.
 open class ServerSessionServerStreamingTestStub<OutputType: Message>: ServerSessionTestStub, ServerSessionServerStreaming {
+  open var lock = Mutex()
+  
   open var outputs: [OutputType] = []
   open var status: ServerStatus?
 
   open func send(_ message: OutputType, completion _: @escaping (Error?) -> Void) throws {
-    outputs.append(message)
+    lock.synchronize { outputs.append(message) }
   }
 
   open func _send(_ message: OutputType, timeout: DispatchTime) throws {
-    outputs.append(message)
+    lock.synchronize { outputs.append(message) }
   }
 
   open func close(withStatus status: ServerStatus, completion: (() -> Void)?) throws {
-    self.status = status
+    lock.synchronize { self.status = status }
     completion?()
   }
 


### PR DESCRIPTION
Given that the methods on `Call` and `Session` can be called from any thread, so should the test stubs'.