### PR TITLE
Update to cocoapods example

### DIFF
--- a/Examples/Cocoapods/NaturalLanguage/.gitignore
+++ b/Examples/Cocoapods/NaturalLanguage/.gitignore
@@ -1,0 +1,4 @@
+NaturalLanguage/*.pb.swift
+NaturalLanguage/*.grpc.swift
+
+googleapis/

--- a/Examples/Cocoapods/NaturalLanguage/Podfile
+++ b/Examples/Cocoapods/NaturalLanguage/Podfile
@@ -1,10 +1,12 @@
 # Uncomment this line if you're using Swift
 use_frameworks!
 
+platform :ios, '9.0'
+
 target 'NaturalLanguage' do
-
   pod 'SwiftGRPC'
-
 end
 
-
+post_install do |installer|
+  %x[ './RUNME' ]
+end

--- a/Examples/Cocoapods/NaturalLanguage/README.md
+++ b/Examples/Cocoapods/NaturalLanguage/README.md
@@ -5,13 +5,13 @@ This directory contains a very simple sample that calls the
 Calls are made directly to the Cloud Natural Language RPC interface. 
 In practice, these would be wrapped in idiomatic code.
 
-1. Use [RUNME](RUNME) to generate the necessary Protocol Buffer
-and gRPC support code. It uses protoc and the Swift Protocol
-Buffer and gRPC plugins, so please be sure these are in your
-path. The plugins can be built by running `make` in the 
-top-level grpc-swift directory.
+1. Run `pod install` to install the SwiftGRPC pod and its dependencies.
 
-2. Run `pod install` to install the SwiftGRPC pod and its dependencies.
+2. Running `pod install` will invoke [RUNME](RUNME) to generate the 
+necessary Protocol Buffer and gRPC support code. It uses protoc and 
+the Swift Protocol Buffer and gRPC plugins, so please be sure these 
+are in your path. The plugins can be built by running `make` in the 
+top-level grpc-swift directory.
 
 3. Open NaturalLanguage.xcworkspace and set GOOGLE_API_KEY in the application delegate.
 


### PR DESCRIPTION
A minor update to the example to eliminate an extra step (also added a .gitignore). 

Note that I did this to see what it would take to generate the client as a new pod, but that may not be possible right now due to the visibility of the generated code. It might be useful to consider if you want to use Cocoapods as a means to distribute the tools/scripts for generating things.