### PR TITLE
Add server/client codegen options to protoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,21 @@ search path. Invoke them with commands like the following:
 By convention the `--swift_out` option invokes the `protoc-gen-swift`
 plugin and `--swiftgrpc_out` invokes `protoc-gen-swiftgrpc`.
 
+#### Parameters
+To pass extra parameters to the plugin, use a comma-separated parameter list 
+separated from the output directory by a colon.
+
+| Flag | Values | Default | Description |
+|:-|:-|:-|:-|
+| `Visibility` | `Internal`/`Public` | `Internal` | ACL of generated code |
+| `Server` |  `true`/`false` | `true` | Whether to generate server code |
+| `Client` |  `true`/`false` | `true` | Whether to generate client code |
+| `TestStubs` |  `true`/`false` | `false` | Whether to generate test stub code |
+
+Example:
+
+    $ protoc <your proto> --swiftgrpc_out=Client=true,Server=false:.
+
 ### Building your project
 
 Most `grpc-swift` development is done with the Swift Package Manager.

--- a/Sources/protoc-gen-swiftgrpc/options.swift
+++ b/Sources/protoc-gen-swiftgrpc/options.swift
@@ -31,57 +31,61 @@ enum GenerationError: Error {
   }
 }
 
-class GeneratorOptions {
+final class GeneratorOptions {
   enum Visibility: String {
-    case Internal
-    case Public
+    case `internal` = "Internal"
+    case `public` = "Public"
 
     var sourceSnippet: String {
       switch self {
-      case .Internal:
+      case .internal:
         return "internal"
-      case .Public:
+      case .public:
         return "public"
       }
     }
   }
 
-  let visibility: Visibility
-  let generateTestStubs: Bool
-  let generateClient: Bool
-  let generateServer: Bool
+  private(set) var visibility = Visibility.internal
+  private(set) var generateServer = true
+  private(set) var generateClient = true
+  private(set) var generateTestStubs = false
 
   init(parameter: String?) throws {
-    var visibility: Visibility = .Internal
-
-    var generateTestStubs = false
-
     for pair in GeneratorOptions.parseParameter(string: parameter) {
       switch pair.key {
       case "Visibility":
         if let value = Visibility(rawValue: pair.value) {
           visibility = value
         } else {
-          throw GenerationError.invalidParameterValue(name: pair.key,
-                                                      value: pair.value)
+          throw GenerationError.invalidParameterValue(name: pair.key, value: pair.value)
         }
+
+      case "Server":
+        if let value = Bool(pair.value) {
+          generateServer = value
+        } else {
+          throw GenerationError.invalidParameterValue(name: pair.key, value: pair.value)
+        }
+
+      case "Client":
+        if let value = Bool(pair.value) {
+          generateClient = value
+        } else {
+          throw GenerationError.invalidParameterValue(name: pair.key, value: pair.value)
+        }
+
       case "TestStubs":
-        switch pair.value {
-        case "true": generateTestStubs = true
-        case "false": generateTestStubs = false
-        default: throw GenerationError.invalidParameterValue(name: pair.key,
-                                                             value: pair.value)
+        if let value = Bool(pair.value) {
+            generateTestStubs = value
+        } else {
+            throw GenerationError.invalidParameterValue(name: pair.key, value: pair.value)
         }
 
       default:
         throw GenerationError.unknownParameter(name: pair.key)
       }
     }
-
-    self.visibility = visibility
-    self.generateTestStubs = generateTestStubs
-    self.generateClient = true
-    self.generateServer = true
   }
 
   static func parseParameter(string: String?) -> [(key: String, value: String)] {


### PR DESCRIPTION
Implements support for specifying additional options for `protoc` gRPC codegen to exclude client and/or server code.

Usage:
```
protoc TestEvent.proto --swiftgrpc_out=Client=true,Server=false:.
```

Also updated the readme with examples of all supported parameters.