### PR TITLE
Streamline the interface of the server-side response handling code

### DIFF
--- a/Sources/Examples/Echo/EchoProvider.swift
+++ b/Sources/Examples/Echo/EchoProvider.swift
@@ -26,7 +26,7 @@ class EchoProvider: Echo_EchoProvider {
   }
 
   // expand splits a request into words and returns each word in a separate message.
-  func expand(request: Echo_EchoRequest, session: Echo_EchoExpandSession) throws {
+  func expand(request: Echo_EchoRequest, session: Echo_EchoExpandSession) throws -> ServerStatus? {
     let parts = request.text.components(separatedBy: " ")
     for (i, part) in parts.enumerated() {
       var response = Echo_EchoResponse()
@@ -37,12 +37,11 @@ class EchoProvider: Echo_EchoProvider {
         }
       }
     }
-    session.waitForSendOperationsToFinish()
-    try session.close(withStatus: .ok, completion: nil)
+    return .ok
   }
 
   // collect collects a sequence of messages and returns them concatenated when the caller closes.
-  func collect(session: Echo_EchoCollectSession) throws {
+  func collect(session: Echo_EchoCollectSession) throws -> Echo_EchoResponse? {
     var parts: [String] = []
     while true {
       do {
@@ -56,11 +55,11 @@ class EchoProvider: Echo_EchoProvider {
     }
     var response = Echo_EchoResponse()
     response.text = "Swift echo collect: " + parts.joined(separator: " ")
-    try session.sendAndClose(response: response, status: .ok, completion: nil)
+    return response
   }
 
   // update streams back messages as they are received in an input stream.
-  func update(session: Echo_EchoUpdateSession) throws {
+  func update(session: Echo_EchoUpdateSession) throws -> ServerStatus? {
     var count = 0
     while true {
       do {
@@ -79,7 +78,6 @@ class EchoProvider: Echo_EchoProvider {
         break
       }
     }
-    session.waitForSendOperationsToFinish()
-    try session.close(withStatus: .ok, completion: nil)
+    return .ok
   }
 }

--- a/Sources/Examples/Echo/Generated/echo.grpc.swift
+++ b/Sources/Examples/Echo/Generated/echo.grpc.swift
@@ -319,32 +319,32 @@ internal final class Echo_EchoServer: ServiceServer {
   }
 
   /// Start the server.
-  internal override func handleMethod(_ method: String, handler: Handler, queue: DispatchQueue) throws -> Bool {
+  internal override func handleMethod(_ method: String, handler: Handler) throws -> Bool {
     let provider = self.provider
     switch method {
     case "/echo.Echo/Get":
       try Echo_EchoGetSessionBase(
         handler: handler,
         providerBlock: { try provider.get(request: $0, session: $1 as! Echo_EchoGetSessionBase) })
-          .run(queue: queue)
+          .run()
       return true
     case "/echo.Echo/Expand":
       try Echo_EchoExpandSessionBase(
         handler: handler,
         providerBlock: { try provider.expand(request: $0, session: $1 as! Echo_EchoExpandSessionBase) })
-          .run(queue: queue)
+          .run()
       return true
     case "/echo.Echo/Collect":
       try Echo_EchoCollectSessionBase(
         handler: handler,
         providerBlock: { try provider.collect(session: $0 as! Echo_EchoCollectSessionBase) })
-          .run(queue: queue)
+          .run()
       return true
     case "/echo.Echo/Update":
       try Echo_EchoUpdateSessionBase(
         handler: handler,
         providerBlock: { try provider.update(session: $0 as! Echo_EchoUpdateSessionBase) })
-          .run(queue: queue)
+          .run()
       return true
     default:
       return false

--- a/Sources/SwiftGRPC/Core/Call.swift
+++ b/Sources/SwiftGRPC/Core/Call.swift
@@ -104,6 +104,7 @@ public class Call {
   /// - Parameter completion: a block to call with call results
   ///     The argument to `completion` will always have `.success = true`
   ///     because operations containing `.receiveCloseOnClient` always succeed.
+  ///   Runs synchronously on the completion queue's thread. Should not be blocking.
   /// - Throws: `CallError` if fails to call.
   public func start(_ style: CallStyle,
                     metadata: Metadata,
@@ -157,7 +158,8 @@ public class Call {
 
   /// Sends a message over a streaming connection.
   ///
-  /// Parameter data: the message data to send
+  /// - Parameter data: the message data to send
+  /// - Parameter completion: Runs synchronously on the completion queue's thread once the message has been sent. Should not be blocking.
   /// - Throws: `CallError` if fails to call. `CallWarning` if blocked.
   public func sendMessage(data: Data, completion: ((Error?) -> Void)? = nil) throws {
     try sendMutex.synchronize {
@@ -202,6 +204,7 @@ public class Call {
   }
 
   // Receive a message over a streaming connection.
+  /// - Parameter completion: Runs synchronously on the completion queue's thread once the message has been received. Should not be blocking.
   /// - Throws: `CallError` if fails to call.
   public func closeAndReceiveMessage(completion: @escaping (CallResult) -> Void) throws {
     try perform(OperationGroup(call: self, operations: [.sendCloseFromClient, .receiveMessage]) { operationGroup in
@@ -210,6 +213,7 @@ public class Call {
   }
 
   // Receive a message over a streaming connection.
+  /// - Parameter completion: Runs synchronously on the completion queue's thread once the message has been received. Should not be blocking.
   /// - Throws: `CallError` if fails to call.
   public func receiveMessage(completion: @escaping (CallResult) -> Void) throws {
     try perform(OperationGroup(call: self, operations: [.receiveMessage]) { operationGroup in
@@ -218,6 +222,7 @@ public class Call {
   }
 
   // Closes a streaming connection.
+  /// - Parameter completion: Runs synchronously on the completion queue's thread once the connection has been closed. Should not be blocking.
   /// - Throws: `CallError` if fails to call.
   public func close(completion: (() -> Void)? = nil) throws {
     try perform(OperationGroup(call: self, operations: [.sendCloseFromClient],

--- a/Sources/SwiftGRPC/Core/CompletionQueue.swift
+++ b/Sources/SwiftGRPC/Core/CompletionQueue.swift
@@ -113,7 +113,8 @@ class CompletionQueue {
   /// - Parameter completion: a completion handler that is called when the queue stops running
   func runToCompletion(completion: (() -> Void)?) {
     // run the completion queue on a new background thread
-    DispatchQueue.global().async {
+    let spinloopThreadQueue = DispatchQueue(label: "SwiftGRPC.CompletionQueue.runToCompletion.spinloopThread")
+    spinloopThreadQueue.async {
       spinloop: while true {
         let event = cgrpc_completion_queue_get_next_event(self.underlyingCompletionQueue, 600)
         switch event.type {

--- a/Sources/SwiftGRPC/Core/CompletionQueue.swift
+++ b/Sources/SwiftGRPC/Core/CompletionQueue.swift
@@ -98,7 +98,7 @@ class CompletionQueue {
 
   /// Register an operation group for handling upon completion. Will throw if the queue has been shutdown already.
   ///
-  /// - Parameter operationGroup: the operation group to handle. Runs synchronously on the queue's thread, so should not be blocking.
+  /// - Parameter operationGroup: the operation group to handle.
   func register(_ operationGroup: OperationGroup, onSuccess: () throws -> Void) throws {
     try operationGroupsMutex.synchronize {
       guard !hasBeenShutdown

--- a/Sources/SwiftGRPC/Core/CompletionQueue.swift
+++ b/Sources/SwiftGRPC/Core/CompletionQueue.swift
@@ -98,7 +98,7 @@ class CompletionQueue {
 
   /// Register an operation group for handling upon completion. Will throw if the queue has been shutdown already.
   ///
-  /// - Parameter operationGroup: the operation group to handle
+  /// - Parameter operationGroup: the operation group to handle. Runs synchronously on the queue's thread, so should not be blocking.
   func register(_ operationGroup: OperationGroup, onSuccess: () throws -> Void) throws {
     try operationGroupsMutex.synchronize {
       guard !hasBeenShutdown

--- a/Sources/SwiftGRPC/Core/Server.swift
+++ b/Sources/SwiftGRPC/Core/Server.swift
@@ -62,8 +62,7 @@ public class Server {
   }
 
   /// Run the server
-  public func run(dispatchQueue: DispatchQueue = DispatchQueue.global(),
-                  handlerFunction: @escaping (Handler) -> Void) {
+  public func run(handlerFunction: @escaping (Handler) -> Void) {
     cgrpc_server_start(underlyingServer)
     // run the server on a new background thread
     let spinloopThreadQueue = DispatchQueue(label: "SwiftGRPC.CompletionQueue.runToCompletion.spinloopThread")

--- a/Sources/SwiftGRPC/Runtime/ServerSession.swift
+++ b/Sources/SwiftGRPC/Runtime/ServerSession.swift
@@ -57,6 +57,7 @@ open class ServerSessionBase: ServerSession {
   
   public func cancel() {
     call.cancel()
+    handler.shutdown()
   }
   
   func sendInitialMetadataAndWait() throws {

--- a/Sources/SwiftGRPC/Runtime/ServerSessionBidirectionalStreaming.swift
+++ b/Sources/SwiftGRPC/Runtime/ServerSessionBidirectionalStreaming.swift
@@ -36,7 +36,8 @@ open class ServerSessionBidirectionalStreamingBase<InputType: Message, OutputTyp
   
   public func run(queue: DispatchQueue) throws {
     try handler.sendMetadata(initialMetadata: initialMetadata) { success in
-      queue.async {
+      let handlerThreadQueue = DispatchQueue(label: "SwiftGRPC.ServerSessionBidirectionalStreamingBase.run.handlerThread")
+      handlerThreadQueue.async {
         var responseStatus: ServerStatus?
         if success {
           do {

--- a/Sources/SwiftGRPC/Runtime/ServerSessionBidirectionalStreaming.swift
+++ b/Sources/SwiftGRPC/Runtime/ServerSessionBidirectionalStreaming.swift
@@ -34,7 +34,7 @@ open class ServerSessionBidirectionalStreamingBase<InputType: Message, OutputTyp
     super.init(handler: handler)
   }
   
-  public func run(queue: DispatchQueue) throws {
+  public func run() throws {
     try handler.sendMetadata(initialMetadata: initialMetadata) { success in
       let handlerThreadQueue = DispatchQueue(label: "SwiftGRPC.ServerSessionBidirectionalStreamingBase.run.handlerThread")
       handlerThreadQueue.async {

--- a/Sources/SwiftGRPC/Runtime/ServerSessionClientStreaming.swift
+++ b/Sources/SwiftGRPC/Runtime/ServerSessionClientStreaming.swift
@@ -41,29 +41,32 @@ open class ServerSessionClientStreamingBase<InputType: Message, OutputType: Mess
   }
   
   public func run() throws {
-    try handler.sendMetadata(initialMetadata: initialMetadata) { success in
-      let handlerThreadQueue = DispatchQueue(label: "SwiftGRPC.ServerSessionClientStreamingBase.run.handlerThread")
-      handlerThreadQueue.async {
-        var responseStatus: ServerStatus?
-        if success {
-          do {
-            try self.providerBlock(self)
-          } catch {
-            responseStatus = (error as? ServerStatus) ?? .processingError
-          }
-        } else {
-          print("ServerSessionClientStreamingBase.run sending initial metadata failed")
-          responseStatus = .sendingInitialMetadataFailed
-        }
-        
-        if let responseStatus = responseStatus {
-          // Error encountered, notify the client.
-          do {
-            try self.handler.sendStatus(responseStatus)
-          } catch {
-            print("ServerSessionClientStreamingBase.run error sending status: \(error)")
-          }
-        }
+    let sendMetadataSignal = DispatchSemaphore(value: 0)
+    var success = false
+    try handler.sendMetadata(initialMetadata: initialMetadata) {
+      success = $0
+      sendMetadataSignal.signal()
+    }
+    sendMetadataSignal.wait()
+    
+    var responseStatus: ServerStatus?
+    if success {
+      do {
+        try self.providerBlock(self)
+      } catch {
+        responseStatus = (error as? ServerStatus) ?? .processingError
+      }
+    } else {
+      print("ServerSessionClientStreamingBase.run sending initial metadata failed")
+      responseStatus = .sendingInitialMetadataFailed
+    }
+    
+    if let responseStatus = responseStatus {
+      // Error encountered, notify the client.
+      do {
+        try self.handler.sendStatus(responseStatus)
+      } catch {
+        print("ServerSessionClientStreamingBase.run error sending status: \(error)")
       }
     }
   }

--- a/Sources/SwiftGRPC/Runtime/ServerSessionClientStreaming.swift
+++ b/Sources/SwiftGRPC/Runtime/ServerSessionClientStreaming.swift
@@ -42,7 +42,8 @@ open class ServerSessionClientStreamingBase<InputType: Message, OutputType: Mess
   
   public func run(queue: DispatchQueue) throws {
     try handler.sendMetadata(initialMetadata: initialMetadata) { success in
-      queue.async {
+      let handlerThreadQueue = DispatchQueue(label: "SwiftGRPC.ServerSessionClientStreamingBase.run.handlerThread")
+      handlerThreadQueue.async {
         var responseStatus: ServerStatus?
         if success {
           do {

--- a/Sources/SwiftGRPC/Runtime/ServerSessionClientStreaming.swift
+++ b/Sources/SwiftGRPC/Runtime/ServerSessionClientStreaming.swift
@@ -40,7 +40,7 @@ open class ServerSessionClientStreamingBase<InputType: Message, OutputType: Mess
     try handler.sendStatus(status, completion: completion)
   }
   
-  public func run(queue: DispatchQueue) throws {
+  public func run() throws {
     try handler.sendMetadata(initialMetadata: initialMetadata) { success in
       let handlerThreadQueue = DispatchQueue(label: "SwiftGRPC.ServerSessionClientStreamingBase.run.handlerThread")
       handlerThreadQueue.async {

--- a/Sources/SwiftGRPC/Runtime/ServerSessionServerStreaming.swift
+++ b/Sources/SwiftGRPC/Runtime/ServerSessionServerStreaming.swift
@@ -35,7 +35,8 @@ open class ServerSessionServerStreamingBase<InputType: Message, OutputType: Mess
   
   public func run(queue: DispatchQueue) throws {
     try handler.receiveMessage(initialMetadata: initialMetadata) { requestData in
-      queue.async {
+      let handlerThreadQueue = DispatchQueue(label: "SwiftGRPC.ServerSessionServerStreamingBase.run.handlerThread")
+      handlerThreadQueue.async {
         var responseStatus: ServerStatus?
         if let requestData = requestData {
           do {

--- a/Sources/SwiftGRPC/Runtime/ServerSessionServerStreaming.swift
+++ b/Sources/SwiftGRPC/Runtime/ServerSessionServerStreaming.swift
@@ -25,7 +25,7 @@ public protocol ServerSessionServerStreaming: ServerSession {
 open class ServerSessionServerStreamingBase<InputType: Message, OutputType: Message>: ServerSessionBase, ServerSessionServerStreaming, StreamSending {
   public typealias SentType = OutputType
   
-  public typealias ProviderBlock = (InputType, ServerSessionServerStreamingBase) throws -> Void
+  public typealias ProviderBlock = (InputType, ServerSessionServerStreamingBase) throws -> ServerStatus?
   private var providerBlock: ProviderBlock
 
   public init(handler: Handler, providerBlock: @escaping ProviderBlock) {
@@ -33,35 +33,15 @@ open class ServerSessionServerStreamingBase<InputType: Message, OutputType: Mess
     super.init(handler: handler)
   }
   
-  public func run() throws {
-    let sendMetadataSignal = DispatchSemaphore(value: 0)
-    var requestData: Data?
-    try handler.receiveMessage(initialMetadata: initialMetadata) {
-      requestData = $0
-      sendMetadataSignal.signal()
-    }
-    sendMetadataSignal.wait()
-    
-    var responseStatus: ServerStatus?
-    if let requestData = requestData {
-      do {
-        let requestMessage = try InputType(serializedData: requestData)
-        try self.providerBlock(requestMessage, self)
-      } catch {
-        responseStatus = (error as? ServerStatus) ?? .processingError
-      }
-    } else {
-      print("ServerSessionServerStreamingBase.run no request data")
-      responseStatus = .noRequestData
-    }
-    
-    if let responseStatus = responseStatus {
-      // Error encountered, notify the client.
-      do {
-        try self.handler.sendStatus(responseStatus)
-      } catch {
-        print("ServerSessionServerStreamingBase.run error sending status: \(error)")
-      }
+  public func run() throws -> ServerStatus? {
+    let requestData = try receiveRequestAndWait()
+    let requestMessage = try InputType(serializedData: requestData)
+    do {
+      return try self.providerBlock(requestMessage, self)
+    } catch {
+      // Errors thrown by `providerBlock` should be logged in that method;
+      // we return the error as a status code to avoid `ServiceServer` logging this as a "really unexpected" error.
+      return (error as? ServerStatus) ?? .processingError
     }
   }
 }

--- a/Sources/SwiftGRPC/Runtime/ServerSessionServerStreaming.swift
+++ b/Sources/SwiftGRPC/Runtime/ServerSessionServerStreaming.swift
@@ -33,7 +33,7 @@ open class ServerSessionServerStreamingBase<InputType: Message, OutputType: Mess
     super.init(handler: handler)
   }
   
-  public func run(queue: DispatchQueue) throws {
+  public func run() throws {
     try handler.receiveMessage(initialMetadata: initialMetadata) { requestData in
       let handlerThreadQueue = DispatchQueue(label: "SwiftGRPC.ServerSessionServerStreamingBase.run.handlerThread")
       handlerThreadQueue.async {

--- a/Sources/SwiftGRPC/Runtime/ServerSessionServerStreaming.swift
+++ b/Sources/SwiftGRPC/Runtime/ServerSessionServerStreaming.swift
@@ -34,30 +34,33 @@ open class ServerSessionServerStreamingBase<InputType: Message, OutputType: Mess
   }
   
   public func run() throws {
-    try handler.receiveMessage(initialMetadata: initialMetadata) { requestData in
-      let handlerThreadQueue = DispatchQueue(label: "SwiftGRPC.ServerSessionServerStreamingBase.run.handlerThread")
-      handlerThreadQueue.async {
-        var responseStatus: ServerStatus?
-        if let requestData = requestData {
-          do {
-            let requestMessage = try InputType(serializedData: requestData)
-            try self.providerBlock(requestMessage, self)
-          } catch {
-            responseStatus = (error as? ServerStatus) ?? .processingError
-          }
-        } else {
-          print("ServerSessionServerStreamingBase.run empty request data")
-          responseStatus = .noRequestData
-        }
-        
-        if let responseStatus = responseStatus {
-          // Error encountered, notify the client.
-          do {
-            try self.handler.sendStatus(responseStatus)
-          } catch {
-            print("ServerSessionServerStreamingBase.run error sending status: \(error)")
-          }
-        }
+    let sendMetadataSignal = DispatchSemaphore(value: 0)
+    var requestData: Data?
+    try handler.receiveMessage(initialMetadata: initialMetadata) {
+      requestData = $0
+      sendMetadataSignal.signal()
+    }
+    sendMetadataSignal.wait()
+    
+    var responseStatus: ServerStatus?
+    if let requestData = requestData {
+      do {
+        let requestMessage = try InputType(serializedData: requestData)
+        try self.providerBlock(requestMessage, self)
+      } catch {
+        responseStatus = (error as? ServerStatus) ?? .processingError
+      }
+    } else {
+      print("ServerSessionServerStreamingBase.run no request data")
+      responseStatus = .noRequestData
+    }
+    
+    if let responseStatus = responseStatus {
+      // Error encountered, notify the client.
+      do {
+        try self.handler.sendStatus(responseStatus)
+      } catch {
+        print("ServerSessionServerStreamingBase.run error sending status: \(error)")
       }
     }
   }

--- a/Sources/SwiftGRPC/Runtime/ServerSessionUnary.swift
+++ b/Sources/SwiftGRPC/Runtime/ServerSessionUnary.swift
@@ -31,7 +31,7 @@ open class ServerSessionUnaryBase<InputType: Message, OutputType: Message>: Serv
     super.init(handler: handler)
   }
   
-  public func run(queue: DispatchQueue) throws {
+  public func run() throws {
     try handler.receiveMessage(initialMetadata: initialMetadata) { requestData in
       let handlerThreadQueue = DispatchQueue(label: "SwiftGRPC.ServerSessionUnaryBase.run.handlerThread")
       handlerThreadQueue.async {

--- a/Sources/SwiftGRPC/Runtime/ServerSessionUnary.swift
+++ b/Sources/SwiftGRPC/Runtime/ServerSessionUnary.swift
@@ -33,7 +33,8 @@ open class ServerSessionUnaryBase<InputType: Message, OutputType: Message>: Serv
   
   public func run(queue: DispatchQueue) throws {
     try handler.receiveMessage(initialMetadata: initialMetadata) { requestData in
-      queue.async {
+      let handlerThreadQueue = DispatchQueue(label: "SwiftGRPC.ServerSessionUnaryBase.run.handlerThread")
+      handlerThreadQueue.async {
         let responseStatus: ServerStatus
         if let requestData = requestData {
           do {

--- a/Sources/SwiftGRPC/Runtime/ServerSessionUnary.swift
+++ b/Sources/SwiftGRPC/Runtime/ServerSessionUnary.swift
@@ -32,34 +32,45 @@ open class ServerSessionUnaryBase<InputType: Message, OutputType: Message>: Serv
   }
   
   public func run() throws {
-    try handler.receiveMessage(initialMetadata: initialMetadata) { requestData in
-      let handlerThreadQueue = DispatchQueue(label: "SwiftGRPC.ServerSessionUnaryBase.run.handlerThread")
-      handlerThreadQueue.async {
-        let responseStatus: ServerStatus
-        if let requestData = requestData {
-          do {
-            let requestMessage = try InputType(serializedData: requestData)
-            let responseMessage = try self.providerBlock(requestMessage, self)
-            try self.handler.call.sendMessage(data: responseMessage.serializedData()) {
-              guard let error = $0
-                else { return }
-              print("ServerSessionUnaryBase.run error sending response: \(error)")
-            }
-            responseStatus = .ok
-          } catch {
-            responseStatus = (error as? ServerStatus) ?? .processingError
-          }
-        } else {
-          print("ServerSessionUnaryBase.run empty request data")
-          responseStatus = .noRequestData
+    let sendMetadataSignal = DispatchSemaphore(value: 0)
+    var requestData: Data?
+    try handler.receiveMessage(initialMetadata: initialMetadata) {
+      requestData = $0
+      sendMetadataSignal.signal()
+    }
+    sendMetadataSignal.wait()
+    
+    let responseStatus: ServerStatus
+    if let requestData = requestData {
+      do {
+        let requestMessage = try InputType(serializedData: requestData)
+        let responseMessage = try self.providerBlock(requestMessage, self)
+        
+        let sendResponseSignal = DispatchSemaphore(value: 0)
+        var sendResponseError: Error?
+        try self.handler.call.sendMessage(data: responseMessage.serializedData()) {
+          sendResponseError = $0
+          sendResponseSignal.signal()
+        }
+        sendResponseSignal.wait()
+        if let sendResponseError = sendResponseError {
+          print("ServerSessionUnaryBase.run error sending response: \(sendResponseError)")
+          throw sendResponseError
         }
         
-        do {
-          try self.handler.sendStatus(responseStatus)
-        } catch {
-          print("ServerSessionUnaryBase.run error sending status: \(error)")
-        }
+        responseStatus = .ok
+      } catch {
+        responseStatus = (error as? ServerStatus) ?? .processingError
       }
+    } else {
+      print("ServerSessionUnaryBase.run no request data")
+      responseStatus = .noRequestData
+    }
+    
+    do {
+      try self.handler.sendStatus(responseStatus)
+    } catch {
+      print("ServerSessionUnaryBase.run error sending status: \(error)")
     }
   }
 }

--- a/Sources/SwiftGRPC/Runtime/ServiceServer.swift
+++ b/Sources/SwiftGRPC/Runtime/ServiceServer.swift
@@ -48,9 +48,13 @@ open class ServiceServer {
     server = Server(address: address, key: key, certs: certificate)
   }
 
+  public enum HandleMethodError: Error {
+    case unknownMethod
+  }
+  
   /// Handle the given method. Needs to be overridden by actual implementations.
   /// Returns whether the method was actually handled.
-  open func handleMethod(_ method: String, handler: Handler) throws -> Bool { fatalError("needs to be overridden") }
+  open func handleMethod(_ method: String, handler: Handler) throws -> ServerStatus? { fatalError("needs to be overridden") }
 
   /// Start the server.
   public func start() {
@@ -71,23 +75,36 @@ open class ServiceServer {
       }
       
       do {
-        if !(try strongSelf.handleMethod(unwrappedMethod, handler: handler)) {
-          do {
-            try handler.call.perform(OperationGroup(
-              call: handler.call,
-              operations: [
-                .sendInitialMetadata(Metadata()),
-                .receiveCloseOnServer,
-                .sendStatusFromServer(.unimplemented, "unknown method " + unwrappedMethod, Metadata())
-            ]) { _ in
-              handler.shutdown()
-            })
-          } catch {
-            print("ServiceServer.start error sending status for unknown method: \(error)")
+        do {
+          if let responseStatus = try strongSelf.handleMethod(unwrappedMethod, handler: handler) {
+            // The handler wants us to send the status for them; do that.
+            // But first, ensure that all outgoing messages have been enqueued, to avoid ending the stream prematurely:
+            handler.call.messageQueueEmpty.wait()
+            try handler.sendStatus(responseStatus)
           }
+        } catch _ as HandleMethodError {
+          // The method is not implemented by the service - send a status saying so.
+          try handler.call.perform(OperationGroup(
+            call: handler.call,
+            operations: [
+              .sendInitialMetadata(Metadata()),
+              .receiveCloseOnServer,
+              .sendStatusFromServer(.unimplemented, "unknown method " + unwrappedMethod, Metadata())
+          ]) { _ in
+            handler.shutdown()
+          })
         }
       } catch {
-        print("Server error: \(error)")
+        // The individual sessions' `run` methods (which are called by `self.handleMethod`) only throw errors if
+        // they encountered an error that has not also been "seen" by the actual request handler implementation.
+        // Therefore, this error is "really unexpected" and  should be logged here - there's nowhere else to log it otherwise.
+        print("ServiceServer error: \(error)")
+        do {
+          try handler.sendStatus((error as? ServerStatus) ?? .processingError)
+        } catch {
+          print("ServiceServer error sending status: \(error)")
+          handler.shutdown()
+        }
       }
     }
   }

--- a/Sources/SwiftGRPC/Runtime/ServiceServer.swift
+++ b/Sources/SwiftGRPC/Runtime/ServiceServer.swift
@@ -50,10 +50,10 @@ open class ServiceServer {
 
   /// Handle the given method. Needs to be overridden by actual implementations.
   /// Returns whether the method was actually handled.
-  open func handleMethod(_ method: String, handler: Handler, queue: DispatchQueue) throws -> Bool { fatalError("needs to be overridden") }
+  open func handleMethod(_ method: String, handler: Handler) throws -> Bool { fatalError("needs to be overridden") }
 
   /// Start the server.
-  public func start(queue: DispatchQueue = DispatchQueue.global()) {
+  public func start() {
     server.run { [weak self] handler in
       guard let strongSelf = self else {
         print("ERROR: ServiceServer has been asked to handle a request even though it has already been deallocated")
@@ -71,7 +71,7 @@ open class ServiceServer {
       }
       
       do {
-        if !(try strongSelf.handleMethod(unwrappedMethod, handler: handler, queue: queue)) {
+        if !(try strongSelf.handleMethod(unwrappedMethod, handler: handler)) {
           do {
             try handler.call.perform(OperationGroup(
               call: handler.call,

--- a/Sources/protoc-gen-swiftgrpc/Generator-Server.swift
+++ b/Sources/protoc-gen-swiftgrpc/Generator-Server.swift
@@ -89,7 +89,7 @@ extension Generator {
     println("}")
     println()
     println("/// Start the server.")
-    println("\(access) override func handleMethod(_ method: String, handler: Handler, queue: DispatchQueue) throws -> Bool {")
+    println("\(access) override func handleMethod(_ method: String, handler: Handler) throws -> Bool {")
     indent()
     println("let provider = self.provider")
     println("switch method {")
@@ -104,7 +104,7 @@ extension Generator {
         println("handler: handler,")
         println("providerBlock: { try provider.\(methodFunctionName)(request: $0, session: $1 as! \(methodSessionName)Base) })")
         indent()
-        println(".run(queue: queue)")
+        println(".run()")
         outdent()
         outdent()
       default:
@@ -113,7 +113,7 @@ extension Generator {
         println("handler: handler,")
         println("providerBlock: { try provider.\(methodFunctionName)(session: $0 as! \(methodSessionName)Base) })")
         indent()
-        println(".run(queue: queue)")
+        println(".run()")
         outdent()
         outdent()
       }

--- a/Tests/SwiftGRPCTests/BasicEchoTestCase.swift
+++ b/Tests/SwiftGRPCTests/BasicEchoTestCase.swift
@@ -52,12 +52,12 @@ class BasicEchoTestCase: XCTestCase {
                                certificateString: certificateString,
                                keyString: String(data: keyForTests, encoding: .utf8)!,
                                provider: provider)
-      server.start(queue: DispatchQueue.global())
+      server.start()
       client = Echo_EchoServiceClient(address: address, certificates: certificateString, arguments: [.sslTargetNameOverride("example.com")])
       client.host = "example.com"
     } else {
       server = Echo_EchoServer(address: address, provider: provider)
-      server.start(queue: DispatchQueue.global())
+      server.start()
       client = Echo_EchoServiceClient(address: address, secure: false)
     }
     

--- a/Tests/SwiftGRPCTests/ChannelArgumentTests.swift
+++ b/Tests/SwiftGRPCTests/ChannelArgumentTests.swift
@@ -26,15 +26,15 @@ fileprivate class ChannelArgumentTestProvider: Echo_EchoProvider {
     return Echo_EchoResponse(text: (session as! ServerSessionBase).handler.requestMetadata["user-agent"]!)
   }
   
-  func expand(request: Echo_EchoRequest, session: Echo_EchoExpandSession) throws {
+  func expand(request: Echo_EchoRequest, session: Echo_EchoExpandSession) throws -> ServerStatus? {
     fatalError("not implemented")
   }
   
-  func collect(session: Echo_EchoCollectSession) throws {
+  func collect(session: Echo_EchoCollectSession) throws -> Echo_EchoResponse? {
     fatalError("not implemented")
   }
   
-  func update(session: Echo_EchoUpdateSession) throws {
+  func update(session: Echo_EchoUpdateSession) throws -> ServerStatus? {
     fatalError("not implemented")
   }
 }

--- a/Tests/SwiftGRPCTests/CompletionQueueTests.swift
+++ b/Tests/SwiftGRPCTests/CompletionQueueTests.swift
@@ -25,18 +25,19 @@ fileprivate class ClosingProvider: Echo_EchoProvider {
     return Echo_EchoResponse()
   }
   
-  func expand(request: Echo_EchoRequest, session: Echo_EchoExpandSession) throws {
+  func expand(request: Echo_EchoRequest, session: Echo_EchoExpandSession) throws -> ServerStatus? {
     let closeSem = DispatchSemaphore(value: 0)
     try! session.close(withStatus: .ok) {
       closeSem.signal()
     }
     XCTAssertThrowsError(try session.send(Echo_EchoResponse()))
     doneExpectation.fulfill()
+    return nil
   }
   
-  func collect(session: Echo_EchoCollectSession) throws { }
+  func collect(session: Echo_EchoCollectSession) throws -> Echo_EchoResponse? { fatalError("not implemented") }
   
-  func update(session: Echo_EchoUpdateSession) throws { }
+  func update(session: Echo_EchoUpdateSession) throws -> ServerStatus? { fatalError("not implemented") }
 }
 
 class CompletionQueueTests: BasicEchoTestCase {

--- a/Tests/SwiftGRPCTests/ServerCancellingTests.swift
+++ b/Tests/SwiftGRPCTests/ServerCancellingTests.swift
@@ -24,19 +24,21 @@ fileprivate class CancellingProvider: Echo_EchoProvider {
     return Echo_EchoResponse()
   }
   
-  func expand(request: Echo_EchoRequest, session: Echo_EchoExpandSession) throws {
+  func expand(request: Echo_EchoRequest, session: Echo_EchoExpandSession) throws -> ServerStatus? {
     session.cancel()
     XCTAssertThrowsError(try session.send(Echo_EchoResponse()))
+    return nil
   }
   
-  func collect(session: Echo_EchoCollectSession) throws {
+  func collect(session: Echo_EchoCollectSession) throws -> Echo_EchoResponse? {
     session.cancel()
-    try! session.sendAndClose(response: Echo_EchoResponse(), status: .ok, completion: nil)
+    return Echo_EchoResponse()
   }
   
-  func update(session: Echo_EchoUpdateSession) throws {
+  func update(session: Echo_EchoUpdateSession) throws -> ServerStatus? {
     session.cancel()
     XCTAssertThrowsError(try session.send(Echo_EchoResponse()))
+    return nil
   }
 }
 

--- a/Tests/SwiftGRPCTests/ServerTestExample.swift
+++ b/Tests/SwiftGRPCTests/ServerTestExample.swift
@@ -61,18 +61,13 @@ extension ServerTestExample {
     let session = Echo_EchoCollectSessionTestStub()
     session.inputs = ["foo", "bar", "baz"].map { Echo_EchoRequest(text: $0) }
     
-    XCTAssertNoThrow(try provider.collect(session: session))
-    
-    XCTAssertEqual(.ok, session.status!.code)
-    XCTAssertEqual(Echo_EchoResponse(text: "Swift echo collect: foo bar baz"),
-                   session.output)
+    XCTAssertEqual(Echo_EchoResponse(text: "Swift echo collect: foo bar baz"), try provider.collect(session: session)!)
   }
   
   func testServerStreaming() {
     let session = Echo_EchoExpandSessionTestStub()
-    XCTAssertNoThrow(try provider.expand(request: Echo_EchoRequest(text: "foo bar baz"), session: session))
+    XCTAssertEqual(.ok, try provider.expand(request: Echo_EchoRequest(text: "foo bar baz"), session: session)!.code)
     
-    XCTAssertEqual(.ok, session.status!.code)
     XCTAssertEqual(["foo", "bar", "baz"].enumerated()
       .map { Echo_EchoResponse(text: "Swift echo expand (\($0)): \($1)") },
                    session.outputs)
@@ -82,9 +77,8 @@ extension ServerTestExample {
     let inputStrings = ["foo", "bar", "baz"]
     let session = Echo_EchoUpdateSessionTestStub()
     session.inputs = inputStrings.map { Echo_EchoRequest(text: $0) }
-    XCTAssertNoThrow(try provider.update(session: session))
+    XCTAssertEqual(.ok, try! provider.update(session: session)!.code)
     
-    XCTAssertEqual(.ok, session.status!.code)
     XCTAssertEqual(inputStrings.enumerated()
       .map { Echo_EchoResponse(text: "Swift echo update (\($0)): \($1)") },
                    session.outputs)

--- a/Tests/SwiftGRPCTests/ServerThrowingTests.swift
+++ b/Tests/SwiftGRPCTests/ServerThrowingTests.swift
@@ -25,15 +25,15 @@ fileprivate class StatusThrowingProvider: Echo_EchoProvider {
     throw testStatus
   }
   
-  func expand(request: Echo_EchoRequest, session: Echo_EchoExpandSession) throws {
+  func expand(request: Echo_EchoRequest, session: Echo_EchoExpandSession) throws -> ServerStatus? {
     throw testStatus
   }
   
-  func collect(session: Echo_EchoCollectSession) throws {
+  func collect(session: Echo_EchoCollectSession) throws -> Echo_EchoResponse? {
     throw testStatus
   }
   
-  func update(session: Echo_EchoUpdateSession) throws {
+  func update(session: Echo_EchoUpdateSession) throws -> ServerStatus? {
     throw testStatus
   }
 }

--- a/Tests/SwiftGRPCTests/ServerTimeoutTests.swift
+++ b/Tests/SwiftGRPCTests/ServerTimeoutTests.swift
@@ -26,17 +26,17 @@ fileprivate class TimingOutEchoProvider: Echo_EchoProvider {
   
   func expand(request: Echo_EchoRequest, session: Echo_EchoExpandSession) throws -> ServerStatus? {
     Thread.sleep(forTimeInterval: 0.2)
-    return nil
+    return .ok
   }
   
   func collect(session: Echo_EchoCollectSession) throws -> Echo_EchoResponse? {
     Thread.sleep(forTimeInterval: 0.2)
-    return nil
+    return Echo_EchoResponse()
   }
   
   func update(session: Echo_EchoUpdateSession) throws -> ServerStatus? {
     Thread.sleep(forTimeInterval: 0.2)
-    return nil
+    return .ok
   }
 }
 

--- a/Tests/SwiftGRPCTests/ServerTimeoutTests.swift
+++ b/Tests/SwiftGRPCTests/ServerTimeoutTests.swift
@@ -24,16 +24,19 @@ fileprivate class TimingOutEchoProvider: Echo_EchoProvider {
     return Echo_EchoResponse()
   }
   
-  func expand(request: Echo_EchoRequest, session: Echo_EchoExpandSession) throws {
+  func expand(request: Echo_EchoRequest, session: Echo_EchoExpandSession) throws -> ServerStatus? {
     Thread.sleep(forTimeInterval: 0.2)
+    return nil
   }
   
-  func collect(session: Echo_EchoCollectSession) throws {
+  func collect(session: Echo_EchoCollectSession) throws -> Echo_EchoResponse? {
     Thread.sleep(forTimeInterval: 0.2)
+    return nil
   }
   
-  func update(session: Echo_EchoUpdateSession) throws {
+  func update(session: Echo_EchoUpdateSession) throws -> ServerStatus? {
     Thread.sleep(forTimeInterval: 0.2)
+    return nil
   }
 }
 

--- a/Tests/SwiftGRPCTests/ServiceClientTests.swift
+++ b/Tests/SwiftGRPCTests/ServiceClientTests.swift
@@ -18,11 +18,16 @@ import Foundation
 import XCTest
 
 class ServiceClientTests: BasicEchoTestCase {
-  private lazy var sharedChannel = Channel(address: address, secure: false)
+  private var sharedChannel: Channel?
 
   override func setUp() {
     super.setUp()
     sharedChannel = Channel(address: address, secure: false)
+  }
+  
+  override func tearDown() {
+    sharedChannel = nil
+    super.tearDown()
   }
 
   func testSharingChannelBetweenClientsUnaryAsync() {
@@ -30,13 +35,13 @@ class ServiceClientTests: BasicEchoTestCase {
     let secondCallExpectation = expectation(description: "Second call completes successfully")
 
     do {
-      let client1 = Echo_EchoServiceClient(channel: sharedChannel)
+      let client1 = Echo_EchoServiceClient(channel: sharedChannel!)
       try _ = client1.get(Echo_EchoRequest(text: "foo")) { _, callResult in
         XCTAssertEqual(.ok, callResult.statusCode)
         firstCallExpectation.fulfill()
       }
 
-      let client2 = Echo_EchoServiceClient(channel: sharedChannel)
+      let client2 = Echo_EchoServiceClient(channel: sharedChannel!)
       try _ = client2.get(Echo_EchoRequest(text: "foo")) { _, callResult in
         XCTAssertEqual(.ok, callResult.statusCode)
         secondCallExpectation.fulfill()
@@ -50,7 +55,7 @@ class ServiceClientTests: BasicEchoTestCase {
 
   func testSharedChannelStillWorksAfterFirstUnaryClientCompletes() {
     do {
-      let client1 = Echo_EchoServiceClient(channel: sharedChannel)
+      let client1 = Echo_EchoServiceClient(channel: sharedChannel!)
       let response1 = try client1.get(Echo_EchoRequest(text: "foo")).text
       XCTAssertEqual("Swift echo get: foo", response1)
     } catch let error {
@@ -58,7 +63,7 @@ class ServiceClientTests: BasicEchoTestCase {
     }
 
     do {
-      let client2 = Echo_EchoServiceClient(channel: sharedChannel)
+      let client2 = Echo_EchoServiceClient(channel: sharedChannel!)
       let response2 = try client2.get(Echo_EchoRequest(text: "foo")).text
       XCTAssertEqual("Swift echo get: foo", response2)
     } catch let error {


### PR DESCRIPTION
Based on #227.

In the default (successful) case, most request handlers can now simply return `.ok` and have `ServiceServer` handle sending back the status for them. This also streamlines the `run()` implementations of the `ServerSession` subclasses.