### PR TITLE
Leave `zlib` dependency only for non-Apple platforms

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,16 +17,21 @@
  */
 import PackageDescription
 
+var dependencies: [Package.Dependency] = [
+  .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.0.2"),
+  .package(url: "https://github.com/kylef/Commander.git", from: "0.8.0")
+]
+
+#if !os(macOS)
+dependencies.insert(.package(url: "https://github.com/apple/swift-nio-zlib-support.git", from: "1.0.0"), at: 0)
+#endif
+
 let package = Package(
   name: "SwiftGRPC",
   products: [
     .library(name: "SwiftGRPC", targets: ["SwiftGRPC"]),
   ],
-  dependencies: [
-    .package(url: "https://github.com/apple/swift-nio-zlib-support.git", from: "1.0.0"),
-    .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.0.2"),
-    .package(url: "https://github.com/kylef/Commander.git", from: "0.8.0")
-  ],
+  dependencies: dependencies,
   targets: [
     .target(name: "SwiftGRPC",
             dependencies: ["CgRPC", "SwiftProtobuf"]),


### PR DESCRIPTION
because Apple already ships with its own.

This somewhat fragile fix allows building grpc-swift when Macports is present on a system and ships its own `zlib`.
Without this hack pkgConfig emits `-I/opt/local/include` and brings various header version incompatibilities,
because Macports (unlike Homebrew) doesn't offer scoped header includes. Further here:
https://github.com/apple/swift-nio-zlib-support/issues/2#issuecomment-384681975