### PR TITLE
Replace `Metadata.description` with `Metadata.dictionaryRepresentation.description`

### DIFF
--- a/Sources/SwiftGRPC/Core/CallResult.swift
+++ b/Sources/SwiftGRPC/Core/CallResult.swift
@@ -62,11 +62,11 @@ public struct CallResult: CustomStringConvertible {
     }
     if let initialMetadata = self.initialMetadata {
       result += "\ninitialMetadata: "
-      result += initialMetadata.description
+      result += initialMetadata.dictionaryRepresentation.description
     }
     if let trailingMetadata = self.trailingMetadata {
       result += "\ntrailingMetadata: "
-      result += trailingMetadata.description
+      result += trailingMetadata.dictionaryRepresentation.description
     }
     return result
   }

--- a/Sources/SwiftGRPC/Core/Metadata.swift
+++ b/Sources/SwiftGRPC/Core/Metadata.swift
@@ -19,7 +19,7 @@
 import Foundation // for String.Encoding
 
 /// Metadata sent with gRPC messages
-public class Metadata: CustomStringConvertible {
+public class Metadata {
   public enum Error: Swift.Error {
     /// Field ownership can only be transferred once. Likewise, it is not advisable to write to a metadata array whose
     /// fields we do not own.
@@ -88,14 +88,20 @@ public class Metadata: CustomStringConvertible {
     cgrpc_metadata_array_append_metadata(underlyingArray, key, value)
   }
   
-  public var description: String {
-    var lines: [String] = []
+  public var dictionaryRepresentation: [String: String] {
+    var result: [String: String] = [:]
+    var unknownKeyCount = 0
     for i in 0..<count() {
-      let key = self.key(i)
-      let value = self.value(i)
-      lines.append((key ?? "(nil)") + ":" + (value ?? "(nil)"))
+      let key: String
+      if let unwrappedKey = self.key(i) {
+        key = unwrappedKey
+      } else {
+        key = "(unknown\(unknownKeyCount))"
+        unknownKeyCount += 1
+      }
+      result[key] = self.value(i) ?? "(unknown)"
     }
-    return lines.joined(separator: "\n")
+    return result
   }
   
   public func copy() -> Metadata {

--- a/Sources/SwiftGRPC/Runtime/ServiceServer.swift
+++ b/Sources/SwiftGRPC/Runtime/ServiceServer.swift
@@ -84,6 +84,7 @@ open class ServiceServer {
             try handler.sendStatus(responseStatus)
           }
         } catch _ as HandleMethodError {
+          print("ServiceServer call to unknown method '\(unwrappedMethod)'")
           if !handler.completionQueue.hasBeenShutdown {
             // The method is not implemented by the service - send a status saying so.
             try handler.call.perform(OperationGroup(

--- a/Sources/SwiftGRPC/Runtime/ServiceServer.swift
+++ b/Sources/SwiftGRPC/Runtime/ServiceServer.swift
@@ -71,7 +71,7 @@ open class ServiceServer {
         print("Server received request to " + unwrappedHost
           + " calling " + unwrappedMethod
           + " from " + unwrappedCaller
-          + " with " + handler.requestMetadata.description)
+          + " with metadata " + handler.requestMetadata.dictionaryRepresentation.description)
       }
       
       do {


### PR DESCRIPTION
The newlines in the metadata description made logs in Google Cloud Stackdriver harder to parse than necessary (each line is a separate log entry).

Also made ServiceServer log calls to unknown methods.