### PR TITLE
Allow gRPC to connect with Google Credentials

### DIFF
--- a/Sources/CgRPC/shim/cgrpc.h
+++ b/Sources/CgRPC/shim/cgrpc.h
@@ -171,6 +171,10 @@ cgrpc_channel *cgrpc_channel_create_secure(const char *address,
                                            grpc_arg *args,
                                            int num_args);
 
+cgrpc_channel *cgrpc_channel_create_google(const char *address,
+                                          grpc_arg *args,
+                                          int num_args);
+
 void cgrpc_channel_destroy(cgrpc_channel *channel);
 cgrpc_call *cgrpc_channel_create_call(cgrpc_channel *channel,
                                       const char *method,

--- a/Sources/CgRPC/shim/cgrpc.h
+++ b/Sources/CgRPC/shim/cgrpc.h
@@ -172,8 +172,8 @@ cgrpc_channel *cgrpc_channel_create_secure(const char *address,
                                            int num_args);
 
 cgrpc_channel *cgrpc_channel_create_google(const char *address,
-                                          grpc_arg *args,
-                                          int num_args);
+                                           grpc_arg *args,
+                                           int num_args);
 
 void cgrpc_channel_destroy(cgrpc_channel *channel);
 cgrpc_call *cgrpc_channel_create_call(cgrpc_channel *channel,

--- a/Sources/CgRPC/shim/channel.c
+++ b/Sources/CgRPC/shim/channel.c
@@ -66,17 +66,17 @@ cgrpc_channel *cgrpc_channel_create_secure(const char *address,
 cgrpc_channel *cgrpc_channel_create_google(const char *address,
                                            grpc_arg *args,
                                            int num_args) {
-    cgrpc_channel *c = (cgrpc_channel *) malloc(sizeof (cgrpc_channel));
+  cgrpc_channel *c = (cgrpc_channel *) malloc(sizeof (cgrpc_channel));
 
-    grpc_channel_args channel_args;
-    channel_args.args = args;
-    channel_args.num_args = num_args;
+  grpc_channel_args channel_args;
+  channel_args.args = args;
+  channel_args.num_args = num_args;
 
-    grpc_channel_credentials *google_creds = grpc_google_default_credentials_create();
+  grpc_channel_credentials *google_creds = grpc_google_default_credentials_create();
 
-    c->channel = grpc_secure_channel_create(google_creds, address, &channel_args, NULL);
-    c->completion_queue = grpc_completion_queue_create_for_next(NULL);
-    return c;
+  c->channel = grpc_secure_channel_create(google_creds, address, &channel_args, NULL);
+  c->completion_queue = grpc_completion_queue_create_for_next(NULL);
+  return c;
 }
 
 

--- a/Sources/CgRPC/shim/channel.c
+++ b/Sources/CgRPC/shim/channel.c
@@ -63,6 +63,22 @@ cgrpc_channel *cgrpc_channel_create_secure(const char *address,
   return c;
 }
 
+cgrpc_channel *cgrpc_channel_create_google(const char *address,
+                                           grpc_arg *args,
+                                           int num_args) {
+    cgrpc_channel *c = (cgrpc_channel *) malloc(sizeof (cgrpc_channel));
+
+    grpc_channel_args channel_args;
+    channel_args.args = args;
+    channel_args.num_args = num_args;
+
+    grpc_channel_credentials *google_creds = grpc_google_default_credentials_create();
+
+    c->channel = grpc_secure_channel_create(google_creds, address, &channel_args, NULL);
+    c->completion_queue = grpc_completion_queue_create_for_next(NULL);
+    return c;
+}
+
 
 void cgrpc_channel_destroy(cgrpc_channel *c) {
   grpc_channel_destroy(c->channel);

--- a/Sources/SwiftGRPC/Runtime/ServiceClient.swift
+++ b/Sources/SwiftGRPC/Runtime/ServiceClient.swift
@@ -60,7 +60,25 @@ open class ServiceClientBase: ServiceClient {
     self.channel = channel
     metadata = Metadata()
   }
-  
+
+  /// Create a client with Google credentials.
+  /// - Parameter googleApi: the name of the Google API service (e.g. "cloudkms" in "cloudkms.googleapis.com")
+  /// - Parameter arguments: list of channel configuration options
+  ///
+  /// Note: cgRPC's `grpc_google_default_credentials_create` doesn't accept a root pem argument.
+  /// To override: `export GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=/path/to/your/root/cert.pem`
+  required public init(googleApi: String, arguments: [Channel.Argument] = []) {
+    gRPC.initialize()
+
+    // Force the address of the Google API to account for the security concern mentioned in
+    // Sources/CgRPC/include/grpc/grpc_security.h:
+    //    WARNING: Do NOT use this credentials to connect to a non-google service as
+    //    this could result in an oauth2 token leak.
+    let address = googleApi + ".googleapis.com"
+    channel = Channel(googleAddress: address, arguments: arguments)
+    metadata = Metadata()
+  }
+
   /// Create a client that makes secure connections with a custom certificate.
   required public init(address: String, certificates: String, clientCertificates: String? = nil, clientKey: String? = nil, arguments: [Channel.Argument] = []) {
     gRPC.initialize()

--- a/Sources/SwiftGRPC/Runtime/ServiceClient.swift
+++ b/Sources/SwiftGRPC/Runtime/ServiceClient.swift
@@ -61,20 +61,21 @@ open class ServiceClientBase: ServiceClient {
     metadata = Metadata()
   }
 
-  /// Create a client with Google credentials.
-  /// - Parameter googleApi: the name of the Google API service (e.g. "cloudkms" in "cloudkms.googleapis.com")
+  /// Create a client with Google credentials suitable for connecting to a Google-provided API.
+  /// gRPC protobuf defnitions for use with this method are here: https://github.com/googleapis/googleapis
+  /// - Parameter googleAPI: the name of the Google API service (e.g. "cloudkms" in "cloudkms.googleapis.com")
   /// - Parameter arguments: list of channel configuration options
   ///
-  /// Note: cgRPC's `grpc_google_default_credentials_create` doesn't accept a root pem argument.
+  /// Note: CgRPC's `grpc_google_default_credentials_create` doesn't accept a root pem argument.
   /// To override: `export GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=/path/to/your/root/cert.pem`
-  required public init(googleApi: String, arguments: [Channel.Argument] = []) {
+  required public init(googleAPI: String, arguments: [Channel.Argument] = []) {
     gRPC.initialize()
 
     // Force the address of the Google API to account for the security concern mentioned in
     // Sources/CgRPC/include/grpc/grpc_security.h:
     //    WARNING: Do NOT use this credentials to connect to a non-google service as
     //    this could result in an oauth2 token leak.
-    let address = googleApi + ".googleapis.com"
+    let address = googleAPI + ".googleapis.com"
     channel = Channel(googleAddress: address, arguments: arguments)
     metadata = Metadata()
   }


### PR DESCRIPTION
This is a feature of c-gRPC, but isn't currently exposed through the grpc-swift shim.

This was originally discussed in https://github.com/grpc/grpc-swift/pull/247 but that PR was closed due to issues we were having with BoringSSL on Linux (subsequently fixed in https://github.com/grpc/grpc-swift/pull/238 )

To answer the question in https://github.com/grpc/grpc-swift/pull/247#issuecomment-394493819 - this allows cGRPC to load standard google credential files (ie, `GOOGLE_APPLICATION_CREDENTIALS` or `application_default_credentials.json`) on our behalf rather than having to use an external OAuth library (ie; in the examples here: https://github.com/grpc/grpc-swift/blob/master/Examples/Google/Datastore/Sources/main.swift#L64-L67 )

The main issue with that example is that it doesn't keep the token fresh, so you have to check for freshness and potentially update the metadata _on every request_, which becomes burdensome when wrapping larger Google Cloud APIs.

Using this in practice ends up being very simple:

```
let serviceClient = Google_Cloud_Kms_V1_KeyManagementServiceServiceClient(googleApi: "cloudkms")
```