### PR TITLE
Enable carthage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,3 +58,4 @@ script:
   - make test-plugin
   - make test-echo
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then make xcodebuild; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then make clean && travis_wait 20 make build-carthage; fi

--- a/Makefile
+++ b/Makefile
@@ -36,10 +36,10 @@ xcodebuild: project
 		xcodebuild -configuration "Debug" -parallelizeTargets -target SwiftGRPC -target Echo -target Simple -target protoc-gen-swiftgrpc build
 
 clean:
-	rm -rf Packages
-	rm -rf .build build
-	rm -rf SwiftGRPC.xcodeproj
-	rm -rf Package.pins Package.resolved
-	rm -rf protoc-gen-swift protoc-gen-swiftgrpc
-	cd Examples/Echo/PackageManager; make clean
-	cd Examples/Simple/PackageManager; make clean
+	-rm -rf Packages
+	-rm -rf .build build
+	-rm -rf SwiftGRPC.xcodeproj
+	-rm -rf Package.pins Package.resolved
+	-rm -rf protoc-gen-swift protoc-gen-swiftgrpc
+	-cd Examples/Echo/PackageManager && make clean
+	-cd Examples/Simple/PackageManager && make clean

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,14 @@ all:
 	cp .build/debug/protoc-gen-swiftgrpc .
 	
 project:
-	swift package $(CFLAGS) generate-xcodeproj
-	@-ruby fix-project-settings.rb || echo "Consider running 'sudo gem install xcodeproj' to automatically set correct indentation settings for the generated project."
+	swift package $(CFLAGS) generate-xcodeproj --output SwiftGRPC.xcodeproj
+	@-ruby fix-project-settings.rb SwiftGRPC.xcodeproj || echo "Consider running 'sudo gem install xcodeproj' to automatically set correct indentation settings for the generated project."
+
+project-carthage:
+	swift package generate-xcodeproj --output SwiftGRPC-Carthage.xcodeproj
+	@-ruby fix-project-settings.rb SwiftGRPC-Carthage.xcodeproj || echo "You may need to install xcodeproj ('sudo gem install xcodeproj')!"
+	@ruby remove-unwanted-targets-for-carthage.rb SwiftGRPC-Carthage.xcodeproj || echo "xcodeproj ('sudo gem install xcodeproj') is required in order to generate the Carthage-compatible project!"
+	@ruby add-swift-resolve-prebuild-phase.rb || echo "xcodeproj ('sudo gem install xcodeproj') is required in order to generate the Carthage-compatible project!"
 
 test:	all
 	swift test $(CFLAGS)
@@ -33,7 +39,10 @@ test-plugin:
 	diff -u /tmp/echo.grpc.swift Sources/Examples/Echo/Generated/echo.grpc.swift
 
 xcodebuild: project
-		xcodebuild -configuration "Debug" -parallelizeTargets -target SwiftGRPC -target Echo -target Simple -target protoc-gen-swiftgrpc build
+		xcodebuild -project SwiftGRPC.xcodeproj -configuration "Debug" -parallelizeTargets -target SwiftGRPC -target Echo -target Simple -target protoc-gen-swiftgrpc build
+
+build-carthage:
+	carthage build --no-skip-current
 
 clean:
 	-rm -rf Packages

--- a/SwiftGRPC-Carthage.xcodeproj/BoringSSL_Info.plist
+++ b/SwiftGRPC-Carthage.xcodeproj/BoringSSL_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/SwiftGRPC-Carthage.xcodeproj/CgRPC_Info.plist
+++ b/SwiftGRPC-Carthage.xcodeproj/CgRPC_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/SwiftGRPC-Carthage.xcodeproj/Commander_Info.plist
+++ b/SwiftGRPC-Carthage.xcodeproj/Commander_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/SwiftGRPC-Carthage.xcodeproj/GeneratedModuleMap/BoringSSL/module.modulemap
+++ b/SwiftGRPC-Carthage.xcodeproj/GeneratedModuleMap/BoringSSL/module.modulemap
@@ -1,0 +1,4 @@
+module BoringSSL {
+    umbrella "/private/tmp/PR/grpc-swift/Sources/BoringSSL/include"
+    export *
+}

--- a/SwiftGRPC-Carthage.xcodeproj/SwiftGRPCTests_Info.plist
+++ b/SwiftGRPC-Carthage.xcodeproj/SwiftGRPCTests_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>BNDL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/SwiftGRPC-Carthage.xcodeproj/SwiftGRPC_Info.plist
+++ b/SwiftGRPC-Carthage.xcodeproj/SwiftGRPC_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/SwiftGRPC-Carthage.xcodeproj/SwiftProtobufPluginLibrary_Info.plist
+++ b/SwiftGRPC-Carthage.xcodeproj/SwiftProtobufPluginLibrary_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/SwiftGRPC-Carthage.xcodeproj/SwiftProtobuf_Info.plist
+++ b/SwiftGRPC-Carthage.xcodeproj/SwiftProtobuf_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/SwiftGRPC-Carthage.xcodeproj/project.pbxproj
+++ b/SwiftGRPC-Carthage.xcodeproj/project.pbxproj
@@ -1,0 +1,5583 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		OBJ_1178 /* a_bitstr.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* a_bitstr.c */; };
+		OBJ_1179 /* a_bool.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* a_bool.c */; };
+		OBJ_1180 /* a_d2i_fp.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* a_d2i_fp.c */; };
+		OBJ_1181 /* a_dup.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_14 /* a_dup.c */; };
+		OBJ_1182 /* a_enum.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_15 /* a_enum.c */; };
+		OBJ_1183 /* a_gentm.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_16 /* a_gentm.c */; };
+		OBJ_1184 /* a_i2d_fp.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_17 /* a_i2d_fp.c */; };
+		OBJ_1185 /* a_int.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_18 /* a_int.c */; };
+		OBJ_1186 /* a_mbstr.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_19 /* a_mbstr.c */; };
+		OBJ_1187 /* a_object.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_20 /* a_object.c */; };
+		OBJ_1188 /* a_octet.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_21 /* a_octet.c */; };
+		OBJ_1189 /* a_print.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_22 /* a_print.c */; };
+		OBJ_1190 /* a_strnid.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_23 /* a_strnid.c */; };
+		OBJ_1191 /* a_time.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_24 /* a_time.c */; };
+		OBJ_1192 /* a_type.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_25 /* a_type.c */; };
+		OBJ_1193 /* a_utctm.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_26 /* a_utctm.c */; };
+		OBJ_1194 /* a_utf8.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_27 /* a_utf8.c */; };
+		OBJ_1195 /* asn1_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_28 /* asn1_lib.c */; };
+		OBJ_1196 /* asn1_par.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_29 /* asn1_par.c */; };
+		OBJ_1197 /* asn_pack.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_30 /* asn_pack.c */; };
+		OBJ_1198 /* f_enum.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_31 /* f_enum.c */; };
+		OBJ_1199 /* f_int.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_32 /* f_int.c */; };
+		OBJ_1200 /* f_string.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_33 /* f_string.c */; };
+		OBJ_1201 /* tasn_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_34 /* tasn_dec.c */; };
+		OBJ_1202 /* tasn_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_35 /* tasn_enc.c */; };
+		OBJ_1203 /* tasn_fre.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_36 /* tasn_fre.c */; };
+		OBJ_1204 /* tasn_new.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_37 /* tasn_new.c */; };
+		OBJ_1205 /* tasn_typ.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_38 /* tasn_typ.c */; };
+		OBJ_1206 /* tasn_utl.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_39 /* tasn_utl.c */; };
+		OBJ_1207 /* time_support.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_40 /* time_support.c */; };
+		OBJ_1208 /* base64.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_42 /* base64.c */; };
+		OBJ_1209 /* bio.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_44 /* bio.c */; };
+		OBJ_1210 /* bio_mem.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_45 /* bio_mem.c */; };
+		OBJ_1211 /* connect.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_46 /* connect.c */; };
+		OBJ_1212 /* fd.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_47 /* fd.c */; };
+		OBJ_1213 /* file.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_48 /* file.c */; };
+		OBJ_1214 /* hexdump.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_49 /* hexdump.c */; };
+		OBJ_1215 /* pair.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_50 /* pair.c */; };
+		OBJ_1216 /* printf.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_51 /* printf.c */; };
+		OBJ_1217 /* socket.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_52 /* socket.c */; };
+		OBJ_1218 /* socket_helper.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_53 /* socket_helper.c */; };
+		OBJ_1219 /* bn_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_55 /* bn_asn1.c */; };
+		OBJ_1220 /* convert.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_56 /* convert.c */; };
+		OBJ_1221 /* buf.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_58 /* buf.c */; };
+		OBJ_1222 /* asn1_compat.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_60 /* asn1_compat.c */; };
+		OBJ_1223 /* ber.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_61 /* ber.c */; };
+		OBJ_1224 /* cbb.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_62 /* cbb.c */; };
+		OBJ_1225 /* cbs.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_63 /* cbs.c */; };
+		OBJ_1226 /* chacha.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_65 /* chacha.c */; };
+		OBJ_1227 /* cipher_extra.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_67 /* cipher_extra.c */; };
+		OBJ_1228 /* derive_key.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_68 /* derive_key.c */; };
+		OBJ_1229 /* e_aesctrhmac.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_69 /* e_aesctrhmac.c */; };
+		OBJ_1230 /* e_aesgcmsiv.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_70 /* e_aesgcmsiv.c */; };
+		OBJ_1231 /* e_chacha20poly1305.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_71 /* e_chacha20poly1305.c */; };
+		OBJ_1232 /* e_null.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_72 /* e_null.c */; };
+		OBJ_1233 /* e_rc2.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_73 /* e_rc2.c */; };
+		OBJ_1234 /* e_rc4.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_74 /* e_rc4.c */; };
+		OBJ_1235 /* e_ssl3.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_75 /* e_ssl3.c */; };
+		OBJ_1236 /* e_tls.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_76 /* e_tls.c */; };
+		OBJ_1237 /* tls_cbc.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_77 /* tls_cbc.c */; };
+		OBJ_1238 /* cmac.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_79 /* cmac.c */; };
+		OBJ_1239 /* conf.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_81 /* conf.c */; };
+		OBJ_1240 /* cpu-aarch64-linux.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_82 /* cpu-aarch64-linux.c */; };
+		OBJ_1241 /* cpu-arm-linux.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_83 /* cpu-arm-linux.c */; };
+		OBJ_1242 /* cpu-arm.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_84 /* cpu-arm.c */; };
+		OBJ_1243 /* cpu-intel.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_85 /* cpu-intel.c */; };
+		OBJ_1244 /* cpu-ppc64le.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_86 /* cpu-ppc64le.c */; };
+		OBJ_1245 /* crypto.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_87 /* crypto.c */; };
+		OBJ_1246 /* spake25519.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_89 /* spake25519.c */; };
+		OBJ_1247 /* x25519-x86_64.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_90 /* x25519-x86_64.c */; };
+		OBJ_1248 /* check.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_92 /* check.c */; };
+		OBJ_1249 /* dh.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_93 /* dh.c */; };
+		OBJ_1250 /* dh_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_94 /* dh_asn1.c */; };
+		OBJ_1251 /* params.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_95 /* params.c */; };
+		OBJ_1252 /* digest_extra.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_97 /* digest_extra.c */; };
+		OBJ_1253 /* dsa.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_99 /* dsa.c */; };
+		OBJ_1254 /* dsa_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_100 /* dsa_asn1.c */; };
+		OBJ_1255 /* ec_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_102 /* ec_asn1.c */; };
+		OBJ_1256 /* ecdh.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_104 /* ecdh.c */; };
+		OBJ_1257 /* ecdsa_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_106 /* ecdsa_asn1.c */; };
+		OBJ_1258 /* engine.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_108 /* engine.c */; };
+		OBJ_1259 /* err.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_110 /* err.c */; };
+		OBJ_1260 /* err_data.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_111 /* err_data.c */; };
+		OBJ_1261 /* digestsign.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_113 /* digestsign.c */; };
+		OBJ_1262 /* evp.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_114 /* evp.c */; };
+		OBJ_1263 /* evp_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_115 /* evp_asn1.c */; };
+		OBJ_1264 /* evp_ctx.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_116 /* evp_ctx.c */; };
+		OBJ_1265 /* p_dsa_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_117 /* p_dsa_asn1.c */; };
+		OBJ_1266 /* p_ec.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_118 /* p_ec.c */; };
+		OBJ_1267 /* p_ec_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_119 /* p_ec_asn1.c */; };
+		OBJ_1268 /* p_ed25519.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_120 /* p_ed25519.c */; };
+		OBJ_1269 /* p_ed25519_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_121 /* p_ed25519_asn1.c */; };
+		OBJ_1270 /* p_rsa.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_122 /* p_rsa.c */; };
+		OBJ_1271 /* p_rsa_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_123 /* p_rsa_asn1.c */; };
+		OBJ_1272 /* pbkdf.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_124 /* pbkdf.c */; };
+		OBJ_1273 /* print.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_125 /* print.c */; };
+		OBJ_1274 /* scrypt.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_126 /* scrypt.c */; };
+		OBJ_1275 /* sign.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_127 /* sign.c */; };
+		OBJ_1276 /* ex_data.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_128 /* ex_data.c */; };
+		OBJ_1277 /* aes.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_131 /* aes.c */; };
+		OBJ_1278 /* key_wrap.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_132 /* key_wrap.c */; };
+		OBJ_1279 /* mode_wrappers.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_133 /* mode_wrappers.c */; };
+		OBJ_1280 /* add.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_135 /* add.c */; };
+		OBJ_1281 /* bn.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_136 /* bn.c */; };
+		OBJ_1282 /* bytes.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_137 /* bytes.c */; };
+		OBJ_1283 /* cmp.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_138 /* cmp.c */; };
+		OBJ_1284 /* ctx.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_139 /* ctx.c */; };
+		OBJ_1285 /* div.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_140 /* div.c */; };
+		OBJ_1286 /* exponentiation.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_141 /* exponentiation.c */; };
+		OBJ_1287 /* gcd.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_142 /* gcd.c */; };
+		OBJ_1288 /* generic.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_143 /* generic.c */; };
+		OBJ_1289 /* jacobi.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_144 /* jacobi.c */; };
+		OBJ_1290 /* montgomery.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_145 /* montgomery.c */; };
+		OBJ_1291 /* montgomery_inv.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_146 /* montgomery_inv.c */; };
+		OBJ_1292 /* mul.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_147 /* mul.c */; };
+		OBJ_1293 /* prime.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_148 /* prime.c */; };
+		OBJ_1294 /* random.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_149 /* random.c */; };
+		OBJ_1295 /* rsaz_exp.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_150 /* rsaz_exp.c */; };
+		OBJ_1296 /* shift.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_151 /* shift.c */; };
+		OBJ_1297 /* sqrt.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_152 /* sqrt.c */; };
+		OBJ_1298 /* aead.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_154 /* aead.c */; };
+		OBJ_1299 /* cipher.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_155 /* cipher.c */; };
+		OBJ_1300 /* e_aes.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_156 /* e_aes.c */; };
+		OBJ_1301 /* e_des.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_157 /* e_des.c */; };
+		OBJ_1302 /* des.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_159 /* des.c */; };
+		OBJ_1303 /* digest.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_161 /* digest.c */; };
+		OBJ_1304 /* digests.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_162 /* digests.c */; };
+		OBJ_1305 /* ec.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_164 /* ec.c */; };
+		OBJ_1306 /* ec_key.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_165 /* ec_key.c */; };
+		OBJ_1307 /* ec_montgomery.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_166 /* ec_montgomery.c */; };
+		OBJ_1308 /* oct.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_167 /* oct.c */; };
+		OBJ_1309 /* p224-64.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_168 /* p224-64.c */; };
+		OBJ_1310 /* p256-64.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_169 /* p256-64.c */; };
+		OBJ_1311 /* p256-x86_64.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_170 /* p256-x86_64.c */; };
+		OBJ_1312 /* simple.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_171 /* simple.c */; };
+		OBJ_1313 /* util-64.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_172 /* util-64.c */; };
+		OBJ_1314 /* wnaf.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_173 /* wnaf.c */; };
+		OBJ_1315 /* ecdsa.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_175 /* ecdsa.c */; };
+		OBJ_1316 /* hmac.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_177 /* hmac.c */; };
+		OBJ_1317 /* is_fips.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_178 /* is_fips.c */; };
+		OBJ_1318 /* md4.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_180 /* md4.c */; };
+		OBJ_1319 /* md5.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_182 /* md5.c */; };
+		OBJ_1320 /* cbc.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_184 /* cbc.c */; };
+		OBJ_1321 /* cfb.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_185 /* cfb.c */; };
+		OBJ_1322 /* ctr.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_186 /* ctr.c */; };
+		OBJ_1323 /* gcm.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_187 /* gcm.c */; };
+		OBJ_1324 /* ofb.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_188 /* ofb.c */; };
+		OBJ_1325 /* polyval.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_189 /* polyval.c */; };
+		OBJ_1326 /* ctrdrbg.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_191 /* ctrdrbg.c */; };
+		OBJ_1327 /* rand.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_192 /* rand.c */; };
+		OBJ_1328 /* urandom.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_193 /* urandom.c */; };
+		OBJ_1329 /* blinding.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_195 /* blinding.c */; };
+		OBJ_1330 /* padding.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_196 /* padding.c */; };
+		OBJ_1331 /* rsa.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_197 /* rsa.c */; };
+		OBJ_1332 /* rsa_impl.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_198 /* rsa_impl.c */; };
+		OBJ_1333 /* sha1-altivec.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_200 /* sha1-altivec.c */; };
+		OBJ_1334 /* sha1.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_201 /* sha1.c */; };
+		OBJ_1335 /* sha256.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_202 /* sha256.c */; };
+		OBJ_1336 /* sha512.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_203 /* sha512.c */; };
+		OBJ_1337 /* hkdf.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_205 /* hkdf.c */; };
+		OBJ_1338 /* lhash.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_207 /* lhash.c */; };
+		OBJ_1339 /* mem.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_208 /* mem.c */; };
+		OBJ_1340 /* obj.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_210 /* obj.c */; };
+		OBJ_1341 /* obj_xref.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_211 /* obj_xref.c */; };
+		OBJ_1342 /* pem_all.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_213 /* pem_all.c */; };
+		OBJ_1343 /* pem_info.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_214 /* pem_info.c */; };
+		OBJ_1344 /* pem_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_215 /* pem_lib.c */; };
+		OBJ_1345 /* pem_oth.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_216 /* pem_oth.c */; };
+		OBJ_1346 /* pem_pk8.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_217 /* pem_pk8.c */; };
+		OBJ_1347 /* pem_pkey.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_218 /* pem_pkey.c */; };
+		OBJ_1348 /* pem_x509.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_219 /* pem_x509.c */; };
+		OBJ_1349 /* pem_xaux.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_220 /* pem_xaux.c */; };
+		OBJ_1350 /* pkcs7.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_222 /* pkcs7.c */; };
+		OBJ_1351 /* pkcs7_x509.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_223 /* pkcs7_x509.c */; };
+		OBJ_1352 /* p5_pbev2.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_225 /* p5_pbev2.c */; };
+		OBJ_1353 /* pkcs8.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_226 /* pkcs8.c */; };
+		OBJ_1354 /* pkcs8_x509.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_227 /* pkcs8_x509.c */; };
+		OBJ_1355 /* poly1305.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_229 /* poly1305.c */; };
+		OBJ_1356 /* poly1305_arm.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_230 /* poly1305_arm.c */; };
+		OBJ_1357 /* poly1305_vec.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_231 /* poly1305_vec.c */; };
+		OBJ_1358 /* pool.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_233 /* pool.c */; };
+		OBJ_1359 /* deterministic.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_235 /* deterministic.c */; };
+		OBJ_1360 /* forkunsafe.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_236 /* forkunsafe.c */; };
+		OBJ_1361 /* fuchsia.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_237 /* fuchsia.c */; };
+		OBJ_1362 /* rand_extra.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_238 /* rand_extra.c */; };
+		OBJ_1363 /* windows.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_239 /* windows.c */; };
+		OBJ_1364 /* rc4.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_241 /* rc4.c */; };
+		OBJ_1365 /* refcount_c11.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_242 /* refcount_c11.c */; };
+		OBJ_1366 /* refcount_lock.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_243 /* refcount_lock.c */; };
+		OBJ_1367 /* rsa_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_245 /* rsa_asn1.c */; };
+		OBJ_1368 /* stack.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_247 /* stack.c */; };
+		OBJ_1369 /* thread.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_248 /* thread.c */; };
+		OBJ_1370 /* thread_none.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_249 /* thread_none.c */; };
+		OBJ_1371 /* thread_pthread.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_250 /* thread_pthread.c */; };
+		OBJ_1372 /* thread_win.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_251 /* thread_win.c */; };
+		OBJ_1373 /* a_digest.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_253 /* a_digest.c */; };
+		OBJ_1374 /* a_sign.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_254 /* a_sign.c */; };
+		OBJ_1375 /* a_strex.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_255 /* a_strex.c */; };
+		OBJ_1376 /* a_verify.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_256 /* a_verify.c */; };
+		OBJ_1377 /* algorithm.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_257 /* algorithm.c */; };
+		OBJ_1378 /* asn1_gen.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_258 /* asn1_gen.c */; };
+		OBJ_1379 /* by_dir.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_259 /* by_dir.c */; };
+		OBJ_1380 /* by_file.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_260 /* by_file.c */; };
+		OBJ_1381 /* i2d_pr.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_261 /* i2d_pr.c */; };
+		OBJ_1382 /* rsa_pss.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_262 /* rsa_pss.c */; };
+		OBJ_1383 /* t_crl.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_263 /* t_crl.c */; };
+		OBJ_1384 /* t_req.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_264 /* t_req.c */; };
+		OBJ_1385 /* t_x509.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_265 /* t_x509.c */; };
+		OBJ_1386 /* t_x509a.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_266 /* t_x509a.c */; };
+		OBJ_1387 /* x509.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_267 /* x509.c */; };
+		OBJ_1388 /* x509_att.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_268 /* x509_att.c */; };
+		OBJ_1389 /* x509_cmp.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_269 /* x509_cmp.c */; };
+		OBJ_1390 /* x509_d2.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_270 /* x509_d2.c */; };
+		OBJ_1391 /* x509_def.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_271 /* x509_def.c */; };
+		OBJ_1392 /* x509_ext.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_272 /* x509_ext.c */; };
+		OBJ_1393 /* x509_lu.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_273 /* x509_lu.c */; };
+		OBJ_1394 /* x509_obj.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_274 /* x509_obj.c */; };
+		OBJ_1395 /* x509_r2x.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_275 /* x509_r2x.c */; };
+		OBJ_1396 /* x509_req.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_276 /* x509_req.c */; };
+		OBJ_1397 /* x509_set.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_277 /* x509_set.c */; };
+		OBJ_1398 /* x509_trs.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_278 /* x509_trs.c */; };
+		OBJ_1399 /* x509_txt.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_279 /* x509_txt.c */; };
+		OBJ_1400 /* x509_v3.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_280 /* x509_v3.c */; };
+		OBJ_1401 /* x509_vfy.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_281 /* x509_vfy.c */; };
+		OBJ_1402 /* x509_vpm.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_282 /* x509_vpm.c */; };
+		OBJ_1403 /* x509cset.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_283 /* x509cset.c */; };
+		OBJ_1404 /* x509name.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_284 /* x509name.c */; };
+		OBJ_1405 /* x509rset.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_285 /* x509rset.c */; };
+		OBJ_1406 /* x509spki.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_286 /* x509spki.c */; };
+		OBJ_1407 /* x_algor.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_287 /* x_algor.c */; };
+		OBJ_1408 /* x_all.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_288 /* x_all.c */; };
+		OBJ_1409 /* x_attrib.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_289 /* x_attrib.c */; };
+		OBJ_1410 /* x_crl.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_290 /* x_crl.c */; };
+		OBJ_1411 /* x_exten.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_291 /* x_exten.c */; };
+		OBJ_1412 /* x_info.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_292 /* x_info.c */; };
+		OBJ_1413 /* x_name.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_293 /* x_name.c */; };
+		OBJ_1414 /* x_pkey.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_294 /* x_pkey.c */; };
+		OBJ_1415 /* x_pubkey.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_295 /* x_pubkey.c */; };
+		OBJ_1416 /* x_req.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_296 /* x_req.c */; };
+		OBJ_1417 /* x_sig.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_297 /* x_sig.c */; };
+		OBJ_1418 /* x_spki.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_298 /* x_spki.c */; };
+		OBJ_1419 /* x_val.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_299 /* x_val.c */; };
+		OBJ_1420 /* x_x509.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_300 /* x_x509.c */; };
+		OBJ_1421 /* x_x509a.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_301 /* x_x509a.c */; };
+		OBJ_1422 /* pcy_cache.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_303 /* pcy_cache.c */; };
+		OBJ_1423 /* pcy_data.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_304 /* pcy_data.c */; };
+		OBJ_1424 /* pcy_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_305 /* pcy_lib.c */; };
+		OBJ_1425 /* pcy_map.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_306 /* pcy_map.c */; };
+		OBJ_1426 /* pcy_node.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_307 /* pcy_node.c */; };
+		OBJ_1427 /* pcy_tree.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_308 /* pcy_tree.c */; };
+		OBJ_1428 /* v3_akey.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_309 /* v3_akey.c */; };
+		OBJ_1429 /* v3_akeya.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_310 /* v3_akeya.c */; };
+		OBJ_1430 /* v3_alt.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_311 /* v3_alt.c */; };
+		OBJ_1431 /* v3_bcons.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_312 /* v3_bcons.c */; };
+		OBJ_1432 /* v3_bitst.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_313 /* v3_bitst.c */; };
+		OBJ_1433 /* v3_conf.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_314 /* v3_conf.c */; };
+		OBJ_1434 /* v3_cpols.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_315 /* v3_cpols.c */; };
+		OBJ_1435 /* v3_crld.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_316 /* v3_crld.c */; };
+		OBJ_1436 /* v3_enum.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_317 /* v3_enum.c */; };
+		OBJ_1437 /* v3_extku.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_318 /* v3_extku.c */; };
+		OBJ_1438 /* v3_genn.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_319 /* v3_genn.c */; };
+		OBJ_1439 /* v3_ia5.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_320 /* v3_ia5.c */; };
+		OBJ_1440 /* v3_info.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_321 /* v3_info.c */; };
+		OBJ_1441 /* v3_int.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_322 /* v3_int.c */; };
+		OBJ_1442 /* v3_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_323 /* v3_lib.c */; };
+		OBJ_1443 /* v3_ncons.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_324 /* v3_ncons.c */; };
+		OBJ_1444 /* v3_pci.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_325 /* v3_pci.c */; };
+		OBJ_1445 /* v3_pcia.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_326 /* v3_pcia.c */; };
+		OBJ_1446 /* v3_pcons.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_327 /* v3_pcons.c */; };
+		OBJ_1447 /* v3_pku.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_328 /* v3_pku.c */; };
+		OBJ_1448 /* v3_pmaps.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_329 /* v3_pmaps.c */; };
+		OBJ_1449 /* v3_prn.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_330 /* v3_prn.c */; };
+		OBJ_1450 /* v3_purp.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_331 /* v3_purp.c */; };
+		OBJ_1451 /* v3_skey.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_332 /* v3_skey.c */; };
+		OBJ_1452 /* v3_sxnet.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_333 /* v3_sxnet.c */; };
+		OBJ_1453 /* v3_utl.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_334 /* v3_utl.c */; };
+		OBJ_1454 /* err_data.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_335 /* err_data.c */; };
+		OBJ_1455 /* bio_ssl.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_337 /* bio_ssl.cc */; };
+		OBJ_1456 /* custom_extensions.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_338 /* custom_extensions.cc */; };
+		OBJ_1457 /* d1_both.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_339 /* d1_both.cc */; };
+		OBJ_1458 /* d1_lib.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_340 /* d1_lib.cc */; };
+		OBJ_1459 /* d1_pkt.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_341 /* d1_pkt.cc */; };
+		OBJ_1460 /* d1_srtp.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_342 /* d1_srtp.cc */; };
+		OBJ_1461 /* dtls_method.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_343 /* dtls_method.cc */; };
+		OBJ_1462 /* dtls_record.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_344 /* dtls_record.cc */; };
+		OBJ_1463 /* handshake.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_345 /* handshake.cc */; };
+		OBJ_1464 /* handshake_client.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_346 /* handshake_client.cc */; };
+		OBJ_1465 /* handshake_server.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_347 /* handshake_server.cc */; };
+		OBJ_1466 /* s3_both.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_348 /* s3_both.cc */; };
+		OBJ_1467 /* s3_lib.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_349 /* s3_lib.cc */; };
+		OBJ_1468 /* s3_pkt.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_350 /* s3_pkt.cc */; };
+		OBJ_1469 /* ssl_aead_ctx.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_351 /* ssl_aead_ctx.cc */; };
+		OBJ_1470 /* ssl_asn1.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_352 /* ssl_asn1.cc */; };
+		OBJ_1471 /* ssl_buffer.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_353 /* ssl_buffer.cc */; };
+		OBJ_1472 /* ssl_cert.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_354 /* ssl_cert.cc */; };
+		OBJ_1473 /* ssl_cipher.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_355 /* ssl_cipher.cc */; };
+		OBJ_1474 /* ssl_file.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_356 /* ssl_file.cc */; };
+		OBJ_1475 /* ssl_key_share.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_357 /* ssl_key_share.cc */; };
+		OBJ_1476 /* ssl_lib.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_358 /* ssl_lib.cc */; };
+		OBJ_1477 /* ssl_privkey.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_359 /* ssl_privkey.cc */; };
+		OBJ_1478 /* ssl_session.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_360 /* ssl_session.cc */; };
+		OBJ_1479 /* ssl_stat.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_361 /* ssl_stat.cc */; };
+		OBJ_1480 /* ssl_transcript.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_362 /* ssl_transcript.cc */; };
+		OBJ_1481 /* ssl_versions.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_363 /* ssl_versions.cc */; };
+		OBJ_1482 /* ssl_x509.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_364 /* ssl_x509.cc */; };
+		OBJ_1483 /* t1_enc.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_365 /* t1_enc.cc */; };
+		OBJ_1484 /* t1_lib.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_366 /* t1_lib.cc */; };
+		OBJ_1485 /* tls13_both.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_367 /* tls13_both.cc */; };
+		OBJ_1486 /* tls13_client.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_368 /* tls13_client.cc */; };
+		OBJ_1487 /* tls13_enc.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_369 /* tls13_enc.cc */; };
+		OBJ_1488 /* tls13_server.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_370 /* tls13_server.cc */; };
+		OBJ_1489 /* tls_method.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_371 /* tls_method.cc */; };
+		OBJ_1490 /* tls_record.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_372 /* tls_record.cc */; };
+		OBJ_1491 /* curve25519.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_375 /* curve25519.c */; };
+		OBJ_1498 /* byte_buffer.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_505 /* byte_buffer.c */; };
+		OBJ_1499 /* call.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_506 /* call.c */; };
+		OBJ_1500 /* channel.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_507 /* channel.c */; };
+		OBJ_1501 /* completion_queue.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_508 /* completion_queue.c */; };
+		OBJ_1502 /* event.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_509 /* event.c */; };
+		OBJ_1503 /* handler.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_510 /* handler.c */; };
+		OBJ_1504 /* internal.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_511 /* internal.c */; };
+		OBJ_1505 /* metadata.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_512 /* metadata.c */; };
+		OBJ_1506 /* mutex.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_513 /* mutex.c */; };
+		OBJ_1507 /* observers.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_514 /* observers.c */; };
+		OBJ_1508 /* operations.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_515 /* operations.c */; };
+		OBJ_1509 /* server.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_516 /* server.c */; };
+		OBJ_1510 /* grpc_context.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_521 /* grpc_context.cc */; };
+		OBJ_1511 /* backup_poller.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_524 /* backup_poller.cc */; };
+		OBJ_1512 /* channel_connectivity.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_525 /* channel_connectivity.cc */; };
+		OBJ_1513 /* client_channel.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_526 /* client_channel.cc */; };
+		OBJ_1514 /* client_channel_factory.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_527 /* client_channel_factory.cc */; };
+		OBJ_1515 /* client_channel_plugin.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_528 /* client_channel_plugin.cc */; };
+		OBJ_1516 /* connector.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_529 /* connector.cc */; };
+		OBJ_1517 /* http_connect_handshaker.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_530 /* http_connect_handshaker.cc */; };
+		OBJ_1518 /* http_proxy.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_531 /* http_proxy.cc */; };
+		OBJ_1519 /* lb_policy.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_532 /* lb_policy.cc */; };
+		OBJ_1520 /* client_load_reporting_filter.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_535 /* client_load_reporting_filter.cc */; };
+		OBJ_1521 /* grpclb.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_536 /* grpclb.cc */; };
+		OBJ_1522 /* grpclb_channel_secure.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_537 /* grpclb_channel_secure.cc */; };
+		OBJ_1523 /* grpclb_client_stats.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_538 /* grpclb_client_stats.cc */; };
+		OBJ_1524 /* load_balancer_api.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_539 /* load_balancer_api.cc */; };
+		OBJ_1525 /* load_balancer.pb.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_544 /* load_balancer.pb.c */; };
+		OBJ_1526 /* pick_first.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_546 /* pick_first.cc */; };
+		OBJ_1527 /* round_robin.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_548 /* round_robin.cc */; };
+		OBJ_1528 /* lb_policy_factory.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_549 /* lb_policy_factory.cc */; };
+		OBJ_1529 /* lb_policy_registry.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_550 /* lb_policy_registry.cc */; };
+		OBJ_1530 /* method_params.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_551 /* method_params.cc */; };
+		OBJ_1531 /* parse_address.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_552 /* parse_address.cc */; };
+		OBJ_1532 /* proxy_mapper.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_553 /* proxy_mapper.cc */; };
+		OBJ_1533 /* proxy_mapper_registry.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_554 /* proxy_mapper_registry.cc */; };
+		OBJ_1534 /* resolver.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_555 /* resolver.cc */; };
+		OBJ_1535 /* dns_resolver_ares.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_559 /* dns_resolver_ares.cc */; };
+		OBJ_1536 /* grpc_ares_ev_driver_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_560 /* grpc_ares_ev_driver_posix.cc */; };
+		OBJ_1537 /* grpc_ares_wrapper.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_561 /* grpc_ares_wrapper.cc */; };
+		OBJ_1538 /* grpc_ares_wrapper_fallback.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_562 /* grpc_ares_wrapper_fallback.cc */; };
+		OBJ_1539 /* dns_resolver.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_564 /* dns_resolver.cc */; };
+		OBJ_1540 /* fake_resolver.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_566 /* fake_resolver.cc */; };
+		OBJ_1541 /* sockaddr_resolver.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_568 /* sockaddr_resolver.cc */; };
+		OBJ_1542 /* resolver_registry.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_569 /* resolver_registry.cc */; };
+		OBJ_1543 /* retry_throttle.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_570 /* retry_throttle.cc */; };
+		OBJ_1544 /* subchannel.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_571 /* subchannel.cc */; };
+		OBJ_1545 /* subchannel_index.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_572 /* subchannel_index.cc */; };
+		OBJ_1546 /* uri_parser.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_573 /* uri_parser.cc */; };
+		OBJ_1547 /* deadline_filter.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_575 /* deadline_filter.cc */; };
+		OBJ_1548 /* http_client_filter.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_578 /* http_client_filter.cc */; };
+		OBJ_1549 /* client_authority_filter.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_579 /* client_authority_filter.cc */; };
+		OBJ_1550 /* http_filters_plugin.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_580 /* http_filters_plugin.cc */; };
+		OBJ_1551 /* message_compress_filter.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_582 /* message_compress_filter.cc */; };
+		OBJ_1552 /* http_server_filter.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_584 /* http_server_filter.cc */; };
+		OBJ_1553 /* server_load_reporting_filter.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_586 /* server_load_reporting_filter.cc */; };
+		OBJ_1554 /* server_load_reporting_plugin.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_587 /* server_load_reporting_plugin.cc */; };
+		OBJ_1555 /* max_age_filter.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_589 /* max_age_filter.cc */; };
+		OBJ_1556 /* message_size_filter.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_591 /* message_size_filter.cc */; };
+		OBJ_1557 /* workaround_cronet_compression_filter.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_593 /* workaround_cronet_compression_filter.cc */; };
+		OBJ_1558 /* workaround_utils.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_594 /* workaround_utils.cc */; };
+		OBJ_1559 /* alpn.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_598 /* alpn.cc */; };
+		OBJ_1560 /* authority.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_600 /* authority.cc */; };
+		OBJ_1561 /* chttp2_connector.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_601 /* chttp2_connector.cc */; };
+		OBJ_1562 /* channel_create.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_603 /* channel_create.cc */; };
+		OBJ_1563 /* channel_create_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_604 /* channel_create_posix.cc */; };
+		OBJ_1564 /* secure_channel_create.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_606 /* secure_channel_create.cc */; };
+		OBJ_1565 /* chttp2_server.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_608 /* chttp2_server.cc */; };
+		OBJ_1566 /* server_chttp2.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_610 /* server_chttp2.cc */; };
+		OBJ_1567 /* server_chttp2_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_611 /* server_chttp2_posix.cc */; };
+		OBJ_1568 /* server_secure_chttp2.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_613 /* server_secure_chttp2.cc */; };
+		OBJ_1569 /* bin_decoder.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_615 /* bin_decoder.cc */; };
+		OBJ_1570 /* bin_encoder.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_616 /* bin_encoder.cc */; };
+		OBJ_1571 /* chttp2_plugin.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_617 /* chttp2_plugin.cc */; };
+		OBJ_1572 /* chttp2_transport.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_618 /* chttp2_transport.cc */; };
+		OBJ_1573 /* flow_control.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_619 /* flow_control.cc */; };
+		OBJ_1574 /* frame_data.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_620 /* frame_data.cc */; };
+		OBJ_1575 /* frame_goaway.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_621 /* frame_goaway.cc */; };
+		OBJ_1576 /* frame_ping.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_622 /* frame_ping.cc */; };
+		OBJ_1577 /* frame_rst_stream.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_623 /* frame_rst_stream.cc */; };
+		OBJ_1578 /* frame_settings.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_624 /* frame_settings.cc */; };
+		OBJ_1579 /* frame_window_update.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_625 /* frame_window_update.cc */; };
+		OBJ_1580 /* hpack_encoder.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_626 /* hpack_encoder.cc */; };
+		OBJ_1581 /* hpack_parser.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_627 /* hpack_parser.cc */; };
+		OBJ_1582 /* hpack_table.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_628 /* hpack_table.cc */; };
+		OBJ_1583 /* http2_settings.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_629 /* http2_settings.cc */; };
+		OBJ_1584 /* huffsyms.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_630 /* huffsyms.cc */; };
+		OBJ_1585 /* incoming_metadata.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_631 /* incoming_metadata.cc */; };
+		OBJ_1586 /* parsing.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_632 /* parsing.cc */; };
+		OBJ_1587 /* stream_lists.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_633 /* stream_lists.cc */; };
+		OBJ_1588 /* stream_map.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_634 /* stream_map.cc */; };
+		OBJ_1589 /* varint.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_635 /* varint.cc */; };
+		OBJ_1590 /* writing.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_636 /* writing.cc */; };
+		OBJ_1591 /* inproc_plugin.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_638 /* inproc_plugin.cc */; };
+		OBJ_1592 /* inproc_transport.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_639 /* inproc_transport.cc */; };
+		OBJ_1593 /* avl.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_642 /* avl.cc */; };
+		OBJ_1594 /* backoff.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_644 /* backoff.cc */; };
+		OBJ_1595 /* channel_args.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_646 /* channel_args.cc */; };
+		OBJ_1596 /* channel_stack.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_647 /* channel_stack.cc */; };
+		OBJ_1597 /* channel_stack_builder.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_648 /* channel_stack_builder.cc */; };
+		OBJ_1598 /* channel_trace.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_649 /* channel_trace.cc */; };
+		OBJ_1599 /* channel_trace_registry.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_650 /* channel_trace_registry.cc */; };
+		OBJ_1600 /* connected_channel.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_651 /* connected_channel.cc */; };
+		OBJ_1601 /* handshaker.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_652 /* handshaker.cc */; };
+		OBJ_1602 /* handshaker_factory.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_653 /* handshaker_factory.cc */; };
+		OBJ_1603 /* handshaker_registry.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_654 /* handshaker_registry.cc */; };
+		OBJ_1604 /* status_util.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_655 /* status_util.cc */; };
+		OBJ_1605 /* compression.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_657 /* compression.cc */; };
+		OBJ_1606 /* compression_internal.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_658 /* compression_internal.cc */; };
+		OBJ_1607 /* message_compress.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_659 /* message_compress.cc */; };
+		OBJ_1608 /* stream_compression.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_660 /* stream_compression.cc */; };
+		OBJ_1609 /* stream_compression_gzip.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_661 /* stream_compression_gzip.cc */; };
+		OBJ_1610 /* stream_compression_identity.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_662 /* stream_compression_identity.cc */; };
+		OBJ_1611 /* stats.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_664 /* stats.cc */; };
+		OBJ_1612 /* stats_data.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_665 /* stats_data.cc */; };
+		OBJ_1613 /* trace.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_666 /* trace.cc */; };
+		OBJ_1614 /* alloc.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_668 /* alloc.cc */; };
+		OBJ_1615 /* arena.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_669 /* arena.cc */; };
+		OBJ_1616 /* atm.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_670 /* atm.cc */; };
+		OBJ_1617 /* cpu_iphone.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_671 /* cpu_iphone.cc */; };
+		OBJ_1618 /* cpu_linux.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_672 /* cpu_linux.cc */; };
+		OBJ_1619 /* cpu_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_673 /* cpu_posix.cc */; };
+		OBJ_1620 /* cpu_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_674 /* cpu_windows.cc */; };
+		OBJ_1621 /* env_linux.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_675 /* env_linux.cc */; };
+		OBJ_1622 /* env_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_676 /* env_posix.cc */; };
+		OBJ_1623 /* env_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_677 /* env_windows.cc */; };
+		OBJ_1624 /* fork.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_678 /* fork.cc */; };
+		OBJ_1625 /* host_port.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_679 /* host_port.cc */; };
+		OBJ_1626 /* log.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_680 /* log.cc */; };
+		OBJ_1627 /* log_android.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_681 /* log_android.cc */; };
+		OBJ_1628 /* log_linux.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_682 /* log_linux.cc */; };
+		OBJ_1629 /* log_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_683 /* log_posix.cc */; };
+		OBJ_1630 /* log_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_684 /* log_windows.cc */; };
+		OBJ_1631 /* mpscq.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_685 /* mpscq.cc */; };
+		OBJ_1632 /* murmur_hash.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_686 /* murmur_hash.cc */; };
+		OBJ_1633 /* string.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_687 /* string.cc */; };
+		OBJ_1634 /* string_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_688 /* string_posix.cc */; };
+		OBJ_1635 /* string_util_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_689 /* string_util_windows.cc */; };
+		OBJ_1636 /* string_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_690 /* string_windows.cc */; };
+		OBJ_1637 /* sync.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_691 /* sync.cc */; };
+		OBJ_1638 /* sync_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_692 /* sync_posix.cc */; };
+		OBJ_1639 /* sync_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_693 /* sync_windows.cc */; };
+		OBJ_1640 /* time.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_694 /* time.cc */; };
+		OBJ_1641 /* time_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_695 /* time_posix.cc */; };
+		OBJ_1642 /* time_precise.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_696 /* time_precise.cc */; };
+		OBJ_1643 /* time_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_697 /* time_windows.cc */; };
+		OBJ_1644 /* tls_pthread.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_698 /* tls_pthread.cc */; };
+		OBJ_1645 /* tmpfile_msys.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_699 /* tmpfile_msys.cc */; };
+		OBJ_1646 /* tmpfile_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_700 /* tmpfile_posix.cc */; };
+		OBJ_1647 /* tmpfile_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_701 /* tmpfile_windows.cc */; };
+		OBJ_1648 /* wrap_memcpy.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_702 /* wrap_memcpy.cc */; };
+		OBJ_1649 /* thd_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_704 /* thd_posix.cc */; };
+		OBJ_1650 /* thd_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_705 /* thd_windows.cc */; };
+		OBJ_1651 /* format_request.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_707 /* format_request.cc */; };
+		OBJ_1652 /* httpcli.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_708 /* httpcli.cc */; };
+		OBJ_1653 /* httpcli_security_connector.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_709 /* httpcli_security_connector.cc */; };
+		OBJ_1654 /* parser.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_710 /* parser.cc */; };
+		OBJ_1655 /* call_combiner.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_712 /* call_combiner.cc */; };
+		OBJ_1656 /* combiner.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_713 /* combiner.cc */; };
+		OBJ_1657 /* endpoint.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_714 /* endpoint.cc */; };
+		OBJ_1658 /* endpoint_pair_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_715 /* endpoint_pair_posix.cc */; };
+		OBJ_1659 /* endpoint_pair_uv.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_716 /* endpoint_pair_uv.cc */; };
+		OBJ_1660 /* endpoint_pair_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_717 /* endpoint_pair_windows.cc */; };
+		OBJ_1661 /* error.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_718 /* error.cc */; };
+		OBJ_1662 /* ev_epoll1_linux.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_719 /* ev_epoll1_linux.cc */; };
+		OBJ_1663 /* ev_epollex_linux.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_720 /* ev_epollex_linux.cc */; };
+		OBJ_1664 /* ev_epollsig_linux.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_721 /* ev_epollsig_linux.cc */; };
+		OBJ_1665 /* ev_poll_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_722 /* ev_poll_posix.cc */; };
+		OBJ_1666 /* ev_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_723 /* ev_posix.cc */; };
+		OBJ_1667 /* ev_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_724 /* ev_windows.cc */; };
+		OBJ_1668 /* exec_ctx.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_725 /* exec_ctx.cc */; };
+		OBJ_1669 /* executor.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_726 /* executor.cc */; };
+		OBJ_1670 /* fork_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_727 /* fork_posix.cc */; };
+		OBJ_1671 /* fork_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_728 /* fork_windows.cc */; };
+		OBJ_1672 /* gethostname_fallback.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_729 /* gethostname_fallback.cc */; };
+		OBJ_1673 /* gethostname_host_name_max.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_730 /* gethostname_host_name_max.cc */; };
+		OBJ_1674 /* gethostname_sysconf.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_731 /* gethostname_sysconf.cc */; };
+		OBJ_1675 /* iocp_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_732 /* iocp_windows.cc */; };
+		OBJ_1676 /* iomgr.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_733 /* iomgr.cc */; };
+		OBJ_1677 /* iomgr_custom.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_734 /* iomgr_custom.cc */; };
+		OBJ_1678 /* iomgr_internal.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_735 /* iomgr_internal.cc */; };
+		OBJ_1679 /* iomgr_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_736 /* iomgr_posix.cc */; };
+		OBJ_1680 /* iomgr_uv.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_737 /* iomgr_uv.cc */; };
+		OBJ_1681 /* iomgr_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_738 /* iomgr_windows.cc */; };
+		OBJ_1682 /* is_epollexclusive_available.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_739 /* is_epollexclusive_available.cc */; };
+		OBJ_1683 /* load_file.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_740 /* load_file.cc */; };
+		OBJ_1684 /* lockfree_event.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_741 /* lockfree_event.cc */; };
+		OBJ_1685 /* network_status_tracker.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_742 /* network_status_tracker.cc */; };
+		OBJ_1686 /* polling_entity.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_743 /* polling_entity.cc */; };
+		OBJ_1687 /* pollset.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_744 /* pollset.cc */; };
+		OBJ_1688 /* pollset_custom.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_745 /* pollset_custom.cc */; };
+		OBJ_1689 /* pollset_set.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_746 /* pollset_set.cc */; };
+		OBJ_1690 /* pollset_set_custom.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_747 /* pollset_set_custom.cc */; };
+		OBJ_1691 /* pollset_set_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_748 /* pollset_set_windows.cc */; };
+		OBJ_1692 /* pollset_uv.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_749 /* pollset_uv.cc */; };
+		OBJ_1693 /* pollset_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_750 /* pollset_windows.cc */; };
+		OBJ_1694 /* resolve_address.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_751 /* resolve_address.cc */; };
+		OBJ_1695 /* resolve_address_custom.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_752 /* resolve_address_custom.cc */; };
+		OBJ_1696 /* resolve_address_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_753 /* resolve_address_posix.cc */; };
+		OBJ_1697 /* resolve_address_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_754 /* resolve_address_windows.cc */; };
+		OBJ_1698 /* resource_quota.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_755 /* resource_quota.cc */; };
+		OBJ_1699 /* sockaddr_utils.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_756 /* sockaddr_utils.cc */; };
+		OBJ_1700 /* socket_factory_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_757 /* socket_factory_posix.cc */; };
+		OBJ_1701 /* socket_mutator.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_758 /* socket_mutator.cc */; };
+		OBJ_1702 /* socket_utils_common_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_759 /* socket_utils_common_posix.cc */; };
+		OBJ_1703 /* socket_utils_linux.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_760 /* socket_utils_linux.cc */; };
+		OBJ_1704 /* socket_utils_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_761 /* socket_utils_posix.cc */; };
+		OBJ_1705 /* socket_utils_uv.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_762 /* socket_utils_uv.cc */; };
+		OBJ_1706 /* socket_utils_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_763 /* socket_utils_windows.cc */; };
+		OBJ_1707 /* socket_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_764 /* socket_windows.cc */; };
+		OBJ_1708 /* tcp_client.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_765 /* tcp_client.cc */; };
+		OBJ_1709 /* tcp_client_custom.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_766 /* tcp_client_custom.cc */; };
+		OBJ_1710 /* tcp_client_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_767 /* tcp_client_posix.cc */; };
+		OBJ_1711 /* tcp_client_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_768 /* tcp_client_windows.cc */; };
+		OBJ_1712 /* tcp_custom.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_769 /* tcp_custom.cc */; };
+		OBJ_1713 /* tcp_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_770 /* tcp_posix.cc */; };
+		OBJ_1714 /* tcp_server.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_771 /* tcp_server.cc */; };
+		OBJ_1715 /* tcp_server_custom.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_772 /* tcp_server_custom.cc */; };
+		OBJ_1716 /* tcp_server_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_773 /* tcp_server_posix.cc */; };
+		OBJ_1717 /* tcp_server_utils_posix_common.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_774 /* tcp_server_utils_posix_common.cc */; };
+		OBJ_1718 /* tcp_server_utils_posix_ifaddrs.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_775 /* tcp_server_utils_posix_ifaddrs.cc */; };
+		OBJ_1719 /* tcp_server_utils_posix_noifaddrs.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_776 /* tcp_server_utils_posix_noifaddrs.cc */; };
+		OBJ_1720 /* tcp_server_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_777 /* tcp_server_windows.cc */; };
+		OBJ_1721 /* tcp_uv.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_778 /* tcp_uv.cc */; };
+		OBJ_1722 /* tcp_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_779 /* tcp_windows.cc */; };
+		OBJ_1723 /* time_averaged_stats.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_780 /* time_averaged_stats.cc */; };
+		OBJ_1724 /* timer.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_781 /* timer.cc */; };
+		OBJ_1725 /* timer_custom.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_782 /* timer_custom.cc */; };
+		OBJ_1726 /* timer_generic.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_783 /* timer_generic.cc */; };
+		OBJ_1727 /* timer_heap.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_784 /* timer_heap.cc */; };
+		OBJ_1728 /* timer_manager.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_785 /* timer_manager.cc */; };
+		OBJ_1729 /* timer_uv.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_786 /* timer_uv.cc */; };
+		OBJ_1730 /* udp_server.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_787 /* udp_server.cc */; };
+		OBJ_1731 /* unix_sockets_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_788 /* unix_sockets_posix.cc */; };
+		OBJ_1732 /* unix_sockets_posix_noop.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_789 /* unix_sockets_posix_noop.cc */; };
+		OBJ_1733 /* wakeup_fd_cv.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_790 /* wakeup_fd_cv.cc */; };
+		OBJ_1734 /* wakeup_fd_eventfd.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_791 /* wakeup_fd_eventfd.cc */; };
+		OBJ_1735 /* wakeup_fd_nospecial.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_792 /* wakeup_fd_nospecial.cc */; };
+		OBJ_1736 /* wakeup_fd_pipe.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_793 /* wakeup_fd_pipe.cc */; };
+		OBJ_1737 /* wakeup_fd_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_794 /* wakeup_fd_posix.cc */; };
+		OBJ_1738 /* json.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_796 /* json.cc */; };
+		OBJ_1739 /* json_reader.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_797 /* json_reader.cc */; };
+		OBJ_1740 /* json_string.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_798 /* json_string.cc */; };
+		OBJ_1741 /* json_writer.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_799 /* json_writer.cc */; };
+		OBJ_1742 /* basic_timers.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_801 /* basic_timers.cc */; };
+		OBJ_1743 /* stap_timers.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_802 /* stap_timers.cc */; };
+		OBJ_1744 /* security_context.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_805 /* security_context.cc */; };
+		OBJ_1745 /* alts_credentials.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_808 /* alts_credentials.cc */; };
+		OBJ_1746 /* check_gcp_environment.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_809 /* check_gcp_environment.cc */; };
+		OBJ_1747 /* check_gcp_environment_linux.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_810 /* check_gcp_environment_linux.cc */; };
+		OBJ_1748 /* check_gcp_environment_no_op.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_811 /* check_gcp_environment_no_op.cc */; };
+		OBJ_1749 /* check_gcp_environment_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_812 /* check_gcp_environment_windows.cc */; };
+		OBJ_1750 /* grpc_alts_credentials_client_options.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_813 /* grpc_alts_credentials_client_options.cc */; };
+		OBJ_1751 /* grpc_alts_credentials_options.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_814 /* grpc_alts_credentials_options.cc */; };
+		OBJ_1752 /* grpc_alts_credentials_server_options.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_815 /* grpc_alts_credentials_server_options.cc */; };
+		OBJ_1753 /* composite_credentials.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_817 /* composite_credentials.cc */; };
+		OBJ_1754 /* credentials.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_818 /* credentials.cc */; };
+		OBJ_1755 /* credentials_metadata.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_819 /* credentials_metadata.cc */; };
+		OBJ_1756 /* fake_credentials.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_821 /* fake_credentials.cc */; };
+		OBJ_1757 /* credentials_generic.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_823 /* credentials_generic.cc */; };
+		OBJ_1758 /* google_default_credentials.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_824 /* google_default_credentials.cc */; };
+		OBJ_1759 /* iam_credentials.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_826 /* iam_credentials.cc */; };
+		OBJ_1760 /* json_token.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_828 /* json_token.cc */; };
+		OBJ_1761 /* jwt_credentials.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_829 /* jwt_credentials.cc */; };
+		OBJ_1762 /* jwt_verifier.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_830 /* jwt_verifier.cc */; };
+		OBJ_1763 /* oauth2_credentials.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_832 /* oauth2_credentials.cc */; };
+		OBJ_1764 /* plugin_credentials.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_834 /* plugin_credentials.cc */; };
+		OBJ_1765 /* ssl_credentials.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_836 /* ssl_credentials.cc */; };
+		OBJ_1766 /* alts_security_connector.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_838 /* alts_security_connector.cc */; };
+		OBJ_1767 /* security_connector.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_839 /* security_connector.cc */; };
+		OBJ_1768 /* client_auth_filter.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_841 /* client_auth_filter.cc */; };
+		OBJ_1769 /* secure_endpoint.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_842 /* secure_endpoint.cc */; };
+		OBJ_1770 /* security_handshaker.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_843 /* security_handshaker.cc */; };
+		OBJ_1771 /* server_auth_filter.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_844 /* server_auth_filter.cc */; };
+		OBJ_1772 /* target_authority_table.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_845 /* target_authority_table.cc */; };
+		OBJ_1773 /* tsi_error.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_846 /* tsi_error.cc */; };
+		OBJ_1774 /* json_util.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_848 /* json_util.cc */; };
+		OBJ_1775 /* b64.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_850 /* b64.cc */; };
+		OBJ_1776 /* percent_encoding.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_851 /* percent_encoding.cc */; };
+		OBJ_1777 /* slice.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_852 /* slice.cc */; };
+		OBJ_1778 /* slice_buffer.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_853 /* slice_buffer.cc */; };
+		OBJ_1779 /* slice_intern.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_854 /* slice_intern.cc */; };
+		OBJ_1780 /* slice_string_helpers.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_855 /* slice_string_helpers.cc */; };
+		OBJ_1781 /* api_trace.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_857 /* api_trace.cc */; };
+		OBJ_1782 /* byte_buffer.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_858 /* byte_buffer.cc */; };
+		OBJ_1783 /* byte_buffer_reader.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_859 /* byte_buffer_reader.cc */; };
+		OBJ_1784 /* call.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_860 /* call.cc */; };
+		OBJ_1785 /* call_details.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_861 /* call_details.cc */; };
+		OBJ_1786 /* call_log_batch.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_862 /* call_log_batch.cc */; };
+		OBJ_1787 /* channel.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_863 /* channel.cc */; };
+		OBJ_1788 /* channel_init.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_864 /* channel_init.cc */; };
+		OBJ_1789 /* channel_ping.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_865 /* channel_ping.cc */; };
+		OBJ_1790 /* channel_stack_type.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_866 /* channel_stack_type.cc */; };
+		OBJ_1791 /* completion_queue.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_867 /* completion_queue.cc */; };
+		OBJ_1792 /* completion_queue_factory.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_868 /* completion_queue_factory.cc */; };
+		OBJ_1793 /* event_string.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_869 /* event_string.cc */; };
+		OBJ_1794 /* init.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_870 /* init.cc */; };
+		OBJ_1795 /* init_secure.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_871 /* init_secure.cc */; };
+		OBJ_1796 /* lame_client.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_872 /* lame_client.cc */; };
+		OBJ_1797 /* metadata_array.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_873 /* metadata_array.cc */; };
+		OBJ_1798 /* server.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_874 /* server.cc */; };
+		OBJ_1799 /* validate_metadata.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_875 /* validate_metadata.cc */; };
+		OBJ_1800 /* version.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_876 /* version.cc */; };
+		OBJ_1801 /* bdp_estimator.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_878 /* bdp_estimator.cc */; };
+		OBJ_1802 /* byte_stream.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_879 /* byte_stream.cc */; };
+		OBJ_1803 /* connectivity_state.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_880 /* connectivity_state.cc */; };
+		OBJ_1804 /* error_utils.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_881 /* error_utils.cc */; };
+		OBJ_1805 /* metadata.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_882 /* metadata.cc */; };
+		OBJ_1806 /* metadata_batch.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_883 /* metadata_batch.cc */; };
+		OBJ_1807 /* pid_controller.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_884 /* pid_controller.cc */; };
+		OBJ_1808 /* service_config.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_885 /* service_config.cc */; };
+		OBJ_1809 /* static_metadata.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_886 /* static_metadata.cc */; };
+		OBJ_1810 /* status_conversion.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_887 /* status_conversion.cc */; };
+		OBJ_1811 /* status_metadata.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_888 /* status_metadata.cc */; };
+		OBJ_1812 /* timeout_encoding.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_889 /* timeout_encoding.cc */; };
+		OBJ_1813 /* transport.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_890 /* transport.cc */; };
+		OBJ_1814 /* transport_op_string.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_891 /* transport_op_string.cc */; };
+		OBJ_1815 /* grpc_plugin_registry.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_893 /* grpc_plugin_registry.cc */; };
+		OBJ_1816 /* aes_gcm.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_897 /* aes_gcm.cc */; };
+		OBJ_1817 /* gsec.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_898 /* gsec.cc */; };
+		OBJ_1818 /* alts_counter.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_900 /* alts_counter.cc */; };
+		OBJ_1819 /* alts_crypter.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_901 /* alts_crypter.cc */; };
+		OBJ_1820 /* alts_frame_protector.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_902 /* alts_frame_protector.cc */; };
+		OBJ_1821 /* alts_record_protocol_crypter_common.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_903 /* alts_record_protocol_crypter_common.cc */; };
+		OBJ_1822 /* alts_seal_privacy_integrity_crypter.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_904 /* alts_seal_privacy_integrity_crypter.cc */; };
+		OBJ_1823 /* alts_unseal_privacy_integrity_crypter.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_905 /* alts_unseal_privacy_integrity_crypter.cc */; };
+		OBJ_1824 /* frame_handler.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_906 /* frame_handler.cc */; };
+		OBJ_1825 /* alts_handshaker_client.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_908 /* alts_handshaker_client.cc */; };
+		OBJ_1826 /* alts_handshaker_service_api.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_909 /* alts_handshaker_service_api.cc */; };
+		OBJ_1827 /* alts_handshaker_service_api_util.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_910 /* alts_handshaker_service_api_util.cc */; };
+		OBJ_1828 /* alts_tsi_event.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_911 /* alts_tsi_event.cc */; };
+		OBJ_1829 /* alts_tsi_handshaker.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_912 /* alts_tsi_handshaker.cc */; };
+		OBJ_1830 /* alts_tsi_utils.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_913 /* alts_tsi_utils.cc */; };
+		OBJ_1831 /* altscontext.pb.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_914 /* altscontext.pb.c */; };
+		OBJ_1832 /* handshaker.pb.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_915 /* handshaker.pb.c */; };
+		OBJ_1833 /* transport_security_common.pb.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_916 /* transport_security_common.pb.c */; };
+		OBJ_1834 /* transport_security_common_api.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_917 /* transport_security_common_api.cc */; };
+		OBJ_1835 /* alts_grpc_integrity_only_record_protocol.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_919 /* alts_grpc_integrity_only_record_protocol.cc */; };
+		OBJ_1836 /* alts_grpc_privacy_integrity_record_protocol.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_920 /* alts_grpc_privacy_integrity_record_protocol.cc */; };
+		OBJ_1837 /* alts_grpc_record_protocol_common.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_921 /* alts_grpc_record_protocol_common.cc */; };
+		OBJ_1838 /* alts_iovec_record_protocol.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_922 /* alts_iovec_record_protocol.cc */; };
+		OBJ_1839 /* alts_zero_copy_grpc_protector.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_923 /* alts_zero_copy_grpc_protector.cc */; };
+		OBJ_1840 /* alts_transport_security.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_924 /* alts_transport_security.cc */; };
+		OBJ_1841 /* fake_transport_security.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_925 /* fake_transport_security.cc */; };
+		OBJ_1842 /* ssl_session_boringssl.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_928 /* ssl_session_boringssl.cc */; };
+		OBJ_1843 /* ssl_session_cache.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_929 /* ssl_session_cache.cc */; };
+		OBJ_1844 /* ssl_session_openssl.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_930 /* ssl_session_openssl.cc */; };
+		OBJ_1845 /* ssl_transport_security.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_931 /* ssl_transport_security.cc */; };
+		OBJ_1846 /* transport_security.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_932 /* transport_security.cc */; };
+		OBJ_1847 /* transport_security_adapter.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_933 /* transport_security_adapter.cc */; };
+		OBJ_1848 /* transport_security_grpc.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_934 /* transport_security_grpc.cc */; };
+		OBJ_1849 /* pb_common.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_937 /* pb_common.c */; };
+		OBJ_1850 /* pb_decode.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_938 /* pb_decode.c */; };
+		OBJ_1851 /* pb_encode.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_939 /* pb_encode.c */; };
+		OBJ_1853 /* BoringSSL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = SwiftGRPC::BoringSSL::Product /* BoringSSL.framework */; };
+		OBJ_1926 /* ByteBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_470 /* ByteBuffer.swift */; };
+		OBJ_1927 /* Call.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_471 /* Call.swift */; };
+		OBJ_1928 /* CallError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_472 /* CallError.swift */; };
+		OBJ_1929 /* CallResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_473 /* CallResult.swift */; };
+		OBJ_1930 /* Channel.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_474 /* Channel.swift */; };
+		OBJ_1931 /* ChannelArgument.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_475 /* ChannelArgument.swift */; };
+		OBJ_1932 /* CompletionQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_476 /* CompletionQueue.swift */; };
+		OBJ_1933 /* Handler.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_477 /* Handler.swift */; };
+		OBJ_1934 /* Metadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_478 /* Metadata.swift */; };
+		OBJ_1935 /* Mutex.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_479 /* Mutex.swift */; };
+		OBJ_1936 /* Operation.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_480 /* Operation.swift */; };
+		OBJ_1937 /* OperationGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_481 /* OperationGroup.swift */; };
+		OBJ_1938 /* Roots.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_482 /* Roots.swift */; };
+		OBJ_1939 /* Server.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_483 /* Server.swift */; };
+		OBJ_1940 /* ServerStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_484 /* ServerStatus.swift */; };
+		OBJ_1941 /* gRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_485 /* gRPC.swift */; };
+		OBJ_1942 /* ClientCall.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_487 /* ClientCall.swift */; };
+		OBJ_1943 /* ClientCallBidirectionalStreaming.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_488 /* ClientCallBidirectionalStreaming.swift */; };
+		OBJ_1944 /* ClientCallClientStreaming.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_489 /* ClientCallClientStreaming.swift */; };
+		OBJ_1945 /* ClientCallServerStreaming.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_490 /* ClientCallServerStreaming.swift */; };
+		OBJ_1946 /* ClientCallUnary.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_491 /* ClientCallUnary.swift */; };
+		OBJ_1947 /* RPCError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_492 /* RPCError.swift */; };
+		OBJ_1948 /* ServerSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_493 /* ServerSession.swift */; };
+		OBJ_1949 /* ServerSessionBidirectionalStreaming.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_494 /* ServerSessionBidirectionalStreaming.swift */; };
+		OBJ_1950 /* ServerSessionClientStreaming.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_495 /* ServerSessionClientStreaming.swift */; };
+		OBJ_1951 /* ServerSessionServerStreaming.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_496 /* ServerSessionServerStreaming.swift */; };
+		OBJ_1952 /* ServerSessionUnary.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_497 /* ServerSessionUnary.swift */; };
+		OBJ_1953 /* ServiceClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_498 /* ServiceClient.swift */; };
+		OBJ_1954 /* ServiceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_499 /* ServiceProvider.swift */; };
+		OBJ_1955 /* ServiceServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_500 /* ServiceServer.swift */; };
+		OBJ_1956 /* StreamReceiving.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_501 /* StreamReceiving.swift */; };
+		OBJ_1957 /* StreamSending.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_502 /* StreamSending.swift */; };
+		OBJ_1959 /* SwiftProtobuf.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = SwiftProtobuf::SwiftProtobuf::Product /* SwiftProtobuf.framework */; };
+		OBJ_1960 /* CgRPC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = SwiftGRPC::CgRPC::Product /* CgRPC.framework */; };
+		OBJ_1961 /* BoringSSL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = SwiftGRPC::BoringSSL::Product /* BoringSSL.framework */; };
+		OBJ_2013 /* AnyMessageStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1083 /* AnyMessageStorage.swift */; };
+		OBJ_2014 /* AnyUnpackError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1084 /* AnyUnpackError.swift */; };
+		OBJ_2015 /* BinaryDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1085 /* BinaryDecoder.swift */; };
+		OBJ_2016 /* BinaryDecodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1086 /* BinaryDecodingError.swift */; };
+		OBJ_2017 /* BinaryDecodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1087 /* BinaryDecodingOptions.swift */; };
+		OBJ_2018 /* BinaryDelimited.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1088 /* BinaryDelimited.swift */; };
+		OBJ_2019 /* BinaryEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1089 /* BinaryEncoder.swift */; };
+		OBJ_2020 /* BinaryEncodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1090 /* BinaryEncodingError.swift */; };
+		OBJ_2021 /* BinaryEncodingSizeVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1091 /* BinaryEncodingSizeVisitor.swift */; };
+		OBJ_2022 /* BinaryEncodingVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1092 /* BinaryEncodingVisitor.swift */; };
+		OBJ_2023 /* CustomJSONCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1093 /* CustomJSONCodable.swift */; };
+		OBJ_2024 /* Decoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1094 /* Decoder.swift */; };
+		OBJ_2025 /* DoubleFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1095 /* DoubleFormatter.swift */; };
+		OBJ_2026 /* Enum.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1096 /* Enum.swift */; };
+		OBJ_2027 /* ExtensibleMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1097 /* ExtensibleMessage.swift */; };
+		OBJ_2028 /* ExtensionFieldValueSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1098 /* ExtensionFieldValueSet.swift */; };
+		OBJ_2029 /* ExtensionFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1099 /* ExtensionFields.swift */; };
+		OBJ_2030 /* ExtensionMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1100 /* ExtensionMap.swift */; };
+		OBJ_2031 /* FieldTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1101 /* FieldTag.swift */; };
+		OBJ_2032 /* FieldTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1102 /* FieldTypes.swift */; };
+		OBJ_2033 /* Google_Protobuf_Any+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1103 /* Google_Protobuf_Any+Extensions.swift */; };
+		OBJ_2034 /* Google_Protobuf_Any+Registry.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1104 /* Google_Protobuf_Any+Registry.swift */; };
+		OBJ_2035 /* Google_Protobuf_Duration+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1105 /* Google_Protobuf_Duration+Extensions.swift */; };
+		OBJ_2036 /* Google_Protobuf_FieldMask+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1106 /* Google_Protobuf_FieldMask+Extensions.swift */; };
+		OBJ_2037 /* Google_Protobuf_ListValue+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1107 /* Google_Protobuf_ListValue+Extensions.swift */; };
+		OBJ_2038 /* Google_Protobuf_Struct+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1108 /* Google_Protobuf_Struct+Extensions.swift */; };
+		OBJ_2039 /* Google_Protobuf_Timestamp+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1109 /* Google_Protobuf_Timestamp+Extensions.swift */; };
+		OBJ_2040 /* Google_Protobuf_Value+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1110 /* Google_Protobuf_Value+Extensions.swift */; };
+		OBJ_2041 /* Google_Protobuf_Wrappers+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1111 /* Google_Protobuf_Wrappers+Extensions.swift */; };
+		OBJ_2042 /* HashVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1112 /* HashVisitor.swift */; };
+		OBJ_2043 /* Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1113 /* Internal.swift */; };
+		OBJ_2044 /* JSONDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1114 /* JSONDecoder.swift */; };
+		OBJ_2045 /* JSONDecodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1115 /* JSONDecodingError.swift */; };
+		OBJ_2046 /* JSONDecodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1116 /* JSONDecodingOptions.swift */; };
+		OBJ_2047 /* JSONEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1117 /* JSONEncoder.swift */; };
+		OBJ_2048 /* JSONEncodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1118 /* JSONEncodingError.swift */; };
+		OBJ_2049 /* JSONEncodingVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1119 /* JSONEncodingVisitor.swift */; };
+		OBJ_2050 /* JSONMapEncodingVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1120 /* JSONMapEncodingVisitor.swift */; };
+		OBJ_2051 /* JSONScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1121 /* JSONScanner.swift */; };
+		OBJ_2052 /* MathUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1122 /* MathUtils.swift */; };
+		OBJ_2053 /* Message+AnyAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1123 /* Message+AnyAdditions.swift */; };
+		OBJ_2054 /* Message+BinaryAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1124 /* Message+BinaryAdditions.swift */; };
+		OBJ_2055 /* Message+JSONAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1125 /* Message+JSONAdditions.swift */; };
+		OBJ_2056 /* Message+JSONArrayAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1126 /* Message+JSONArrayAdditions.swift */; };
+		OBJ_2057 /* Message+TextFormatAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1127 /* Message+TextFormatAdditions.swift */; };
+		OBJ_2058 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1128 /* Message.swift */; };
+		OBJ_2059 /* MessageExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1129 /* MessageExtension.swift */; };
+		OBJ_2060 /* NameMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1130 /* NameMap.swift */; };
+		OBJ_2061 /* ProtoNameProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1131 /* ProtoNameProviding.swift */; };
+		OBJ_2062 /* ProtobufAPIVersionCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1132 /* ProtobufAPIVersionCheck.swift */; };
+		OBJ_2063 /* ProtobufMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1133 /* ProtobufMap.swift */; };
+		OBJ_2064 /* SelectiveVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1134 /* SelectiveVisitor.swift */; };
+		OBJ_2065 /* SimpleExtensionMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1135 /* SimpleExtensionMap.swift */; };
+		OBJ_2066 /* StringUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1136 /* StringUtils.swift */; };
+		OBJ_2067 /* TextFormatDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1137 /* TextFormatDecoder.swift */; };
+		OBJ_2068 /* TextFormatDecodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1138 /* TextFormatDecodingError.swift */; };
+		OBJ_2069 /* TextFormatEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1139 /* TextFormatEncoder.swift */; };
+		OBJ_2070 /* TextFormatEncodingVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1140 /* TextFormatEncodingVisitor.swift */; };
+		OBJ_2071 /* TextFormatScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1141 /* TextFormatScanner.swift */; };
+		OBJ_2072 /* TimeUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1142 /* TimeUtils.swift */; };
+		OBJ_2073 /* UnknownStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1143 /* UnknownStorage.swift */; };
+		OBJ_2074 /* Varint.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1144 /* Varint.swift */; };
+		OBJ_2075 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1145 /* Version.swift */; };
+		OBJ_2076 /* Visitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1146 /* Visitor.swift */; };
+		OBJ_2077 /* WireFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1147 /* WireFormat.swift */; };
+		OBJ_2078 /* ZigZag.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1148 /* ZigZag.swift */; };
+		OBJ_2079 /* any.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1149 /* any.pb.swift */; };
+		OBJ_2080 /* api.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1150 /* api.pb.swift */; };
+		OBJ_2081 /* duration.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1151 /* duration.pb.swift */; };
+		OBJ_2082 /* empty.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1152 /* empty.pb.swift */; };
+		OBJ_2083 /* field_mask.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1153 /* field_mask.pb.swift */; };
+		OBJ_2084 /* source_context.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1154 /* source_context.pb.swift */; };
+		OBJ_2085 /* struct.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1155 /* struct.pb.swift */; };
+		OBJ_2086 /* timestamp.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1156 /* timestamp.pb.swift */; };
+		OBJ_2087 /* type.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1157 /* type.pb.swift */; };
+		OBJ_2088 /* wrappers.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1158 /* wrappers.pb.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		Commander::Commander::Product /* Commander.framework */ = {isa = PBXFileReference; path = Commander.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		OBJ_100 /* dsa_asn1.c */ = {isa = PBXFileReference; path = dsa_asn1.c; sourceTree = "<group>"; };
+		OBJ_1000 /* main.swift */ = {isa = PBXFileReference; path = main.swift; sourceTree = "<group>"; };
+		OBJ_1002 /* main.swift */ = {isa = PBXFileReference; path = main.swift; sourceTree = "<group>"; };
+		OBJ_1005 /* BasicEchoTestCase.swift */ = {isa = PBXFileReference; path = BasicEchoTestCase.swift; sourceTree = "<group>"; };
+		OBJ_1006 /* ChannelArgumentTests.swift */ = {isa = PBXFileReference; path = ChannelArgumentTests.swift; sourceTree = "<group>"; };
+		OBJ_1007 /* ClientCancellingTests.swift */ = {isa = PBXFileReference; path = ClientCancellingTests.swift; sourceTree = "<group>"; };
+		OBJ_1008 /* ClientTestExample.swift */ = {isa = PBXFileReference; path = ClientTestExample.swift; sourceTree = "<group>"; };
+		OBJ_1009 /* ClientTimeoutTests.swift */ = {isa = PBXFileReference; path = ClientTimeoutTests.swift; sourceTree = "<group>"; };
+		OBJ_1010 /* CompletionQueueTests.swift */ = {isa = PBXFileReference; path = CompletionQueueTests.swift; sourceTree = "<group>"; };
+		OBJ_1011 /* ConnectionFailureTests.swift */ = {isa = PBXFileReference; path = ConnectionFailureTests.swift; sourceTree = "<group>"; };
+		OBJ_1012 /* EchoProvider.swift */ = {isa = PBXFileReference; path = EchoProvider.swift; sourceTree = "<group>"; };
+		OBJ_1013 /* EchoTests.swift */ = {isa = PBXFileReference; path = EchoTests.swift; sourceTree = "<group>"; };
+		OBJ_1014 /* GRPCTests.swift */ = {isa = PBXFileReference; path = GRPCTests.swift; sourceTree = "<group>"; };
+		OBJ_1015 /* MetadataTests.swift */ = {isa = PBXFileReference; path = MetadataTests.swift; sourceTree = "<group>"; };
+		OBJ_1016 /* ServerCancellingTests.swift */ = {isa = PBXFileReference; path = ServerCancellingTests.swift; sourceTree = "<group>"; };
+		OBJ_1017 /* ServerTestExample.swift */ = {isa = PBXFileReference; path = ServerTestExample.swift; sourceTree = "<group>"; };
+		OBJ_1018 /* ServerThrowingTests.swift */ = {isa = PBXFileReference; path = ServerThrowingTests.swift; sourceTree = "<group>"; };
+		OBJ_1019 /* ServerTimeoutTests.swift */ = {isa = PBXFileReference; path = ServerTimeoutTests.swift; sourceTree = "<group>"; };
+		OBJ_102 /* ec_asn1.c */ = {isa = PBXFileReference; path = ec_asn1.c; sourceTree = "<group>"; };
+		OBJ_1020 /* ServiceClientTests.swift */ = {isa = PBXFileReference; path = ServiceClientTests.swift; sourceTree = "<group>"; };
+		OBJ_1021 /* TestKeys.swift */ = {isa = PBXFileReference; path = TestKeys.swift; sourceTree = "<group>"; };
+		OBJ_1022 /* echo.grpc.swift */ = {isa = PBXFileReference; path = echo.grpc.swift; sourceTree = "<group>"; };
+		OBJ_1023 /* echo.pb.swift */ = {isa = PBXFileReference; path = echo.pb.swift; sourceTree = "<group>"; };
+		OBJ_1024 /* Docker */ = {isa = PBXFileReference; path = Docker; sourceTree = SOURCE_ROOT; };
+		OBJ_1025 /* third_party */ = {isa = PBXFileReference; path = third_party; sourceTree = SOURCE_ROOT; };
+		OBJ_1026 /* Examples */ = {isa = PBXFileReference; path = Examples; sourceTree = SOURCE_ROOT; };
+		OBJ_1027 /* scripts */ = {isa = PBXFileReference; path = scripts; sourceTree = SOURCE_ROOT; };
+		OBJ_1028 /* Assets */ = {isa = PBXFileReference; path = Assets; sourceTree = SOURCE_ROOT; };
+		OBJ_1032 /* ArgumentConvertible.swift */ = {isa = PBXFileReference; path = ArgumentConvertible.swift; sourceTree = "<group>"; };
+		OBJ_1033 /* ArgumentDescription.swift */ = {isa = PBXFileReference; path = ArgumentDescription.swift; sourceTree = "<group>"; };
+		OBJ_1034 /* ArgumentParser.swift */ = {isa = PBXFileReference; path = ArgumentParser.swift; sourceTree = "<group>"; };
+		OBJ_1035 /* Command.swift */ = {isa = PBXFileReference; path = Command.swift; sourceTree = "<group>"; };
+		OBJ_1036 /* CommandRunner.swift */ = {isa = PBXFileReference; path = CommandRunner.swift; sourceTree = "<group>"; };
+		OBJ_1037 /* CommandType.swift */ = {isa = PBXFileReference; path = CommandType.swift; sourceTree = "<group>"; };
+		OBJ_1038 /* Commands.swift */ = {isa = PBXFileReference; path = Commands.swift; sourceTree = "<group>"; };
+		OBJ_1039 /* Error.swift */ = {isa = PBXFileReference; path = Error.swift; sourceTree = "<group>"; };
+		OBJ_104 /* ecdh.c */ = {isa = PBXFileReference; path = ecdh.c; sourceTree = "<group>"; };
+		OBJ_1040 /* Group.swift */ = {isa = PBXFileReference; path = Group.swift; sourceTree = "<group>"; };
+		OBJ_1041 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = "/private/tmp/PR/grpc-swift/.build/checkouts/Commander.git-8842944228949165507/Package.swift"; sourceTree = "<group>"; };
+		OBJ_1045 /* CommandLine+Extensions.swift */ = {isa = PBXFileReference; path = "CommandLine+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_1046 /* Descriptor+Extensions.swift */ = {isa = PBXFileReference; path = "Descriptor+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_1047 /* EnumGenerator.swift */ = {isa = PBXFileReference; path = EnumGenerator.swift; sourceTree = "<group>"; };
+		OBJ_1048 /* ExtensionSetGenerator.swift */ = {isa = PBXFileReference; path = ExtensionSetGenerator.swift; sourceTree = "<group>"; };
+		OBJ_1049 /* FieldGenerator.swift */ = {isa = PBXFileReference; path = FieldGenerator.swift; sourceTree = "<group>"; };
+		OBJ_1050 /* FileGenerator.swift */ = {isa = PBXFileReference; path = FileGenerator.swift; sourceTree = "<group>"; };
+		OBJ_1051 /* FileIo.swift */ = {isa = PBXFileReference; path = FileIo.swift; sourceTree = "<group>"; };
+		OBJ_1052 /* GenerationError.swift */ = {isa = PBXFileReference; path = GenerationError.swift; sourceTree = "<group>"; };
+		OBJ_1053 /* GeneratorOptions.swift */ = {isa = PBXFileReference; path = GeneratorOptions.swift; sourceTree = "<group>"; };
+		OBJ_1054 /* Google_Protobuf_DescriptorProto+Extensions.swift */ = {isa = PBXFileReference; path = "Google_Protobuf_DescriptorProto+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_1055 /* Google_Protobuf_FileDescriptorProto+Extensions.swift */ = {isa = PBXFileReference; path = "Google_Protobuf_FileDescriptorProto+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_1056 /* MessageFieldGenerator.swift */ = {isa = PBXFileReference; path = MessageFieldGenerator.swift; sourceTree = "<group>"; };
+		OBJ_1057 /* MessageGenerator.swift */ = {isa = PBXFileReference; path = MessageGenerator.swift; sourceTree = "<group>"; };
+		OBJ_1058 /* MessageStorageClassGenerator.swift */ = {isa = PBXFileReference; path = MessageStorageClassGenerator.swift; sourceTree = "<group>"; };
+		OBJ_1059 /* OneofGenerator.swift */ = {isa = PBXFileReference; path = OneofGenerator.swift; sourceTree = "<group>"; };
+		OBJ_106 /* ecdsa_asn1.c */ = {isa = PBXFileReference; path = ecdsa_asn1.c; sourceTree = "<group>"; };
+		OBJ_1060 /* StringUtils.swift */ = {isa = PBXFileReference; path = StringUtils.swift; sourceTree = "<group>"; };
+		OBJ_1061 /* Version.swift */ = {isa = PBXFileReference; path = Version.swift; sourceTree = "<group>"; };
+		OBJ_1062 /* main.swift */ = {isa = PBXFileReference; path = main.swift; sourceTree = "<group>"; };
+		OBJ_1064 /* Array+Extensions.swift */ = {isa = PBXFileReference; path = "Array+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_1065 /* CodePrinter.swift */ = {isa = PBXFileReference; path = CodePrinter.swift; sourceTree = "<group>"; };
+		OBJ_1066 /* Descriptor+Extensions.swift */ = {isa = PBXFileReference; path = "Descriptor+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_1067 /* Descriptor.swift */ = {isa = PBXFileReference; path = Descriptor.swift; sourceTree = "<group>"; };
+		OBJ_1068 /* FieldNumbers.swift */ = {isa = PBXFileReference; path = FieldNumbers.swift; sourceTree = "<group>"; };
+		OBJ_1069 /* Google_Protobuf_Compiler_CodeGeneratorResponse+Extensions.swift */ = {isa = PBXFileReference; path = "Google_Protobuf_Compiler_CodeGeneratorResponse+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_1070 /* Google_Protobuf_SourceCodeInfo+Extensions.swift */ = {isa = PBXFileReference; path = "Google_Protobuf_SourceCodeInfo+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_1071 /* NamingUtils.swift */ = {isa = PBXFileReference; path = NamingUtils.swift; sourceTree = "<group>"; };
+		OBJ_1072 /* ProtoFileToModuleMappings.swift */ = {isa = PBXFileReference; path = ProtoFileToModuleMappings.swift; sourceTree = "<group>"; };
+		OBJ_1073 /* ProvidesLocationPath.swift */ = {isa = PBXFileReference; path = ProvidesLocationPath.swift; sourceTree = "<group>"; };
+		OBJ_1074 /* ProvidesSourceCodeLocation.swift */ = {isa = PBXFileReference; path = ProvidesSourceCodeLocation.swift; sourceTree = "<group>"; };
+		OBJ_1075 /* SwiftLanguage.swift */ = {isa = PBXFileReference; path = SwiftLanguage.swift; sourceTree = "<group>"; };
+		OBJ_1076 /* SwiftProtobufInfo.swift */ = {isa = PBXFileReference; path = SwiftProtobufInfo.swift; sourceTree = "<group>"; };
+		OBJ_1077 /* SwiftProtobufNamer.swift */ = {isa = PBXFileReference; path = SwiftProtobufNamer.swift; sourceTree = "<group>"; };
+		OBJ_1078 /* UnicodeScalar+Extensions.swift */ = {isa = PBXFileReference; path = "UnicodeScalar+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_1079 /* descriptor.pb.swift */ = {isa = PBXFileReference; path = descriptor.pb.swift; sourceTree = "<group>"; };
+		OBJ_108 /* engine.c */ = {isa = PBXFileReference; path = engine.c; sourceTree = "<group>"; };
+		OBJ_1080 /* plugin.pb.swift */ = {isa = PBXFileReference; path = plugin.pb.swift; sourceTree = "<group>"; };
+		OBJ_1081 /* swift_protobuf_module_mappings.pb.swift */ = {isa = PBXFileReference; path = swift_protobuf_module_mappings.pb.swift; sourceTree = "<group>"; };
+		OBJ_1083 /* AnyMessageStorage.swift */ = {isa = PBXFileReference; path = AnyMessageStorage.swift; sourceTree = "<group>"; };
+		OBJ_1084 /* AnyUnpackError.swift */ = {isa = PBXFileReference; path = AnyUnpackError.swift; sourceTree = "<group>"; };
+		OBJ_1085 /* BinaryDecoder.swift */ = {isa = PBXFileReference; path = BinaryDecoder.swift; sourceTree = "<group>"; };
+		OBJ_1086 /* BinaryDecodingError.swift */ = {isa = PBXFileReference; path = BinaryDecodingError.swift; sourceTree = "<group>"; };
+		OBJ_1087 /* BinaryDecodingOptions.swift */ = {isa = PBXFileReference; path = BinaryDecodingOptions.swift; sourceTree = "<group>"; };
+		OBJ_1088 /* BinaryDelimited.swift */ = {isa = PBXFileReference; path = BinaryDelimited.swift; sourceTree = "<group>"; };
+		OBJ_1089 /* BinaryEncoder.swift */ = {isa = PBXFileReference; path = BinaryEncoder.swift; sourceTree = "<group>"; };
+		OBJ_1090 /* BinaryEncodingError.swift */ = {isa = PBXFileReference; path = BinaryEncodingError.swift; sourceTree = "<group>"; };
+		OBJ_1091 /* BinaryEncodingSizeVisitor.swift */ = {isa = PBXFileReference; path = BinaryEncodingSizeVisitor.swift; sourceTree = "<group>"; };
+		OBJ_1092 /* BinaryEncodingVisitor.swift */ = {isa = PBXFileReference; path = BinaryEncodingVisitor.swift; sourceTree = "<group>"; };
+		OBJ_1093 /* CustomJSONCodable.swift */ = {isa = PBXFileReference; path = CustomJSONCodable.swift; sourceTree = "<group>"; };
+		OBJ_1094 /* Decoder.swift */ = {isa = PBXFileReference; path = Decoder.swift; sourceTree = "<group>"; };
+		OBJ_1095 /* DoubleFormatter.swift */ = {isa = PBXFileReference; path = DoubleFormatter.swift; sourceTree = "<group>"; };
+		OBJ_1096 /* Enum.swift */ = {isa = PBXFileReference; path = Enum.swift; sourceTree = "<group>"; };
+		OBJ_1097 /* ExtensibleMessage.swift */ = {isa = PBXFileReference; path = ExtensibleMessage.swift; sourceTree = "<group>"; };
+		OBJ_1098 /* ExtensionFieldValueSet.swift */ = {isa = PBXFileReference; path = ExtensionFieldValueSet.swift; sourceTree = "<group>"; };
+		OBJ_1099 /* ExtensionFields.swift */ = {isa = PBXFileReference; path = ExtensionFields.swift; sourceTree = "<group>"; };
+		OBJ_11 /* a_bitstr.c */ = {isa = PBXFileReference; path = a_bitstr.c; sourceTree = "<group>"; };
+		OBJ_110 /* err.c */ = {isa = PBXFileReference; path = err.c; sourceTree = "<group>"; };
+		OBJ_1100 /* ExtensionMap.swift */ = {isa = PBXFileReference; path = ExtensionMap.swift; sourceTree = "<group>"; };
+		OBJ_1101 /* FieldTag.swift */ = {isa = PBXFileReference; path = FieldTag.swift; sourceTree = "<group>"; };
+		OBJ_1102 /* FieldTypes.swift */ = {isa = PBXFileReference; path = FieldTypes.swift; sourceTree = "<group>"; };
+		OBJ_1103 /* Google_Protobuf_Any+Extensions.swift */ = {isa = PBXFileReference; path = "Google_Protobuf_Any+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_1104 /* Google_Protobuf_Any+Registry.swift */ = {isa = PBXFileReference; path = "Google_Protobuf_Any+Registry.swift"; sourceTree = "<group>"; };
+		OBJ_1105 /* Google_Protobuf_Duration+Extensions.swift */ = {isa = PBXFileReference; path = "Google_Protobuf_Duration+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_1106 /* Google_Protobuf_FieldMask+Extensions.swift */ = {isa = PBXFileReference; path = "Google_Protobuf_FieldMask+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_1107 /* Google_Protobuf_ListValue+Extensions.swift */ = {isa = PBXFileReference; path = "Google_Protobuf_ListValue+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_1108 /* Google_Protobuf_Struct+Extensions.swift */ = {isa = PBXFileReference; path = "Google_Protobuf_Struct+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_1109 /* Google_Protobuf_Timestamp+Extensions.swift */ = {isa = PBXFileReference; path = "Google_Protobuf_Timestamp+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_111 /* err_data.c */ = {isa = PBXFileReference; path = err_data.c; sourceTree = "<group>"; };
+		OBJ_1110 /* Google_Protobuf_Value+Extensions.swift */ = {isa = PBXFileReference; path = "Google_Protobuf_Value+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_1111 /* Google_Protobuf_Wrappers+Extensions.swift */ = {isa = PBXFileReference; path = "Google_Protobuf_Wrappers+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_1112 /* HashVisitor.swift */ = {isa = PBXFileReference; path = HashVisitor.swift; sourceTree = "<group>"; };
+		OBJ_1113 /* Internal.swift */ = {isa = PBXFileReference; path = Internal.swift; sourceTree = "<group>"; };
+		OBJ_1114 /* JSONDecoder.swift */ = {isa = PBXFileReference; path = JSONDecoder.swift; sourceTree = "<group>"; };
+		OBJ_1115 /* JSONDecodingError.swift */ = {isa = PBXFileReference; path = JSONDecodingError.swift; sourceTree = "<group>"; };
+		OBJ_1116 /* JSONDecodingOptions.swift */ = {isa = PBXFileReference; path = JSONDecodingOptions.swift; sourceTree = "<group>"; };
+		OBJ_1117 /* JSONEncoder.swift */ = {isa = PBXFileReference; path = JSONEncoder.swift; sourceTree = "<group>"; };
+		OBJ_1118 /* JSONEncodingError.swift */ = {isa = PBXFileReference; path = JSONEncodingError.swift; sourceTree = "<group>"; };
+		OBJ_1119 /* JSONEncodingVisitor.swift */ = {isa = PBXFileReference; path = JSONEncodingVisitor.swift; sourceTree = "<group>"; };
+		OBJ_1120 /* JSONMapEncodingVisitor.swift */ = {isa = PBXFileReference; path = JSONMapEncodingVisitor.swift; sourceTree = "<group>"; };
+		OBJ_1121 /* JSONScanner.swift */ = {isa = PBXFileReference; path = JSONScanner.swift; sourceTree = "<group>"; };
+		OBJ_1122 /* MathUtils.swift */ = {isa = PBXFileReference; path = MathUtils.swift; sourceTree = "<group>"; };
+		OBJ_1123 /* Message+AnyAdditions.swift */ = {isa = PBXFileReference; path = "Message+AnyAdditions.swift"; sourceTree = "<group>"; };
+		OBJ_1124 /* Message+BinaryAdditions.swift */ = {isa = PBXFileReference; path = "Message+BinaryAdditions.swift"; sourceTree = "<group>"; };
+		OBJ_1125 /* Message+JSONAdditions.swift */ = {isa = PBXFileReference; path = "Message+JSONAdditions.swift"; sourceTree = "<group>"; };
+		OBJ_1126 /* Message+JSONArrayAdditions.swift */ = {isa = PBXFileReference; path = "Message+JSONArrayAdditions.swift"; sourceTree = "<group>"; };
+		OBJ_1127 /* Message+TextFormatAdditions.swift */ = {isa = PBXFileReference; path = "Message+TextFormatAdditions.swift"; sourceTree = "<group>"; };
+		OBJ_1128 /* Message.swift */ = {isa = PBXFileReference; path = Message.swift; sourceTree = "<group>"; };
+		OBJ_1129 /* MessageExtension.swift */ = {isa = PBXFileReference; path = MessageExtension.swift; sourceTree = "<group>"; };
+		OBJ_113 /* digestsign.c */ = {isa = PBXFileReference; path = digestsign.c; sourceTree = "<group>"; };
+		OBJ_1130 /* NameMap.swift */ = {isa = PBXFileReference; path = NameMap.swift; sourceTree = "<group>"; };
+		OBJ_1131 /* ProtoNameProviding.swift */ = {isa = PBXFileReference; path = ProtoNameProviding.swift; sourceTree = "<group>"; };
+		OBJ_1132 /* ProtobufAPIVersionCheck.swift */ = {isa = PBXFileReference; path = ProtobufAPIVersionCheck.swift; sourceTree = "<group>"; };
+		OBJ_1133 /* ProtobufMap.swift */ = {isa = PBXFileReference; path = ProtobufMap.swift; sourceTree = "<group>"; };
+		OBJ_1134 /* SelectiveVisitor.swift */ = {isa = PBXFileReference; path = SelectiveVisitor.swift; sourceTree = "<group>"; };
+		OBJ_1135 /* SimpleExtensionMap.swift */ = {isa = PBXFileReference; path = SimpleExtensionMap.swift; sourceTree = "<group>"; };
+		OBJ_1136 /* StringUtils.swift */ = {isa = PBXFileReference; path = StringUtils.swift; sourceTree = "<group>"; };
+		OBJ_1137 /* TextFormatDecoder.swift */ = {isa = PBXFileReference; path = TextFormatDecoder.swift; sourceTree = "<group>"; };
+		OBJ_1138 /* TextFormatDecodingError.swift */ = {isa = PBXFileReference; path = TextFormatDecodingError.swift; sourceTree = "<group>"; };
+		OBJ_1139 /* TextFormatEncoder.swift */ = {isa = PBXFileReference; path = TextFormatEncoder.swift; sourceTree = "<group>"; };
+		OBJ_114 /* evp.c */ = {isa = PBXFileReference; path = evp.c; sourceTree = "<group>"; };
+		OBJ_1140 /* TextFormatEncodingVisitor.swift */ = {isa = PBXFileReference; path = TextFormatEncodingVisitor.swift; sourceTree = "<group>"; };
+		OBJ_1141 /* TextFormatScanner.swift */ = {isa = PBXFileReference; path = TextFormatScanner.swift; sourceTree = "<group>"; };
+		OBJ_1142 /* TimeUtils.swift */ = {isa = PBXFileReference; path = TimeUtils.swift; sourceTree = "<group>"; };
+		OBJ_1143 /* UnknownStorage.swift */ = {isa = PBXFileReference; path = UnknownStorage.swift; sourceTree = "<group>"; };
+		OBJ_1144 /* Varint.swift */ = {isa = PBXFileReference; path = Varint.swift; sourceTree = "<group>"; };
+		OBJ_1145 /* Version.swift */ = {isa = PBXFileReference; path = Version.swift; sourceTree = "<group>"; };
+		OBJ_1146 /* Visitor.swift */ = {isa = PBXFileReference; path = Visitor.swift; sourceTree = "<group>"; };
+		OBJ_1147 /* WireFormat.swift */ = {isa = PBXFileReference; path = WireFormat.swift; sourceTree = "<group>"; };
+		OBJ_1148 /* ZigZag.swift */ = {isa = PBXFileReference; path = ZigZag.swift; sourceTree = "<group>"; };
+		OBJ_1149 /* any.pb.swift */ = {isa = PBXFileReference; path = any.pb.swift; sourceTree = "<group>"; };
+		OBJ_115 /* evp_asn1.c */ = {isa = PBXFileReference; path = evp_asn1.c; sourceTree = "<group>"; };
+		OBJ_1150 /* api.pb.swift */ = {isa = PBXFileReference; path = api.pb.swift; sourceTree = "<group>"; };
+		OBJ_1151 /* duration.pb.swift */ = {isa = PBXFileReference; path = duration.pb.swift; sourceTree = "<group>"; };
+		OBJ_1152 /* empty.pb.swift */ = {isa = PBXFileReference; path = empty.pb.swift; sourceTree = "<group>"; };
+		OBJ_1153 /* field_mask.pb.swift */ = {isa = PBXFileReference; path = field_mask.pb.swift; sourceTree = "<group>"; };
+		OBJ_1154 /* source_context.pb.swift */ = {isa = PBXFileReference; path = source_context.pb.swift; sourceTree = "<group>"; };
+		OBJ_1155 /* struct.pb.swift */ = {isa = PBXFileReference; path = struct.pb.swift; sourceTree = "<group>"; };
+		OBJ_1156 /* timestamp.pb.swift */ = {isa = PBXFileReference; path = timestamp.pb.swift; sourceTree = "<group>"; };
+		OBJ_1157 /* type.pb.swift */ = {isa = PBXFileReference; path = type.pb.swift; sourceTree = "<group>"; };
+		OBJ_1158 /* wrappers.pb.swift */ = {isa = PBXFileReference; path = wrappers.pb.swift; sourceTree = "<group>"; };
+		OBJ_1159 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = "/private/tmp/PR/grpc-swift/.build/checkouts/swift-protobuf.git--7219529775138357838/Package.swift"; sourceTree = "<group>"; };
+		OBJ_116 /* evp_ctx.c */ = {isa = PBXFileReference; path = evp_ctx.c; sourceTree = "<group>"; };
+		OBJ_117 /* p_dsa_asn1.c */ = {isa = PBXFileReference; path = p_dsa_asn1.c; sourceTree = "<group>"; };
+		OBJ_118 /* p_ec.c */ = {isa = PBXFileReference; path = p_ec.c; sourceTree = "<group>"; };
+		OBJ_119 /* p_ec_asn1.c */ = {isa = PBXFileReference; path = p_ec_asn1.c; sourceTree = "<group>"; };
+		OBJ_12 /* a_bool.c */ = {isa = PBXFileReference; path = a_bool.c; sourceTree = "<group>"; };
+		OBJ_120 /* p_ed25519.c */ = {isa = PBXFileReference; path = p_ed25519.c; sourceTree = "<group>"; };
+		OBJ_121 /* p_ed25519_asn1.c */ = {isa = PBXFileReference; path = p_ed25519_asn1.c; sourceTree = "<group>"; };
+		OBJ_122 /* p_rsa.c */ = {isa = PBXFileReference; path = p_rsa.c; sourceTree = "<group>"; };
+		OBJ_123 /* p_rsa_asn1.c */ = {isa = PBXFileReference; path = p_rsa_asn1.c; sourceTree = "<group>"; };
+		OBJ_124 /* pbkdf.c */ = {isa = PBXFileReference; path = pbkdf.c; sourceTree = "<group>"; };
+		OBJ_125 /* print.c */ = {isa = PBXFileReference; path = print.c; sourceTree = "<group>"; };
+		OBJ_126 /* scrypt.c */ = {isa = PBXFileReference; path = scrypt.c; sourceTree = "<group>"; };
+		OBJ_127 /* sign.c */ = {isa = PBXFileReference; path = sign.c; sourceTree = "<group>"; };
+		OBJ_128 /* ex_data.c */ = {isa = PBXFileReference; path = ex_data.c; sourceTree = "<group>"; };
+		OBJ_13 /* a_d2i_fp.c */ = {isa = PBXFileReference; path = a_d2i_fp.c; sourceTree = "<group>"; };
+		OBJ_131 /* aes.c */ = {isa = PBXFileReference; path = aes.c; sourceTree = "<group>"; };
+		OBJ_132 /* key_wrap.c */ = {isa = PBXFileReference; path = key_wrap.c; sourceTree = "<group>"; };
+		OBJ_133 /* mode_wrappers.c */ = {isa = PBXFileReference; path = mode_wrappers.c; sourceTree = "<group>"; };
+		OBJ_135 /* add.c */ = {isa = PBXFileReference; path = add.c; sourceTree = "<group>"; };
+		OBJ_136 /* bn.c */ = {isa = PBXFileReference; path = bn.c; sourceTree = "<group>"; };
+		OBJ_137 /* bytes.c */ = {isa = PBXFileReference; path = bytes.c; sourceTree = "<group>"; };
+		OBJ_138 /* cmp.c */ = {isa = PBXFileReference; path = cmp.c; sourceTree = "<group>"; };
+		OBJ_139 /* ctx.c */ = {isa = PBXFileReference; path = ctx.c; sourceTree = "<group>"; };
+		OBJ_14 /* a_dup.c */ = {isa = PBXFileReference; path = a_dup.c; sourceTree = "<group>"; };
+		OBJ_140 /* div.c */ = {isa = PBXFileReference; path = div.c; sourceTree = "<group>"; };
+		OBJ_141 /* exponentiation.c */ = {isa = PBXFileReference; path = exponentiation.c; sourceTree = "<group>"; };
+		OBJ_142 /* gcd.c */ = {isa = PBXFileReference; path = gcd.c; sourceTree = "<group>"; };
+		OBJ_143 /* generic.c */ = {isa = PBXFileReference; path = generic.c; sourceTree = "<group>"; };
+		OBJ_144 /* jacobi.c */ = {isa = PBXFileReference; path = jacobi.c; sourceTree = "<group>"; };
+		OBJ_145 /* montgomery.c */ = {isa = PBXFileReference; path = montgomery.c; sourceTree = "<group>"; };
+		OBJ_146 /* montgomery_inv.c */ = {isa = PBXFileReference; path = montgomery_inv.c; sourceTree = "<group>"; };
+		OBJ_147 /* mul.c */ = {isa = PBXFileReference; path = mul.c; sourceTree = "<group>"; };
+		OBJ_148 /* prime.c */ = {isa = PBXFileReference; path = prime.c; sourceTree = "<group>"; };
+		OBJ_149 /* random.c */ = {isa = PBXFileReference; path = random.c; sourceTree = "<group>"; };
+		OBJ_15 /* a_enum.c */ = {isa = PBXFileReference; path = a_enum.c; sourceTree = "<group>"; };
+		OBJ_150 /* rsaz_exp.c */ = {isa = PBXFileReference; path = rsaz_exp.c; sourceTree = "<group>"; };
+		OBJ_151 /* shift.c */ = {isa = PBXFileReference; path = shift.c; sourceTree = "<group>"; };
+		OBJ_152 /* sqrt.c */ = {isa = PBXFileReference; path = sqrt.c; sourceTree = "<group>"; };
+		OBJ_154 /* aead.c */ = {isa = PBXFileReference; path = aead.c; sourceTree = "<group>"; };
+		OBJ_155 /* cipher.c */ = {isa = PBXFileReference; path = cipher.c; sourceTree = "<group>"; };
+		OBJ_156 /* e_aes.c */ = {isa = PBXFileReference; path = e_aes.c; sourceTree = "<group>"; };
+		OBJ_157 /* e_des.c */ = {isa = PBXFileReference; path = e_des.c; sourceTree = "<group>"; };
+		OBJ_159 /* des.c */ = {isa = PBXFileReference; path = des.c; sourceTree = "<group>"; };
+		OBJ_16 /* a_gentm.c */ = {isa = PBXFileReference; path = a_gentm.c; sourceTree = "<group>"; };
+		OBJ_161 /* digest.c */ = {isa = PBXFileReference; path = digest.c; sourceTree = "<group>"; };
+		OBJ_162 /* digests.c */ = {isa = PBXFileReference; path = digests.c; sourceTree = "<group>"; };
+		OBJ_164 /* ec.c */ = {isa = PBXFileReference; path = ec.c; sourceTree = "<group>"; };
+		OBJ_165 /* ec_key.c */ = {isa = PBXFileReference; path = ec_key.c; sourceTree = "<group>"; };
+		OBJ_166 /* ec_montgomery.c */ = {isa = PBXFileReference; path = ec_montgomery.c; sourceTree = "<group>"; };
+		OBJ_167 /* oct.c */ = {isa = PBXFileReference; path = oct.c; sourceTree = "<group>"; };
+		OBJ_168 /* p224-64.c */ = {isa = PBXFileReference; path = "p224-64.c"; sourceTree = "<group>"; };
+		OBJ_169 /* p256-64.c */ = {isa = PBXFileReference; path = "p256-64.c"; sourceTree = "<group>"; };
+		OBJ_17 /* a_i2d_fp.c */ = {isa = PBXFileReference; path = a_i2d_fp.c; sourceTree = "<group>"; };
+		OBJ_170 /* p256-x86_64.c */ = {isa = PBXFileReference; path = "p256-x86_64.c"; sourceTree = "<group>"; };
+		OBJ_171 /* simple.c */ = {isa = PBXFileReference; path = simple.c; sourceTree = "<group>"; };
+		OBJ_172 /* util-64.c */ = {isa = PBXFileReference; path = "util-64.c"; sourceTree = "<group>"; };
+		OBJ_173 /* wnaf.c */ = {isa = PBXFileReference; path = wnaf.c; sourceTree = "<group>"; };
+		OBJ_175 /* ecdsa.c */ = {isa = PBXFileReference; path = ecdsa.c; sourceTree = "<group>"; };
+		OBJ_177 /* hmac.c */ = {isa = PBXFileReference; path = hmac.c; sourceTree = "<group>"; };
+		OBJ_178 /* is_fips.c */ = {isa = PBXFileReference; path = is_fips.c; sourceTree = "<group>"; };
+		OBJ_18 /* a_int.c */ = {isa = PBXFileReference; path = a_int.c; sourceTree = "<group>"; };
+		OBJ_180 /* md4.c */ = {isa = PBXFileReference; path = md4.c; sourceTree = "<group>"; };
+		OBJ_182 /* md5.c */ = {isa = PBXFileReference; path = md5.c; sourceTree = "<group>"; };
+		OBJ_184 /* cbc.c */ = {isa = PBXFileReference; path = cbc.c; sourceTree = "<group>"; };
+		OBJ_185 /* cfb.c */ = {isa = PBXFileReference; path = cfb.c; sourceTree = "<group>"; };
+		OBJ_186 /* ctr.c */ = {isa = PBXFileReference; path = ctr.c; sourceTree = "<group>"; };
+		OBJ_187 /* gcm.c */ = {isa = PBXFileReference; path = gcm.c; sourceTree = "<group>"; };
+		OBJ_188 /* ofb.c */ = {isa = PBXFileReference; path = ofb.c; sourceTree = "<group>"; };
+		OBJ_189 /* polyval.c */ = {isa = PBXFileReference; path = polyval.c; sourceTree = "<group>"; };
+		OBJ_19 /* a_mbstr.c */ = {isa = PBXFileReference; path = a_mbstr.c; sourceTree = "<group>"; };
+		OBJ_191 /* ctrdrbg.c */ = {isa = PBXFileReference; path = ctrdrbg.c; sourceTree = "<group>"; };
+		OBJ_192 /* rand.c */ = {isa = PBXFileReference; path = rand.c; sourceTree = "<group>"; };
+		OBJ_193 /* urandom.c */ = {isa = PBXFileReference; path = urandom.c; sourceTree = "<group>"; };
+		OBJ_195 /* blinding.c */ = {isa = PBXFileReference; path = blinding.c; sourceTree = "<group>"; };
+		OBJ_196 /* padding.c */ = {isa = PBXFileReference; path = padding.c; sourceTree = "<group>"; };
+		OBJ_197 /* rsa.c */ = {isa = PBXFileReference; path = rsa.c; sourceTree = "<group>"; };
+		OBJ_198 /* rsa_impl.c */ = {isa = PBXFileReference; path = rsa_impl.c; sourceTree = "<group>"; };
+		OBJ_20 /* a_object.c */ = {isa = PBXFileReference; path = a_object.c; sourceTree = "<group>"; };
+		OBJ_200 /* sha1-altivec.c */ = {isa = PBXFileReference; path = "sha1-altivec.c"; sourceTree = "<group>"; };
+		OBJ_201 /* sha1.c */ = {isa = PBXFileReference; path = sha1.c; sourceTree = "<group>"; };
+		OBJ_202 /* sha256.c */ = {isa = PBXFileReference; path = sha256.c; sourceTree = "<group>"; };
+		OBJ_203 /* sha512.c */ = {isa = PBXFileReference; path = sha512.c; sourceTree = "<group>"; };
+		OBJ_205 /* hkdf.c */ = {isa = PBXFileReference; path = hkdf.c; sourceTree = "<group>"; };
+		OBJ_207 /* lhash.c */ = {isa = PBXFileReference; path = lhash.c; sourceTree = "<group>"; };
+		OBJ_208 /* mem.c */ = {isa = PBXFileReference; path = mem.c; sourceTree = "<group>"; };
+		OBJ_21 /* a_octet.c */ = {isa = PBXFileReference; path = a_octet.c; sourceTree = "<group>"; };
+		OBJ_210 /* obj.c */ = {isa = PBXFileReference; path = obj.c; sourceTree = "<group>"; };
+		OBJ_211 /* obj_xref.c */ = {isa = PBXFileReference; path = obj_xref.c; sourceTree = "<group>"; };
+		OBJ_213 /* pem_all.c */ = {isa = PBXFileReference; path = pem_all.c; sourceTree = "<group>"; };
+		OBJ_214 /* pem_info.c */ = {isa = PBXFileReference; path = pem_info.c; sourceTree = "<group>"; };
+		OBJ_215 /* pem_lib.c */ = {isa = PBXFileReference; path = pem_lib.c; sourceTree = "<group>"; };
+		OBJ_216 /* pem_oth.c */ = {isa = PBXFileReference; path = pem_oth.c; sourceTree = "<group>"; };
+		OBJ_217 /* pem_pk8.c */ = {isa = PBXFileReference; path = pem_pk8.c; sourceTree = "<group>"; };
+		OBJ_218 /* pem_pkey.c */ = {isa = PBXFileReference; path = pem_pkey.c; sourceTree = "<group>"; };
+		OBJ_219 /* pem_x509.c */ = {isa = PBXFileReference; path = pem_x509.c; sourceTree = "<group>"; };
+		OBJ_22 /* a_print.c */ = {isa = PBXFileReference; path = a_print.c; sourceTree = "<group>"; };
+		OBJ_220 /* pem_xaux.c */ = {isa = PBXFileReference; path = pem_xaux.c; sourceTree = "<group>"; };
+		OBJ_222 /* pkcs7.c */ = {isa = PBXFileReference; path = pkcs7.c; sourceTree = "<group>"; };
+		OBJ_223 /* pkcs7_x509.c */ = {isa = PBXFileReference; path = pkcs7_x509.c; sourceTree = "<group>"; };
+		OBJ_225 /* p5_pbev2.c */ = {isa = PBXFileReference; path = p5_pbev2.c; sourceTree = "<group>"; };
+		OBJ_226 /* pkcs8.c */ = {isa = PBXFileReference; path = pkcs8.c; sourceTree = "<group>"; };
+		OBJ_227 /* pkcs8_x509.c */ = {isa = PBXFileReference; path = pkcs8_x509.c; sourceTree = "<group>"; };
+		OBJ_229 /* poly1305.c */ = {isa = PBXFileReference; path = poly1305.c; sourceTree = "<group>"; };
+		OBJ_23 /* a_strnid.c */ = {isa = PBXFileReference; path = a_strnid.c; sourceTree = "<group>"; };
+		OBJ_230 /* poly1305_arm.c */ = {isa = PBXFileReference; path = poly1305_arm.c; sourceTree = "<group>"; };
+		OBJ_231 /* poly1305_vec.c */ = {isa = PBXFileReference; path = poly1305_vec.c; sourceTree = "<group>"; };
+		OBJ_233 /* pool.c */ = {isa = PBXFileReference; path = pool.c; sourceTree = "<group>"; };
+		OBJ_235 /* deterministic.c */ = {isa = PBXFileReference; path = deterministic.c; sourceTree = "<group>"; };
+		OBJ_236 /* forkunsafe.c */ = {isa = PBXFileReference; path = forkunsafe.c; sourceTree = "<group>"; };
+		OBJ_237 /* fuchsia.c */ = {isa = PBXFileReference; path = fuchsia.c; sourceTree = "<group>"; };
+		OBJ_238 /* rand_extra.c */ = {isa = PBXFileReference; path = rand_extra.c; sourceTree = "<group>"; };
+		OBJ_239 /* windows.c */ = {isa = PBXFileReference; path = windows.c; sourceTree = "<group>"; };
+		OBJ_24 /* a_time.c */ = {isa = PBXFileReference; path = a_time.c; sourceTree = "<group>"; };
+		OBJ_241 /* rc4.c */ = {isa = PBXFileReference; path = rc4.c; sourceTree = "<group>"; };
+		OBJ_242 /* refcount_c11.c */ = {isa = PBXFileReference; path = refcount_c11.c; sourceTree = "<group>"; };
+		OBJ_243 /* refcount_lock.c */ = {isa = PBXFileReference; path = refcount_lock.c; sourceTree = "<group>"; };
+		OBJ_245 /* rsa_asn1.c */ = {isa = PBXFileReference; path = rsa_asn1.c; sourceTree = "<group>"; };
+		OBJ_247 /* stack.c */ = {isa = PBXFileReference; path = stack.c; sourceTree = "<group>"; };
+		OBJ_248 /* thread.c */ = {isa = PBXFileReference; path = thread.c; sourceTree = "<group>"; };
+		OBJ_249 /* thread_none.c */ = {isa = PBXFileReference; path = thread_none.c; sourceTree = "<group>"; };
+		OBJ_25 /* a_type.c */ = {isa = PBXFileReference; path = a_type.c; sourceTree = "<group>"; };
+		OBJ_250 /* thread_pthread.c */ = {isa = PBXFileReference; path = thread_pthread.c; sourceTree = "<group>"; };
+		OBJ_251 /* thread_win.c */ = {isa = PBXFileReference; path = thread_win.c; sourceTree = "<group>"; };
+		OBJ_253 /* a_digest.c */ = {isa = PBXFileReference; path = a_digest.c; sourceTree = "<group>"; };
+		OBJ_254 /* a_sign.c */ = {isa = PBXFileReference; path = a_sign.c; sourceTree = "<group>"; };
+		OBJ_255 /* a_strex.c */ = {isa = PBXFileReference; path = a_strex.c; sourceTree = "<group>"; };
+		OBJ_256 /* a_verify.c */ = {isa = PBXFileReference; path = a_verify.c; sourceTree = "<group>"; };
+		OBJ_257 /* algorithm.c */ = {isa = PBXFileReference; path = algorithm.c; sourceTree = "<group>"; };
+		OBJ_258 /* asn1_gen.c */ = {isa = PBXFileReference; path = asn1_gen.c; sourceTree = "<group>"; };
+		OBJ_259 /* by_dir.c */ = {isa = PBXFileReference; path = by_dir.c; sourceTree = "<group>"; };
+		OBJ_26 /* a_utctm.c */ = {isa = PBXFileReference; path = a_utctm.c; sourceTree = "<group>"; };
+		OBJ_260 /* by_file.c */ = {isa = PBXFileReference; path = by_file.c; sourceTree = "<group>"; };
+		OBJ_261 /* i2d_pr.c */ = {isa = PBXFileReference; path = i2d_pr.c; sourceTree = "<group>"; };
+		OBJ_262 /* rsa_pss.c */ = {isa = PBXFileReference; path = rsa_pss.c; sourceTree = "<group>"; };
+		OBJ_263 /* t_crl.c */ = {isa = PBXFileReference; path = t_crl.c; sourceTree = "<group>"; };
+		OBJ_264 /* t_req.c */ = {isa = PBXFileReference; path = t_req.c; sourceTree = "<group>"; };
+		OBJ_265 /* t_x509.c */ = {isa = PBXFileReference; path = t_x509.c; sourceTree = "<group>"; };
+		OBJ_266 /* t_x509a.c */ = {isa = PBXFileReference; path = t_x509a.c; sourceTree = "<group>"; };
+		OBJ_267 /* x509.c */ = {isa = PBXFileReference; path = x509.c; sourceTree = "<group>"; };
+		OBJ_268 /* x509_att.c */ = {isa = PBXFileReference; path = x509_att.c; sourceTree = "<group>"; };
+		OBJ_269 /* x509_cmp.c */ = {isa = PBXFileReference; path = x509_cmp.c; sourceTree = "<group>"; };
+		OBJ_27 /* a_utf8.c */ = {isa = PBXFileReference; path = a_utf8.c; sourceTree = "<group>"; };
+		OBJ_270 /* x509_d2.c */ = {isa = PBXFileReference; path = x509_d2.c; sourceTree = "<group>"; };
+		OBJ_271 /* x509_def.c */ = {isa = PBXFileReference; path = x509_def.c; sourceTree = "<group>"; };
+		OBJ_272 /* x509_ext.c */ = {isa = PBXFileReference; path = x509_ext.c; sourceTree = "<group>"; };
+		OBJ_273 /* x509_lu.c */ = {isa = PBXFileReference; path = x509_lu.c; sourceTree = "<group>"; };
+		OBJ_274 /* x509_obj.c */ = {isa = PBXFileReference; path = x509_obj.c; sourceTree = "<group>"; };
+		OBJ_275 /* x509_r2x.c */ = {isa = PBXFileReference; path = x509_r2x.c; sourceTree = "<group>"; };
+		OBJ_276 /* x509_req.c */ = {isa = PBXFileReference; path = x509_req.c; sourceTree = "<group>"; };
+		OBJ_277 /* x509_set.c */ = {isa = PBXFileReference; path = x509_set.c; sourceTree = "<group>"; };
+		OBJ_278 /* x509_trs.c */ = {isa = PBXFileReference; path = x509_trs.c; sourceTree = "<group>"; };
+		OBJ_279 /* x509_txt.c */ = {isa = PBXFileReference; path = x509_txt.c; sourceTree = "<group>"; };
+		OBJ_28 /* asn1_lib.c */ = {isa = PBXFileReference; path = asn1_lib.c; sourceTree = "<group>"; };
+		OBJ_280 /* x509_v3.c */ = {isa = PBXFileReference; path = x509_v3.c; sourceTree = "<group>"; };
+		OBJ_281 /* x509_vfy.c */ = {isa = PBXFileReference; path = x509_vfy.c; sourceTree = "<group>"; };
+		OBJ_282 /* x509_vpm.c */ = {isa = PBXFileReference; path = x509_vpm.c; sourceTree = "<group>"; };
+		OBJ_283 /* x509cset.c */ = {isa = PBXFileReference; path = x509cset.c; sourceTree = "<group>"; };
+		OBJ_284 /* x509name.c */ = {isa = PBXFileReference; path = x509name.c; sourceTree = "<group>"; };
+		OBJ_285 /* x509rset.c */ = {isa = PBXFileReference; path = x509rset.c; sourceTree = "<group>"; };
+		OBJ_286 /* x509spki.c */ = {isa = PBXFileReference; path = x509spki.c; sourceTree = "<group>"; };
+		OBJ_287 /* x_algor.c */ = {isa = PBXFileReference; path = x_algor.c; sourceTree = "<group>"; };
+		OBJ_288 /* x_all.c */ = {isa = PBXFileReference; path = x_all.c; sourceTree = "<group>"; };
+		OBJ_289 /* x_attrib.c */ = {isa = PBXFileReference; path = x_attrib.c; sourceTree = "<group>"; };
+		OBJ_29 /* asn1_par.c */ = {isa = PBXFileReference; path = asn1_par.c; sourceTree = "<group>"; };
+		OBJ_290 /* x_crl.c */ = {isa = PBXFileReference; path = x_crl.c; sourceTree = "<group>"; };
+		OBJ_291 /* x_exten.c */ = {isa = PBXFileReference; path = x_exten.c; sourceTree = "<group>"; };
+		OBJ_292 /* x_info.c */ = {isa = PBXFileReference; path = x_info.c; sourceTree = "<group>"; };
+		OBJ_293 /* x_name.c */ = {isa = PBXFileReference; path = x_name.c; sourceTree = "<group>"; };
+		OBJ_294 /* x_pkey.c */ = {isa = PBXFileReference; path = x_pkey.c; sourceTree = "<group>"; };
+		OBJ_295 /* x_pubkey.c */ = {isa = PBXFileReference; path = x_pubkey.c; sourceTree = "<group>"; };
+		OBJ_296 /* x_req.c */ = {isa = PBXFileReference; path = x_req.c; sourceTree = "<group>"; };
+		OBJ_297 /* x_sig.c */ = {isa = PBXFileReference; path = x_sig.c; sourceTree = "<group>"; };
+		OBJ_298 /* x_spki.c */ = {isa = PBXFileReference; path = x_spki.c; sourceTree = "<group>"; };
+		OBJ_299 /* x_val.c */ = {isa = PBXFileReference; path = x_val.c; sourceTree = "<group>"; };
+		OBJ_30 /* asn_pack.c */ = {isa = PBXFileReference; path = asn_pack.c; sourceTree = "<group>"; };
+		OBJ_300 /* x_x509.c */ = {isa = PBXFileReference; path = x_x509.c; sourceTree = "<group>"; };
+		OBJ_301 /* x_x509a.c */ = {isa = PBXFileReference; path = x_x509a.c; sourceTree = "<group>"; };
+		OBJ_303 /* pcy_cache.c */ = {isa = PBXFileReference; path = pcy_cache.c; sourceTree = "<group>"; };
+		OBJ_304 /* pcy_data.c */ = {isa = PBXFileReference; path = pcy_data.c; sourceTree = "<group>"; };
+		OBJ_305 /* pcy_lib.c */ = {isa = PBXFileReference; path = pcy_lib.c; sourceTree = "<group>"; };
+		OBJ_306 /* pcy_map.c */ = {isa = PBXFileReference; path = pcy_map.c; sourceTree = "<group>"; };
+		OBJ_307 /* pcy_node.c */ = {isa = PBXFileReference; path = pcy_node.c; sourceTree = "<group>"; };
+		OBJ_308 /* pcy_tree.c */ = {isa = PBXFileReference; path = pcy_tree.c; sourceTree = "<group>"; };
+		OBJ_309 /* v3_akey.c */ = {isa = PBXFileReference; path = v3_akey.c; sourceTree = "<group>"; };
+		OBJ_31 /* f_enum.c */ = {isa = PBXFileReference; path = f_enum.c; sourceTree = "<group>"; };
+		OBJ_310 /* v3_akeya.c */ = {isa = PBXFileReference; path = v3_akeya.c; sourceTree = "<group>"; };
+		OBJ_311 /* v3_alt.c */ = {isa = PBXFileReference; path = v3_alt.c; sourceTree = "<group>"; };
+		OBJ_312 /* v3_bcons.c */ = {isa = PBXFileReference; path = v3_bcons.c; sourceTree = "<group>"; };
+		OBJ_313 /* v3_bitst.c */ = {isa = PBXFileReference; path = v3_bitst.c; sourceTree = "<group>"; };
+		OBJ_314 /* v3_conf.c */ = {isa = PBXFileReference; path = v3_conf.c; sourceTree = "<group>"; };
+		OBJ_315 /* v3_cpols.c */ = {isa = PBXFileReference; path = v3_cpols.c; sourceTree = "<group>"; };
+		OBJ_316 /* v3_crld.c */ = {isa = PBXFileReference; path = v3_crld.c; sourceTree = "<group>"; };
+		OBJ_317 /* v3_enum.c */ = {isa = PBXFileReference; path = v3_enum.c; sourceTree = "<group>"; };
+		OBJ_318 /* v3_extku.c */ = {isa = PBXFileReference; path = v3_extku.c; sourceTree = "<group>"; };
+		OBJ_319 /* v3_genn.c */ = {isa = PBXFileReference; path = v3_genn.c; sourceTree = "<group>"; };
+		OBJ_32 /* f_int.c */ = {isa = PBXFileReference; path = f_int.c; sourceTree = "<group>"; };
+		OBJ_320 /* v3_ia5.c */ = {isa = PBXFileReference; path = v3_ia5.c; sourceTree = "<group>"; };
+		OBJ_321 /* v3_info.c */ = {isa = PBXFileReference; path = v3_info.c; sourceTree = "<group>"; };
+		OBJ_322 /* v3_int.c */ = {isa = PBXFileReference; path = v3_int.c; sourceTree = "<group>"; };
+		OBJ_323 /* v3_lib.c */ = {isa = PBXFileReference; path = v3_lib.c; sourceTree = "<group>"; };
+		OBJ_324 /* v3_ncons.c */ = {isa = PBXFileReference; path = v3_ncons.c; sourceTree = "<group>"; };
+		OBJ_325 /* v3_pci.c */ = {isa = PBXFileReference; path = v3_pci.c; sourceTree = "<group>"; };
+		OBJ_326 /* v3_pcia.c */ = {isa = PBXFileReference; path = v3_pcia.c; sourceTree = "<group>"; };
+		OBJ_327 /* v3_pcons.c */ = {isa = PBXFileReference; path = v3_pcons.c; sourceTree = "<group>"; };
+		OBJ_328 /* v3_pku.c */ = {isa = PBXFileReference; path = v3_pku.c; sourceTree = "<group>"; };
+		OBJ_329 /* v3_pmaps.c */ = {isa = PBXFileReference; path = v3_pmaps.c; sourceTree = "<group>"; };
+		OBJ_33 /* f_string.c */ = {isa = PBXFileReference; path = f_string.c; sourceTree = "<group>"; };
+		OBJ_330 /* v3_prn.c */ = {isa = PBXFileReference; path = v3_prn.c; sourceTree = "<group>"; };
+		OBJ_331 /* v3_purp.c */ = {isa = PBXFileReference; path = v3_purp.c; sourceTree = "<group>"; };
+		OBJ_332 /* v3_skey.c */ = {isa = PBXFileReference; path = v3_skey.c; sourceTree = "<group>"; };
+		OBJ_333 /* v3_sxnet.c */ = {isa = PBXFileReference; path = v3_sxnet.c; sourceTree = "<group>"; };
+		OBJ_334 /* v3_utl.c */ = {isa = PBXFileReference; path = v3_utl.c; sourceTree = "<group>"; };
+		OBJ_335 /* err_data.c */ = {isa = PBXFileReference; path = err_data.c; sourceTree = "<group>"; };
+		OBJ_337 /* bio_ssl.cc */ = {isa = PBXFileReference; path = bio_ssl.cc; sourceTree = "<group>"; };
+		OBJ_338 /* custom_extensions.cc */ = {isa = PBXFileReference; path = custom_extensions.cc; sourceTree = "<group>"; };
+		OBJ_339 /* d1_both.cc */ = {isa = PBXFileReference; path = d1_both.cc; sourceTree = "<group>"; };
+		OBJ_34 /* tasn_dec.c */ = {isa = PBXFileReference; path = tasn_dec.c; sourceTree = "<group>"; };
+		OBJ_340 /* d1_lib.cc */ = {isa = PBXFileReference; path = d1_lib.cc; sourceTree = "<group>"; };
+		OBJ_341 /* d1_pkt.cc */ = {isa = PBXFileReference; path = d1_pkt.cc; sourceTree = "<group>"; };
+		OBJ_342 /* d1_srtp.cc */ = {isa = PBXFileReference; path = d1_srtp.cc; sourceTree = "<group>"; };
+		OBJ_343 /* dtls_method.cc */ = {isa = PBXFileReference; path = dtls_method.cc; sourceTree = "<group>"; };
+		OBJ_344 /* dtls_record.cc */ = {isa = PBXFileReference; path = dtls_record.cc; sourceTree = "<group>"; };
+		OBJ_345 /* handshake.cc */ = {isa = PBXFileReference; path = handshake.cc; sourceTree = "<group>"; };
+		OBJ_346 /* handshake_client.cc */ = {isa = PBXFileReference; path = handshake_client.cc; sourceTree = "<group>"; };
+		OBJ_347 /* handshake_server.cc */ = {isa = PBXFileReference; path = handshake_server.cc; sourceTree = "<group>"; };
+		OBJ_348 /* s3_both.cc */ = {isa = PBXFileReference; path = s3_both.cc; sourceTree = "<group>"; };
+		OBJ_349 /* s3_lib.cc */ = {isa = PBXFileReference; path = s3_lib.cc; sourceTree = "<group>"; };
+		OBJ_35 /* tasn_enc.c */ = {isa = PBXFileReference; path = tasn_enc.c; sourceTree = "<group>"; };
+		OBJ_350 /* s3_pkt.cc */ = {isa = PBXFileReference; path = s3_pkt.cc; sourceTree = "<group>"; };
+		OBJ_351 /* ssl_aead_ctx.cc */ = {isa = PBXFileReference; path = ssl_aead_ctx.cc; sourceTree = "<group>"; };
+		OBJ_352 /* ssl_asn1.cc */ = {isa = PBXFileReference; path = ssl_asn1.cc; sourceTree = "<group>"; };
+		OBJ_353 /* ssl_buffer.cc */ = {isa = PBXFileReference; path = ssl_buffer.cc; sourceTree = "<group>"; };
+		OBJ_354 /* ssl_cert.cc */ = {isa = PBXFileReference; path = ssl_cert.cc; sourceTree = "<group>"; };
+		OBJ_355 /* ssl_cipher.cc */ = {isa = PBXFileReference; path = ssl_cipher.cc; sourceTree = "<group>"; };
+		OBJ_356 /* ssl_file.cc */ = {isa = PBXFileReference; path = ssl_file.cc; sourceTree = "<group>"; };
+		OBJ_357 /* ssl_key_share.cc */ = {isa = PBXFileReference; path = ssl_key_share.cc; sourceTree = "<group>"; };
+		OBJ_358 /* ssl_lib.cc */ = {isa = PBXFileReference; path = ssl_lib.cc; sourceTree = "<group>"; };
+		OBJ_359 /* ssl_privkey.cc */ = {isa = PBXFileReference; path = ssl_privkey.cc; sourceTree = "<group>"; };
+		OBJ_36 /* tasn_fre.c */ = {isa = PBXFileReference; path = tasn_fre.c; sourceTree = "<group>"; };
+		OBJ_360 /* ssl_session.cc */ = {isa = PBXFileReference; path = ssl_session.cc; sourceTree = "<group>"; };
+		OBJ_361 /* ssl_stat.cc */ = {isa = PBXFileReference; path = ssl_stat.cc; sourceTree = "<group>"; };
+		OBJ_362 /* ssl_transcript.cc */ = {isa = PBXFileReference; path = ssl_transcript.cc; sourceTree = "<group>"; };
+		OBJ_363 /* ssl_versions.cc */ = {isa = PBXFileReference; path = ssl_versions.cc; sourceTree = "<group>"; };
+		OBJ_364 /* ssl_x509.cc */ = {isa = PBXFileReference; path = ssl_x509.cc; sourceTree = "<group>"; };
+		OBJ_365 /* t1_enc.cc */ = {isa = PBXFileReference; path = t1_enc.cc; sourceTree = "<group>"; };
+		OBJ_366 /* t1_lib.cc */ = {isa = PBXFileReference; path = t1_lib.cc; sourceTree = "<group>"; };
+		OBJ_367 /* tls13_both.cc */ = {isa = PBXFileReference; path = tls13_both.cc; sourceTree = "<group>"; };
+		OBJ_368 /* tls13_client.cc */ = {isa = PBXFileReference; path = tls13_client.cc; sourceTree = "<group>"; };
+		OBJ_369 /* tls13_enc.cc */ = {isa = PBXFileReference; path = tls13_enc.cc; sourceTree = "<group>"; };
+		OBJ_37 /* tasn_new.c */ = {isa = PBXFileReference; path = tasn_new.c; sourceTree = "<group>"; };
+		OBJ_370 /* tls13_server.cc */ = {isa = PBXFileReference; path = tls13_server.cc; sourceTree = "<group>"; };
+		OBJ_371 /* tls_method.cc */ = {isa = PBXFileReference; path = tls_method.cc; sourceTree = "<group>"; };
+		OBJ_372 /* tls_record.cc */ = {isa = PBXFileReference; path = tls_record.cc; sourceTree = "<group>"; };
+		OBJ_375 /* curve25519.c */ = {isa = PBXFileReference; path = curve25519.c; sourceTree = "<group>"; };
+		OBJ_378 /* pem.h */ = {isa = PBXFileReference; path = pem.h; sourceTree = "<group>"; };
+		OBJ_379 /* nid.h */ = {isa = PBXFileReference; path = nid.h; sourceTree = "<group>"; };
+		OBJ_38 /* tasn_typ.c */ = {isa = PBXFileReference; path = tasn_typ.c; sourceTree = "<group>"; };
+		OBJ_380 /* ssl3.h */ = {isa = PBXFileReference; path = ssl3.h; sourceTree = "<group>"; };
+		OBJ_381 /* ossl_typ.h */ = {isa = PBXFileReference; path = ossl_typ.h; sourceTree = "<group>"; };
+		OBJ_382 /* dtls1.h */ = {isa = PBXFileReference; path = dtls1.h; sourceTree = "<group>"; };
+		OBJ_383 /* err.h */ = {isa = PBXFileReference; path = err.h; sourceTree = "<group>"; };
+		OBJ_384 /* bn.h */ = {isa = PBXFileReference; path = bn.h; sourceTree = "<group>"; };
+		OBJ_385 /* blowfish.h */ = {isa = PBXFileReference; path = blowfish.h; sourceTree = "<group>"; };
+		OBJ_386 /* engine.h */ = {isa = PBXFileReference; path = engine.h; sourceTree = "<group>"; };
+		OBJ_387 /* bytestring.h */ = {isa = PBXFileReference; path = bytestring.h; sourceTree = "<group>"; };
+		OBJ_388 /* x509.h */ = {isa = PBXFileReference; path = x509.h; sourceTree = "<group>"; };
+		OBJ_389 /* asn1_mac.h */ = {isa = PBXFileReference; path = asn1_mac.h; sourceTree = "<group>"; };
+		OBJ_39 /* tasn_utl.c */ = {isa = PBXFileReference; path = tasn_utl.c; sourceTree = "<group>"; };
+		OBJ_390 /* pool.h */ = {isa = PBXFileReference; path = pool.h; sourceTree = "<group>"; };
+		OBJ_391 /* ec_key.h */ = {isa = PBXFileReference; path = ec_key.h; sourceTree = "<group>"; };
+		OBJ_392 /* base64.h */ = {isa = PBXFileReference; path = base64.h; sourceTree = "<group>"; };
+		OBJ_393 /* is_boringssl.h */ = {isa = PBXFileReference; path = is_boringssl.h; sourceTree = "<group>"; };
+		OBJ_394 /* sha.h */ = {isa = PBXFileReference; path = sha.h; sourceTree = "<group>"; };
+		OBJ_395 /* asn1.h */ = {isa = PBXFileReference; path = asn1.h; sourceTree = "<group>"; };
+		OBJ_396 /* chacha.h */ = {isa = PBXFileReference; path = chacha.h; sourceTree = "<group>"; };
+		OBJ_397 /* opensslconf.h */ = {isa = PBXFileReference; path = opensslconf.h; sourceTree = "<group>"; };
+		OBJ_398 /* arm_arch.h */ = {isa = PBXFileReference; path = arm_arch.h; sourceTree = "<group>"; };
+		OBJ_399 /* bio.h */ = {isa = PBXFileReference; path = bio.h; sourceTree = "<group>"; };
+		OBJ_40 /* time_support.c */ = {isa = PBXFileReference; path = time_support.c; sourceTree = "<group>"; };
+		OBJ_400 /* dh.h */ = {isa = PBXFileReference; path = dh.h; sourceTree = "<group>"; };
+		OBJ_401 /* digest.h */ = {isa = PBXFileReference; path = digest.h; sourceTree = "<group>"; };
+		OBJ_402 /* x509v3.h */ = {isa = PBXFileReference; path = x509v3.h; sourceTree = "<group>"; };
+		OBJ_403 /* conf.h */ = {isa = PBXFileReference; path = conf.h; sourceTree = "<group>"; };
+		OBJ_404 /* poly1305.h */ = {isa = PBXFileReference; path = poly1305.h; sourceTree = "<group>"; };
+		OBJ_405 /* hkdf.h */ = {isa = PBXFileReference; path = hkdf.h; sourceTree = "<group>"; };
+		OBJ_406 /* type_check.h */ = {isa = PBXFileReference; path = type_check.h; sourceTree = "<group>"; };
+		OBJ_407 /* md5.h */ = {isa = PBXFileReference; path = md5.h; sourceTree = "<group>"; };
+		OBJ_408 /* x509_vfy.h */ = {isa = PBXFileReference; path = x509_vfy.h; sourceTree = "<group>"; };
+		OBJ_409 /* pkcs8.h */ = {isa = PBXFileReference; path = pkcs8.h; sourceTree = "<group>"; };
+		OBJ_410 /* safestack.h */ = {isa = PBXFileReference; path = safestack.h; sourceTree = "<group>"; };
+		OBJ_411 /* buf.h */ = {isa = PBXFileReference; path = buf.h; sourceTree = "<group>"; };
+		OBJ_412 /* obj.h */ = {isa = PBXFileReference; path = obj.h; sourceTree = "<group>"; };
+		OBJ_413 /* ecdsa.h */ = {isa = PBXFileReference; path = ecdsa.h; sourceTree = "<group>"; };
+		OBJ_414 /* cipher.h */ = {isa = PBXFileReference; path = cipher.h; sourceTree = "<group>"; };
+		OBJ_415 /* objects.h */ = {isa = PBXFileReference; path = objects.h; sourceTree = "<group>"; };
+		OBJ_416 /* pkcs12.h */ = {isa = PBXFileReference; path = pkcs12.h; sourceTree = "<group>"; };
+		OBJ_417 /* crypto.h */ = {isa = PBXFileReference; path = crypto.h; sourceTree = "<group>"; };
+		OBJ_418 /* opensslv.h */ = {isa = PBXFileReference; path = opensslv.h; sourceTree = "<group>"; };
+		OBJ_419 /* pkcs7.h */ = {isa = PBXFileReference; path = pkcs7.h; sourceTree = "<group>"; };
+		OBJ_42 /* base64.c */ = {isa = PBXFileReference; path = base64.c; sourceTree = "<group>"; };
+		OBJ_420 /* obj_mac.h */ = {isa = PBXFileReference; path = obj_mac.h; sourceTree = "<group>"; };
+		OBJ_421 /* buffer.h */ = {isa = PBXFileReference; path = buffer.h; sourceTree = "<group>"; };
+		OBJ_422 /* ssl.h */ = {isa = PBXFileReference; path = ssl.h; sourceTree = "<group>"; };
+		OBJ_423 /* thread.h */ = {isa = PBXFileReference; path = thread.h; sourceTree = "<group>"; };
+		OBJ_424 /* evp.h */ = {isa = PBXFileReference; path = evp.h; sourceTree = "<group>"; };
+		OBJ_425 /* md4.h */ = {isa = PBXFileReference; path = md4.h; sourceTree = "<group>"; };
+		OBJ_426 /* hmac.h */ = {isa = PBXFileReference; path = hmac.h; sourceTree = "<group>"; };
+		OBJ_427 /* aes.h */ = {isa = PBXFileReference; path = aes.h; sourceTree = "<group>"; };
+		OBJ_428 /* cast.h */ = {isa = PBXFileReference; path = cast.h; sourceTree = "<group>"; };
+		OBJ_429 /* rc4.h */ = {isa = PBXFileReference; path = rc4.h; sourceTree = "<group>"; };
+		OBJ_430 /* cpu.h */ = {isa = PBXFileReference; path = cpu.h; sourceTree = "<group>"; };
+		OBJ_431 /* stack.h */ = {isa = PBXFileReference; path = stack.h; sourceTree = "<group>"; };
+		OBJ_432 /* des.h */ = {isa = PBXFileReference; path = des.h; sourceTree = "<group>"; };
+		OBJ_433 /* ec.h */ = {isa = PBXFileReference; path = ec.h; sourceTree = "<group>"; };
+		OBJ_434 /* ecdh.h */ = {isa = PBXFileReference; path = ecdh.h; sourceTree = "<group>"; };
+		OBJ_435 /* rand.h */ = {isa = PBXFileReference; path = rand.h; sourceTree = "<group>"; };
+		OBJ_436 /* aead.h */ = {isa = PBXFileReference; path = aead.h; sourceTree = "<group>"; };
+		OBJ_437 /* lhash_macros.h */ = {isa = PBXFileReference; path = lhash_macros.h; sourceTree = "<group>"; };
+		OBJ_438 /* span.h */ = {isa = PBXFileReference; path = span.h; sourceTree = "<group>"; };
+		OBJ_439 /* rsa.h */ = {isa = PBXFileReference; path = rsa.h; sourceTree = "<group>"; };
+		OBJ_44 /* bio.c */ = {isa = PBXFileReference; path = bio.c; sourceTree = "<group>"; };
+		OBJ_440 /* mem.h */ = {isa = PBXFileReference; path = mem.h; sourceTree = "<group>"; };
+		OBJ_441 /* ripemd.h */ = {isa = PBXFileReference; path = ripemd.h; sourceTree = "<group>"; };
+		OBJ_442 /* curve25519.h */ = {isa = PBXFileReference; path = curve25519.h; sourceTree = "<group>"; };
+		OBJ_443 /* tls1.h */ = {isa = PBXFileReference; path = tls1.h; sourceTree = "<group>"; };
+		OBJ_444 /* dsa.h */ = {isa = PBXFileReference; path = dsa.h; sourceTree = "<group>"; };
+		OBJ_445 /* srtp.h */ = {isa = PBXFileReference; path = srtp.h; sourceTree = "<group>"; };
+		OBJ_446 /* asn1t.h */ = {isa = PBXFileReference; path = asn1t.h; sourceTree = "<group>"; };
+		OBJ_447 /* cmac.h */ = {isa = PBXFileReference; path = cmac.h; sourceTree = "<group>"; };
+		OBJ_448 /* lhash.h */ = {isa = PBXFileReference; path = lhash.h; sourceTree = "<group>"; };
+		OBJ_449 /* ex_data.h */ = {isa = PBXFileReference; path = ex_data.h; sourceTree = "<group>"; };
+		OBJ_45 /* bio_mem.c */ = {isa = PBXFileReference; path = bio_mem.c; sourceTree = "<group>"; };
+		OBJ_450 /* base.h */ = {isa = PBXFileReference; path = base.h; sourceTree = "<group>"; };
+		OBJ_451 /* module.modulemap */ = {isa = PBXFileReference; name = module.modulemap; path = "/private/tmp/PR/grpc-swift/SwiftGRPC-Carthage.xcodeproj/GeneratedModuleMap/BoringSSL/module.modulemap"; sourceTree = "<group>"; };
+		OBJ_453 /* EchoProvider.swift */ = {isa = PBXFileReference; path = EchoProvider.swift; sourceTree = "<group>"; };
+		OBJ_455 /* echo.grpc.swift */ = {isa = PBXFileReference; path = echo.grpc.swift; sourceTree = "<group>"; };
+		OBJ_456 /* echo.pb.swift */ = {isa = PBXFileReference; path = echo.pb.swift; sourceTree = "<group>"; };
+		OBJ_457 /* main.swift */ = {isa = PBXFileReference; path = main.swift; sourceTree = "<group>"; };
+		OBJ_459 /* Generator-Client.swift */ = {isa = PBXFileReference; path = "Generator-Client.swift"; sourceTree = "<group>"; };
+		OBJ_46 /* connect.c */ = {isa = PBXFileReference; path = connect.c; sourceTree = "<group>"; };
+		OBJ_460 /* Generator-Methods.swift */ = {isa = PBXFileReference; path = "Generator-Methods.swift"; sourceTree = "<group>"; };
+		OBJ_461 /* Generator-Names.swift */ = {isa = PBXFileReference; path = "Generator-Names.swift"; sourceTree = "<group>"; };
+		OBJ_462 /* Generator-Server.swift */ = {isa = PBXFileReference; path = "Generator-Server.swift"; sourceTree = "<group>"; };
+		OBJ_463 /* Generator.swift */ = {isa = PBXFileReference; path = Generator.swift; sourceTree = "<group>"; };
+		OBJ_464 /* StreamingType.swift */ = {isa = PBXFileReference; path = StreamingType.swift; sourceTree = "<group>"; };
+		OBJ_465 /* io.swift */ = {isa = PBXFileReference; path = io.swift; sourceTree = "<group>"; };
+		OBJ_466 /* main.swift */ = {isa = PBXFileReference; path = main.swift; sourceTree = "<group>"; };
+		OBJ_467 /* options.swift */ = {isa = PBXFileReference; path = options.swift; sourceTree = "<group>"; };
+		OBJ_47 /* fd.c */ = {isa = PBXFileReference; path = fd.c; sourceTree = "<group>"; };
+		OBJ_470 /* ByteBuffer.swift */ = {isa = PBXFileReference; path = ByteBuffer.swift; sourceTree = "<group>"; };
+		OBJ_471 /* Call.swift */ = {isa = PBXFileReference; path = Call.swift; sourceTree = "<group>"; };
+		OBJ_472 /* CallError.swift */ = {isa = PBXFileReference; path = CallError.swift; sourceTree = "<group>"; };
+		OBJ_473 /* CallResult.swift */ = {isa = PBXFileReference; path = CallResult.swift; sourceTree = "<group>"; };
+		OBJ_474 /* Channel.swift */ = {isa = PBXFileReference; path = Channel.swift; sourceTree = "<group>"; };
+		OBJ_475 /* ChannelArgument.swift */ = {isa = PBXFileReference; path = ChannelArgument.swift; sourceTree = "<group>"; };
+		OBJ_476 /* CompletionQueue.swift */ = {isa = PBXFileReference; path = CompletionQueue.swift; sourceTree = "<group>"; };
+		OBJ_477 /* Handler.swift */ = {isa = PBXFileReference; path = Handler.swift; sourceTree = "<group>"; };
+		OBJ_478 /* Metadata.swift */ = {isa = PBXFileReference; path = Metadata.swift; sourceTree = "<group>"; };
+		OBJ_479 /* Mutex.swift */ = {isa = PBXFileReference; path = Mutex.swift; sourceTree = "<group>"; };
+		OBJ_48 /* file.c */ = {isa = PBXFileReference; path = file.c; sourceTree = "<group>"; };
+		OBJ_480 /* Operation.swift */ = {isa = PBXFileReference; path = Operation.swift; sourceTree = "<group>"; };
+		OBJ_481 /* OperationGroup.swift */ = {isa = PBXFileReference; path = OperationGroup.swift; sourceTree = "<group>"; };
+		OBJ_482 /* Roots.swift */ = {isa = PBXFileReference; path = Roots.swift; sourceTree = "<group>"; };
+		OBJ_483 /* Server.swift */ = {isa = PBXFileReference; path = Server.swift; sourceTree = "<group>"; };
+		OBJ_484 /* ServerStatus.swift */ = {isa = PBXFileReference; path = ServerStatus.swift; sourceTree = "<group>"; };
+		OBJ_485 /* gRPC.swift */ = {isa = PBXFileReference; path = gRPC.swift; sourceTree = "<group>"; };
+		OBJ_487 /* ClientCall.swift */ = {isa = PBXFileReference; path = ClientCall.swift; sourceTree = "<group>"; };
+		OBJ_488 /* ClientCallBidirectionalStreaming.swift */ = {isa = PBXFileReference; path = ClientCallBidirectionalStreaming.swift; sourceTree = "<group>"; };
+		OBJ_489 /* ClientCallClientStreaming.swift */ = {isa = PBXFileReference; path = ClientCallClientStreaming.swift; sourceTree = "<group>"; };
+		OBJ_49 /* hexdump.c */ = {isa = PBXFileReference; path = hexdump.c; sourceTree = "<group>"; };
+		OBJ_490 /* ClientCallServerStreaming.swift */ = {isa = PBXFileReference; path = ClientCallServerStreaming.swift; sourceTree = "<group>"; };
+		OBJ_491 /* ClientCallUnary.swift */ = {isa = PBXFileReference; path = ClientCallUnary.swift; sourceTree = "<group>"; };
+		OBJ_492 /* RPCError.swift */ = {isa = PBXFileReference; path = RPCError.swift; sourceTree = "<group>"; };
+		OBJ_493 /* ServerSession.swift */ = {isa = PBXFileReference; path = ServerSession.swift; sourceTree = "<group>"; };
+		OBJ_494 /* ServerSessionBidirectionalStreaming.swift */ = {isa = PBXFileReference; path = ServerSessionBidirectionalStreaming.swift; sourceTree = "<group>"; };
+		OBJ_495 /* ServerSessionClientStreaming.swift */ = {isa = PBXFileReference; path = ServerSessionClientStreaming.swift; sourceTree = "<group>"; };
+		OBJ_496 /* ServerSessionServerStreaming.swift */ = {isa = PBXFileReference; path = ServerSessionServerStreaming.swift; sourceTree = "<group>"; };
+		OBJ_497 /* ServerSessionUnary.swift */ = {isa = PBXFileReference; path = ServerSessionUnary.swift; sourceTree = "<group>"; };
+		OBJ_498 /* ServiceClient.swift */ = {isa = PBXFileReference; path = ServiceClient.swift; sourceTree = "<group>"; };
+		OBJ_499 /* ServiceProvider.swift */ = {isa = PBXFileReference; path = ServiceProvider.swift; sourceTree = "<group>"; };
+		OBJ_50 /* pair.c */ = {isa = PBXFileReference; path = pair.c; sourceTree = "<group>"; };
+		OBJ_500 /* ServiceServer.swift */ = {isa = PBXFileReference; path = ServiceServer.swift; sourceTree = "<group>"; };
+		OBJ_501 /* StreamReceiving.swift */ = {isa = PBXFileReference; path = StreamReceiving.swift; sourceTree = "<group>"; };
+		OBJ_502 /* StreamSending.swift */ = {isa = PBXFileReference; path = StreamSending.swift; sourceTree = "<group>"; };
+		OBJ_505 /* byte_buffer.c */ = {isa = PBXFileReference; path = byte_buffer.c; sourceTree = "<group>"; };
+		OBJ_506 /* call.c */ = {isa = PBXFileReference; path = call.c; sourceTree = "<group>"; };
+		OBJ_507 /* channel.c */ = {isa = PBXFileReference; path = channel.c; sourceTree = "<group>"; };
+		OBJ_508 /* completion_queue.c */ = {isa = PBXFileReference; path = completion_queue.c; sourceTree = "<group>"; };
+		OBJ_509 /* event.c */ = {isa = PBXFileReference; path = event.c; sourceTree = "<group>"; };
+		OBJ_51 /* printf.c */ = {isa = PBXFileReference; path = printf.c; sourceTree = "<group>"; };
+		OBJ_510 /* handler.c */ = {isa = PBXFileReference; path = handler.c; sourceTree = "<group>"; };
+		OBJ_511 /* internal.c */ = {isa = PBXFileReference; path = internal.c; sourceTree = "<group>"; };
+		OBJ_512 /* metadata.c */ = {isa = PBXFileReference; path = metadata.c; sourceTree = "<group>"; };
+		OBJ_513 /* mutex.c */ = {isa = PBXFileReference; path = mutex.c; sourceTree = "<group>"; };
+		OBJ_514 /* observers.c */ = {isa = PBXFileReference; path = observers.c; sourceTree = "<group>"; };
+		OBJ_515 /* operations.c */ = {isa = PBXFileReference; path = operations.c; sourceTree = "<group>"; };
+		OBJ_516 /* server.c */ = {isa = PBXFileReference; path = server.c; sourceTree = "<group>"; };
+		OBJ_52 /* socket.c */ = {isa = PBXFileReference; path = socket.c; sourceTree = "<group>"; };
+		OBJ_521 /* grpc_context.cc */ = {isa = PBXFileReference; path = grpc_context.cc; sourceTree = "<group>"; };
+		OBJ_524 /* backup_poller.cc */ = {isa = PBXFileReference; path = backup_poller.cc; sourceTree = "<group>"; };
+		OBJ_525 /* channel_connectivity.cc */ = {isa = PBXFileReference; path = channel_connectivity.cc; sourceTree = "<group>"; };
+		OBJ_526 /* client_channel.cc */ = {isa = PBXFileReference; path = client_channel.cc; sourceTree = "<group>"; };
+		OBJ_527 /* client_channel_factory.cc */ = {isa = PBXFileReference; path = client_channel_factory.cc; sourceTree = "<group>"; };
+		OBJ_528 /* client_channel_plugin.cc */ = {isa = PBXFileReference; path = client_channel_plugin.cc; sourceTree = "<group>"; };
+		OBJ_529 /* connector.cc */ = {isa = PBXFileReference; path = connector.cc; sourceTree = "<group>"; };
+		OBJ_53 /* socket_helper.c */ = {isa = PBXFileReference; path = socket_helper.c; sourceTree = "<group>"; };
+		OBJ_530 /* http_connect_handshaker.cc */ = {isa = PBXFileReference; path = http_connect_handshaker.cc; sourceTree = "<group>"; };
+		OBJ_531 /* http_proxy.cc */ = {isa = PBXFileReference; path = http_proxy.cc; sourceTree = "<group>"; };
+		OBJ_532 /* lb_policy.cc */ = {isa = PBXFileReference; path = lb_policy.cc; sourceTree = "<group>"; };
+		OBJ_535 /* client_load_reporting_filter.cc */ = {isa = PBXFileReference; path = client_load_reporting_filter.cc; sourceTree = "<group>"; };
+		OBJ_536 /* grpclb.cc */ = {isa = PBXFileReference; path = grpclb.cc; sourceTree = "<group>"; };
+		OBJ_537 /* grpclb_channel_secure.cc */ = {isa = PBXFileReference; path = grpclb_channel_secure.cc; sourceTree = "<group>"; };
+		OBJ_538 /* grpclb_client_stats.cc */ = {isa = PBXFileReference; path = grpclb_client_stats.cc; sourceTree = "<group>"; };
+		OBJ_539 /* load_balancer_api.cc */ = {isa = PBXFileReference; path = load_balancer_api.cc; sourceTree = "<group>"; };
+		OBJ_544 /* load_balancer.pb.c */ = {isa = PBXFileReference; path = load_balancer.pb.c; sourceTree = "<group>"; };
+		OBJ_546 /* pick_first.cc */ = {isa = PBXFileReference; path = pick_first.cc; sourceTree = "<group>"; };
+		OBJ_548 /* round_robin.cc */ = {isa = PBXFileReference; path = round_robin.cc; sourceTree = "<group>"; };
+		OBJ_549 /* lb_policy_factory.cc */ = {isa = PBXFileReference; path = lb_policy_factory.cc; sourceTree = "<group>"; };
+		OBJ_55 /* bn_asn1.c */ = {isa = PBXFileReference; path = bn_asn1.c; sourceTree = "<group>"; };
+		OBJ_550 /* lb_policy_registry.cc */ = {isa = PBXFileReference; path = lb_policy_registry.cc; sourceTree = "<group>"; };
+		OBJ_551 /* method_params.cc */ = {isa = PBXFileReference; path = method_params.cc; sourceTree = "<group>"; };
+		OBJ_552 /* parse_address.cc */ = {isa = PBXFileReference; path = parse_address.cc; sourceTree = "<group>"; };
+		OBJ_553 /* proxy_mapper.cc */ = {isa = PBXFileReference; path = proxy_mapper.cc; sourceTree = "<group>"; };
+		OBJ_554 /* proxy_mapper_registry.cc */ = {isa = PBXFileReference; path = proxy_mapper_registry.cc; sourceTree = "<group>"; };
+		OBJ_555 /* resolver.cc */ = {isa = PBXFileReference; path = resolver.cc; sourceTree = "<group>"; };
+		OBJ_559 /* dns_resolver_ares.cc */ = {isa = PBXFileReference; path = dns_resolver_ares.cc; sourceTree = "<group>"; };
+		OBJ_56 /* convert.c */ = {isa = PBXFileReference; path = convert.c; sourceTree = "<group>"; };
+		OBJ_560 /* grpc_ares_ev_driver_posix.cc */ = {isa = PBXFileReference; path = grpc_ares_ev_driver_posix.cc; sourceTree = "<group>"; };
+		OBJ_561 /* grpc_ares_wrapper.cc */ = {isa = PBXFileReference; path = grpc_ares_wrapper.cc; sourceTree = "<group>"; };
+		OBJ_562 /* grpc_ares_wrapper_fallback.cc */ = {isa = PBXFileReference; path = grpc_ares_wrapper_fallback.cc; sourceTree = "<group>"; };
+		OBJ_564 /* dns_resolver.cc */ = {isa = PBXFileReference; path = dns_resolver.cc; sourceTree = "<group>"; };
+		OBJ_566 /* fake_resolver.cc */ = {isa = PBXFileReference; path = fake_resolver.cc; sourceTree = "<group>"; };
+		OBJ_568 /* sockaddr_resolver.cc */ = {isa = PBXFileReference; path = sockaddr_resolver.cc; sourceTree = "<group>"; };
+		OBJ_569 /* resolver_registry.cc */ = {isa = PBXFileReference; path = resolver_registry.cc; sourceTree = "<group>"; };
+		OBJ_570 /* retry_throttle.cc */ = {isa = PBXFileReference; path = retry_throttle.cc; sourceTree = "<group>"; };
+		OBJ_571 /* subchannel.cc */ = {isa = PBXFileReference; path = subchannel.cc; sourceTree = "<group>"; };
+		OBJ_572 /* subchannel_index.cc */ = {isa = PBXFileReference; path = subchannel_index.cc; sourceTree = "<group>"; };
+		OBJ_573 /* uri_parser.cc */ = {isa = PBXFileReference; path = uri_parser.cc; sourceTree = "<group>"; };
+		OBJ_575 /* deadline_filter.cc */ = {isa = PBXFileReference; path = deadline_filter.cc; sourceTree = "<group>"; };
+		OBJ_578 /* http_client_filter.cc */ = {isa = PBXFileReference; path = http_client_filter.cc; sourceTree = "<group>"; };
+		OBJ_579 /* client_authority_filter.cc */ = {isa = PBXFileReference; path = client_authority_filter.cc; sourceTree = "<group>"; };
+		OBJ_58 /* buf.c */ = {isa = PBXFileReference; path = buf.c; sourceTree = "<group>"; };
+		OBJ_580 /* http_filters_plugin.cc */ = {isa = PBXFileReference; path = http_filters_plugin.cc; sourceTree = "<group>"; };
+		OBJ_582 /* message_compress_filter.cc */ = {isa = PBXFileReference; path = message_compress_filter.cc; sourceTree = "<group>"; };
+		OBJ_584 /* http_server_filter.cc */ = {isa = PBXFileReference; path = http_server_filter.cc; sourceTree = "<group>"; };
+		OBJ_586 /* server_load_reporting_filter.cc */ = {isa = PBXFileReference; path = server_load_reporting_filter.cc; sourceTree = "<group>"; };
+		OBJ_587 /* server_load_reporting_plugin.cc */ = {isa = PBXFileReference; path = server_load_reporting_plugin.cc; sourceTree = "<group>"; };
+		OBJ_589 /* max_age_filter.cc */ = {isa = PBXFileReference; path = max_age_filter.cc; sourceTree = "<group>"; };
+		OBJ_591 /* message_size_filter.cc */ = {isa = PBXFileReference; path = message_size_filter.cc; sourceTree = "<group>"; };
+		OBJ_593 /* workaround_cronet_compression_filter.cc */ = {isa = PBXFileReference; path = workaround_cronet_compression_filter.cc; sourceTree = "<group>"; };
+		OBJ_594 /* workaround_utils.cc */ = {isa = PBXFileReference; path = workaround_utils.cc; sourceTree = "<group>"; };
+		OBJ_598 /* alpn.cc */ = {isa = PBXFileReference; path = alpn.cc; sourceTree = "<group>"; };
+		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
+		OBJ_60 /* asn1_compat.c */ = {isa = PBXFileReference; path = asn1_compat.c; sourceTree = "<group>"; };
+		OBJ_600 /* authority.cc */ = {isa = PBXFileReference; path = authority.cc; sourceTree = "<group>"; };
+		OBJ_601 /* chttp2_connector.cc */ = {isa = PBXFileReference; path = chttp2_connector.cc; sourceTree = "<group>"; };
+		OBJ_603 /* channel_create.cc */ = {isa = PBXFileReference; path = channel_create.cc; sourceTree = "<group>"; };
+		OBJ_604 /* channel_create_posix.cc */ = {isa = PBXFileReference; path = channel_create_posix.cc; sourceTree = "<group>"; };
+		OBJ_606 /* secure_channel_create.cc */ = {isa = PBXFileReference; path = secure_channel_create.cc; sourceTree = "<group>"; };
+		OBJ_608 /* chttp2_server.cc */ = {isa = PBXFileReference; path = chttp2_server.cc; sourceTree = "<group>"; };
+		OBJ_61 /* ber.c */ = {isa = PBXFileReference; path = ber.c; sourceTree = "<group>"; };
+		OBJ_610 /* server_chttp2.cc */ = {isa = PBXFileReference; path = server_chttp2.cc; sourceTree = "<group>"; };
+		OBJ_611 /* server_chttp2_posix.cc */ = {isa = PBXFileReference; path = server_chttp2_posix.cc; sourceTree = "<group>"; };
+		OBJ_613 /* server_secure_chttp2.cc */ = {isa = PBXFileReference; path = server_secure_chttp2.cc; sourceTree = "<group>"; };
+		OBJ_615 /* bin_decoder.cc */ = {isa = PBXFileReference; path = bin_decoder.cc; sourceTree = "<group>"; };
+		OBJ_616 /* bin_encoder.cc */ = {isa = PBXFileReference; path = bin_encoder.cc; sourceTree = "<group>"; };
+		OBJ_617 /* chttp2_plugin.cc */ = {isa = PBXFileReference; path = chttp2_plugin.cc; sourceTree = "<group>"; };
+		OBJ_618 /* chttp2_transport.cc */ = {isa = PBXFileReference; path = chttp2_transport.cc; sourceTree = "<group>"; };
+		OBJ_619 /* flow_control.cc */ = {isa = PBXFileReference; path = flow_control.cc; sourceTree = "<group>"; };
+		OBJ_62 /* cbb.c */ = {isa = PBXFileReference; path = cbb.c; sourceTree = "<group>"; };
+		OBJ_620 /* frame_data.cc */ = {isa = PBXFileReference; path = frame_data.cc; sourceTree = "<group>"; };
+		OBJ_621 /* frame_goaway.cc */ = {isa = PBXFileReference; path = frame_goaway.cc; sourceTree = "<group>"; };
+		OBJ_622 /* frame_ping.cc */ = {isa = PBXFileReference; path = frame_ping.cc; sourceTree = "<group>"; };
+		OBJ_623 /* frame_rst_stream.cc */ = {isa = PBXFileReference; path = frame_rst_stream.cc; sourceTree = "<group>"; };
+		OBJ_624 /* frame_settings.cc */ = {isa = PBXFileReference; path = frame_settings.cc; sourceTree = "<group>"; };
+		OBJ_625 /* frame_window_update.cc */ = {isa = PBXFileReference; path = frame_window_update.cc; sourceTree = "<group>"; };
+		OBJ_626 /* hpack_encoder.cc */ = {isa = PBXFileReference; path = hpack_encoder.cc; sourceTree = "<group>"; };
+		OBJ_627 /* hpack_parser.cc */ = {isa = PBXFileReference; path = hpack_parser.cc; sourceTree = "<group>"; };
+		OBJ_628 /* hpack_table.cc */ = {isa = PBXFileReference; path = hpack_table.cc; sourceTree = "<group>"; };
+		OBJ_629 /* http2_settings.cc */ = {isa = PBXFileReference; path = http2_settings.cc; sourceTree = "<group>"; };
+		OBJ_63 /* cbs.c */ = {isa = PBXFileReference; path = cbs.c; sourceTree = "<group>"; };
+		OBJ_630 /* huffsyms.cc */ = {isa = PBXFileReference; path = huffsyms.cc; sourceTree = "<group>"; };
+		OBJ_631 /* incoming_metadata.cc */ = {isa = PBXFileReference; path = incoming_metadata.cc; sourceTree = "<group>"; };
+		OBJ_632 /* parsing.cc */ = {isa = PBXFileReference; path = parsing.cc; sourceTree = "<group>"; };
+		OBJ_633 /* stream_lists.cc */ = {isa = PBXFileReference; path = stream_lists.cc; sourceTree = "<group>"; };
+		OBJ_634 /* stream_map.cc */ = {isa = PBXFileReference; path = stream_map.cc; sourceTree = "<group>"; };
+		OBJ_635 /* varint.cc */ = {isa = PBXFileReference; path = varint.cc; sourceTree = "<group>"; };
+		OBJ_636 /* writing.cc */ = {isa = PBXFileReference; path = writing.cc; sourceTree = "<group>"; };
+		OBJ_638 /* inproc_plugin.cc */ = {isa = PBXFileReference; path = inproc_plugin.cc; sourceTree = "<group>"; };
+		OBJ_639 /* inproc_transport.cc */ = {isa = PBXFileReference; path = inproc_transport.cc; sourceTree = "<group>"; };
+		OBJ_642 /* avl.cc */ = {isa = PBXFileReference; path = avl.cc; sourceTree = "<group>"; };
+		OBJ_644 /* backoff.cc */ = {isa = PBXFileReference; path = backoff.cc; sourceTree = "<group>"; };
+		OBJ_646 /* channel_args.cc */ = {isa = PBXFileReference; path = channel_args.cc; sourceTree = "<group>"; };
+		OBJ_647 /* channel_stack.cc */ = {isa = PBXFileReference; path = channel_stack.cc; sourceTree = "<group>"; };
+		OBJ_648 /* channel_stack_builder.cc */ = {isa = PBXFileReference; path = channel_stack_builder.cc; sourceTree = "<group>"; };
+		OBJ_649 /* channel_trace.cc */ = {isa = PBXFileReference; path = channel_trace.cc; sourceTree = "<group>"; };
+		OBJ_65 /* chacha.c */ = {isa = PBXFileReference; path = chacha.c; sourceTree = "<group>"; };
+		OBJ_650 /* channel_trace_registry.cc */ = {isa = PBXFileReference; path = channel_trace_registry.cc; sourceTree = "<group>"; };
+		OBJ_651 /* connected_channel.cc */ = {isa = PBXFileReference; path = connected_channel.cc; sourceTree = "<group>"; };
+		OBJ_652 /* handshaker.cc */ = {isa = PBXFileReference; path = handshaker.cc; sourceTree = "<group>"; };
+		OBJ_653 /* handshaker_factory.cc */ = {isa = PBXFileReference; path = handshaker_factory.cc; sourceTree = "<group>"; };
+		OBJ_654 /* handshaker_registry.cc */ = {isa = PBXFileReference; path = handshaker_registry.cc; sourceTree = "<group>"; };
+		OBJ_655 /* status_util.cc */ = {isa = PBXFileReference; path = status_util.cc; sourceTree = "<group>"; };
+		OBJ_657 /* compression.cc */ = {isa = PBXFileReference; path = compression.cc; sourceTree = "<group>"; };
+		OBJ_658 /* compression_internal.cc */ = {isa = PBXFileReference; path = compression_internal.cc; sourceTree = "<group>"; };
+		OBJ_659 /* message_compress.cc */ = {isa = PBXFileReference; path = message_compress.cc; sourceTree = "<group>"; };
+		OBJ_660 /* stream_compression.cc */ = {isa = PBXFileReference; path = stream_compression.cc; sourceTree = "<group>"; };
+		OBJ_661 /* stream_compression_gzip.cc */ = {isa = PBXFileReference; path = stream_compression_gzip.cc; sourceTree = "<group>"; };
+		OBJ_662 /* stream_compression_identity.cc */ = {isa = PBXFileReference; path = stream_compression_identity.cc; sourceTree = "<group>"; };
+		OBJ_664 /* stats.cc */ = {isa = PBXFileReference; path = stats.cc; sourceTree = "<group>"; };
+		OBJ_665 /* stats_data.cc */ = {isa = PBXFileReference; path = stats_data.cc; sourceTree = "<group>"; };
+		OBJ_666 /* trace.cc */ = {isa = PBXFileReference; path = trace.cc; sourceTree = "<group>"; };
+		OBJ_668 /* alloc.cc */ = {isa = PBXFileReference; path = alloc.cc; sourceTree = "<group>"; };
+		OBJ_669 /* arena.cc */ = {isa = PBXFileReference; path = arena.cc; sourceTree = "<group>"; };
+		OBJ_67 /* cipher_extra.c */ = {isa = PBXFileReference; path = cipher_extra.c; sourceTree = "<group>"; };
+		OBJ_670 /* atm.cc */ = {isa = PBXFileReference; path = atm.cc; sourceTree = "<group>"; };
+		OBJ_671 /* cpu_iphone.cc */ = {isa = PBXFileReference; path = cpu_iphone.cc; sourceTree = "<group>"; };
+		OBJ_672 /* cpu_linux.cc */ = {isa = PBXFileReference; path = cpu_linux.cc; sourceTree = "<group>"; };
+		OBJ_673 /* cpu_posix.cc */ = {isa = PBXFileReference; path = cpu_posix.cc; sourceTree = "<group>"; };
+		OBJ_674 /* cpu_windows.cc */ = {isa = PBXFileReference; path = cpu_windows.cc; sourceTree = "<group>"; };
+		OBJ_675 /* env_linux.cc */ = {isa = PBXFileReference; path = env_linux.cc; sourceTree = "<group>"; };
+		OBJ_676 /* env_posix.cc */ = {isa = PBXFileReference; path = env_posix.cc; sourceTree = "<group>"; };
+		OBJ_677 /* env_windows.cc */ = {isa = PBXFileReference; path = env_windows.cc; sourceTree = "<group>"; };
+		OBJ_678 /* fork.cc */ = {isa = PBXFileReference; path = fork.cc; sourceTree = "<group>"; };
+		OBJ_679 /* host_port.cc */ = {isa = PBXFileReference; path = host_port.cc; sourceTree = "<group>"; };
+		OBJ_68 /* derive_key.c */ = {isa = PBXFileReference; path = derive_key.c; sourceTree = "<group>"; };
+		OBJ_680 /* log.cc */ = {isa = PBXFileReference; path = log.cc; sourceTree = "<group>"; };
+		OBJ_681 /* log_android.cc */ = {isa = PBXFileReference; path = log_android.cc; sourceTree = "<group>"; };
+		OBJ_682 /* log_linux.cc */ = {isa = PBXFileReference; path = log_linux.cc; sourceTree = "<group>"; };
+		OBJ_683 /* log_posix.cc */ = {isa = PBXFileReference; path = log_posix.cc; sourceTree = "<group>"; };
+		OBJ_684 /* log_windows.cc */ = {isa = PBXFileReference; path = log_windows.cc; sourceTree = "<group>"; };
+		OBJ_685 /* mpscq.cc */ = {isa = PBXFileReference; path = mpscq.cc; sourceTree = "<group>"; };
+		OBJ_686 /* murmur_hash.cc */ = {isa = PBXFileReference; path = murmur_hash.cc; sourceTree = "<group>"; };
+		OBJ_687 /* string.cc */ = {isa = PBXFileReference; path = string.cc; sourceTree = "<group>"; };
+		OBJ_688 /* string_posix.cc */ = {isa = PBXFileReference; path = string_posix.cc; sourceTree = "<group>"; };
+		OBJ_689 /* string_util_windows.cc */ = {isa = PBXFileReference; path = string_util_windows.cc; sourceTree = "<group>"; };
+		OBJ_69 /* e_aesctrhmac.c */ = {isa = PBXFileReference; path = e_aesctrhmac.c; sourceTree = "<group>"; };
+		OBJ_690 /* string_windows.cc */ = {isa = PBXFileReference; path = string_windows.cc; sourceTree = "<group>"; };
+		OBJ_691 /* sync.cc */ = {isa = PBXFileReference; path = sync.cc; sourceTree = "<group>"; };
+		OBJ_692 /* sync_posix.cc */ = {isa = PBXFileReference; path = sync_posix.cc; sourceTree = "<group>"; };
+		OBJ_693 /* sync_windows.cc */ = {isa = PBXFileReference; path = sync_windows.cc; sourceTree = "<group>"; };
+		OBJ_694 /* time.cc */ = {isa = PBXFileReference; path = time.cc; sourceTree = "<group>"; };
+		OBJ_695 /* time_posix.cc */ = {isa = PBXFileReference; path = time_posix.cc; sourceTree = "<group>"; };
+		OBJ_696 /* time_precise.cc */ = {isa = PBXFileReference; path = time_precise.cc; sourceTree = "<group>"; };
+		OBJ_697 /* time_windows.cc */ = {isa = PBXFileReference; path = time_windows.cc; sourceTree = "<group>"; };
+		OBJ_698 /* tls_pthread.cc */ = {isa = PBXFileReference; path = tls_pthread.cc; sourceTree = "<group>"; };
+		OBJ_699 /* tmpfile_msys.cc */ = {isa = PBXFileReference; path = tmpfile_msys.cc; sourceTree = "<group>"; };
+		OBJ_70 /* e_aesgcmsiv.c */ = {isa = PBXFileReference; path = e_aesgcmsiv.c; sourceTree = "<group>"; };
+		OBJ_700 /* tmpfile_posix.cc */ = {isa = PBXFileReference; path = tmpfile_posix.cc; sourceTree = "<group>"; };
+		OBJ_701 /* tmpfile_windows.cc */ = {isa = PBXFileReference; path = tmpfile_windows.cc; sourceTree = "<group>"; };
+		OBJ_702 /* wrap_memcpy.cc */ = {isa = PBXFileReference; path = wrap_memcpy.cc; sourceTree = "<group>"; };
+		OBJ_704 /* thd_posix.cc */ = {isa = PBXFileReference; path = thd_posix.cc; sourceTree = "<group>"; };
+		OBJ_705 /* thd_windows.cc */ = {isa = PBXFileReference; path = thd_windows.cc; sourceTree = "<group>"; };
+		OBJ_707 /* format_request.cc */ = {isa = PBXFileReference; path = format_request.cc; sourceTree = "<group>"; };
+		OBJ_708 /* httpcli.cc */ = {isa = PBXFileReference; path = httpcli.cc; sourceTree = "<group>"; };
+		OBJ_709 /* httpcli_security_connector.cc */ = {isa = PBXFileReference; path = httpcli_security_connector.cc; sourceTree = "<group>"; };
+		OBJ_71 /* e_chacha20poly1305.c */ = {isa = PBXFileReference; path = e_chacha20poly1305.c; sourceTree = "<group>"; };
+		OBJ_710 /* parser.cc */ = {isa = PBXFileReference; path = parser.cc; sourceTree = "<group>"; };
+		OBJ_712 /* call_combiner.cc */ = {isa = PBXFileReference; path = call_combiner.cc; sourceTree = "<group>"; };
+		OBJ_713 /* combiner.cc */ = {isa = PBXFileReference; path = combiner.cc; sourceTree = "<group>"; };
+		OBJ_714 /* endpoint.cc */ = {isa = PBXFileReference; path = endpoint.cc; sourceTree = "<group>"; };
+		OBJ_715 /* endpoint_pair_posix.cc */ = {isa = PBXFileReference; path = endpoint_pair_posix.cc; sourceTree = "<group>"; };
+		OBJ_716 /* endpoint_pair_uv.cc */ = {isa = PBXFileReference; path = endpoint_pair_uv.cc; sourceTree = "<group>"; };
+		OBJ_717 /* endpoint_pair_windows.cc */ = {isa = PBXFileReference; path = endpoint_pair_windows.cc; sourceTree = "<group>"; };
+		OBJ_718 /* error.cc */ = {isa = PBXFileReference; path = error.cc; sourceTree = "<group>"; };
+		OBJ_719 /* ev_epoll1_linux.cc */ = {isa = PBXFileReference; path = ev_epoll1_linux.cc; sourceTree = "<group>"; };
+		OBJ_72 /* e_null.c */ = {isa = PBXFileReference; path = e_null.c; sourceTree = "<group>"; };
+		OBJ_720 /* ev_epollex_linux.cc */ = {isa = PBXFileReference; path = ev_epollex_linux.cc; sourceTree = "<group>"; };
+		OBJ_721 /* ev_epollsig_linux.cc */ = {isa = PBXFileReference; path = ev_epollsig_linux.cc; sourceTree = "<group>"; };
+		OBJ_722 /* ev_poll_posix.cc */ = {isa = PBXFileReference; path = ev_poll_posix.cc; sourceTree = "<group>"; };
+		OBJ_723 /* ev_posix.cc */ = {isa = PBXFileReference; path = ev_posix.cc; sourceTree = "<group>"; };
+		OBJ_724 /* ev_windows.cc */ = {isa = PBXFileReference; path = ev_windows.cc; sourceTree = "<group>"; };
+		OBJ_725 /* exec_ctx.cc */ = {isa = PBXFileReference; path = exec_ctx.cc; sourceTree = "<group>"; };
+		OBJ_726 /* executor.cc */ = {isa = PBXFileReference; path = executor.cc; sourceTree = "<group>"; };
+		OBJ_727 /* fork_posix.cc */ = {isa = PBXFileReference; path = fork_posix.cc; sourceTree = "<group>"; };
+		OBJ_728 /* fork_windows.cc */ = {isa = PBXFileReference; path = fork_windows.cc; sourceTree = "<group>"; };
+		OBJ_729 /* gethostname_fallback.cc */ = {isa = PBXFileReference; path = gethostname_fallback.cc; sourceTree = "<group>"; };
+		OBJ_73 /* e_rc2.c */ = {isa = PBXFileReference; path = e_rc2.c; sourceTree = "<group>"; };
+		OBJ_730 /* gethostname_host_name_max.cc */ = {isa = PBXFileReference; path = gethostname_host_name_max.cc; sourceTree = "<group>"; };
+		OBJ_731 /* gethostname_sysconf.cc */ = {isa = PBXFileReference; path = gethostname_sysconf.cc; sourceTree = "<group>"; };
+		OBJ_732 /* iocp_windows.cc */ = {isa = PBXFileReference; path = iocp_windows.cc; sourceTree = "<group>"; };
+		OBJ_733 /* iomgr.cc */ = {isa = PBXFileReference; path = iomgr.cc; sourceTree = "<group>"; };
+		OBJ_734 /* iomgr_custom.cc */ = {isa = PBXFileReference; path = iomgr_custom.cc; sourceTree = "<group>"; };
+		OBJ_735 /* iomgr_internal.cc */ = {isa = PBXFileReference; path = iomgr_internal.cc; sourceTree = "<group>"; };
+		OBJ_736 /* iomgr_posix.cc */ = {isa = PBXFileReference; path = iomgr_posix.cc; sourceTree = "<group>"; };
+		OBJ_737 /* iomgr_uv.cc */ = {isa = PBXFileReference; path = iomgr_uv.cc; sourceTree = "<group>"; };
+		OBJ_738 /* iomgr_windows.cc */ = {isa = PBXFileReference; path = iomgr_windows.cc; sourceTree = "<group>"; };
+		OBJ_739 /* is_epollexclusive_available.cc */ = {isa = PBXFileReference; path = is_epollexclusive_available.cc; sourceTree = "<group>"; };
+		OBJ_74 /* e_rc4.c */ = {isa = PBXFileReference; path = e_rc4.c; sourceTree = "<group>"; };
+		OBJ_740 /* load_file.cc */ = {isa = PBXFileReference; path = load_file.cc; sourceTree = "<group>"; };
+		OBJ_741 /* lockfree_event.cc */ = {isa = PBXFileReference; path = lockfree_event.cc; sourceTree = "<group>"; };
+		OBJ_742 /* network_status_tracker.cc */ = {isa = PBXFileReference; path = network_status_tracker.cc; sourceTree = "<group>"; };
+		OBJ_743 /* polling_entity.cc */ = {isa = PBXFileReference; path = polling_entity.cc; sourceTree = "<group>"; };
+		OBJ_744 /* pollset.cc */ = {isa = PBXFileReference; path = pollset.cc; sourceTree = "<group>"; };
+		OBJ_745 /* pollset_custom.cc */ = {isa = PBXFileReference; path = pollset_custom.cc; sourceTree = "<group>"; };
+		OBJ_746 /* pollset_set.cc */ = {isa = PBXFileReference; path = pollset_set.cc; sourceTree = "<group>"; };
+		OBJ_747 /* pollset_set_custom.cc */ = {isa = PBXFileReference; path = pollset_set_custom.cc; sourceTree = "<group>"; };
+		OBJ_748 /* pollset_set_windows.cc */ = {isa = PBXFileReference; path = pollset_set_windows.cc; sourceTree = "<group>"; };
+		OBJ_749 /* pollset_uv.cc */ = {isa = PBXFileReference; path = pollset_uv.cc; sourceTree = "<group>"; };
+		OBJ_75 /* e_ssl3.c */ = {isa = PBXFileReference; path = e_ssl3.c; sourceTree = "<group>"; };
+		OBJ_750 /* pollset_windows.cc */ = {isa = PBXFileReference; path = pollset_windows.cc; sourceTree = "<group>"; };
+		OBJ_751 /* resolve_address.cc */ = {isa = PBXFileReference; path = resolve_address.cc; sourceTree = "<group>"; };
+		OBJ_752 /* resolve_address_custom.cc */ = {isa = PBXFileReference; path = resolve_address_custom.cc; sourceTree = "<group>"; };
+		OBJ_753 /* resolve_address_posix.cc */ = {isa = PBXFileReference; path = resolve_address_posix.cc; sourceTree = "<group>"; };
+		OBJ_754 /* resolve_address_windows.cc */ = {isa = PBXFileReference; path = resolve_address_windows.cc; sourceTree = "<group>"; };
+		OBJ_755 /* resource_quota.cc */ = {isa = PBXFileReference; path = resource_quota.cc; sourceTree = "<group>"; };
+		OBJ_756 /* sockaddr_utils.cc */ = {isa = PBXFileReference; path = sockaddr_utils.cc; sourceTree = "<group>"; };
+		OBJ_757 /* socket_factory_posix.cc */ = {isa = PBXFileReference; path = socket_factory_posix.cc; sourceTree = "<group>"; };
+		OBJ_758 /* socket_mutator.cc */ = {isa = PBXFileReference; path = socket_mutator.cc; sourceTree = "<group>"; };
+		OBJ_759 /* socket_utils_common_posix.cc */ = {isa = PBXFileReference; path = socket_utils_common_posix.cc; sourceTree = "<group>"; };
+		OBJ_76 /* e_tls.c */ = {isa = PBXFileReference; path = e_tls.c; sourceTree = "<group>"; };
+		OBJ_760 /* socket_utils_linux.cc */ = {isa = PBXFileReference; path = socket_utils_linux.cc; sourceTree = "<group>"; };
+		OBJ_761 /* socket_utils_posix.cc */ = {isa = PBXFileReference; path = socket_utils_posix.cc; sourceTree = "<group>"; };
+		OBJ_762 /* socket_utils_uv.cc */ = {isa = PBXFileReference; path = socket_utils_uv.cc; sourceTree = "<group>"; };
+		OBJ_763 /* socket_utils_windows.cc */ = {isa = PBXFileReference; path = socket_utils_windows.cc; sourceTree = "<group>"; };
+		OBJ_764 /* socket_windows.cc */ = {isa = PBXFileReference; path = socket_windows.cc; sourceTree = "<group>"; };
+		OBJ_765 /* tcp_client.cc */ = {isa = PBXFileReference; path = tcp_client.cc; sourceTree = "<group>"; };
+		OBJ_766 /* tcp_client_custom.cc */ = {isa = PBXFileReference; path = tcp_client_custom.cc; sourceTree = "<group>"; };
+		OBJ_767 /* tcp_client_posix.cc */ = {isa = PBXFileReference; path = tcp_client_posix.cc; sourceTree = "<group>"; };
+		OBJ_768 /* tcp_client_windows.cc */ = {isa = PBXFileReference; path = tcp_client_windows.cc; sourceTree = "<group>"; };
+		OBJ_769 /* tcp_custom.cc */ = {isa = PBXFileReference; path = tcp_custom.cc; sourceTree = "<group>"; };
+		OBJ_77 /* tls_cbc.c */ = {isa = PBXFileReference; path = tls_cbc.c; sourceTree = "<group>"; };
+		OBJ_770 /* tcp_posix.cc */ = {isa = PBXFileReference; path = tcp_posix.cc; sourceTree = "<group>"; };
+		OBJ_771 /* tcp_server.cc */ = {isa = PBXFileReference; path = tcp_server.cc; sourceTree = "<group>"; };
+		OBJ_772 /* tcp_server_custom.cc */ = {isa = PBXFileReference; path = tcp_server_custom.cc; sourceTree = "<group>"; };
+		OBJ_773 /* tcp_server_posix.cc */ = {isa = PBXFileReference; path = tcp_server_posix.cc; sourceTree = "<group>"; };
+		OBJ_774 /* tcp_server_utils_posix_common.cc */ = {isa = PBXFileReference; path = tcp_server_utils_posix_common.cc; sourceTree = "<group>"; };
+		OBJ_775 /* tcp_server_utils_posix_ifaddrs.cc */ = {isa = PBXFileReference; path = tcp_server_utils_posix_ifaddrs.cc; sourceTree = "<group>"; };
+		OBJ_776 /* tcp_server_utils_posix_noifaddrs.cc */ = {isa = PBXFileReference; path = tcp_server_utils_posix_noifaddrs.cc; sourceTree = "<group>"; };
+		OBJ_777 /* tcp_server_windows.cc */ = {isa = PBXFileReference; path = tcp_server_windows.cc; sourceTree = "<group>"; };
+		OBJ_778 /* tcp_uv.cc */ = {isa = PBXFileReference; path = tcp_uv.cc; sourceTree = "<group>"; };
+		OBJ_779 /* tcp_windows.cc */ = {isa = PBXFileReference; path = tcp_windows.cc; sourceTree = "<group>"; };
+		OBJ_780 /* time_averaged_stats.cc */ = {isa = PBXFileReference; path = time_averaged_stats.cc; sourceTree = "<group>"; };
+		OBJ_781 /* timer.cc */ = {isa = PBXFileReference; path = timer.cc; sourceTree = "<group>"; };
+		OBJ_782 /* timer_custom.cc */ = {isa = PBXFileReference; path = timer_custom.cc; sourceTree = "<group>"; };
+		OBJ_783 /* timer_generic.cc */ = {isa = PBXFileReference; path = timer_generic.cc; sourceTree = "<group>"; };
+		OBJ_784 /* timer_heap.cc */ = {isa = PBXFileReference; path = timer_heap.cc; sourceTree = "<group>"; };
+		OBJ_785 /* timer_manager.cc */ = {isa = PBXFileReference; path = timer_manager.cc; sourceTree = "<group>"; };
+		OBJ_786 /* timer_uv.cc */ = {isa = PBXFileReference; path = timer_uv.cc; sourceTree = "<group>"; };
+		OBJ_787 /* udp_server.cc */ = {isa = PBXFileReference; path = udp_server.cc; sourceTree = "<group>"; };
+		OBJ_788 /* unix_sockets_posix.cc */ = {isa = PBXFileReference; path = unix_sockets_posix.cc; sourceTree = "<group>"; };
+		OBJ_789 /* unix_sockets_posix_noop.cc */ = {isa = PBXFileReference; path = unix_sockets_posix_noop.cc; sourceTree = "<group>"; };
+		OBJ_79 /* cmac.c */ = {isa = PBXFileReference; path = cmac.c; sourceTree = "<group>"; };
+		OBJ_790 /* wakeup_fd_cv.cc */ = {isa = PBXFileReference; path = wakeup_fd_cv.cc; sourceTree = "<group>"; };
+		OBJ_791 /* wakeup_fd_eventfd.cc */ = {isa = PBXFileReference; path = wakeup_fd_eventfd.cc; sourceTree = "<group>"; };
+		OBJ_792 /* wakeup_fd_nospecial.cc */ = {isa = PBXFileReference; path = wakeup_fd_nospecial.cc; sourceTree = "<group>"; };
+		OBJ_793 /* wakeup_fd_pipe.cc */ = {isa = PBXFileReference; path = wakeup_fd_pipe.cc; sourceTree = "<group>"; };
+		OBJ_794 /* wakeup_fd_posix.cc */ = {isa = PBXFileReference; path = wakeup_fd_posix.cc; sourceTree = "<group>"; };
+		OBJ_796 /* json.cc */ = {isa = PBXFileReference; path = json.cc; sourceTree = "<group>"; };
+		OBJ_797 /* json_reader.cc */ = {isa = PBXFileReference; path = json_reader.cc; sourceTree = "<group>"; };
+		OBJ_798 /* json_string.cc */ = {isa = PBXFileReference; path = json_string.cc; sourceTree = "<group>"; };
+		OBJ_799 /* json_writer.cc */ = {isa = PBXFileReference; path = json_writer.cc; sourceTree = "<group>"; };
+		OBJ_801 /* basic_timers.cc */ = {isa = PBXFileReference; path = basic_timers.cc; sourceTree = "<group>"; };
+		OBJ_802 /* stap_timers.cc */ = {isa = PBXFileReference; path = stap_timers.cc; sourceTree = "<group>"; };
+		OBJ_805 /* security_context.cc */ = {isa = PBXFileReference; path = security_context.cc; sourceTree = "<group>"; };
+		OBJ_808 /* alts_credentials.cc */ = {isa = PBXFileReference; path = alts_credentials.cc; sourceTree = "<group>"; };
+		OBJ_809 /* check_gcp_environment.cc */ = {isa = PBXFileReference; path = check_gcp_environment.cc; sourceTree = "<group>"; };
+		OBJ_81 /* conf.c */ = {isa = PBXFileReference; path = conf.c; sourceTree = "<group>"; };
+		OBJ_810 /* check_gcp_environment_linux.cc */ = {isa = PBXFileReference; path = check_gcp_environment_linux.cc; sourceTree = "<group>"; };
+		OBJ_811 /* check_gcp_environment_no_op.cc */ = {isa = PBXFileReference; path = check_gcp_environment_no_op.cc; sourceTree = "<group>"; };
+		OBJ_812 /* check_gcp_environment_windows.cc */ = {isa = PBXFileReference; path = check_gcp_environment_windows.cc; sourceTree = "<group>"; };
+		OBJ_813 /* grpc_alts_credentials_client_options.cc */ = {isa = PBXFileReference; path = grpc_alts_credentials_client_options.cc; sourceTree = "<group>"; };
+		OBJ_814 /* grpc_alts_credentials_options.cc */ = {isa = PBXFileReference; path = grpc_alts_credentials_options.cc; sourceTree = "<group>"; };
+		OBJ_815 /* grpc_alts_credentials_server_options.cc */ = {isa = PBXFileReference; path = grpc_alts_credentials_server_options.cc; sourceTree = "<group>"; };
+		OBJ_817 /* composite_credentials.cc */ = {isa = PBXFileReference; path = composite_credentials.cc; sourceTree = "<group>"; };
+		OBJ_818 /* credentials.cc */ = {isa = PBXFileReference; path = credentials.cc; sourceTree = "<group>"; };
+		OBJ_819 /* credentials_metadata.cc */ = {isa = PBXFileReference; path = credentials_metadata.cc; sourceTree = "<group>"; };
+		OBJ_82 /* cpu-aarch64-linux.c */ = {isa = PBXFileReference; path = "cpu-aarch64-linux.c"; sourceTree = "<group>"; };
+		OBJ_821 /* fake_credentials.cc */ = {isa = PBXFileReference; path = fake_credentials.cc; sourceTree = "<group>"; };
+		OBJ_823 /* credentials_generic.cc */ = {isa = PBXFileReference; path = credentials_generic.cc; sourceTree = "<group>"; };
+		OBJ_824 /* google_default_credentials.cc */ = {isa = PBXFileReference; path = google_default_credentials.cc; sourceTree = "<group>"; };
+		OBJ_826 /* iam_credentials.cc */ = {isa = PBXFileReference; path = iam_credentials.cc; sourceTree = "<group>"; };
+		OBJ_828 /* json_token.cc */ = {isa = PBXFileReference; path = json_token.cc; sourceTree = "<group>"; };
+		OBJ_829 /* jwt_credentials.cc */ = {isa = PBXFileReference; path = jwt_credentials.cc; sourceTree = "<group>"; };
+		OBJ_83 /* cpu-arm-linux.c */ = {isa = PBXFileReference; path = "cpu-arm-linux.c"; sourceTree = "<group>"; };
+		OBJ_830 /* jwt_verifier.cc */ = {isa = PBXFileReference; path = jwt_verifier.cc; sourceTree = "<group>"; };
+		OBJ_832 /* oauth2_credentials.cc */ = {isa = PBXFileReference; path = oauth2_credentials.cc; sourceTree = "<group>"; };
+		OBJ_834 /* plugin_credentials.cc */ = {isa = PBXFileReference; path = plugin_credentials.cc; sourceTree = "<group>"; };
+		OBJ_836 /* ssl_credentials.cc */ = {isa = PBXFileReference; path = ssl_credentials.cc; sourceTree = "<group>"; };
+		OBJ_838 /* alts_security_connector.cc */ = {isa = PBXFileReference; path = alts_security_connector.cc; sourceTree = "<group>"; };
+		OBJ_839 /* security_connector.cc */ = {isa = PBXFileReference; path = security_connector.cc; sourceTree = "<group>"; };
+		OBJ_84 /* cpu-arm.c */ = {isa = PBXFileReference; path = "cpu-arm.c"; sourceTree = "<group>"; };
+		OBJ_841 /* client_auth_filter.cc */ = {isa = PBXFileReference; path = client_auth_filter.cc; sourceTree = "<group>"; };
+		OBJ_842 /* secure_endpoint.cc */ = {isa = PBXFileReference; path = secure_endpoint.cc; sourceTree = "<group>"; };
+		OBJ_843 /* security_handshaker.cc */ = {isa = PBXFileReference; path = security_handshaker.cc; sourceTree = "<group>"; };
+		OBJ_844 /* server_auth_filter.cc */ = {isa = PBXFileReference; path = server_auth_filter.cc; sourceTree = "<group>"; };
+		OBJ_845 /* target_authority_table.cc */ = {isa = PBXFileReference; path = target_authority_table.cc; sourceTree = "<group>"; };
+		OBJ_846 /* tsi_error.cc */ = {isa = PBXFileReference; path = tsi_error.cc; sourceTree = "<group>"; };
+		OBJ_848 /* json_util.cc */ = {isa = PBXFileReference; path = json_util.cc; sourceTree = "<group>"; };
+		OBJ_85 /* cpu-intel.c */ = {isa = PBXFileReference; path = "cpu-intel.c"; sourceTree = "<group>"; };
+		OBJ_850 /* b64.cc */ = {isa = PBXFileReference; path = b64.cc; sourceTree = "<group>"; };
+		OBJ_851 /* percent_encoding.cc */ = {isa = PBXFileReference; path = percent_encoding.cc; sourceTree = "<group>"; };
+		OBJ_852 /* slice.cc */ = {isa = PBXFileReference; path = slice.cc; sourceTree = "<group>"; };
+		OBJ_853 /* slice_buffer.cc */ = {isa = PBXFileReference; path = slice_buffer.cc; sourceTree = "<group>"; };
+		OBJ_854 /* slice_intern.cc */ = {isa = PBXFileReference; path = slice_intern.cc; sourceTree = "<group>"; };
+		OBJ_855 /* slice_string_helpers.cc */ = {isa = PBXFileReference; path = slice_string_helpers.cc; sourceTree = "<group>"; };
+		OBJ_857 /* api_trace.cc */ = {isa = PBXFileReference; path = api_trace.cc; sourceTree = "<group>"; };
+		OBJ_858 /* byte_buffer.cc */ = {isa = PBXFileReference; path = byte_buffer.cc; sourceTree = "<group>"; };
+		OBJ_859 /* byte_buffer_reader.cc */ = {isa = PBXFileReference; path = byte_buffer_reader.cc; sourceTree = "<group>"; };
+		OBJ_86 /* cpu-ppc64le.c */ = {isa = PBXFileReference; path = "cpu-ppc64le.c"; sourceTree = "<group>"; };
+		OBJ_860 /* call.cc */ = {isa = PBXFileReference; path = call.cc; sourceTree = "<group>"; };
+		OBJ_861 /* call_details.cc */ = {isa = PBXFileReference; path = call_details.cc; sourceTree = "<group>"; };
+		OBJ_862 /* call_log_batch.cc */ = {isa = PBXFileReference; path = call_log_batch.cc; sourceTree = "<group>"; };
+		OBJ_863 /* channel.cc */ = {isa = PBXFileReference; path = channel.cc; sourceTree = "<group>"; };
+		OBJ_864 /* channel_init.cc */ = {isa = PBXFileReference; path = channel_init.cc; sourceTree = "<group>"; };
+		OBJ_865 /* channel_ping.cc */ = {isa = PBXFileReference; path = channel_ping.cc; sourceTree = "<group>"; };
+		OBJ_866 /* channel_stack_type.cc */ = {isa = PBXFileReference; path = channel_stack_type.cc; sourceTree = "<group>"; };
+		OBJ_867 /* completion_queue.cc */ = {isa = PBXFileReference; path = completion_queue.cc; sourceTree = "<group>"; };
+		OBJ_868 /* completion_queue_factory.cc */ = {isa = PBXFileReference; path = completion_queue_factory.cc; sourceTree = "<group>"; };
+		OBJ_869 /* event_string.cc */ = {isa = PBXFileReference; path = event_string.cc; sourceTree = "<group>"; };
+		OBJ_87 /* crypto.c */ = {isa = PBXFileReference; path = crypto.c; sourceTree = "<group>"; };
+		OBJ_870 /* init.cc */ = {isa = PBXFileReference; path = init.cc; sourceTree = "<group>"; };
+		OBJ_871 /* init_secure.cc */ = {isa = PBXFileReference; path = init_secure.cc; sourceTree = "<group>"; };
+		OBJ_872 /* lame_client.cc */ = {isa = PBXFileReference; path = lame_client.cc; sourceTree = "<group>"; };
+		OBJ_873 /* metadata_array.cc */ = {isa = PBXFileReference; path = metadata_array.cc; sourceTree = "<group>"; };
+		OBJ_874 /* server.cc */ = {isa = PBXFileReference; path = server.cc; sourceTree = "<group>"; };
+		OBJ_875 /* validate_metadata.cc */ = {isa = PBXFileReference; path = validate_metadata.cc; sourceTree = "<group>"; };
+		OBJ_876 /* version.cc */ = {isa = PBXFileReference; path = version.cc; sourceTree = "<group>"; };
+		OBJ_878 /* bdp_estimator.cc */ = {isa = PBXFileReference; path = bdp_estimator.cc; sourceTree = "<group>"; };
+		OBJ_879 /* byte_stream.cc */ = {isa = PBXFileReference; path = byte_stream.cc; sourceTree = "<group>"; };
+		OBJ_880 /* connectivity_state.cc */ = {isa = PBXFileReference; path = connectivity_state.cc; sourceTree = "<group>"; };
+		OBJ_881 /* error_utils.cc */ = {isa = PBXFileReference; path = error_utils.cc; sourceTree = "<group>"; };
+		OBJ_882 /* metadata.cc */ = {isa = PBXFileReference; path = metadata.cc; sourceTree = "<group>"; };
+		OBJ_883 /* metadata_batch.cc */ = {isa = PBXFileReference; path = metadata_batch.cc; sourceTree = "<group>"; };
+		OBJ_884 /* pid_controller.cc */ = {isa = PBXFileReference; path = pid_controller.cc; sourceTree = "<group>"; };
+		OBJ_885 /* service_config.cc */ = {isa = PBXFileReference; path = service_config.cc; sourceTree = "<group>"; };
+		OBJ_886 /* static_metadata.cc */ = {isa = PBXFileReference; path = static_metadata.cc; sourceTree = "<group>"; };
+		OBJ_887 /* status_conversion.cc */ = {isa = PBXFileReference; path = status_conversion.cc; sourceTree = "<group>"; };
+		OBJ_888 /* status_metadata.cc */ = {isa = PBXFileReference; path = status_metadata.cc; sourceTree = "<group>"; };
+		OBJ_889 /* timeout_encoding.cc */ = {isa = PBXFileReference; path = timeout_encoding.cc; sourceTree = "<group>"; };
+		OBJ_89 /* spake25519.c */ = {isa = PBXFileReference; path = spake25519.c; sourceTree = "<group>"; };
+		OBJ_890 /* transport.cc */ = {isa = PBXFileReference; path = transport.cc; sourceTree = "<group>"; };
+		OBJ_891 /* transport_op_string.cc */ = {isa = PBXFileReference; path = transport_op_string.cc; sourceTree = "<group>"; };
+		OBJ_893 /* grpc_plugin_registry.cc */ = {isa = PBXFileReference; path = grpc_plugin_registry.cc; sourceTree = "<group>"; };
+		OBJ_897 /* aes_gcm.cc */ = {isa = PBXFileReference; path = aes_gcm.cc; sourceTree = "<group>"; };
+		OBJ_898 /* gsec.cc */ = {isa = PBXFileReference; path = gsec.cc; sourceTree = "<group>"; };
+		OBJ_90 /* x25519-x86_64.c */ = {isa = PBXFileReference; path = "x25519-x86_64.c"; sourceTree = "<group>"; };
+		OBJ_900 /* alts_counter.cc */ = {isa = PBXFileReference; path = alts_counter.cc; sourceTree = "<group>"; };
+		OBJ_901 /* alts_crypter.cc */ = {isa = PBXFileReference; path = alts_crypter.cc; sourceTree = "<group>"; };
+		OBJ_902 /* alts_frame_protector.cc */ = {isa = PBXFileReference; path = alts_frame_protector.cc; sourceTree = "<group>"; };
+		OBJ_903 /* alts_record_protocol_crypter_common.cc */ = {isa = PBXFileReference; path = alts_record_protocol_crypter_common.cc; sourceTree = "<group>"; };
+		OBJ_904 /* alts_seal_privacy_integrity_crypter.cc */ = {isa = PBXFileReference; path = alts_seal_privacy_integrity_crypter.cc; sourceTree = "<group>"; };
+		OBJ_905 /* alts_unseal_privacy_integrity_crypter.cc */ = {isa = PBXFileReference; path = alts_unseal_privacy_integrity_crypter.cc; sourceTree = "<group>"; };
+		OBJ_906 /* frame_handler.cc */ = {isa = PBXFileReference; path = frame_handler.cc; sourceTree = "<group>"; };
+		OBJ_908 /* alts_handshaker_client.cc */ = {isa = PBXFileReference; path = alts_handshaker_client.cc; sourceTree = "<group>"; };
+		OBJ_909 /* alts_handshaker_service_api.cc */ = {isa = PBXFileReference; path = alts_handshaker_service_api.cc; sourceTree = "<group>"; };
+		OBJ_910 /* alts_handshaker_service_api_util.cc */ = {isa = PBXFileReference; path = alts_handshaker_service_api_util.cc; sourceTree = "<group>"; };
+		OBJ_911 /* alts_tsi_event.cc */ = {isa = PBXFileReference; path = alts_tsi_event.cc; sourceTree = "<group>"; };
+		OBJ_912 /* alts_tsi_handshaker.cc */ = {isa = PBXFileReference; path = alts_tsi_handshaker.cc; sourceTree = "<group>"; };
+		OBJ_913 /* alts_tsi_utils.cc */ = {isa = PBXFileReference; path = alts_tsi_utils.cc; sourceTree = "<group>"; };
+		OBJ_914 /* altscontext.pb.c */ = {isa = PBXFileReference; path = altscontext.pb.c; sourceTree = "<group>"; };
+		OBJ_915 /* handshaker.pb.c */ = {isa = PBXFileReference; path = handshaker.pb.c; sourceTree = "<group>"; };
+		OBJ_916 /* transport_security_common.pb.c */ = {isa = PBXFileReference; path = transport_security_common.pb.c; sourceTree = "<group>"; };
+		OBJ_917 /* transport_security_common_api.cc */ = {isa = PBXFileReference; path = transport_security_common_api.cc; sourceTree = "<group>"; };
+		OBJ_919 /* alts_grpc_integrity_only_record_protocol.cc */ = {isa = PBXFileReference; path = alts_grpc_integrity_only_record_protocol.cc; sourceTree = "<group>"; };
+		OBJ_92 /* check.c */ = {isa = PBXFileReference; path = check.c; sourceTree = "<group>"; };
+		OBJ_920 /* alts_grpc_privacy_integrity_record_protocol.cc */ = {isa = PBXFileReference; path = alts_grpc_privacy_integrity_record_protocol.cc; sourceTree = "<group>"; };
+		OBJ_921 /* alts_grpc_record_protocol_common.cc */ = {isa = PBXFileReference; path = alts_grpc_record_protocol_common.cc; sourceTree = "<group>"; };
+		OBJ_922 /* alts_iovec_record_protocol.cc */ = {isa = PBXFileReference; path = alts_iovec_record_protocol.cc; sourceTree = "<group>"; };
+		OBJ_923 /* alts_zero_copy_grpc_protector.cc */ = {isa = PBXFileReference; path = alts_zero_copy_grpc_protector.cc; sourceTree = "<group>"; };
+		OBJ_924 /* alts_transport_security.cc */ = {isa = PBXFileReference; path = alts_transport_security.cc; sourceTree = "<group>"; };
+		OBJ_925 /* fake_transport_security.cc */ = {isa = PBXFileReference; path = fake_transport_security.cc; sourceTree = "<group>"; };
+		OBJ_928 /* ssl_session_boringssl.cc */ = {isa = PBXFileReference; path = ssl_session_boringssl.cc; sourceTree = "<group>"; };
+		OBJ_929 /* ssl_session_cache.cc */ = {isa = PBXFileReference; path = ssl_session_cache.cc; sourceTree = "<group>"; };
+		OBJ_93 /* dh.c */ = {isa = PBXFileReference; path = dh.c; sourceTree = "<group>"; };
+		OBJ_930 /* ssl_session_openssl.cc */ = {isa = PBXFileReference; path = ssl_session_openssl.cc; sourceTree = "<group>"; };
+		OBJ_931 /* ssl_transport_security.cc */ = {isa = PBXFileReference; path = ssl_transport_security.cc; sourceTree = "<group>"; };
+		OBJ_932 /* transport_security.cc */ = {isa = PBXFileReference; path = transport_security.cc; sourceTree = "<group>"; };
+		OBJ_933 /* transport_security_adapter.cc */ = {isa = PBXFileReference; path = transport_security_adapter.cc; sourceTree = "<group>"; };
+		OBJ_934 /* transport_security_grpc.cc */ = {isa = PBXFileReference; path = transport_security_grpc.cc; sourceTree = "<group>"; };
+		OBJ_937 /* pb_common.c */ = {isa = PBXFileReference; path = pb_common.c; sourceTree = "<group>"; };
+		OBJ_938 /* pb_decode.c */ = {isa = PBXFileReference; path = pb_decode.c; sourceTree = "<group>"; };
+		OBJ_939 /* pb_encode.c */ = {isa = PBXFileReference; path = pb_encode.c; sourceTree = "<group>"; };
+		OBJ_94 /* dh_asn1.c */ = {isa = PBXFileReference; path = dh_asn1.c; sourceTree = "<group>"; };
+		OBJ_941 /* cgrpc.h */ = {isa = PBXFileReference; path = cgrpc.h; sourceTree = "<group>"; };
+		OBJ_943 /* grpc.h */ = {isa = PBXFileReference; path = grpc.h; sourceTree = "<group>"; };
+		OBJ_944 /* status.h */ = {isa = PBXFileReference; path = status.h; sourceTree = "<group>"; };
+		OBJ_945 /* census.h */ = {isa = PBXFileReference; path = census.h; sourceTree = "<group>"; };
+		OBJ_946 /* slice.h */ = {isa = PBXFileReference; path = slice.h; sourceTree = "<group>"; };
+		OBJ_947 /* compression.h */ = {isa = PBXFileReference; path = compression.h; sourceTree = "<group>"; };
+		OBJ_948 /* fork.h */ = {isa = PBXFileReference; path = fork.h; sourceTree = "<group>"; };
+		OBJ_949 /* byte_buffer_reader.h */ = {isa = PBXFileReference; path = byte_buffer_reader.h; sourceTree = "<group>"; };
+		OBJ_95 /* params.c */ = {isa = PBXFileReference; path = params.c; sourceTree = "<group>"; };
+		OBJ_950 /* grpc_security_constants.h */ = {isa = PBXFileReference; path = grpc_security_constants.h; sourceTree = "<group>"; };
+		OBJ_951 /* byte_buffer.h */ = {isa = PBXFileReference; path = byte_buffer.h; sourceTree = "<group>"; };
+		OBJ_952 /* slice_buffer.h */ = {isa = PBXFileReference; path = slice_buffer.h; sourceTree = "<group>"; };
+		OBJ_953 /* grpc_posix.h */ = {isa = PBXFileReference; path = grpc_posix.h; sourceTree = "<group>"; };
+		OBJ_954 /* grpc_security.h */ = {isa = PBXFileReference; path = grpc_security.h; sourceTree = "<group>"; };
+		OBJ_955 /* load_reporting.h */ = {isa = PBXFileReference; path = load_reporting.h; sourceTree = "<group>"; };
+		OBJ_957 /* time.h */ = {isa = PBXFileReference; path = time.h; sourceTree = "<group>"; };
+		OBJ_958 /* port_platform.h */ = {isa = PBXFileReference; path = port_platform.h; sourceTree = "<group>"; };
+		OBJ_959 /* log_windows.h */ = {isa = PBXFileReference; path = log_windows.h; sourceTree = "<group>"; };
+		OBJ_960 /* sync.h */ = {isa = PBXFileReference; path = sync.h; sourceTree = "<group>"; };
+		OBJ_961 /* string_util.h */ = {isa = PBXFileReference; path = string_util.h; sourceTree = "<group>"; };
+		OBJ_962 /* sync_custom.h */ = {isa = PBXFileReference; path = sync_custom.h; sourceTree = "<group>"; };
+		OBJ_963 /* thd_id.h */ = {isa = PBXFileReference; path = thd_id.h; sourceTree = "<group>"; };
+		OBJ_964 /* workaround_list.h */ = {isa = PBXFileReference; path = workaround_list.h; sourceTree = "<group>"; };
+		OBJ_965 /* atm_gcc_sync.h */ = {isa = PBXFileReference; path = atm_gcc_sync.h; sourceTree = "<group>"; };
+		OBJ_966 /* atm_gcc_atomic.h */ = {isa = PBXFileReference; path = atm_gcc_atomic.h; sourceTree = "<group>"; };
+		OBJ_967 /* atm.h */ = {isa = PBXFileReference; path = atm.h; sourceTree = "<group>"; };
+		OBJ_968 /* sync_generic.h */ = {isa = PBXFileReference; path = sync_generic.h; sourceTree = "<group>"; };
+		OBJ_969 /* log.h */ = {isa = PBXFileReference; path = log.h; sourceTree = "<group>"; };
+		OBJ_97 /* digest_extra.c */ = {isa = PBXFileReference; path = digest_extra.c; sourceTree = "<group>"; };
+		OBJ_970 /* cpu.h */ = {isa = PBXFileReference; path = cpu.h; sourceTree = "<group>"; };
+		OBJ_971 /* sync_posix.h */ = {isa = PBXFileReference; path = sync_posix.h; sourceTree = "<group>"; };
+		OBJ_972 /* atm_windows.h */ = {isa = PBXFileReference; path = atm_windows.h; sourceTree = "<group>"; };
+		OBJ_973 /* sync_windows.h */ = {isa = PBXFileReference; path = sync_windows.h; sourceTree = "<group>"; };
+		OBJ_974 /* alloc.h */ = {isa = PBXFileReference; path = alloc.h; sourceTree = "<group>"; };
+		OBJ_977 /* port_platform.h */ = {isa = PBXFileReference; path = port_platform.h; sourceTree = "<group>"; };
+		OBJ_978 /* status.h */ = {isa = PBXFileReference; path = status.h; sourceTree = "<group>"; };
+		OBJ_979 /* gpr_types.h */ = {isa = PBXFileReference; path = gpr_types.h; sourceTree = "<group>"; };
+		OBJ_980 /* sync.h */ = {isa = PBXFileReference; path = sync.h; sourceTree = "<group>"; };
+		OBJ_981 /* grpc_types.h */ = {isa = PBXFileReference; path = grpc_types.h; sourceTree = "<group>"; };
+		OBJ_982 /* sync_custom.h */ = {isa = PBXFileReference; path = sync_custom.h; sourceTree = "<group>"; };
+		OBJ_983 /* gpr_slice.h */ = {isa = PBXFileReference; path = gpr_slice.h; sourceTree = "<group>"; };
+		OBJ_984 /* slice.h */ = {isa = PBXFileReference; path = slice.h; sourceTree = "<group>"; };
+		OBJ_985 /* compression_types.h */ = {isa = PBXFileReference; path = compression_types.h; sourceTree = "<group>"; };
+		OBJ_986 /* atm_gcc_sync.h */ = {isa = PBXFileReference; path = atm_gcc_sync.h; sourceTree = "<group>"; };
+		OBJ_987 /* atm_gcc_atomic.h */ = {isa = PBXFileReference; path = atm_gcc_atomic.h; sourceTree = "<group>"; };
+		OBJ_988 /* atm.h */ = {isa = PBXFileReference; path = atm.h; sourceTree = "<group>"; };
+		OBJ_989 /* sync_generic.h */ = {isa = PBXFileReference; path = sync_generic.h; sourceTree = "<group>"; };
+		OBJ_99 /* dsa.c */ = {isa = PBXFileReference; path = dsa.c; sourceTree = "<group>"; };
+		OBJ_990 /* fork.h */ = {isa = PBXFileReference; path = fork.h; sourceTree = "<group>"; };
+		OBJ_991 /* byte_buffer_reader.h */ = {isa = PBXFileReference; path = byte_buffer_reader.h; sourceTree = "<group>"; };
+		OBJ_992 /* sync_posix.h */ = {isa = PBXFileReference; path = sync_posix.h; sourceTree = "<group>"; };
+		OBJ_993 /* atm_windows.h */ = {isa = PBXFileReference; path = atm_windows.h; sourceTree = "<group>"; };
+		OBJ_994 /* propagation_bits.h */ = {isa = PBXFileReference; path = propagation_bits.h; sourceTree = "<group>"; };
+		OBJ_995 /* byte_buffer.h */ = {isa = PBXFileReference; path = byte_buffer.h; sourceTree = "<group>"; };
+		OBJ_996 /* connectivity_state.h */ = {isa = PBXFileReference; path = connectivity_state.h; sourceTree = "<group>"; };
+		OBJ_997 /* sync_windows.h */ = {isa = PBXFileReference; path = sync_windows.h; sourceTree = "<group>"; };
+		OBJ_998 /* module.modulemap */ = {isa = PBXFileReference; name = module.modulemap; path = "/private/tmp/PR/grpc-swift/Sources/CgRPC/include/module.modulemap"; sourceTree = "<group>"; };
+		SwiftGRPC::BoringSSL::Product /* BoringSSL.framework */ = {isa = PBXFileReference; path = BoringSSL.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		SwiftGRPC::CgRPC::Product /* CgRPC.framework */ = {isa = PBXFileReference; path = CgRPC.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		SwiftGRPC::Echo::Product /* Echo */ = {isa = PBXFileReference; path = Echo; sourceTree = BUILT_PRODUCTS_DIR; };
+		SwiftGRPC::RootsEncoder::Product /* RootsEncoder */ = {isa = PBXFileReference; path = RootsEncoder; sourceTree = BUILT_PRODUCTS_DIR; };
+		SwiftGRPC::Simple::Product /* Simple */ = {isa = PBXFileReference; path = Simple; sourceTree = BUILT_PRODUCTS_DIR; };
+		SwiftGRPC::SwiftGRPC::Product /* SwiftGRPC.framework */ = {isa = PBXFileReference; path = SwiftGRPC.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		SwiftGRPC::SwiftGRPCTests::Product /* SwiftGRPCTests.xctest */ = {isa = PBXFileReference; path = SwiftGRPCTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		SwiftGRPC::protoc-gen-swiftgrpc::Product /* protoc-gen-swiftgrpc */ = {isa = PBXFileReference; path = "protoc-gen-swiftgrpc"; sourceTree = BUILT_PRODUCTS_DIR; };
+		SwiftProtobuf::SwiftProtobuf::Product /* SwiftProtobuf.framework */ = {isa = PBXFileReference; path = SwiftProtobuf.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		SwiftProtobuf::SwiftProtobufPluginLibrary::Product /* SwiftProtobufPluginLibrary.framework */ = {isa = PBXFileReference; path = SwiftProtobufPluginLibrary.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		SwiftProtobuf::protoc-gen-swift::Product /* protoc-gen-swift */ = {isa = PBXFileReference; path = "protoc-gen-swift"; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		OBJ_1492 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			files = (
+			);
+		};
+		OBJ_1852 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			files = (
+				OBJ_1853 /* BoringSSL.framework in Frameworks */,
+			);
+		};
+		OBJ_1958 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			files = (
+				OBJ_1959 /* SwiftProtobuf.framework in Frameworks */,
+				OBJ_1960 /* CgRPC.framework in Frameworks */,
+				OBJ_1961 /* BoringSSL.framework in Frameworks */,
+			);
+		};
+		OBJ_2089 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			files = (
+			);
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		OBJ_10 /* asn1 */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_11 /* a_bitstr.c */,
+				OBJ_12 /* a_bool.c */,
+				OBJ_13 /* a_d2i_fp.c */,
+				OBJ_14 /* a_dup.c */,
+				OBJ_15 /* a_enum.c */,
+				OBJ_16 /* a_gentm.c */,
+				OBJ_17 /* a_i2d_fp.c */,
+				OBJ_18 /* a_int.c */,
+				OBJ_19 /* a_mbstr.c */,
+				OBJ_20 /* a_object.c */,
+				OBJ_21 /* a_octet.c */,
+				OBJ_22 /* a_print.c */,
+				OBJ_23 /* a_strnid.c */,
+				OBJ_24 /* a_time.c */,
+				OBJ_25 /* a_type.c */,
+				OBJ_26 /* a_utctm.c */,
+				OBJ_27 /* a_utf8.c */,
+				OBJ_28 /* asn1_lib.c */,
+				OBJ_29 /* asn1_par.c */,
+				OBJ_30 /* asn_pack.c */,
+				OBJ_31 /* f_enum.c */,
+				OBJ_32 /* f_int.c */,
+				OBJ_33 /* f_string.c */,
+				OBJ_34 /* tasn_dec.c */,
+				OBJ_35 /* tasn_enc.c */,
+				OBJ_36 /* tasn_fre.c */,
+				OBJ_37 /* tasn_new.c */,
+				OBJ_38 /* tasn_typ.c */,
+				OBJ_39 /* tasn_utl.c */,
+				OBJ_40 /* time_support.c */,
+			);
+			name = asn1;
+			path = asn1;
+			sourceTree = "<group>";
+		};
+		OBJ_1001 /* Simple */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1002 /* main.swift */,
+			);
+			name = Simple;
+			path = Sources/Examples/Simple;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_1003 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1004 /* SwiftGRPCTests */,
+			);
+			name = Tests;
+			path = "";
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_1004 /* SwiftGRPCTests */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1005 /* BasicEchoTestCase.swift */,
+				OBJ_1006 /* ChannelArgumentTests.swift */,
+				OBJ_1007 /* ClientCancellingTests.swift */,
+				OBJ_1008 /* ClientTestExample.swift */,
+				OBJ_1009 /* ClientTimeoutTests.swift */,
+				OBJ_1010 /* CompletionQueueTests.swift */,
+				OBJ_1011 /* ConnectionFailureTests.swift */,
+				OBJ_1012 /* EchoProvider.swift */,
+				OBJ_1013 /* EchoTests.swift */,
+				OBJ_1014 /* GRPCTests.swift */,
+				OBJ_1015 /* MetadataTests.swift */,
+				OBJ_1016 /* ServerCancellingTests.swift */,
+				OBJ_1017 /* ServerTestExample.swift */,
+				OBJ_1018 /* ServerThrowingTests.swift */,
+				OBJ_1019 /* ServerTimeoutTests.swift */,
+				OBJ_1020 /* ServiceClientTests.swift */,
+				OBJ_1021 /* TestKeys.swift */,
+				OBJ_1022 /* echo.grpc.swift */,
+				OBJ_1023 /* echo.pb.swift */,
+			);
+			name = SwiftGRPCTests;
+			path = Tests/SwiftGRPCTests;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_101 /* ec_extra */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_102 /* ec_asn1.c */,
+			);
+			name = ec_extra;
+			path = ec_extra;
+			sourceTree = "<group>";
+		};
+		OBJ_1029 /* Dependencies */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1030 /* Commander 0.8.0 */,
+				OBJ_1042 /* SwiftProtobuf 1.1.0 */,
+			);
+			name = Dependencies;
+			path = "";
+			sourceTree = "<group>";
+		};
+		OBJ_103 /* ecdh */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_104 /* ecdh.c */,
+			);
+			name = ecdh;
+			path = ecdh;
+			sourceTree = "<group>";
+		};
+		OBJ_1030 /* Commander 0.8.0 */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1031 /* Commander */,
+				OBJ_1041 /* Package.swift */,
+			);
+			name = "Commander 0.8.0";
+			path = "";
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_1031 /* Commander */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1032 /* ArgumentConvertible.swift */,
+				OBJ_1033 /* ArgumentDescription.swift */,
+				OBJ_1034 /* ArgumentParser.swift */,
+				OBJ_1035 /* Command.swift */,
+				OBJ_1036 /* CommandRunner.swift */,
+				OBJ_1037 /* CommandType.swift */,
+				OBJ_1038 /* Commands.swift */,
+				OBJ_1039 /* Error.swift */,
+				OBJ_1040 /* Group.swift */,
+			);
+			name = Commander;
+			path = ".build/checkouts/Commander.git-8842944228949165507/Sources/Commander";
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_1042 /* SwiftProtobuf 1.1.0 */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1043 /* Conformance */,
+				OBJ_1044 /* protoc-gen-swift */,
+				OBJ_1063 /* SwiftProtobufPluginLibrary */,
+				OBJ_1082 /* SwiftProtobuf */,
+				OBJ_1159 /* Package.swift */,
+			);
+			name = "SwiftProtobuf 1.1.0";
+			path = "";
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_1043 /* Conformance */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Conformance;
+			path = ".build/checkouts/swift-protobuf.git--7219529775138357838/Sources/Conformance";
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_1044 /* protoc-gen-swift */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1045 /* CommandLine+Extensions.swift */,
+				OBJ_1046 /* Descriptor+Extensions.swift */,
+				OBJ_1047 /* EnumGenerator.swift */,
+				OBJ_1048 /* ExtensionSetGenerator.swift */,
+				OBJ_1049 /* FieldGenerator.swift */,
+				OBJ_1050 /* FileGenerator.swift */,
+				OBJ_1051 /* FileIo.swift */,
+				OBJ_1052 /* GenerationError.swift */,
+				OBJ_1053 /* GeneratorOptions.swift */,
+				OBJ_1054 /* Google_Protobuf_DescriptorProto+Extensions.swift */,
+				OBJ_1055 /* Google_Protobuf_FileDescriptorProto+Extensions.swift */,
+				OBJ_1056 /* MessageFieldGenerator.swift */,
+				OBJ_1057 /* MessageGenerator.swift */,
+				OBJ_1058 /* MessageStorageClassGenerator.swift */,
+				OBJ_1059 /* OneofGenerator.swift */,
+				OBJ_1060 /* StringUtils.swift */,
+				OBJ_1061 /* Version.swift */,
+				OBJ_1062 /* main.swift */,
+			);
+			name = "protoc-gen-swift";
+			path = ".build/checkouts/swift-protobuf.git--7219529775138357838/Sources/protoc-gen-swift";
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_105 /* ecdsa_extra */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_106 /* ecdsa_asn1.c */,
+			);
+			name = ecdsa_extra;
+			path = ecdsa_extra;
+			sourceTree = "<group>";
+		};
+		OBJ_1063 /* SwiftProtobufPluginLibrary */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1064 /* Array+Extensions.swift */,
+				OBJ_1065 /* CodePrinter.swift */,
+				OBJ_1066 /* Descriptor+Extensions.swift */,
+				OBJ_1067 /* Descriptor.swift */,
+				OBJ_1068 /* FieldNumbers.swift */,
+				OBJ_1069 /* Google_Protobuf_Compiler_CodeGeneratorResponse+Extensions.swift */,
+				OBJ_1070 /* Google_Protobuf_SourceCodeInfo+Extensions.swift */,
+				OBJ_1071 /* NamingUtils.swift */,
+				OBJ_1072 /* ProtoFileToModuleMappings.swift */,
+				OBJ_1073 /* ProvidesLocationPath.swift */,
+				OBJ_1074 /* ProvidesSourceCodeLocation.swift */,
+				OBJ_1075 /* SwiftLanguage.swift */,
+				OBJ_1076 /* SwiftProtobufInfo.swift */,
+				OBJ_1077 /* SwiftProtobufNamer.swift */,
+				OBJ_1078 /* UnicodeScalar+Extensions.swift */,
+				OBJ_1079 /* descriptor.pb.swift */,
+				OBJ_1080 /* plugin.pb.swift */,
+				OBJ_1081 /* swift_protobuf_module_mappings.pb.swift */,
+			);
+			name = SwiftProtobufPluginLibrary;
+			path = ".build/checkouts/swift-protobuf.git--7219529775138357838/Sources/SwiftProtobufPluginLibrary";
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_107 /* engine */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_108 /* engine.c */,
+			);
+			name = engine;
+			path = engine;
+			sourceTree = "<group>";
+		};
+		OBJ_1082 /* SwiftProtobuf */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1083 /* AnyMessageStorage.swift */,
+				OBJ_1084 /* AnyUnpackError.swift */,
+				OBJ_1085 /* BinaryDecoder.swift */,
+				OBJ_1086 /* BinaryDecodingError.swift */,
+				OBJ_1087 /* BinaryDecodingOptions.swift */,
+				OBJ_1088 /* BinaryDelimited.swift */,
+				OBJ_1089 /* BinaryEncoder.swift */,
+				OBJ_1090 /* BinaryEncodingError.swift */,
+				OBJ_1091 /* BinaryEncodingSizeVisitor.swift */,
+				OBJ_1092 /* BinaryEncodingVisitor.swift */,
+				OBJ_1093 /* CustomJSONCodable.swift */,
+				OBJ_1094 /* Decoder.swift */,
+				OBJ_1095 /* DoubleFormatter.swift */,
+				OBJ_1096 /* Enum.swift */,
+				OBJ_1097 /* ExtensibleMessage.swift */,
+				OBJ_1098 /* ExtensionFieldValueSet.swift */,
+				OBJ_1099 /* ExtensionFields.swift */,
+				OBJ_1100 /* ExtensionMap.swift */,
+				OBJ_1101 /* FieldTag.swift */,
+				OBJ_1102 /* FieldTypes.swift */,
+				OBJ_1103 /* Google_Protobuf_Any+Extensions.swift */,
+				OBJ_1104 /* Google_Protobuf_Any+Registry.swift */,
+				OBJ_1105 /* Google_Protobuf_Duration+Extensions.swift */,
+				OBJ_1106 /* Google_Protobuf_FieldMask+Extensions.swift */,
+				OBJ_1107 /* Google_Protobuf_ListValue+Extensions.swift */,
+				OBJ_1108 /* Google_Protobuf_Struct+Extensions.swift */,
+				OBJ_1109 /* Google_Protobuf_Timestamp+Extensions.swift */,
+				OBJ_1110 /* Google_Protobuf_Value+Extensions.swift */,
+				OBJ_1111 /* Google_Protobuf_Wrappers+Extensions.swift */,
+				OBJ_1112 /* HashVisitor.swift */,
+				OBJ_1113 /* Internal.swift */,
+				OBJ_1114 /* JSONDecoder.swift */,
+				OBJ_1115 /* JSONDecodingError.swift */,
+				OBJ_1116 /* JSONDecodingOptions.swift */,
+				OBJ_1117 /* JSONEncoder.swift */,
+				OBJ_1118 /* JSONEncodingError.swift */,
+				OBJ_1119 /* JSONEncodingVisitor.swift */,
+				OBJ_1120 /* JSONMapEncodingVisitor.swift */,
+				OBJ_1121 /* JSONScanner.swift */,
+				OBJ_1122 /* MathUtils.swift */,
+				OBJ_1123 /* Message+AnyAdditions.swift */,
+				OBJ_1124 /* Message+BinaryAdditions.swift */,
+				OBJ_1125 /* Message+JSONAdditions.swift */,
+				OBJ_1126 /* Message+JSONArrayAdditions.swift */,
+				OBJ_1127 /* Message+TextFormatAdditions.swift */,
+				OBJ_1128 /* Message.swift */,
+				OBJ_1129 /* MessageExtension.swift */,
+				OBJ_1130 /* NameMap.swift */,
+				OBJ_1131 /* ProtoNameProviding.swift */,
+				OBJ_1132 /* ProtobufAPIVersionCheck.swift */,
+				OBJ_1133 /* ProtobufMap.swift */,
+				OBJ_1134 /* SelectiveVisitor.swift */,
+				OBJ_1135 /* SimpleExtensionMap.swift */,
+				OBJ_1136 /* StringUtils.swift */,
+				OBJ_1137 /* TextFormatDecoder.swift */,
+				OBJ_1138 /* TextFormatDecodingError.swift */,
+				OBJ_1139 /* TextFormatEncoder.swift */,
+				OBJ_1140 /* TextFormatEncodingVisitor.swift */,
+				OBJ_1141 /* TextFormatScanner.swift */,
+				OBJ_1142 /* TimeUtils.swift */,
+				OBJ_1143 /* UnknownStorage.swift */,
+				OBJ_1144 /* Varint.swift */,
+				OBJ_1145 /* Version.swift */,
+				OBJ_1146 /* Visitor.swift */,
+				OBJ_1147 /* WireFormat.swift */,
+				OBJ_1148 /* ZigZag.swift */,
+				OBJ_1149 /* any.pb.swift */,
+				OBJ_1150 /* api.pb.swift */,
+				OBJ_1151 /* duration.pb.swift */,
+				OBJ_1152 /* empty.pb.swift */,
+				OBJ_1153 /* field_mask.pb.swift */,
+				OBJ_1154 /* source_context.pb.swift */,
+				OBJ_1155 /* struct.pb.swift */,
+				OBJ_1156 /* timestamp.pb.swift */,
+				OBJ_1157 /* type.pb.swift */,
+				OBJ_1158 /* wrappers.pb.swift */,
+			);
+			name = SwiftProtobuf;
+			path = ".build/checkouts/swift-protobuf.git--7219529775138357838/Sources/SwiftProtobuf";
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_109 /* err */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_110 /* err.c */,
+				OBJ_111 /* err_data.c */,
+			);
+			name = err;
+			path = err;
+			sourceTree = "<group>";
+		};
+		OBJ_112 /* evp */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_113 /* digestsign.c */,
+				OBJ_114 /* evp.c */,
+				OBJ_115 /* evp_asn1.c */,
+				OBJ_116 /* evp_ctx.c */,
+				OBJ_117 /* p_dsa_asn1.c */,
+				OBJ_118 /* p_ec.c */,
+				OBJ_119 /* p_ec_asn1.c */,
+				OBJ_120 /* p_ed25519.c */,
+				OBJ_121 /* p_ed25519_asn1.c */,
+				OBJ_122 /* p_rsa.c */,
+				OBJ_123 /* p_rsa_asn1.c */,
+				OBJ_124 /* pbkdf.c */,
+				OBJ_125 /* print.c */,
+				OBJ_126 /* scrypt.c */,
+				OBJ_127 /* sign.c */,
+			);
+			name = evp;
+			path = evp;
+			sourceTree = "<group>";
+		};
+		OBJ_1160 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				SwiftGRPC::Echo::Product /* Echo */,
+				SwiftProtobuf::protoc-gen-swift::Product /* protoc-gen-swift */,
+				SwiftGRPC::RootsEncoder::Product /* RootsEncoder */,
+				SwiftGRPC::Simple::Product /* Simple */,
+				SwiftProtobuf::SwiftProtobufPluginLibrary::Product /* SwiftProtobufPluginLibrary.framework */,
+				SwiftGRPC::SwiftGRPCTests::Product /* SwiftGRPCTests.xctest */,
+				SwiftGRPC::SwiftGRPC::Product /* SwiftGRPC.framework */,
+				SwiftGRPC::BoringSSL::Product /* BoringSSL.framework */,
+				Commander::Commander::Product /* Commander.framework */,
+				SwiftGRPC::CgRPC::Product /* CgRPC.framework */,
+				SwiftProtobuf::SwiftProtobuf::Product /* SwiftProtobuf.framework */,
+				SwiftGRPC::protoc-gen-swiftgrpc::Product /* protoc-gen-swiftgrpc */,
+			);
+			name = Products;
+			path = "";
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		OBJ_129 /* fipsmodule */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_130 /* aes */,
+				OBJ_134 /* bn */,
+				OBJ_153 /* cipher */,
+				OBJ_158 /* des */,
+				OBJ_160 /* digest */,
+				OBJ_163 /* ec */,
+				OBJ_174 /* ecdsa */,
+				OBJ_176 /* hmac */,
+				OBJ_178 /* is_fips.c */,
+				OBJ_179 /* md4 */,
+				OBJ_181 /* md5 */,
+				OBJ_183 /* modes */,
+				OBJ_190 /* rand */,
+				OBJ_194 /* rsa */,
+				OBJ_199 /* sha */,
+			);
+			name = fipsmodule;
+			path = fipsmodule;
+			sourceTree = "<group>";
+		};
+		OBJ_130 /* aes */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_131 /* aes.c */,
+				OBJ_132 /* key_wrap.c */,
+				OBJ_133 /* mode_wrappers.c */,
+			);
+			name = aes;
+			path = aes;
+			sourceTree = "<group>";
+		};
+		OBJ_134 /* bn */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_135 /* add.c */,
+				OBJ_136 /* bn.c */,
+				OBJ_137 /* bytes.c */,
+				OBJ_138 /* cmp.c */,
+				OBJ_139 /* ctx.c */,
+				OBJ_140 /* div.c */,
+				OBJ_141 /* exponentiation.c */,
+				OBJ_142 /* gcd.c */,
+				OBJ_143 /* generic.c */,
+				OBJ_144 /* jacobi.c */,
+				OBJ_145 /* montgomery.c */,
+				OBJ_146 /* montgomery_inv.c */,
+				OBJ_147 /* mul.c */,
+				OBJ_148 /* prime.c */,
+				OBJ_149 /* random.c */,
+				OBJ_150 /* rsaz_exp.c */,
+				OBJ_151 /* shift.c */,
+				OBJ_152 /* sqrt.c */,
+			);
+			name = bn;
+			path = bn;
+			sourceTree = "<group>";
+		};
+		OBJ_153 /* cipher */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_154 /* aead.c */,
+				OBJ_155 /* cipher.c */,
+				OBJ_156 /* e_aes.c */,
+				OBJ_157 /* e_des.c */,
+			);
+			name = cipher;
+			path = cipher;
+			sourceTree = "<group>";
+		};
+		OBJ_158 /* des */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_159 /* des.c */,
+			);
+			name = des;
+			path = des;
+			sourceTree = "<group>";
+		};
+		OBJ_160 /* digest */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_161 /* digest.c */,
+				OBJ_162 /* digests.c */,
+			);
+			name = digest;
+			path = digest;
+			sourceTree = "<group>";
+		};
+		OBJ_163 /* ec */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_164 /* ec.c */,
+				OBJ_165 /* ec_key.c */,
+				OBJ_166 /* ec_montgomery.c */,
+				OBJ_167 /* oct.c */,
+				OBJ_168 /* p224-64.c */,
+				OBJ_169 /* p256-64.c */,
+				OBJ_170 /* p256-x86_64.c */,
+				OBJ_171 /* simple.c */,
+				OBJ_172 /* util-64.c */,
+				OBJ_173 /* wnaf.c */,
+			);
+			name = ec;
+			path = ec;
+			sourceTree = "<group>";
+		};
+		OBJ_174 /* ecdsa */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_175 /* ecdsa.c */,
+			);
+			name = ecdsa;
+			path = ecdsa;
+			sourceTree = "<group>";
+		};
+		OBJ_176 /* hmac */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_177 /* hmac.c */,
+			);
+			name = hmac;
+			path = hmac;
+			sourceTree = "<group>";
+		};
+		OBJ_179 /* md4 */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_180 /* md4.c */,
+			);
+			name = md4;
+			path = md4;
+			sourceTree = "<group>";
+		};
+		OBJ_181 /* md5 */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_182 /* md5.c */,
+			);
+			name = md5;
+			path = md5;
+			sourceTree = "<group>";
+		};
+		OBJ_183 /* modes */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_184 /* cbc.c */,
+				OBJ_185 /* cfb.c */,
+				OBJ_186 /* ctr.c */,
+				OBJ_187 /* gcm.c */,
+				OBJ_188 /* ofb.c */,
+				OBJ_189 /* polyval.c */,
+			);
+			name = modes;
+			path = modes;
+			sourceTree = "<group>";
+		};
+		OBJ_190 /* rand */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_191 /* ctrdrbg.c */,
+				OBJ_192 /* rand.c */,
+				OBJ_193 /* urandom.c */,
+			);
+			name = rand;
+			path = rand;
+			sourceTree = "<group>";
+		};
+		OBJ_194 /* rsa */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_195 /* blinding.c */,
+				OBJ_196 /* padding.c */,
+				OBJ_197 /* rsa.c */,
+				OBJ_198 /* rsa_impl.c */,
+			);
+			name = rsa;
+			path = rsa;
+			sourceTree = "<group>";
+		};
+		OBJ_199 /* sha */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_200 /* sha1-altivec.c */,
+				OBJ_201 /* sha1.c */,
+				OBJ_202 /* sha256.c */,
+				OBJ_203 /* sha512.c */,
+			);
+			name = sha;
+			path = sha;
+			sourceTree = "<group>";
+		};
+		OBJ_204 /* hkdf */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_205 /* hkdf.c */,
+			);
+			name = hkdf;
+			path = hkdf;
+			sourceTree = "<group>";
+		};
+		OBJ_206 /* lhash */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_207 /* lhash.c */,
+			);
+			name = lhash;
+			path = lhash;
+			sourceTree = "<group>";
+		};
+		OBJ_209 /* obj */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_210 /* obj.c */,
+				OBJ_211 /* obj_xref.c */,
+			);
+			name = obj;
+			path = obj;
+			sourceTree = "<group>";
+		};
+		OBJ_212 /* pem */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_213 /* pem_all.c */,
+				OBJ_214 /* pem_info.c */,
+				OBJ_215 /* pem_lib.c */,
+				OBJ_216 /* pem_oth.c */,
+				OBJ_217 /* pem_pk8.c */,
+				OBJ_218 /* pem_pkey.c */,
+				OBJ_219 /* pem_x509.c */,
+				OBJ_220 /* pem_xaux.c */,
+			);
+			name = pem;
+			path = pem;
+			sourceTree = "<group>";
+		};
+		OBJ_221 /* pkcs7 */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_222 /* pkcs7.c */,
+				OBJ_223 /* pkcs7_x509.c */,
+			);
+			name = pkcs7;
+			path = pkcs7;
+			sourceTree = "<group>";
+		};
+		OBJ_224 /* pkcs8 */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_225 /* p5_pbev2.c */,
+				OBJ_226 /* pkcs8.c */,
+				OBJ_227 /* pkcs8_x509.c */,
+			);
+			name = pkcs8;
+			path = pkcs8;
+			sourceTree = "<group>";
+		};
+		OBJ_228 /* poly1305 */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_229 /* poly1305.c */,
+				OBJ_230 /* poly1305_arm.c */,
+				OBJ_231 /* poly1305_vec.c */,
+			);
+			name = poly1305;
+			path = poly1305;
+			sourceTree = "<group>";
+		};
+		OBJ_232 /* pool */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_233 /* pool.c */,
+			);
+			name = pool;
+			path = pool;
+			sourceTree = "<group>";
+		};
+		OBJ_234 /* rand_extra */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_235 /* deterministic.c */,
+				OBJ_236 /* forkunsafe.c */,
+				OBJ_237 /* fuchsia.c */,
+				OBJ_238 /* rand_extra.c */,
+				OBJ_239 /* windows.c */,
+			);
+			name = rand_extra;
+			path = rand_extra;
+			sourceTree = "<group>";
+		};
+		OBJ_240 /* rc4 */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_241 /* rc4.c */,
+			);
+			name = rc4;
+			path = rc4;
+			sourceTree = "<group>";
+		};
+		OBJ_244 /* rsa_extra */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_245 /* rsa_asn1.c */,
+			);
+			name = rsa_extra;
+			path = rsa_extra;
+			sourceTree = "<group>";
+		};
+		OBJ_246 /* stack */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_247 /* stack.c */,
+			);
+			name = stack;
+			path = stack;
+			sourceTree = "<group>";
+		};
+		OBJ_252 /* x509 */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_253 /* a_digest.c */,
+				OBJ_254 /* a_sign.c */,
+				OBJ_255 /* a_strex.c */,
+				OBJ_256 /* a_verify.c */,
+				OBJ_257 /* algorithm.c */,
+				OBJ_258 /* asn1_gen.c */,
+				OBJ_259 /* by_dir.c */,
+				OBJ_260 /* by_file.c */,
+				OBJ_261 /* i2d_pr.c */,
+				OBJ_262 /* rsa_pss.c */,
+				OBJ_263 /* t_crl.c */,
+				OBJ_264 /* t_req.c */,
+				OBJ_265 /* t_x509.c */,
+				OBJ_266 /* t_x509a.c */,
+				OBJ_267 /* x509.c */,
+				OBJ_268 /* x509_att.c */,
+				OBJ_269 /* x509_cmp.c */,
+				OBJ_270 /* x509_d2.c */,
+				OBJ_271 /* x509_def.c */,
+				OBJ_272 /* x509_ext.c */,
+				OBJ_273 /* x509_lu.c */,
+				OBJ_274 /* x509_obj.c */,
+				OBJ_275 /* x509_r2x.c */,
+				OBJ_276 /* x509_req.c */,
+				OBJ_277 /* x509_set.c */,
+				OBJ_278 /* x509_trs.c */,
+				OBJ_279 /* x509_txt.c */,
+				OBJ_280 /* x509_v3.c */,
+				OBJ_281 /* x509_vfy.c */,
+				OBJ_282 /* x509_vpm.c */,
+				OBJ_283 /* x509cset.c */,
+				OBJ_284 /* x509name.c */,
+				OBJ_285 /* x509rset.c */,
+				OBJ_286 /* x509spki.c */,
+				OBJ_287 /* x_algor.c */,
+				OBJ_288 /* x_all.c */,
+				OBJ_289 /* x_attrib.c */,
+				OBJ_290 /* x_crl.c */,
+				OBJ_291 /* x_exten.c */,
+				OBJ_292 /* x_info.c */,
+				OBJ_293 /* x_name.c */,
+				OBJ_294 /* x_pkey.c */,
+				OBJ_295 /* x_pubkey.c */,
+				OBJ_296 /* x_req.c */,
+				OBJ_297 /* x_sig.c */,
+				OBJ_298 /* x_spki.c */,
+				OBJ_299 /* x_val.c */,
+				OBJ_300 /* x_x509.c */,
+				OBJ_301 /* x_x509a.c */,
+			);
+			name = x509;
+			path = x509;
+			sourceTree = "<group>";
+		};
+		OBJ_302 /* x509v3 */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_303 /* pcy_cache.c */,
+				OBJ_304 /* pcy_data.c */,
+				OBJ_305 /* pcy_lib.c */,
+				OBJ_306 /* pcy_map.c */,
+				OBJ_307 /* pcy_node.c */,
+				OBJ_308 /* pcy_tree.c */,
+				OBJ_309 /* v3_akey.c */,
+				OBJ_310 /* v3_akeya.c */,
+				OBJ_311 /* v3_alt.c */,
+				OBJ_312 /* v3_bcons.c */,
+				OBJ_313 /* v3_bitst.c */,
+				OBJ_314 /* v3_conf.c */,
+				OBJ_315 /* v3_cpols.c */,
+				OBJ_316 /* v3_crld.c */,
+				OBJ_317 /* v3_enum.c */,
+				OBJ_318 /* v3_extku.c */,
+				OBJ_319 /* v3_genn.c */,
+				OBJ_320 /* v3_ia5.c */,
+				OBJ_321 /* v3_info.c */,
+				OBJ_322 /* v3_int.c */,
+				OBJ_323 /* v3_lib.c */,
+				OBJ_324 /* v3_ncons.c */,
+				OBJ_325 /* v3_pci.c */,
+				OBJ_326 /* v3_pcia.c */,
+				OBJ_327 /* v3_pcons.c */,
+				OBJ_328 /* v3_pku.c */,
+				OBJ_329 /* v3_pmaps.c */,
+				OBJ_330 /* v3_prn.c */,
+				OBJ_331 /* v3_purp.c */,
+				OBJ_332 /* v3_skey.c */,
+				OBJ_333 /* v3_sxnet.c */,
+				OBJ_334 /* v3_utl.c */,
+			);
+			name = x509v3;
+			path = x509v3;
+			sourceTree = "<group>";
+		};
+		OBJ_336 /* ssl */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_337 /* bio_ssl.cc */,
+				OBJ_338 /* custom_extensions.cc */,
+				OBJ_339 /* d1_both.cc */,
+				OBJ_340 /* d1_lib.cc */,
+				OBJ_341 /* d1_pkt.cc */,
+				OBJ_342 /* d1_srtp.cc */,
+				OBJ_343 /* dtls_method.cc */,
+				OBJ_344 /* dtls_record.cc */,
+				OBJ_345 /* handshake.cc */,
+				OBJ_346 /* handshake_client.cc */,
+				OBJ_347 /* handshake_server.cc */,
+				OBJ_348 /* s3_both.cc */,
+				OBJ_349 /* s3_lib.cc */,
+				OBJ_350 /* s3_pkt.cc */,
+				OBJ_351 /* ssl_aead_ctx.cc */,
+				OBJ_352 /* ssl_asn1.cc */,
+				OBJ_353 /* ssl_buffer.cc */,
+				OBJ_354 /* ssl_cert.cc */,
+				OBJ_355 /* ssl_cipher.cc */,
+				OBJ_356 /* ssl_file.cc */,
+				OBJ_357 /* ssl_key_share.cc */,
+				OBJ_358 /* ssl_lib.cc */,
+				OBJ_359 /* ssl_privkey.cc */,
+				OBJ_360 /* ssl_session.cc */,
+				OBJ_361 /* ssl_stat.cc */,
+				OBJ_362 /* ssl_transcript.cc */,
+				OBJ_363 /* ssl_versions.cc */,
+				OBJ_364 /* ssl_x509.cc */,
+				OBJ_365 /* t1_enc.cc */,
+				OBJ_366 /* t1_lib.cc */,
+				OBJ_367 /* tls13_both.cc */,
+				OBJ_368 /* tls13_client.cc */,
+				OBJ_369 /* tls13_enc.cc */,
+				OBJ_370 /* tls13_server.cc */,
+				OBJ_371 /* tls_method.cc */,
+				OBJ_372 /* tls_record.cc */,
+			);
+			name = ssl;
+			path = ssl;
+			sourceTree = "<group>";
+		};
+		OBJ_373 /* third_party */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_374 /* fiat */,
+			);
+			name = third_party;
+			path = third_party;
+			sourceTree = "<group>";
+		};
+		OBJ_374 /* fiat */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_375 /* curve25519.c */,
+			);
+			name = fiat;
+			path = fiat;
+			sourceTree = "<group>";
+		};
+		OBJ_376 /* include */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_377 /* openssl */,
+				OBJ_451 /* module.modulemap */,
+			);
+			name = include;
+			path = include;
+			sourceTree = "<group>";
+		};
+		OBJ_377 /* openssl */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_378 /* pem.h */,
+				OBJ_379 /* nid.h */,
+				OBJ_380 /* ssl3.h */,
+				OBJ_381 /* ossl_typ.h */,
+				OBJ_382 /* dtls1.h */,
+				OBJ_383 /* err.h */,
+				OBJ_384 /* bn.h */,
+				OBJ_385 /* blowfish.h */,
+				OBJ_386 /* engine.h */,
+				OBJ_387 /* bytestring.h */,
+				OBJ_388 /* x509.h */,
+				OBJ_389 /* asn1_mac.h */,
+				OBJ_390 /* pool.h */,
+				OBJ_391 /* ec_key.h */,
+				OBJ_392 /* base64.h */,
+				OBJ_393 /* is_boringssl.h */,
+				OBJ_394 /* sha.h */,
+				OBJ_395 /* asn1.h */,
+				OBJ_396 /* chacha.h */,
+				OBJ_397 /* opensslconf.h */,
+				OBJ_398 /* arm_arch.h */,
+				OBJ_399 /* bio.h */,
+				OBJ_400 /* dh.h */,
+				OBJ_401 /* digest.h */,
+				OBJ_402 /* x509v3.h */,
+				OBJ_403 /* conf.h */,
+				OBJ_404 /* poly1305.h */,
+				OBJ_405 /* hkdf.h */,
+				OBJ_406 /* type_check.h */,
+				OBJ_407 /* md5.h */,
+				OBJ_408 /* x509_vfy.h */,
+				OBJ_409 /* pkcs8.h */,
+				OBJ_410 /* safestack.h */,
+				OBJ_411 /* buf.h */,
+				OBJ_412 /* obj.h */,
+				OBJ_413 /* ecdsa.h */,
+				OBJ_414 /* cipher.h */,
+				OBJ_415 /* objects.h */,
+				OBJ_416 /* pkcs12.h */,
+				OBJ_417 /* crypto.h */,
+				OBJ_418 /* opensslv.h */,
+				OBJ_419 /* pkcs7.h */,
+				OBJ_420 /* obj_mac.h */,
+				OBJ_421 /* buffer.h */,
+				OBJ_422 /* ssl.h */,
+				OBJ_423 /* thread.h */,
+				OBJ_424 /* evp.h */,
+				OBJ_425 /* md4.h */,
+				OBJ_426 /* hmac.h */,
+				OBJ_427 /* aes.h */,
+				OBJ_428 /* cast.h */,
+				OBJ_429 /* rc4.h */,
+				OBJ_430 /* cpu.h */,
+				OBJ_431 /* stack.h */,
+				OBJ_432 /* des.h */,
+				OBJ_433 /* ec.h */,
+				OBJ_434 /* ecdh.h */,
+				OBJ_435 /* rand.h */,
+				OBJ_436 /* aead.h */,
+				OBJ_437 /* lhash_macros.h */,
+				OBJ_438 /* span.h */,
+				OBJ_439 /* rsa.h */,
+				OBJ_440 /* mem.h */,
+				OBJ_441 /* ripemd.h */,
+				OBJ_442 /* curve25519.h */,
+				OBJ_443 /* tls1.h */,
+				OBJ_444 /* dsa.h */,
+				OBJ_445 /* srtp.h */,
+				OBJ_446 /* asn1t.h */,
+				OBJ_447 /* cmac.h */,
+				OBJ_448 /* lhash.h */,
+				OBJ_449 /* ex_data.h */,
+				OBJ_450 /* base.h */,
+			);
+			name = openssl;
+			path = openssl;
+			sourceTree = "<group>";
+		};
+		OBJ_41 /* base64 */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_42 /* base64.c */,
+			);
+			name = base64;
+			path = base64;
+			sourceTree = "<group>";
+		};
+		OBJ_43 /* bio */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_44 /* bio.c */,
+				OBJ_45 /* bio_mem.c */,
+				OBJ_46 /* connect.c */,
+				OBJ_47 /* fd.c */,
+				OBJ_48 /* file.c */,
+				OBJ_49 /* hexdump.c */,
+				OBJ_50 /* pair.c */,
+				OBJ_51 /* printf.c */,
+				OBJ_52 /* socket.c */,
+				OBJ_53 /* socket_helper.c */,
+			);
+			name = bio;
+			path = bio;
+			sourceTree = "<group>";
+		};
+		OBJ_452 /* Echo */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_453 /* EchoProvider.swift */,
+				OBJ_454 /* Generated */,
+				OBJ_457 /* main.swift */,
+			);
+			name = Echo;
+			path = Sources/Examples/Echo;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_454 /* Generated */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_455 /* echo.grpc.swift */,
+				OBJ_456 /* echo.pb.swift */,
+			);
+			name = Generated;
+			path = Generated;
+			sourceTree = "<group>";
+		};
+		OBJ_458 /* protoc-gen-swiftgrpc */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_459 /* Generator-Client.swift */,
+				OBJ_460 /* Generator-Methods.swift */,
+				OBJ_461 /* Generator-Names.swift */,
+				OBJ_462 /* Generator-Server.swift */,
+				OBJ_463 /* Generator.swift */,
+				OBJ_464 /* StreamingType.swift */,
+				OBJ_465 /* io.swift */,
+				OBJ_466 /* main.swift */,
+				OBJ_467 /* options.swift */,
+			);
+			name = "protoc-gen-swiftgrpc";
+			path = "Sources/protoc-gen-swiftgrpc";
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_468 /* SwiftGRPC */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_469 /* Core */,
+				OBJ_486 /* Runtime */,
+			);
+			name = SwiftGRPC;
+			path = Sources/SwiftGRPC;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_469 /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_470 /* ByteBuffer.swift */,
+				OBJ_471 /* Call.swift */,
+				OBJ_472 /* CallError.swift */,
+				OBJ_473 /* CallResult.swift */,
+				OBJ_474 /* Channel.swift */,
+				OBJ_475 /* ChannelArgument.swift */,
+				OBJ_476 /* CompletionQueue.swift */,
+				OBJ_477 /* Handler.swift */,
+				OBJ_478 /* Metadata.swift */,
+				OBJ_479 /* Mutex.swift */,
+				OBJ_480 /* Operation.swift */,
+				OBJ_481 /* OperationGroup.swift */,
+				OBJ_482 /* Roots.swift */,
+				OBJ_483 /* Server.swift */,
+				OBJ_484 /* ServerStatus.swift */,
+				OBJ_485 /* gRPC.swift */,
+			);
+			name = Core;
+			path = Core;
+			sourceTree = "<group>";
+		};
+		OBJ_486 /* Runtime */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_487 /* ClientCall.swift */,
+				OBJ_488 /* ClientCallBidirectionalStreaming.swift */,
+				OBJ_489 /* ClientCallClientStreaming.swift */,
+				OBJ_490 /* ClientCallServerStreaming.swift */,
+				OBJ_491 /* ClientCallUnary.swift */,
+				OBJ_492 /* RPCError.swift */,
+				OBJ_493 /* ServerSession.swift */,
+				OBJ_494 /* ServerSessionBidirectionalStreaming.swift */,
+				OBJ_495 /* ServerSessionClientStreaming.swift */,
+				OBJ_496 /* ServerSessionServerStreaming.swift */,
+				OBJ_497 /* ServerSessionUnary.swift */,
+				OBJ_498 /* ServiceClient.swift */,
+				OBJ_499 /* ServiceProvider.swift */,
+				OBJ_500 /* ServiceServer.swift */,
+				OBJ_501 /* StreamReceiving.swift */,
+				OBJ_502 /* StreamSending.swift */,
+			);
+			name = Runtime;
+			path = Runtime;
+			sourceTree = "<group>";
+		};
+		OBJ_5 = {
+			isa = PBXGroup;
+			children = (
+				OBJ_6 /* Package.swift */,
+				OBJ_7 /* Sources */,
+				OBJ_1003 /* Tests */,
+				OBJ_1024 /* Docker */,
+				OBJ_1025 /* third_party */,
+				OBJ_1026 /* Examples */,
+				OBJ_1027 /* scripts */,
+				OBJ_1028 /* Assets */,
+				OBJ_1029 /* Dependencies */,
+				OBJ_1160 /* Products */,
+			);
+			indentWidth = 2;
+			path = "";
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		OBJ_503 /* CgRPC */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_504 /* shim */,
+				OBJ_517 /* src */,
+				OBJ_935 /* third_party */,
+				OBJ_940 /* include */,
+			);
+			name = CgRPC;
+			path = Sources/CgRPC;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_504 /* shim */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_505 /* byte_buffer.c */,
+				OBJ_506 /* call.c */,
+				OBJ_507 /* channel.c */,
+				OBJ_508 /* completion_queue.c */,
+				OBJ_509 /* event.c */,
+				OBJ_510 /* handler.c */,
+				OBJ_511 /* internal.c */,
+				OBJ_512 /* metadata.c */,
+				OBJ_513 /* mutex.c */,
+				OBJ_514 /* observers.c */,
+				OBJ_515 /* operations.c */,
+				OBJ_516 /* server.c */,
+			);
+			name = shim;
+			path = shim;
+			sourceTree = "<group>";
+		};
+		OBJ_517 /* src */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_518 /* core */,
+			);
+			name = src;
+			path = src;
+			sourceTree = "<group>";
+		};
+		OBJ_518 /* core */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_519 /* ext */,
+				OBJ_640 /* lib */,
+				OBJ_892 /* plugin_registry */,
+				OBJ_894 /* tsi */,
+			);
+			name = core;
+			path = core;
+			sourceTree = "<group>";
+		};
+		OBJ_519 /* ext */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_520 /* census */,
+				OBJ_522 /* filters */,
+				OBJ_595 /* transport */,
+			);
+			name = ext;
+			path = ext;
+			sourceTree = "<group>";
+		};
+		OBJ_520 /* census */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_521 /* grpc_context.cc */,
+			);
+			name = census;
+			path = census;
+			sourceTree = "<group>";
+		};
+		OBJ_522 /* filters */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_523 /* client_channel */,
+				OBJ_574 /* deadline */,
+				OBJ_576 /* http */,
+				OBJ_585 /* load_reporting */,
+				OBJ_588 /* max_age */,
+				OBJ_590 /* message_size */,
+				OBJ_592 /* workarounds */,
+			);
+			name = filters;
+			path = filters;
+			sourceTree = "<group>";
+		};
+		OBJ_523 /* client_channel */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_524 /* backup_poller.cc */,
+				OBJ_525 /* channel_connectivity.cc */,
+				OBJ_526 /* client_channel.cc */,
+				OBJ_527 /* client_channel_factory.cc */,
+				OBJ_528 /* client_channel_plugin.cc */,
+				OBJ_529 /* connector.cc */,
+				OBJ_530 /* http_connect_handshaker.cc */,
+				OBJ_531 /* http_proxy.cc */,
+				OBJ_532 /* lb_policy.cc */,
+				OBJ_533 /* lb_policy */,
+				OBJ_549 /* lb_policy_factory.cc */,
+				OBJ_550 /* lb_policy_registry.cc */,
+				OBJ_551 /* method_params.cc */,
+				OBJ_552 /* parse_address.cc */,
+				OBJ_553 /* proxy_mapper.cc */,
+				OBJ_554 /* proxy_mapper_registry.cc */,
+				OBJ_555 /* resolver.cc */,
+				OBJ_556 /* resolver */,
+				OBJ_569 /* resolver_registry.cc */,
+				OBJ_570 /* retry_throttle.cc */,
+				OBJ_571 /* subchannel.cc */,
+				OBJ_572 /* subchannel_index.cc */,
+				OBJ_573 /* uri_parser.cc */,
+			);
+			name = client_channel;
+			path = client_channel;
+			sourceTree = "<group>";
+		};
+		OBJ_533 /* lb_policy */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_534 /* grpclb */,
+				OBJ_545 /* pick_first */,
+				OBJ_547 /* round_robin */,
+			);
+			name = lb_policy;
+			path = lb_policy;
+			sourceTree = "<group>";
+		};
+		OBJ_534 /* grpclb */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_535 /* client_load_reporting_filter.cc */,
+				OBJ_536 /* grpclb.cc */,
+				OBJ_537 /* grpclb_channel_secure.cc */,
+				OBJ_538 /* grpclb_client_stats.cc */,
+				OBJ_539 /* load_balancer_api.cc */,
+				OBJ_540 /* proto */,
+			);
+			name = grpclb;
+			path = grpclb;
+			sourceTree = "<group>";
+		};
+		OBJ_54 /* bn_extra */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_55 /* bn_asn1.c */,
+				OBJ_56 /* convert.c */,
+			);
+			name = bn_extra;
+			path = bn_extra;
+			sourceTree = "<group>";
+		};
+		OBJ_540 /* proto */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_541 /* grpc */,
+			);
+			name = proto;
+			path = proto;
+			sourceTree = "<group>";
+		};
+		OBJ_541 /* grpc */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_542 /* lb */,
+			);
+			name = grpc;
+			path = grpc;
+			sourceTree = "<group>";
+		};
+		OBJ_542 /* lb */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_543 /* v1 */,
+			);
+			name = lb;
+			path = lb;
+			sourceTree = "<group>";
+		};
+		OBJ_543 /* v1 */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_544 /* load_balancer.pb.c */,
+			);
+			name = v1;
+			path = v1;
+			sourceTree = "<group>";
+		};
+		OBJ_545 /* pick_first */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_546 /* pick_first.cc */,
+			);
+			name = pick_first;
+			path = pick_first;
+			sourceTree = "<group>";
+		};
+		OBJ_547 /* round_robin */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_548 /* round_robin.cc */,
+			);
+			name = round_robin;
+			path = round_robin;
+			sourceTree = "<group>";
+		};
+		OBJ_556 /* resolver */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_557 /* dns */,
+				OBJ_565 /* fake */,
+				OBJ_567 /* sockaddr */,
+			);
+			name = resolver;
+			path = resolver;
+			sourceTree = "<group>";
+		};
+		OBJ_557 /* dns */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_558 /* c_ares */,
+				OBJ_563 /* native */,
+			);
+			name = dns;
+			path = dns;
+			sourceTree = "<group>";
+		};
+		OBJ_558 /* c_ares */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_559 /* dns_resolver_ares.cc */,
+				OBJ_560 /* grpc_ares_ev_driver_posix.cc */,
+				OBJ_561 /* grpc_ares_wrapper.cc */,
+				OBJ_562 /* grpc_ares_wrapper_fallback.cc */,
+			);
+			name = c_ares;
+			path = c_ares;
+			sourceTree = "<group>";
+		};
+		OBJ_563 /* native */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_564 /* dns_resolver.cc */,
+			);
+			name = native;
+			path = native;
+			sourceTree = "<group>";
+		};
+		OBJ_565 /* fake */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_566 /* fake_resolver.cc */,
+			);
+			name = fake;
+			path = fake;
+			sourceTree = "<group>";
+		};
+		OBJ_567 /* sockaddr */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_568 /* sockaddr_resolver.cc */,
+			);
+			name = sockaddr;
+			path = sockaddr;
+			sourceTree = "<group>";
+		};
+		OBJ_57 /* buf */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_58 /* buf.c */,
+			);
+			name = buf;
+			path = buf;
+			sourceTree = "<group>";
+		};
+		OBJ_574 /* deadline */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_575 /* deadline_filter.cc */,
+			);
+			name = deadline;
+			path = deadline;
+			sourceTree = "<group>";
+		};
+		OBJ_576 /* http */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_577 /* client */,
+				OBJ_579 /* client_authority_filter.cc */,
+				OBJ_580 /* http_filters_plugin.cc */,
+				OBJ_581 /* message_compress */,
+				OBJ_583 /* server */,
+			);
+			name = http;
+			path = http;
+			sourceTree = "<group>";
+		};
+		OBJ_577 /* client */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_578 /* http_client_filter.cc */,
+			);
+			name = client;
+			path = client;
+			sourceTree = "<group>";
+		};
+		OBJ_581 /* message_compress */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_582 /* message_compress_filter.cc */,
+			);
+			name = message_compress;
+			path = message_compress;
+			sourceTree = "<group>";
+		};
+		OBJ_583 /* server */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_584 /* http_server_filter.cc */,
+			);
+			name = server;
+			path = server;
+			sourceTree = "<group>";
+		};
+		OBJ_585 /* load_reporting */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_586 /* server_load_reporting_filter.cc */,
+				OBJ_587 /* server_load_reporting_plugin.cc */,
+			);
+			name = load_reporting;
+			path = load_reporting;
+			sourceTree = "<group>";
+		};
+		OBJ_588 /* max_age */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_589 /* max_age_filter.cc */,
+			);
+			name = max_age;
+			path = max_age;
+			sourceTree = "<group>";
+		};
+		OBJ_59 /* bytestring */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_60 /* asn1_compat.c */,
+				OBJ_61 /* ber.c */,
+				OBJ_62 /* cbb.c */,
+				OBJ_63 /* cbs.c */,
+			);
+			name = bytestring;
+			path = bytestring;
+			sourceTree = "<group>";
+		};
+		OBJ_590 /* message_size */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_591 /* message_size_filter.cc */,
+			);
+			name = message_size;
+			path = message_size;
+			sourceTree = "<group>";
+		};
+		OBJ_592 /* workarounds */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_593 /* workaround_cronet_compression_filter.cc */,
+				OBJ_594 /* workaround_utils.cc */,
+			);
+			name = workarounds;
+			path = workarounds;
+			sourceTree = "<group>";
+		};
+		OBJ_595 /* transport */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_596 /* chttp2 */,
+				OBJ_637 /* inproc */,
+			);
+			name = transport;
+			path = transport;
+			sourceTree = "<group>";
+		};
+		OBJ_596 /* chttp2 */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_597 /* alpn */,
+				OBJ_599 /* client */,
+				OBJ_607 /* server */,
+				OBJ_614 /* transport */,
+			);
+			name = chttp2;
+			path = chttp2;
+			sourceTree = "<group>";
+		};
+		OBJ_597 /* alpn */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_598 /* alpn.cc */,
+			);
+			name = alpn;
+			path = alpn;
+			sourceTree = "<group>";
+		};
+		OBJ_599 /* client */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_600 /* authority.cc */,
+				OBJ_601 /* chttp2_connector.cc */,
+				OBJ_602 /* insecure */,
+				OBJ_605 /* secure */,
+			);
+			name = client;
+			path = client;
+			sourceTree = "<group>";
+		};
+		OBJ_602 /* insecure */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_603 /* channel_create.cc */,
+				OBJ_604 /* channel_create_posix.cc */,
+			);
+			name = insecure;
+			path = insecure;
+			sourceTree = "<group>";
+		};
+		OBJ_605 /* secure */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_606 /* secure_channel_create.cc */,
+			);
+			name = secure;
+			path = secure;
+			sourceTree = "<group>";
+		};
+		OBJ_607 /* server */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_608 /* chttp2_server.cc */,
+				OBJ_609 /* insecure */,
+				OBJ_612 /* secure */,
+			);
+			name = server;
+			path = server;
+			sourceTree = "<group>";
+		};
+		OBJ_609 /* insecure */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_610 /* server_chttp2.cc */,
+				OBJ_611 /* server_chttp2_posix.cc */,
+			);
+			name = insecure;
+			path = insecure;
+			sourceTree = "<group>";
+		};
+		OBJ_612 /* secure */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_613 /* server_secure_chttp2.cc */,
+			);
+			name = secure;
+			path = secure;
+			sourceTree = "<group>";
+		};
+		OBJ_614 /* transport */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_615 /* bin_decoder.cc */,
+				OBJ_616 /* bin_encoder.cc */,
+				OBJ_617 /* chttp2_plugin.cc */,
+				OBJ_618 /* chttp2_transport.cc */,
+				OBJ_619 /* flow_control.cc */,
+				OBJ_620 /* frame_data.cc */,
+				OBJ_621 /* frame_goaway.cc */,
+				OBJ_622 /* frame_ping.cc */,
+				OBJ_623 /* frame_rst_stream.cc */,
+				OBJ_624 /* frame_settings.cc */,
+				OBJ_625 /* frame_window_update.cc */,
+				OBJ_626 /* hpack_encoder.cc */,
+				OBJ_627 /* hpack_parser.cc */,
+				OBJ_628 /* hpack_table.cc */,
+				OBJ_629 /* http2_settings.cc */,
+				OBJ_630 /* huffsyms.cc */,
+				OBJ_631 /* incoming_metadata.cc */,
+				OBJ_632 /* parsing.cc */,
+				OBJ_633 /* stream_lists.cc */,
+				OBJ_634 /* stream_map.cc */,
+				OBJ_635 /* varint.cc */,
+				OBJ_636 /* writing.cc */,
+			);
+			name = transport;
+			path = transport;
+			sourceTree = "<group>";
+		};
+		OBJ_637 /* inproc */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_638 /* inproc_plugin.cc */,
+				OBJ_639 /* inproc_transport.cc */,
+			);
+			name = inproc;
+			path = inproc;
+			sourceTree = "<group>";
+		};
+		OBJ_64 /* chacha */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_65 /* chacha.c */,
+			);
+			name = chacha;
+			path = chacha;
+			sourceTree = "<group>";
+		};
+		OBJ_640 /* lib */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_641 /* avl */,
+				OBJ_643 /* backoff */,
+				OBJ_645 /* channel */,
+				OBJ_656 /* compression */,
+				OBJ_663 /* debug */,
+				OBJ_667 /* gpr */,
+				OBJ_703 /* gprpp */,
+				OBJ_706 /* http */,
+				OBJ_711 /* iomgr */,
+				OBJ_795 /* json */,
+				OBJ_800 /* profiling */,
+				OBJ_803 /* security */,
+				OBJ_849 /* slice */,
+				OBJ_856 /* surface */,
+				OBJ_877 /* transport */,
+			);
+			name = lib;
+			path = lib;
+			sourceTree = "<group>";
+		};
+		OBJ_641 /* avl */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_642 /* avl.cc */,
+			);
+			name = avl;
+			path = avl;
+			sourceTree = "<group>";
+		};
+		OBJ_643 /* backoff */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_644 /* backoff.cc */,
+			);
+			name = backoff;
+			path = backoff;
+			sourceTree = "<group>";
+		};
+		OBJ_645 /* channel */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_646 /* channel_args.cc */,
+				OBJ_647 /* channel_stack.cc */,
+				OBJ_648 /* channel_stack_builder.cc */,
+				OBJ_649 /* channel_trace.cc */,
+				OBJ_650 /* channel_trace_registry.cc */,
+				OBJ_651 /* connected_channel.cc */,
+				OBJ_652 /* handshaker.cc */,
+				OBJ_653 /* handshaker_factory.cc */,
+				OBJ_654 /* handshaker_registry.cc */,
+				OBJ_655 /* status_util.cc */,
+			);
+			name = channel;
+			path = channel;
+			sourceTree = "<group>";
+		};
+		OBJ_656 /* compression */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_657 /* compression.cc */,
+				OBJ_658 /* compression_internal.cc */,
+				OBJ_659 /* message_compress.cc */,
+				OBJ_660 /* stream_compression.cc */,
+				OBJ_661 /* stream_compression_gzip.cc */,
+				OBJ_662 /* stream_compression_identity.cc */,
+			);
+			name = compression;
+			path = compression;
+			sourceTree = "<group>";
+		};
+		OBJ_66 /* cipher_extra */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_67 /* cipher_extra.c */,
+				OBJ_68 /* derive_key.c */,
+				OBJ_69 /* e_aesctrhmac.c */,
+				OBJ_70 /* e_aesgcmsiv.c */,
+				OBJ_71 /* e_chacha20poly1305.c */,
+				OBJ_72 /* e_null.c */,
+				OBJ_73 /* e_rc2.c */,
+				OBJ_74 /* e_rc4.c */,
+				OBJ_75 /* e_ssl3.c */,
+				OBJ_76 /* e_tls.c */,
+				OBJ_77 /* tls_cbc.c */,
+			);
+			name = cipher_extra;
+			path = cipher_extra;
+			sourceTree = "<group>";
+		};
+		OBJ_663 /* debug */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_664 /* stats.cc */,
+				OBJ_665 /* stats_data.cc */,
+				OBJ_666 /* trace.cc */,
+			);
+			name = debug;
+			path = debug;
+			sourceTree = "<group>";
+		};
+		OBJ_667 /* gpr */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_668 /* alloc.cc */,
+				OBJ_669 /* arena.cc */,
+				OBJ_670 /* atm.cc */,
+				OBJ_671 /* cpu_iphone.cc */,
+				OBJ_672 /* cpu_linux.cc */,
+				OBJ_673 /* cpu_posix.cc */,
+				OBJ_674 /* cpu_windows.cc */,
+				OBJ_675 /* env_linux.cc */,
+				OBJ_676 /* env_posix.cc */,
+				OBJ_677 /* env_windows.cc */,
+				OBJ_678 /* fork.cc */,
+				OBJ_679 /* host_port.cc */,
+				OBJ_680 /* log.cc */,
+				OBJ_681 /* log_android.cc */,
+				OBJ_682 /* log_linux.cc */,
+				OBJ_683 /* log_posix.cc */,
+				OBJ_684 /* log_windows.cc */,
+				OBJ_685 /* mpscq.cc */,
+				OBJ_686 /* murmur_hash.cc */,
+				OBJ_687 /* string.cc */,
+				OBJ_688 /* string_posix.cc */,
+				OBJ_689 /* string_util_windows.cc */,
+				OBJ_690 /* string_windows.cc */,
+				OBJ_691 /* sync.cc */,
+				OBJ_692 /* sync_posix.cc */,
+				OBJ_693 /* sync_windows.cc */,
+				OBJ_694 /* time.cc */,
+				OBJ_695 /* time_posix.cc */,
+				OBJ_696 /* time_precise.cc */,
+				OBJ_697 /* time_windows.cc */,
+				OBJ_698 /* tls_pthread.cc */,
+				OBJ_699 /* tmpfile_msys.cc */,
+				OBJ_700 /* tmpfile_posix.cc */,
+				OBJ_701 /* tmpfile_windows.cc */,
+				OBJ_702 /* wrap_memcpy.cc */,
+			);
+			name = gpr;
+			path = gpr;
+			sourceTree = "<group>";
+		};
+		OBJ_7 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_8 /* BoringSSL */,
+				OBJ_452 /* Echo */,
+				OBJ_458 /* protoc-gen-swiftgrpc */,
+				OBJ_468 /* SwiftGRPC */,
+				OBJ_503 /* CgRPC */,
+				OBJ_999 /* RootsEncoder */,
+				OBJ_1001 /* Simple */,
+			);
+			name = Sources;
+			path = "";
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_703 /* gprpp */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_704 /* thd_posix.cc */,
+				OBJ_705 /* thd_windows.cc */,
+			);
+			name = gprpp;
+			path = gprpp;
+			sourceTree = "<group>";
+		};
+		OBJ_706 /* http */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_707 /* format_request.cc */,
+				OBJ_708 /* httpcli.cc */,
+				OBJ_709 /* httpcli_security_connector.cc */,
+				OBJ_710 /* parser.cc */,
+			);
+			name = http;
+			path = http;
+			sourceTree = "<group>";
+		};
+		OBJ_711 /* iomgr */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_712 /* call_combiner.cc */,
+				OBJ_713 /* combiner.cc */,
+				OBJ_714 /* endpoint.cc */,
+				OBJ_715 /* endpoint_pair_posix.cc */,
+				OBJ_716 /* endpoint_pair_uv.cc */,
+				OBJ_717 /* endpoint_pair_windows.cc */,
+				OBJ_718 /* error.cc */,
+				OBJ_719 /* ev_epoll1_linux.cc */,
+				OBJ_720 /* ev_epollex_linux.cc */,
+				OBJ_721 /* ev_epollsig_linux.cc */,
+				OBJ_722 /* ev_poll_posix.cc */,
+				OBJ_723 /* ev_posix.cc */,
+				OBJ_724 /* ev_windows.cc */,
+				OBJ_725 /* exec_ctx.cc */,
+				OBJ_726 /* executor.cc */,
+				OBJ_727 /* fork_posix.cc */,
+				OBJ_728 /* fork_windows.cc */,
+				OBJ_729 /* gethostname_fallback.cc */,
+				OBJ_730 /* gethostname_host_name_max.cc */,
+				OBJ_731 /* gethostname_sysconf.cc */,
+				OBJ_732 /* iocp_windows.cc */,
+				OBJ_733 /* iomgr.cc */,
+				OBJ_734 /* iomgr_custom.cc */,
+				OBJ_735 /* iomgr_internal.cc */,
+				OBJ_736 /* iomgr_posix.cc */,
+				OBJ_737 /* iomgr_uv.cc */,
+				OBJ_738 /* iomgr_windows.cc */,
+				OBJ_739 /* is_epollexclusive_available.cc */,
+				OBJ_740 /* load_file.cc */,
+				OBJ_741 /* lockfree_event.cc */,
+				OBJ_742 /* network_status_tracker.cc */,
+				OBJ_743 /* polling_entity.cc */,
+				OBJ_744 /* pollset.cc */,
+				OBJ_745 /* pollset_custom.cc */,
+				OBJ_746 /* pollset_set.cc */,
+				OBJ_747 /* pollset_set_custom.cc */,
+				OBJ_748 /* pollset_set_windows.cc */,
+				OBJ_749 /* pollset_uv.cc */,
+				OBJ_750 /* pollset_windows.cc */,
+				OBJ_751 /* resolve_address.cc */,
+				OBJ_752 /* resolve_address_custom.cc */,
+				OBJ_753 /* resolve_address_posix.cc */,
+				OBJ_754 /* resolve_address_windows.cc */,
+				OBJ_755 /* resource_quota.cc */,
+				OBJ_756 /* sockaddr_utils.cc */,
+				OBJ_757 /* socket_factory_posix.cc */,
+				OBJ_758 /* socket_mutator.cc */,
+				OBJ_759 /* socket_utils_common_posix.cc */,
+				OBJ_760 /* socket_utils_linux.cc */,
+				OBJ_761 /* socket_utils_posix.cc */,
+				OBJ_762 /* socket_utils_uv.cc */,
+				OBJ_763 /* socket_utils_windows.cc */,
+				OBJ_764 /* socket_windows.cc */,
+				OBJ_765 /* tcp_client.cc */,
+				OBJ_766 /* tcp_client_custom.cc */,
+				OBJ_767 /* tcp_client_posix.cc */,
+				OBJ_768 /* tcp_client_windows.cc */,
+				OBJ_769 /* tcp_custom.cc */,
+				OBJ_770 /* tcp_posix.cc */,
+				OBJ_771 /* tcp_server.cc */,
+				OBJ_772 /* tcp_server_custom.cc */,
+				OBJ_773 /* tcp_server_posix.cc */,
+				OBJ_774 /* tcp_server_utils_posix_common.cc */,
+				OBJ_775 /* tcp_server_utils_posix_ifaddrs.cc */,
+				OBJ_776 /* tcp_server_utils_posix_noifaddrs.cc */,
+				OBJ_777 /* tcp_server_windows.cc */,
+				OBJ_778 /* tcp_uv.cc */,
+				OBJ_779 /* tcp_windows.cc */,
+				OBJ_780 /* time_averaged_stats.cc */,
+				OBJ_781 /* timer.cc */,
+				OBJ_782 /* timer_custom.cc */,
+				OBJ_783 /* timer_generic.cc */,
+				OBJ_784 /* timer_heap.cc */,
+				OBJ_785 /* timer_manager.cc */,
+				OBJ_786 /* timer_uv.cc */,
+				OBJ_787 /* udp_server.cc */,
+				OBJ_788 /* unix_sockets_posix.cc */,
+				OBJ_789 /* unix_sockets_posix_noop.cc */,
+				OBJ_790 /* wakeup_fd_cv.cc */,
+				OBJ_791 /* wakeup_fd_eventfd.cc */,
+				OBJ_792 /* wakeup_fd_nospecial.cc */,
+				OBJ_793 /* wakeup_fd_pipe.cc */,
+				OBJ_794 /* wakeup_fd_posix.cc */,
+			);
+			name = iomgr;
+			path = iomgr;
+			sourceTree = "<group>";
+		};
+		OBJ_78 /* cmac */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_79 /* cmac.c */,
+			);
+			name = cmac;
+			path = cmac;
+			sourceTree = "<group>";
+		};
+		OBJ_795 /* json */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_796 /* json.cc */,
+				OBJ_797 /* json_reader.cc */,
+				OBJ_798 /* json_string.cc */,
+				OBJ_799 /* json_writer.cc */,
+			);
+			name = json;
+			path = json;
+			sourceTree = "<group>";
+		};
+		OBJ_8 /* BoringSSL */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_9 /* crypto */,
+				OBJ_335 /* err_data.c */,
+				OBJ_336 /* ssl */,
+				OBJ_373 /* third_party */,
+				OBJ_376 /* include */,
+			);
+			name = BoringSSL;
+			path = Sources/BoringSSL;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_80 /* conf */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_81 /* conf.c */,
+			);
+			name = conf;
+			path = conf;
+			sourceTree = "<group>";
+		};
+		OBJ_800 /* profiling */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_801 /* basic_timers.cc */,
+				OBJ_802 /* stap_timers.cc */,
+			);
+			name = profiling;
+			path = profiling;
+			sourceTree = "<group>";
+		};
+		OBJ_803 /* security */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_804 /* context */,
+				OBJ_806 /* credentials */,
+				OBJ_837 /* security_connector */,
+				OBJ_840 /* transport */,
+				OBJ_847 /* util */,
+			);
+			name = security;
+			path = security;
+			sourceTree = "<group>";
+		};
+		OBJ_804 /* context */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_805 /* security_context.cc */,
+			);
+			name = context;
+			path = context;
+			sourceTree = "<group>";
+		};
+		OBJ_806 /* credentials */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_807 /* alts */,
+				OBJ_816 /* composite */,
+				OBJ_818 /* credentials.cc */,
+				OBJ_819 /* credentials_metadata.cc */,
+				OBJ_820 /* fake */,
+				OBJ_822 /* google_default */,
+				OBJ_825 /* iam */,
+				OBJ_827 /* jwt */,
+				OBJ_831 /* oauth2 */,
+				OBJ_833 /* plugin */,
+				OBJ_835 /* ssl */,
+			);
+			name = credentials;
+			path = credentials;
+			sourceTree = "<group>";
+		};
+		OBJ_807 /* alts */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_808 /* alts_credentials.cc */,
+				OBJ_809 /* check_gcp_environment.cc */,
+				OBJ_810 /* check_gcp_environment_linux.cc */,
+				OBJ_811 /* check_gcp_environment_no_op.cc */,
+				OBJ_812 /* check_gcp_environment_windows.cc */,
+				OBJ_813 /* grpc_alts_credentials_client_options.cc */,
+				OBJ_814 /* grpc_alts_credentials_options.cc */,
+				OBJ_815 /* grpc_alts_credentials_server_options.cc */,
+			);
+			name = alts;
+			path = alts;
+			sourceTree = "<group>";
+		};
+		OBJ_816 /* composite */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_817 /* composite_credentials.cc */,
+			);
+			name = composite;
+			path = composite;
+			sourceTree = "<group>";
+		};
+		OBJ_820 /* fake */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_821 /* fake_credentials.cc */,
+			);
+			name = fake;
+			path = fake;
+			sourceTree = "<group>";
+		};
+		OBJ_822 /* google_default */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_823 /* credentials_generic.cc */,
+				OBJ_824 /* google_default_credentials.cc */,
+			);
+			name = google_default;
+			path = google_default;
+			sourceTree = "<group>";
+		};
+		OBJ_825 /* iam */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_826 /* iam_credentials.cc */,
+			);
+			name = iam;
+			path = iam;
+			sourceTree = "<group>";
+		};
+		OBJ_827 /* jwt */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_828 /* json_token.cc */,
+				OBJ_829 /* jwt_credentials.cc */,
+				OBJ_830 /* jwt_verifier.cc */,
+			);
+			name = jwt;
+			path = jwt;
+			sourceTree = "<group>";
+		};
+		OBJ_831 /* oauth2 */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_832 /* oauth2_credentials.cc */,
+			);
+			name = oauth2;
+			path = oauth2;
+			sourceTree = "<group>";
+		};
+		OBJ_833 /* plugin */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_834 /* plugin_credentials.cc */,
+			);
+			name = plugin;
+			path = plugin;
+			sourceTree = "<group>";
+		};
+		OBJ_835 /* ssl */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_836 /* ssl_credentials.cc */,
+			);
+			name = ssl;
+			path = ssl;
+			sourceTree = "<group>";
+		};
+		OBJ_837 /* security_connector */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_838 /* alts_security_connector.cc */,
+				OBJ_839 /* security_connector.cc */,
+			);
+			name = security_connector;
+			path = security_connector;
+			sourceTree = "<group>";
+		};
+		OBJ_840 /* transport */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_841 /* client_auth_filter.cc */,
+				OBJ_842 /* secure_endpoint.cc */,
+				OBJ_843 /* security_handshaker.cc */,
+				OBJ_844 /* server_auth_filter.cc */,
+				OBJ_845 /* target_authority_table.cc */,
+				OBJ_846 /* tsi_error.cc */,
+			);
+			name = transport;
+			path = transport;
+			sourceTree = "<group>";
+		};
+		OBJ_847 /* util */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_848 /* json_util.cc */,
+			);
+			name = util;
+			path = util;
+			sourceTree = "<group>";
+		};
+		OBJ_849 /* slice */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_850 /* b64.cc */,
+				OBJ_851 /* percent_encoding.cc */,
+				OBJ_852 /* slice.cc */,
+				OBJ_853 /* slice_buffer.cc */,
+				OBJ_854 /* slice_intern.cc */,
+				OBJ_855 /* slice_string_helpers.cc */,
+			);
+			name = slice;
+			path = slice;
+			sourceTree = "<group>";
+		};
+		OBJ_856 /* surface */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_857 /* api_trace.cc */,
+				OBJ_858 /* byte_buffer.cc */,
+				OBJ_859 /* byte_buffer_reader.cc */,
+				OBJ_860 /* call.cc */,
+				OBJ_861 /* call_details.cc */,
+				OBJ_862 /* call_log_batch.cc */,
+				OBJ_863 /* channel.cc */,
+				OBJ_864 /* channel_init.cc */,
+				OBJ_865 /* channel_ping.cc */,
+				OBJ_866 /* channel_stack_type.cc */,
+				OBJ_867 /* completion_queue.cc */,
+				OBJ_868 /* completion_queue_factory.cc */,
+				OBJ_869 /* event_string.cc */,
+				OBJ_870 /* init.cc */,
+				OBJ_871 /* init_secure.cc */,
+				OBJ_872 /* lame_client.cc */,
+				OBJ_873 /* metadata_array.cc */,
+				OBJ_874 /* server.cc */,
+				OBJ_875 /* validate_metadata.cc */,
+				OBJ_876 /* version.cc */,
+			);
+			name = surface;
+			path = surface;
+			sourceTree = "<group>";
+		};
+		OBJ_877 /* transport */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_878 /* bdp_estimator.cc */,
+				OBJ_879 /* byte_stream.cc */,
+				OBJ_880 /* connectivity_state.cc */,
+				OBJ_881 /* error_utils.cc */,
+				OBJ_882 /* metadata.cc */,
+				OBJ_883 /* metadata_batch.cc */,
+				OBJ_884 /* pid_controller.cc */,
+				OBJ_885 /* service_config.cc */,
+				OBJ_886 /* static_metadata.cc */,
+				OBJ_887 /* status_conversion.cc */,
+				OBJ_888 /* status_metadata.cc */,
+				OBJ_889 /* timeout_encoding.cc */,
+				OBJ_890 /* transport.cc */,
+				OBJ_891 /* transport_op_string.cc */,
+			);
+			name = transport;
+			path = transport;
+			sourceTree = "<group>";
+		};
+		OBJ_88 /* curve25519 */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_89 /* spake25519.c */,
+				OBJ_90 /* x25519-x86_64.c */,
+			);
+			name = curve25519;
+			path = curve25519;
+			sourceTree = "<group>";
+		};
+		OBJ_892 /* plugin_registry */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_893 /* grpc_plugin_registry.cc */,
+			);
+			name = plugin_registry;
+			path = plugin_registry;
+			sourceTree = "<group>";
+		};
+		OBJ_894 /* tsi */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_895 /* alts */,
+				OBJ_924 /* alts_transport_security.cc */,
+				OBJ_925 /* fake_transport_security.cc */,
+				OBJ_926 /* ssl */,
+				OBJ_931 /* ssl_transport_security.cc */,
+				OBJ_932 /* transport_security.cc */,
+				OBJ_933 /* transport_security_adapter.cc */,
+				OBJ_934 /* transport_security_grpc.cc */,
+			);
+			name = tsi;
+			path = tsi;
+			sourceTree = "<group>";
+		};
+		OBJ_895 /* alts */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_896 /* crypt */,
+				OBJ_899 /* frame_protector */,
+				OBJ_907 /* handshaker */,
+				OBJ_918 /* zero_copy_frame_protector */,
+			);
+			name = alts;
+			path = alts;
+			sourceTree = "<group>";
+		};
+		OBJ_896 /* crypt */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_897 /* aes_gcm.cc */,
+				OBJ_898 /* gsec.cc */,
+			);
+			name = crypt;
+			path = crypt;
+			sourceTree = "<group>";
+		};
+		OBJ_899 /* frame_protector */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_900 /* alts_counter.cc */,
+				OBJ_901 /* alts_crypter.cc */,
+				OBJ_902 /* alts_frame_protector.cc */,
+				OBJ_903 /* alts_record_protocol_crypter_common.cc */,
+				OBJ_904 /* alts_seal_privacy_integrity_crypter.cc */,
+				OBJ_905 /* alts_unseal_privacy_integrity_crypter.cc */,
+				OBJ_906 /* frame_handler.cc */,
+			);
+			name = frame_protector;
+			path = frame_protector;
+			sourceTree = "<group>";
+		};
+		OBJ_9 /* crypto */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_10 /* asn1 */,
+				OBJ_41 /* base64 */,
+				OBJ_43 /* bio */,
+				OBJ_54 /* bn_extra */,
+				OBJ_57 /* buf */,
+				OBJ_59 /* bytestring */,
+				OBJ_64 /* chacha */,
+				OBJ_66 /* cipher_extra */,
+				OBJ_78 /* cmac */,
+				OBJ_80 /* conf */,
+				OBJ_82 /* cpu-aarch64-linux.c */,
+				OBJ_83 /* cpu-arm-linux.c */,
+				OBJ_84 /* cpu-arm.c */,
+				OBJ_85 /* cpu-intel.c */,
+				OBJ_86 /* cpu-ppc64le.c */,
+				OBJ_87 /* crypto.c */,
+				OBJ_88 /* curve25519 */,
+				OBJ_91 /* dh */,
+				OBJ_96 /* digest_extra */,
+				OBJ_98 /* dsa */,
+				OBJ_101 /* ec_extra */,
+				OBJ_103 /* ecdh */,
+				OBJ_105 /* ecdsa_extra */,
+				OBJ_107 /* engine */,
+				OBJ_109 /* err */,
+				OBJ_112 /* evp */,
+				OBJ_128 /* ex_data.c */,
+				OBJ_129 /* fipsmodule */,
+				OBJ_204 /* hkdf */,
+				OBJ_206 /* lhash */,
+				OBJ_208 /* mem.c */,
+				OBJ_209 /* obj */,
+				OBJ_212 /* pem */,
+				OBJ_221 /* pkcs7 */,
+				OBJ_224 /* pkcs8 */,
+				OBJ_228 /* poly1305 */,
+				OBJ_232 /* pool */,
+				OBJ_234 /* rand_extra */,
+				OBJ_240 /* rc4 */,
+				OBJ_242 /* refcount_c11.c */,
+				OBJ_243 /* refcount_lock.c */,
+				OBJ_244 /* rsa_extra */,
+				OBJ_246 /* stack */,
+				OBJ_248 /* thread.c */,
+				OBJ_249 /* thread_none.c */,
+				OBJ_250 /* thread_pthread.c */,
+				OBJ_251 /* thread_win.c */,
+				OBJ_252 /* x509 */,
+				OBJ_302 /* x509v3 */,
+			);
+			name = crypto;
+			path = crypto;
+			sourceTree = "<group>";
+		};
+		OBJ_907 /* handshaker */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_908 /* alts_handshaker_client.cc */,
+				OBJ_909 /* alts_handshaker_service_api.cc */,
+				OBJ_910 /* alts_handshaker_service_api_util.cc */,
+				OBJ_911 /* alts_tsi_event.cc */,
+				OBJ_912 /* alts_tsi_handshaker.cc */,
+				OBJ_913 /* alts_tsi_utils.cc */,
+				OBJ_914 /* altscontext.pb.c */,
+				OBJ_915 /* handshaker.pb.c */,
+				OBJ_916 /* transport_security_common.pb.c */,
+				OBJ_917 /* transport_security_common_api.cc */,
+			);
+			name = handshaker;
+			path = handshaker;
+			sourceTree = "<group>";
+		};
+		OBJ_91 /* dh */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_92 /* check.c */,
+				OBJ_93 /* dh.c */,
+				OBJ_94 /* dh_asn1.c */,
+				OBJ_95 /* params.c */,
+			);
+			name = dh;
+			path = dh;
+			sourceTree = "<group>";
+		};
+		OBJ_918 /* zero_copy_frame_protector */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_919 /* alts_grpc_integrity_only_record_protocol.cc */,
+				OBJ_920 /* alts_grpc_privacy_integrity_record_protocol.cc */,
+				OBJ_921 /* alts_grpc_record_protocol_common.cc */,
+				OBJ_922 /* alts_iovec_record_protocol.cc */,
+				OBJ_923 /* alts_zero_copy_grpc_protector.cc */,
+			);
+			name = zero_copy_frame_protector;
+			path = zero_copy_frame_protector;
+			sourceTree = "<group>";
+		};
+		OBJ_926 /* ssl */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_927 /* session_cache */,
+			);
+			name = ssl;
+			path = ssl;
+			sourceTree = "<group>";
+		};
+		OBJ_927 /* session_cache */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_928 /* ssl_session_boringssl.cc */,
+				OBJ_929 /* ssl_session_cache.cc */,
+				OBJ_930 /* ssl_session_openssl.cc */,
+			);
+			name = session_cache;
+			path = session_cache;
+			sourceTree = "<group>";
+		};
+		OBJ_935 /* third_party */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_936 /* nanopb */,
+			);
+			name = third_party;
+			path = third_party;
+			sourceTree = "<group>";
+		};
+		OBJ_936 /* nanopb */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_937 /* pb_common.c */,
+				OBJ_938 /* pb_decode.c */,
+				OBJ_939 /* pb_encode.c */,
+			);
+			name = nanopb;
+			path = nanopb;
+			sourceTree = "<group>";
+		};
+		OBJ_940 /* include */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_941 /* cgrpc.h */,
+				OBJ_942 /* grpc */,
+				OBJ_998 /* module.modulemap */,
+			);
+			name = include;
+			path = include;
+			sourceTree = "<group>";
+		};
+		OBJ_942 /* grpc */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_943 /* grpc.h */,
+				OBJ_944 /* status.h */,
+				OBJ_945 /* census.h */,
+				OBJ_946 /* slice.h */,
+				OBJ_947 /* compression.h */,
+				OBJ_948 /* fork.h */,
+				OBJ_949 /* byte_buffer_reader.h */,
+				OBJ_950 /* grpc_security_constants.h */,
+				OBJ_951 /* byte_buffer.h */,
+				OBJ_952 /* slice_buffer.h */,
+				OBJ_953 /* grpc_posix.h */,
+				OBJ_954 /* grpc_security.h */,
+				OBJ_955 /* load_reporting.h */,
+				OBJ_956 /* support */,
+				OBJ_975 /* impl */,
+			);
+			name = grpc;
+			path = grpc;
+			sourceTree = "<group>";
+		};
+		OBJ_956 /* support */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_957 /* time.h */,
+				OBJ_958 /* port_platform.h */,
+				OBJ_959 /* log_windows.h */,
+				OBJ_960 /* sync.h */,
+				OBJ_961 /* string_util.h */,
+				OBJ_962 /* sync_custom.h */,
+				OBJ_963 /* thd_id.h */,
+				OBJ_964 /* workaround_list.h */,
+				OBJ_965 /* atm_gcc_sync.h */,
+				OBJ_966 /* atm_gcc_atomic.h */,
+				OBJ_967 /* atm.h */,
+				OBJ_968 /* sync_generic.h */,
+				OBJ_969 /* log.h */,
+				OBJ_970 /* cpu.h */,
+				OBJ_971 /* sync_posix.h */,
+				OBJ_972 /* atm_windows.h */,
+				OBJ_973 /* sync_windows.h */,
+				OBJ_974 /* alloc.h */,
+			);
+			name = support;
+			path = support;
+			sourceTree = "<group>";
+		};
+		OBJ_96 /* digest_extra */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_97 /* digest_extra.c */,
+			);
+			name = digest_extra;
+			path = digest_extra;
+			sourceTree = "<group>";
+		};
+		OBJ_975 /* impl */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_976 /* codegen */,
+			);
+			name = impl;
+			path = impl;
+			sourceTree = "<group>";
+		};
+		OBJ_976 /* codegen */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_977 /* port_platform.h */,
+				OBJ_978 /* status.h */,
+				OBJ_979 /* gpr_types.h */,
+				OBJ_980 /* sync.h */,
+				OBJ_981 /* grpc_types.h */,
+				OBJ_982 /* sync_custom.h */,
+				OBJ_983 /* gpr_slice.h */,
+				OBJ_984 /* slice.h */,
+				OBJ_985 /* compression_types.h */,
+				OBJ_986 /* atm_gcc_sync.h */,
+				OBJ_987 /* atm_gcc_atomic.h */,
+				OBJ_988 /* atm.h */,
+				OBJ_989 /* sync_generic.h */,
+				OBJ_990 /* fork.h */,
+				OBJ_991 /* byte_buffer_reader.h */,
+				OBJ_992 /* sync_posix.h */,
+				OBJ_993 /* atm_windows.h */,
+				OBJ_994 /* propagation_bits.h */,
+				OBJ_995 /* byte_buffer.h */,
+				OBJ_996 /* connectivity_state.h */,
+				OBJ_997 /* sync_windows.h */,
+			);
+			name = codegen;
+			path = codegen;
+			sourceTree = "<group>";
+		};
+		OBJ_98 /* dsa */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_99 /* dsa.c */,
+				OBJ_100 /* dsa_asn1.c */,
+			);
+			name = dsa;
+			path = dsa;
+			sourceTree = "<group>";
+		};
+		OBJ_999 /* RootsEncoder */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1000 /* main.swift */,
+			);
+			name = RootsEncoder;
+			path = Sources/RootsEncoder;
+			sourceTree = SOURCE_ROOT;
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		SwiftGRPC::BoringSSL /* BoringSSL */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_1174 /* Build configuration list for PBXNativeTarget "BoringSSL" */;
+			buildPhases = (
+				OBJ_1177 /* Sources */,
+				OBJ_1492 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = BoringSSL;
+			productName = BoringSSL;
+			productReference = SwiftGRPC::BoringSSL::Product /* BoringSSL.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		SwiftGRPC::CgRPC /* CgRPC */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_1494 /* Build configuration list for PBXNativeTarget "CgRPC" */;
+			buildPhases = (
+				OBJ_1497 /* Sources */,
+				OBJ_1852 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				OBJ_1854 /* PBXTargetDependency */,
+			);
+			name = CgRPC;
+			productName = CgRPC;
+			productReference = SwiftGRPC::CgRPC::Product /* CgRPC.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		SwiftGRPC::SwiftGRPC /* SwiftGRPC */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_1922 /* Build configuration list for PBXNativeTarget "SwiftGRPC" */;
+			buildPhases = (
+				OBJ_1925 /* Sources */,
+				OBJ_1958 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				OBJ_1962 /* PBXTargetDependency */,
+				OBJ_1963 /* PBXTargetDependency */,
+				OBJ_1964 /* PBXTargetDependency */,
+			);
+			name = SwiftGRPC;
+			productName = SwiftGRPC;
+			productReference = SwiftGRPC::SwiftGRPC::Product /* SwiftGRPC.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		SwiftProtobuf::SwiftProtobuf /* SwiftProtobuf */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_2009 /* Build configuration list for PBXNativeTarget "SwiftProtobuf" */;
+			buildPhases = (
+				31CD0F748721B9677E261D1D /* ShellScript */,
+				OBJ_2012 /* Sources */,
+				OBJ_2089 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SwiftProtobuf;
+			productName = SwiftProtobuf;
+			productReference = SwiftProtobuf::SwiftProtobuf::Product /* SwiftProtobuf.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		OBJ_1 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 9999;
+			};
+			buildConfigurationList = OBJ_2 /* Build configuration list for PBXProject "SwiftGRPC-Carthage" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = OBJ_5;
+			productRefGroup = OBJ_1160 /* Products */;
+			projectDirPath = .;
+			targets = (
+				SwiftGRPC::BoringSSL /* BoringSSL */,
+				SwiftGRPC::CgRPC /* CgRPC */,
+				SwiftGRPC::SwiftGRPC /* SwiftGRPC */,
+				SwiftProtobuf::SwiftProtobuf /* SwiftProtobuf */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		31CD0F748721B9677E261D1D /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "swift package resolve";
+			showEnvVarsInLog = 1;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		OBJ_1177 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			files = (
+				OBJ_1178 /* a_bitstr.c in Sources */,
+				OBJ_1179 /* a_bool.c in Sources */,
+				OBJ_1180 /* a_d2i_fp.c in Sources */,
+				OBJ_1181 /* a_dup.c in Sources */,
+				OBJ_1182 /* a_enum.c in Sources */,
+				OBJ_1183 /* a_gentm.c in Sources */,
+				OBJ_1184 /* a_i2d_fp.c in Sources */,
+				OBJ_1185 /* a_int.c in Sources */,
+				OBJ_1186 /* a_mbstr.c in Sources */,
+				OBJ_1187 /* a_object.c in Sources */,
+				OBJ_1188 /* a_octet.c in Sources */,
+				OBJ_1189 /* a_print.c in Sources */,
+				OBJ_1190 /* a_strnid.c in Sources */,
+				OBJ_1191 /* a_time.c in Sources */,
+				OBJ_1192 /* a_type.c in Sources */,
+				OBJ_1193 /* a_utctm.c in Sources */,
+				OBJ_1194 /* a_utf8.c in Sources */,
+				OBJ_1195 /* asn1_lib.c in Sources */,
+				OBJ_1196 /* asn1_par.c in Sources */,
+				OBJ_1197 /* asn_pack.c in Sources */,
+				OBJ_1198 /* f_enum.c in Sources */,
+				OBJ_1199 /* f_int.c in Sources */,
+				OBJ_1200 /* f_string.c in Sources */,
+				OBJ_1201 /* tasn_dec.c in Sources */,
+				OBJ_1202 /* tasn_enc.c in Sources */,
+				OBJ_1203 /* tasn_fre.c in Sources */,
+				OBJ_1204 /* tasn_new.c in Sources */,
+				OBJ_1205 /* tasn_typ.c in Sources */,
+				OBJ_1206 /* tasn_utl.c in Sources */,
+				OBJ_1207 /* time_support.c in Sources */,
+				OBJ_1208 /* base64.c in Sources */,
+				OBJ_1209 /* bio.c in Sources */,
+				OBJ_1210 /* bio_mem.c in Sources */,
+				OBJ_1211 /* connect.c in Sources */,
+				OBJ_1212 /* fd.c in Sources */,
+				OBJ_1213 /* file.c in Sources */,
+				OBJ_1214 /* hexdump.c in Sources */,
+				OBJ_1215 /* pair.c in Sources */,
+				OBJ_1216 /* printf.c in Sources */,
+				OBJ_1217 /* socket.c in Sources */,
+				OBJ_1218 /* socket_helper.c in Sources */,
+				OBJ_1219 /* bn_asn1.c in Sources */,
+				OBJ_1220 /* convert.c in Sources */,
+				OBJ_1221 /* buf.c in Sources */,
+				OBJ_1222 /* asn1_compat.c in Sources */,
+				OBJ_1223 /* ber.c in Sources */,
+				OBJ_1224 /* cbb.c in Sources */,
+				OBJ_1225 /* cbs.c in Sources */,
+				OBJ_1226 /* chacha.c in Sources */,
+				OBJ_1227 /* cipher_extra.c in Sources */,
+				OBJ_1228 /* derive_key.c in Sources */,
+				OBJ_1229 /* e_aesctrhmac.c in Sources */,
+				OBJ_1230 /* e_aesgcmsiv.c in Sources */,
+				OBJ_1231 /* e_chacha20poly1305.c in Sources */,
+				OBJ_1232 /* e_null.c in Sources */,
+				OBJ_1233 /* e_rc2.c in Sources */,
+				OBJ_1234 /* e_rc4.c in Sources */,
+				OBJ_1235 /* e_ssl3.c in Sources */,
+				OBJ_1236 /* e_tls.c in Sources */,
+				OBJ_1237 /* tls_cbc.c in Sources */,
+				OBJ_1238 /* cmac.c in Sources */,
+				OBJ_1239 /* conf.c in Sources */,
+				OBJ_1240 /* cpu-aarch64-linux.c in Sources */,
+				OBJ_1241 /* cpu-arm-linux.c in Sources */,
+				OBJ_1242 /* cpu-arm.c in Sources */,
+				OBJ_1243 /* cpu-intel.c in Sources */,
+				OBJ_1244 /* cpu-ppc64le.c in Sources */,
+				OBJ_1245 /* crypto.c in Sources */,
+				OBJ_1246 /* spake25519.c in Sources */,
+				OBJ_1247 /* x25519-x86_64.c in Sources */,
+				OBJ_1248 /* check.c in Sources */,
+				OBJ_1249 /* dh.c in Sources */,
+				OBJ_1250 /* dh_asn1.c in Sources */,
+				OBJ_1251 /* params.c in Sources */,
+				OBJ_1252 /* digest_extra.c in Sources */,
+				OBJ_1253 /* dsa.c in Sources */,
+				OBJ_1254 /* dsa_asn1.c in Sources */,
+				OBJ_1255 /* ec_asn1.c in Sources */,
+				OBJ_1256 /* ecdh.c in Sources */,
+				OBJ_1257 /* ecdsa_asn1.c in Sources */,
+				OBJ_1258 /* engine.c in Sources */,
+				OBJ_1259 /* err.c in Sources */,
+				OBJ_1260 /* err_data.c in Sources */,
+				OBJ_1261 /* digestsign.c in Sources */,
+				OBJ_1262 /* evp.c in Sources */,
+				OBJ_1263 /* evp_asn1.c in Sources */,
+				OBJ_1264 /* evp_ctx.c in Sources */,
+				OBJ_1265 /* p_dsa_asn1.c in Sources */,
+				OBJ_1266 /* p_ec.c in Sources */,
+				OBJ_1267 /* p_ec_asn1.c in Sources */,
+				OBJ_1268 /* p_ed25519.c in Sources */,
+				OBJ_1269 /* p_ed25519_asn1.c in Sources */,
+				OBJ_1270 /* p_rsa.c in Sources */,
+				OBJ_1271 /* p_rsa_asn1.c in Sources */,
+				OBJ_1272 /* pbkdf.c in Sources */,
+				OBJ_1273 /* print.c in Sources */,
+				OBJ_1274 /* scrypt.c in Sources */,
+				OBJ_1275 /* sign.c in Sources */,
+				OBJ_1276 /* ex_data.c in Sources */,
+				OBJ_1277 /* aes.c in Sources */,
+				OBJ_1278 /* key_wrap.c in Sources */,
+				OBJ_1279 /* mode_wrappers.c in Sources */,
+				OBJ_1280 /* add.c in Sources */,
+				OBJ_1281 /* bn.c in Sources */,
+				OBJ_1282 /* bytes.c in Sources */,
+				OBJ_1283 /* cmp.c in Sources */,
+				OBJ_1284 /* ctx.c in Sources */,
+				OBJ_1285 /* div.c in Sources */,
+				OBJ_1286 /* exponentiation.c in Sources */,
+				OBJ_1287 /* gcd.c in Sources */,
+				OBJ_1288 /* generic.c in Sources */,
+				OBJ_1289 /* jacobi.c in Sources */,
+				OBJ_1290 /* montgomery.c in Sources */,
+				OBJ_1291 /* montgomery_inv.c in Sources */,
+				OBJ_1292 /* mul.c in Sources */,
+				OBJ_1293 /* prime.c in Sources */,
+				OBJ_1294 /* random.c in Sources */,
+				OBJ_1295 /* rsaz_exp.c in Sources */,
+				OBJ_1296 /* shift.c in Sources */,
+				OBJ_1297 /* sqrt.c in Sources */,
+				OBJ_1298 /* aead.c in Sources */,
+				OBJ_1299 /* cipher.c in Sources */,
+				OBJ_1300 /* e_aes.c in Sources */,
+				OBJ_1301 /* e_des.c in Sources */,
+				OBJ_1302 /* des.c in Sources */,
+				OBJ_1303 /* digest.c in Sources */,
+				OBJ_1304 /* digests.c in Sources */,
+				OBJ_1305 /* ec.c in Sources */,
+				OBJ_1306 /* ec_key.c in Sources */,
+				OBJ_1307 /* ec_montgomery.c in Sources */,
+				OBJ_1308 /* oct.c in Sources */,
+				OBJ_1309 /* p224-64.c in Sources */,
+				OBJ_1310 /* p256-64.c in Sources */,
+				OBJ_1311 /* p256-x86_64.c in Sources */,
+				OBJ_1312 /* simple.c in Sources */,
+				OBJ_1313 /* util-64.c in Sources */,
+				OBJ_1314 /* wnaf.c in Sources */,
+				OBJ_1315 /* ecdsa.c in Sources */,
+				OBJ_1316 /* hmac.c in Sources */,
+				OBJ_1317 /* is_fips.c in Sources */,
+				OBJ_1318 /* md4.c in Sources */,
+				OBJ_1319 /* md5.c in Sources */,
+				OBJ_1320 /* cbc.c in Sources */,
+				OBJ_1321 /* cfb.c in Sources */,
+				OBJ_1322 /* ctr.c in Sources */,
+				OBJ_1323 /* gcm.c in Sources */,
+				OBJ_1324 /* ofb.c in Sources */,
+				OBJ_1325 /* polyval.c in Sources */,
+				OBJ_1326 /* ctrdrbg.c in Sources */,
+				OBJ_1327 /* rand.c in Sources */,
+				OBJ_1328 /* urandom.c in Sources */,
+				OBJ_1329 /* blinding.c in Sources */,
+				OBJ_1330 /* padding.c in Sources */,
+				OBJ_1331 /* rsa.c in Sources */,
+				OBJ_1332 /* rsa_impl.c in Sources */,
+				OBJ_1333 /* sha1-altivec.c in Sources */,
+				OBJ_1334 /* sha1.c in Sources */,
+				OBJ_1335 /* sha256.c in Sources */,
+				OBJ_1336 /* sha512.c in Sources */,
+				OBJ_1337 /* hkdf.c in Sources */,
+				OBJ_1338 /* lhash.c in Sources */,
+				OBJ_1339 /* mem.c in Sources */,
+				OBJ_1340 /* obj.c in Sources */,
+				OBJ_1341 /* obj_xref.c in Sources */,
+				OBJ_1342 /* pem_all.c in Sources */,
+				OBJ_1343 /* pem_info.c in Sources */,
+				OBJ_1344 /* pem_lib.c in Sources */,
+				OBJ_1345 /* pem_oth.c in Sources */,
+				OBJ_1346 /* pem_pk8.c in Sources */,
+				OBJ_1347 /* pem_pkey.c in Sources */,
+				OBJ_1348 /* pem_x509.c in Sources */,
+				OBJ_1349 /* pem_xaux.c in Sources */,
+				OBJ_1350 /* pkcs7.c in Sources */,
+				OBJ_1351 /* pkcs7_x509.c in Sources */,
+				OBJ_1352 /* p5_pbev2.c in Sources */,
+				OBJ_1353 /* pkcs8.c in Sources */,
+				OBJ_1354 /* pkcs8_x509.c in Sources */,
+				OBJ_1355 /* poly1305.c in Sources */,
+				OBJ_1356 /* poly1305_arm.c in Sources */,
+				OBJ_1357 /* poly1305_vec.c in Sources */,
+				OBJ_1358 /* pool.c in Sources */,
+				OBJ_1359 /* deterministic.c in Sources */,
+				OBJ_1360 /* forkunsafe.c in Sources */,
+				OBJ_1361 /* fuchsia.c in Sources */,
+				OBJ_1362 /* rand_extra.c in Sources */,
+				OBJ_1363 /* windows.c in Sources */,
+				OBJ_1364 /* rc4.c in Sources */,
+				OBJ_1365 /* refcount_c11.c in Sources */,
+				OBJ_1366 /* refcount_lock.c in Sources */,
+				OBJ_1367 /* rsa_asn1.c in Sources */,
+				OBJ_1368 /* stack.c in Sources */,
+				OBJ_1369 /* thread.c in Sources */,
+				OBJ_1370 /* thread_none.c in Sources */,
+				OBJ_1371 /* thread_pthread.c in Sources */,
+				OBJ_1372 /* thread_win.c in Sources */,
+				OBJ_1373 /* a_digest.c in Sources */,
+				OBJ_1374 /* a_sign.c in Sources */,
+				OBJ_1375 /* a_strex.c in Sources */,
+				OBJ_1376 /* a_verify.c in Sources */,
+				OBJ_1377 /* algorithm.c in Sources */,
+				OBJ_1378 /* asn1_gen.c in Sources */,
+				OBJ_1379 /* by_dir.c in Sources */,
+				OBJ_1380 /* by_file.c in Sources */,
+				OBJ_1381 /* i2d_pr.c in Sources */,
+				OBJ_1382 /* rsa_pss.c in Sources */,
+				OBJ_1383 /* t_crl.c in Sources */,
+				OBJ_1384 /* t_req.c in Sources */,
+				OBJ_1385 /* t_x509.c in Sources */,
+				OBJ_1386 /* t_x509a.c in Sources */,
+				OBJ_1387 /* x509.c in Sources */,
+				OBJ_1388 /* x509_att.c in Sources */,
+				OBJ_1389 /* x509_cmp.c in Sources */,
+				OBJ_1390 /* x509_d2.c in Sources */,
+				OBJ_1391 /* x509_def.c in Sources */,
+				OBJ_1392 /* x509_ext.c in Sources */,
+				OBJ_1393 /* x509_lu.c in Sources */,
+				OBJ_1394 /* x509_obj.c in Sources */,
+				OBJ_1395 /* x509_r2x.c in Sources */,
+				OBJ_1396 /* x509_req.c in Sources */,
+				OBJ_1397 /* x509_set.c in Sources */,
+				OBJ_1398 /* x509_trs.c in Sources */,
+				OBJ_1399 /* x509_txt.c in Sources */,
+				OBJ_1400 /* x509_v3.c in Sources */,
+				OBJ_1401 /* x509_vfy.c in Sources */,
+				OBJ_1402 /* x509_vpm.c in Sources */,
+				OBJ_1403 /* x509cset.c in Sources */,
+				OBJ_1404 /* x509name.c in Sources */,
+				OBJ_1405 /* x509rset.c in Sources */,
+				OBJ_1406 /* x509spki.c in Sources */,
+				OBJ_1407 /* x_algor.c in Sources */,
+				OBJ_1408 /* x_all.c in Sources */,
+				OBJ_1409 /* x_attrib.c in Sources */,
+				OBJ_1410 /* x_crl.c in Sources */,
+				OBJ_1411 /* x_exten.c in Sources */,
+				OBJ_1412 /* x_info.c in Sources */,
+				OBJ_1413 /* x_name.c in Sources */,
+				OBJ_1414 /* x_pkey.c in Sources */,
+				OBJ_1415 /* x_pubkey.c in Sources */,
+				OBJ_1416 /* x_req.c in Sources */,
+				OBJ_1417 /* x_sig.c in Sources */,
+				OBJ_1418 /* x_spki.c in Sources */,
+				OBJ_1419 /* x_val.c in Sources */,
+				OBJ_1420 /* x_x509.c in Sources */,
+				OBJ_1421 /* x_x509a.c in Sources */,
+				OBJ_1422 /* pcy_cache.c in Sources */,
+				OBJ_1423 /* pcy_data.c in Sources */,
+				OBJ_1424 /* pcy_lib.c in Sources */,
+				OBJ_1425 /* pcy_map.c in Sources */,
+				OBJ_1426 /* pcy_node.c in Sources */,
+				OBJ_1427 /* pcy_tree.c in Sources */,
+				OBJ_1428 /* v3_akey.c in Sources */,
+				OBJ_1429 /* v3_akeya.c in Sources */,
+				OBJ_1430 /* v3_alt.c in Sources */,
+				OBJ_1431 /* v3_bcons.c in Sources */,
+				OBJ_1432 /* v3_bitst.c in Sources */,
+				OBJ_1433 /* v3_conf.c in Sources */,
+				OBJ_1434 /* v3_cpols.c in Sources */,
+				OBJ_1435 /* v3_crld.c in Sources */,
+				OBJ_1436 /* v3_enum.c in Sources */,
+				OBJ_1437 /* v3_extku.c in Sources */,
+				OBJ_1438 /* v3_genn.c in Sources */,
+				OBJ_1439 /* v3_ia5.c in Sources */,
+				OBJ_1440 /* v3_info.c in Sources */,
+				OBJ_1441 /* v3_int.c in Sources */,
+				OBJ_1442 /* v3_lib.c in Sources */,
+				OBJ_1443 /* v3_ncons.c in Sources */,
+				OBJ_1444 /* v3_pci.c in Sources */,
+				OBJ_1445 /* v3_pcia.c in Sources */,
+				OBJ_1446 /* v3_pcons.c in Sources */,
+				OBJ_1447 /* v3_pku.c in Sources */,
+				OBJ_1448 /* v3_pmaps.c in Sources */,
+				OBJ_1449 /* v3_prn.c in Sources */,
+				OBJ_1450 /* v3_purp.c in Sources */,
+				OBJ_1451 /* v3_skey.c in Sources */,
+				OBJ_1452 /* v3_sxnet.c in Sources */,
+				OBJ_1453 /* v3_utl.c in Sources */,
+				OBJ_1454 /* err_data.c in Sources */,
+				OBJ_1455 /* bio_ssl.cc in Sources */,
+				OBJ_1456 /* custom_extensions.cc in Sources */,
+				OBJ_1457 /* d1_both.cc in Sources */,
+				OBJ_1458 /* d1_lib.cc in Sources */,
+				OBJ_1459 /* d1_pkt.cc in Sources */,
+				OBJ_1460 /* d1_srtp.cc in Sources */,
+				OBJ_1461 /* dtls_method.cc in Sources */,
+				OBJ_1462 /* dtls_record.cc in Sources */,
+				OBJ_1463 /* handshake.cc in Sources */,
+				OBJ_1464 /* handshake_client.cc in Sources */,
+				OBJ_1465 /* handshake_server.cc in Sources */,
+				OBJ_1466 /* s3_both.cc in Sources */,
+				OBJ_1467 /* s3_lib.cc in Sources */,
+				OBJ_1468 /* s3_pkt.cc in Sources */,
+				OBJ_1469 /* ssl_aead_ctx.cc in Sources */,
+				OBJ_1470 /* ssl_asn1.cc in Sources */,
+				OBJ_1471 /* ssl_buffer.cc in Sources */,
+				OBJ_1472 /* ssl_cert.cc in Sources */,
+				OBJ_1473 /* ssl_cipher.cc in Sources */,
+				OBJ_1474 /* ssl_file.cc in Sources */,
+				OBJ_1475 /* ssl_key_share.cc in Sources */,
+				OBJ_1476 /* ssl_lib.cc in Sources */,
+				OBJ_1477 /* ssl_privkey.cc in Sources */,
+				OBJ_1478 /* ssl_session.cc in Sources */,
+				OBJ_1479 /* ssl_stat.cc in Sources */,
+				OBJ_1480 /* ssl_transcript.cc in Sources */,
+				OBJ_1481 /* ssl_versions.cc in Sources */,
+				OBJ_1482 /* ssl_x509.cc in Sources */,
+				OBJ_1483 /* t1_enc.cc in Sources */,
+				OBJ_1484 /* t1_lib.cc in Sources */,
+				OBJ_1485 /* tls13_both.cc in Sources */,
+				OBJ_1486 /* tls13_client.cc in Sources */,
+				OBJ_1487 /* tls13_enc.cc in Sources */,
+				OBJ_1488 /* tls13_server.cc in Sources */,
+				OBJ_1489 /* tls_method.cc in Sources */,
+				OBJ_1490 /* tls_record.cc in Sources */,
+				OBJ_1491 /* curve25519.c in Sources */,
+			);
+		};
+		OBJ_1497 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			files = (
+				OBJ_1498 /* byte_buffer.c in Sources */,
+				OBJ_1499 /* call.c in Sources */,
+				OBJ_1500 /* channel.c in Sources */,
+				OBJ_1501 /* completion_queue.c in Sources */,
+				OBJ_1502 /* event.c in Sources */,
+				OBJ_1503 /* handler.c in Sources */,
+				OBJ_1504 /* internal.c in Sources */,
+				OBJ_1505 /* metadata.c in Sources */,
+				OBJ_1506 /* mutex.c in Sources */,
+				OBJ_1507 /* observers.c in Sources */,
+				OBJ_1508 /* operations.c in Sources */,
+				OBJ_1509 /* server.c in Sources */,
+				OBJ_1510 /* grpc_context.cc in Sources */,
+				OBJ_1511 /* backup_poller.cc in Sources */,
+				OBJ_1512 /* channel_connectivity.cc in Sources */,
+				OBJ_1513 /* client_channel.cc in Sources */,
+				OBJ_1514 /* client_channel_factory.cc in Sources */,
+				OBJ_1515 /* client_channel_plugin.cc in Sources */,
+				OBJ_1516 /* connector.cc in Sources */,
+				OBJ_1517 /* http_connect_handshaker.cc in Sources */,
+				OBJ_1518 /* http_proxy.cc in Sources */,
+				OBJ_1519 /* lb_policy.cc in Sources */,
+				OBJ_1520 /* client_load_reporting_filter.cc in Sources */,
+				OBJ_1521 /* grpclb.cc in Sources */,
+				OBJ_1522 /* grpclb_channel_secure.cc in Sources */,
+				OBJ_1523 /* grpclb_client_stats.cc in Sources */,
+				OBJ_1524 /* load_balancer_api.cc in Sources */,
+				OBJ_1525 /* load_balancer.pb.c in Sources */,
+				OBJ_1526 /* pick_first.cc in Sources */,
+				OBJ_1527 /* round_robin.cc in Sources */,
+				OBJ_1528 /* lb_policy_factory.cc in Sources */,
+				OBJ_1529 /* lb_policy_registry.cc in Sources */,
+				OBJ_1530 /* method_params.cc in Sources */,
+				OBJ_1531 /* parse_address.cc in Sources */,
+				OBJ_1532 /* proxy_mapper.cc in Sources */,
+				OBJ_1533 /* proxy_mapper_registry.cc in Sources */,
+				OBJ_1534 /* resolver.cc in Sources */,
+				OBJ_1535 /* dns_resolver_ares.cc in Sources */,
+				OBJ_1536 /* grpc_ares_ev_driver_posix.cc in Sources */,
+				OBJ_1537 /* grpc_ares_wrapper.cc in Sources */,
+				OBJ_1538 /* grpc_ares_wrapper_fallback.cc in Sources */,
+				OBJ_1539 /* dns_resolver.cc in Sources */,
+				OBJ_1540 /* fake_resolver.cc in Sources */,
+				OBJ_1541 /* sockaddr_resolver.cc in Sources */,
+				OBJ_1542 /* resolver_registry.cc in Sources */,
+				OBJ_1543 /* retry_throttle.cc in Sources */,
+				OBJ_1544 /* subchannel.cc in Sources */,
+				OBJ_1545 /* subchannel_index.cc in Sources */,
+				OBJ_1546 /* uri_parser.cc in Sources */,
+				OBJ_1547 /* deadline_filter.cc in Sources */,
+				OBJ_1548 /* http_client_filter.cc in Sources */,
+				OBJ_1549 /* client_authority_filter.cc in Sources */,
+				OBJ_1550 /* http_filters_plugin.cc in Sources */,
+				OBJ_1551 /* message_compress_filter.cc in Sources */,
+				OBJ_1552 /* http_server_filter.cc in Sources */,
+				OBJ_1553 /* server_load_reporting_filter.cc in Sources */,
+				OBJ_1554 /* server_load_reporting_plugin.cc in Sources */,
+				OBJ_1555 /* max_age_filter.cc in Sources */,
+				OBJ_1556 /* message_size_filter.cc in Sources */,
+				OBJ_1557 /* workaround_cronet_compression_filter.cc in Sources */,
+				OBJ_1558 /* workaround_utils.cc in Sources */,
+				OBJ_1559 /* alpn.cc in Sources */,
+				OBJ_1560 /* authority.cc in Sources */,
+				OBJ_1561 /* chttp2_connector.cc in Sources */,
+				OBJ_1562 /* channel_create.cc in Sources */,
+				OBJ_1563 /* channel_create_posix.cc in Sources */,
+				OBJ_1564 /* secure_channel_create.cc in Sources */,
+				OBJ_1565 /* chttp2_server.cc in Sources */,
+				OBJ_1566 /* server_chttp2.cc in Sources */,
+				OBJ_1567 /* server_chttp2_posix.cc in Sources */,
+				OBJ_1568 /* server_secure_chttp2.cc in Sources */,
+				OBJ_1569 /* bin_decoder.cc in Sources */,
+				OBJ_1570 /* bin_encoder.cc in Sources */,
+				OBJ_1571 /* chttp2_plugin.cc in Sources */,
+				OBJ_1572 /* chttp2_transport.cc in Sources */,
+				OBJ_1573 /* flow_control.cc in Sources */,
+				OBJ_1574 /* frame_data.cc in Sources */,
+				OBJ_1575 /* frame_goaway.cc in Sources */,
+				OBJ_1576 /* frame_ping.cc in Sources */,
+				OBJ_1577 /* frame_rst_stream.cc in Sources */,
+				OBJ_1578 /* frame_settings.cc in Sources */,
+				OBJ_1579 /* frame_window_update.cc in Sources */,
+				OBJ_1580 /* hpack_encoder.cc in Sources */,
+				OBJ_1581 /* hpack_parser.cc in Sources */,
+				OBJ_1582 /* hpack_table.cc in Sources */,
+				OBJ_1583 /* http2_settings.cc in Sources */,
+				OBJ_1584 /* huffsyms.cc in Sources */,
+				OBJ_1585 /* incoming_metadata.cc in Sources */,
+				OBJ_1586 /* parsing.cc in Sources */,
+				OBJ_1587 /* stream_lists.cc in Sources */,
+				OBJ_1588 /* stream_map.cc in Sources */,
+				OBJ_1589 /* varint.cc in Sources */,
+				OBJ_1590 /* writing.cc in Sources */,
+				OBJ_1591 /* inproc_plugin.cc in Sources */,
+				OBJ_1592 /* inproc_transport.cc in Sources */,
+				OBJ_1593 /* avl.cc in Sources */,
+				OBJ_1594 /* backoff.cc in Sources */,
+				OBJ_1595 /* channel_args.cc in Sources */,
+				OBJ_1596 /* channel_stack.cc in Sources */,
+				OBJ_1597 /* channel_stack_builder.cc in Sources */,
+				OBJ_1598 /* channel_trace.cc in Sources */,
+				OBJ_1599 /* channel_trace_registry.cc in Sources */,
+				OBJ_1600 /* connected_channel.cc in Sources */,
+				OBJ_1601 /* handshaker.cc in Sources */,
+				OBJ_1602 /* handshaker_factory.cc in Sources */,
+				OBJ_1603 /* handshaker_registry.cc in Sources */,
+				OBJ_1604 /* status_util.cc in Sources */,
+				OBJ_1605 /* compression.cc in Sources */,
+				OBJ_1606 /* compression_internal.cc in Sources */,
+				OBJ_1607 /* message_compress.cc in Sources */,
+				OBJ_1608 /* stream_compression.cc in Sources */,
+				OBJ_1609 /* stream_compression_gzip.cc in Sources */,
+				OBJ_1610 /* stream_compression_identity.cc in Sources */,
+				OBJ_1611 /* stats.cc in Sources */,
+				OBJ_1612 /* stats_data.cc in Sources */,
+				OBJ_1613 /* trace.cc in Sources */,
+				OBJ_1614 /* alloc.cc in Sources */,
+				OBJ_1615 /* arena.cc in Sources */,
+				OBJ_1616 /* atm.cc in Sources */,
+				OBJ_1617 /* cpu_iphone.cc in Sources */,
+				OBJ_1618 /* cpu_linux.cc in Sources */,
+				OBJ_1619 /* cpu_posix.cc in Sources */,
+				OBJ_1620 /* cpu_windows.cc in Sources */,
+				OBJ_1621 /* env_linux.cc in Sources */,
+				OBJ_1622 /* env_posix.cc in Sources */,
+				OBJ_1623 /* env_windows.cc in Sources */,
+				OBJ_1624 /* fork.cc in Sources */,
+				OBJ_1625 /* host_port.cc in Sources */,
+				OBJ_1626 /* log.cc in Sources */,
+				OBJ_1627 /* log_android.cc in Sources */,
+				OBJ_1628 /* log_linux.cc in Sources */,
+				OBJ_1629 /* log_posix.cc in Sources */,
+				OBJ_1630 /* log_windows.cc in Sources */,
+				OBJ_1631 /* mpscq.cc in Sources */,
+				OBJ_1632 /* murmur_hash.cc in Sources */,
+				OBJ_1633 /* string.cc in Sources */,
+				OBJ_1634 /* string_posix.cc in Sources */,
+				OBJ_1635 /* string_util_windows.cc in Sources */,
+				OBJ_1636 /* string_windows.cc in Sources */,
+				OBJ_1637 /* sync.cc in Sources */,
+				OBJ_1638 /* sync_posix.cc in Sources */,
+				OBJ_1639 /* sync_windows.cc in Sources */,
+				OBJ_1640 /* time.cc in Sources */,
+				OBJ_1641 /* time_posix.cc in Sources */,
+				OBJ_1642 /* time_precise.cc in Sources */,
+				OBJ_1643 /* time_windows.cc in Sources */,
+				OBJ_1644 /* tls_pthread.cc in Sources */,
+				OBJ_1645 /* tmpfile_msys.cc in Sources */,
+				OBJ_1646 /* tmpfile_posix.cc in Sources */,
+				OBJ_1647 /* tmpfile_windows.cc in Sources */,
+				OBJ_1648 /* wrap_memcpy.cc in Sources */,
+				OBJ_1649 /* thd_posix.cc in Sources */,
+				OBJ_1650 /* thd_windows.cc in Sources */,
+				OBJ_1651 /* format_request.cc in Sources */,
+				OBJ_1652 /* httpcli.cc in Sources */,
+				OBJ_1653 /* httpcli_security_connector.cc in Sources */,
+				OBJ_1654 /* parser.cc in Sources */,
+				OBJ_1655 /* call_combiner.cc in Sources */,
+				OBJ_1656 /* combiner.cc in Sources */,
+				OBJ_1657 /* endpoint.cc in Sources */,
+				OBJ_1658 /* endpoint_pair_posix.cc in Sources */,
+				OBJ_1659 /* endpoint_pair_uv.cc in Sources */,
+				OBJ_1660 /* endpoint_pair_windows.cc in Sources */,
+				OBJ_1661 /* error.cc in Sources */,
+				OBJ_1662 /* ev_epoll1_linux.cc in Sources */,
+				OBJ_1663 /* ev_epollex_linux.cc in Sources */,
+				OBJ_1664 /* ev_epollsig_linux.cc in Sources */,
+				OBJ_1665 /* ev_poll_posix.cc in Sources */,
+				OBJ_1666 /* ev_posix.cc in Sources */,
+				OBJ_1667 /* ev_windows.cc in Sources */,
+				OBJ_1668 /* exec_ctx.cc in Sources */,
+				OBJ_1669 /* executor.cc in Sources */,
+				OBJ_1670 /* fork_posix.cc in Sources */,
+				OBJ_1671 /* fork_windows.cc in Sources */,
+				OBJ_1672 /* gethostname_fallback.cc in Sources */,
+				OBJ_1673 /* gethostname_host_name_max.cc in Sources */,
+				OBJ_1674 /* gethostname_sysconf.cc in Sources */,
+				OBJ_1675 /* iocp_windows.cc in Sources */,
+				OBJ_1676 /* iomgr.cc in Sources */,
+				OBJ_1677 /* iomgr_custom.cc in Sources */,
+				OBJ_1678 /* iomgr_internal.cc in Sources */,
+				OBJ_1679 /* iomgr_posix.cc in Sources */,
+				OBJ_1680 /* iomgr_uv.cc in Sources */,
+				OBJ_1681 /* iomgr_windows.cc in Sources */,
+				OBJ_1682 /* is_epollexclusive_available.cc in Sources */,
+				OBJ_1683 /* load_file.cc in Sources */,
+				OBJ_1684 /* lockfree_event.cc in Sources */,
+				OBJ_1685 /* network_status_tracker.cc in Sources */,
+				OBJ_1686 /* polling_entity.cc in Sources */,
+				OBJ_1687 /* pollset.cc in Sources */,
+				OBJ_1688 /* pollset_custom.cc in Sources */,
+				OBJ_1689 /* pollset_set.cc in Sources */,
+				OBJ_1690 /* pollset_set_custom.cc in Sources */,
+				OBJ_1691 /* pollset_set_windows.cc in Sources */,
+				OBJ_1692 /* pollset_uv.cc in Sources */,
+				OBJ_1693 /* pollset_windows.cc in Sources */,
+				OBJ_1694 /* resolve_address.cc in Sources */,
+				OBJ_1695 /* resolve_address_custom.cc in Sources */,
+				OBJ_1696 /* resolve_address_posix.cc in Sources */,
+				OBJ_1697 /* resolve_address_windows.cc in Sources */,
+				OBJ_1698 /* resource_quota.cc in Sources */,
+				OBJ_1699 /* sockaddr_utils.cc in Sources */,
+				OBJ_1700 /* socket_factory_posix.cc in Sources */,
+				OBJ_1701 /* socket_mutator.cc in Sources */,
+				OBJ_1702 /* socket_utils_common_posix.cc in Sources */,
+				OBJ_1703 /* socket_utils_linux.cc in Sources */,
+				OBJ_1704 /* socket_utils_posix.cc in Sources */,
+				OBJ_1705 /* socket_utils_uv.cc in Sources */,
+				OBJ_1706 /* socket_utils_windows.cc in Sources */,
+				OBJ_1707 /* socket_windows.cc in Sources */,
+				OBJ_1708 /* tcp_client.cc in Sources */,
+				OBJ_1709 /* tcp_client_custom.cc in Sources */,
+				OBJ_1710 /* tcp_client_posix.cc in Sources */,
+				OBJ_1711 /* tcp_client_windows.cc in Sources */,
+				OBJ_1712 /* tcp_custom.cc in Sources */,
+				OBJ_1713 /* tcp_posix.cc in Sources */,
+				OBJ_1714 /* tcp_server.cc in Sources */,
+				OBJ_1715 /* tcp_server_custom.cc in Sources */,
+				OBJ_1716 /* tcp_server_posix.cc in Sources */,
+				OBJ_1717 /* tcp_server_utils_posix_common.cc in Sources */,
+				OBJ_1718 /* tcp_server_utils_posix_ifaddrs.cc in Sources */,
+				OBJ_1719 /* tcp_server_utils_posix_noifaddrs.cc in Sources */,
+				OBJ_1720 /* tcp_server_windows.cc in Sources */,
+				OBJ_1721 /* tcp_uv.cc in Sources */,
+				OBJ_1722 /* tcp_windows.cc in Sources */,
+				OBJ_1723 /* time_averaged_stats.cc in Sources */,
+				OBJ_1724 /* timer.cc in Sources */,
+				OBJ_1725 /* timer_custom.cc in Sources */,
+				OBJ_1726 /* timer_generic.cc in Sources */,
+				OBJ_1727 /* timer_heap.cc in Sources */,
+				OBJ_1728 /* timer_manager.cc in Sources */,
+				OBJ_1729 /* timer_uv.cc in Sources */,
+				OBJ_1730 /* udp_server.cc in Sources */,
+				OBJ_1731 /* unix_sockets_posix.cc in Sources */,
+				OBJ_1732 /* unix_sockets_posix_noop.cc in Sources */,
+				OBJ_1733 /* wakeup_fd_cv.cc in Sources */,
+				OBJ_1734 /* wakeup_fd_eventfd.cc in Sources */,
+				OBJ_1735 /* wakeup_fd_nospecial.cc in Sources */,
+				OBJ_1736 /* wakeup_fd_pipe.cc in Sources */,
+				OBJ_1737 /* wakeup_fd_posix.cc in Sources */,
+				OBJ_1738 /* json.cc in Sources */,
+				OBJ_1739 /* json_reader.cc in Sources */,
+				OBJ_1740 /* json_string.cc in Sources */,
+				OBJ_1741 /* json_writer.cc in Sources */,
+				OBJ_1742 /* basic_timers.cc in Sources */,
+				OBJ_1743 /* stap_timers.cc in Sources */,
+				OBJ_1744 /* security_context.cc in Sources */,
+				OBJ_1745 /* alts_credentials.cc in Sources */,
+				OBJ_1746 /* check_gcp_environment.cc in Sources */,
+				OBJ_1747 /* check_gcp_environment_linux.cc in Sources */,
+				OBJ_1748 /* check_gcp_environment_no_op.cc in Sources */,
+				OBJ_1749 /* check_gcp_environment_windows.cc in Sources */,
+				OBJ_1750 /* grpc_alts_credentials_client_options.cc in Sources */,
+				OBJ_1751 /* grpc_alts_credentials_options.cc in Sources */,
+				OBJ_1752 /* grpc_alts_credentials_server_options.cc in Sources */,
+				OBJ_1753 /* composite_credentials.cc in Sources */,
+				OBJ_1754 /* credentials.cc in Sources */,
+				OBJ_1755 /* credentials_metadata.cc in Sources */,
+				OBJ_1756 /* fake_credentials.cc in Sources */,
+				OBJ_1757 /* credentials_generic.cc in Sources */,
+				OBJ_1758 /* google_default_credentials.cc in Sources */,
+				OBJ_1759 /* iam_credentials.cc in Sources */,
+				OBJ_1760 /* json_token.cc in Sources */,
+				OBJ_1761 /* jwt_credentials.cc in Sources */,
+				OBJ_1762 /* jwt_verifier.cc in Sources */,
+				OBJ_1763 /* oauth2_credentials.cc in Sources */,
+				OBJ_1764 /* plugin_credentials.cc in Sources */,
+				OBJ_1765 /* ssl_credentials.cc in Sources */,
+				OBJ_1766 /* alts_security_connector.cc in Sources */,
+				OBJ_1767 /* security_connector.cc in Sources */,
+				OBJ_1768 /* client_auth_filter.cc in Sources */,
+				OBJ_1769 /* secure_endpoint.cc in Sources */,
+				OBJ_1770 /* security_handshaker.cc in Sources */,
+				OBJ_1771 /* server_auth_filter.cc in Sources */,
+				OBJ_1772 /* target_authority_table.cc in Sources */,
+				OBJ_1773 /* tsi_error.cc in Sources */,
+				OBJ_1774 /* json_util.cc in Sources */,
+				OBJ_1775 /* b64.cc in Sources */,
+				OBJ_1776 /* percent_encoding.cc in Sources */,
+				OBJ_1777 /* slice.cc in Sources */,
+				OBJ_1778 /* slice_buffer.cc in Sources */,
+				OBJ_1779 /* slice_intern.cc in Sources */,
+				OBJ_1780 /* slice_string_helpers.cc in Sources */,
+				OBJ_1781 /* api_trace.cc in Sources */,
+				OBJ_1782 /* byte_buffer.cc in Sources */,
+				OBJ_1783 /* byte_buffer_reader.cc in Sources */,
+				OBJ_1784 /* call.cc in Sources */,
+				OBJ_1785 /* call_details.cc in Sources */,
+				OBJ_1786 /* call_log_batch.cc in Sources */,
+				OBJ_1787 /* channel.cc in Sources */,
+				OBJ_1788 /* channel_init.cc in Sources */,
+				OBJ_1789 /* channel_ping.cc in Sources */,
+				OBJ_1790 /* channel_stack_type.cc in Sources */,
+				OBJ_1791 /* completion_queue.cc in Sources */,
+				OBJ_1792 /* completion_queue_factory.cc in Sources */,
+				OBJ_1793 /* event_string.cc in Sources */,
+				OBJ_1794 /* init.cc in Sources */,
+				OBJ_1795 /* init_secure.cc in Sources */,
+				OBJ_1796 /* lame_client.cc in Sources */,
+				OBJ_1797 /* metadata_array.cc in Sources */,
+				OBJ_1798 /* server.cc in Sources */,
+				OBJ_1799 /* validate_metadata.cc in Sources */,
+				OBJ_1800 /* version.cc in Sources */,
+				OBJ_1801 /* bdp_estimator.cc in Sources */,
+				OBJ_1802 /* byte_stream.cc in Sources */,
+				OBJ_1803 /* connectivity_state.cc in Sources */,
+				OBJ_1804 /* error_utils.cc in Sources */,
+				OBJ_1805 /* metadata.cc in Sources */,
+				OBJ_1806 /* metadata_batch.cc in Sources */,
+				OBJ_1807 /* pid_controller.cc in Sources */,
+				OBJ_1808 /* service_config.cc in Sources */,
+				OBJ_1809 /* static_metadata.cc in Sources */,
+				OBJ_1810 /* status_conversion.cc in Sources */,
+				OBJ_1811 /* status_metadata.cc in Sources */,
+				OBJ_1812 /* timeout_encoding.cc in Sources */,
+				OBJ_1813 /* transport.cc in Sources */,
+				OBJ_1814 /* transport_op_string.cc in Sources */,
+				OBJ_1815 /* grpc_plugin_registry.cc in Sources */,
+				OBJ_1816 /* aes_gcm.cc in Sources */,
+				OBJ_1817 /* gsec.cc in Sources */,
+				OBJ_1818 /* alts_counter.cc in Sources */,
+				OBJ_1819 /* alts_crypter.cc in Sources */,
+				OBJ_1820 /* alts_frame_protector.cc in Sources */,
+				OBJ_1821 /* alts_record_protocol_crypter_common.cc in Sources */,
+				OBJ_1822 /* alts_seal_privacy_integrity_crypter.cc in Sources */,
+				OBJ_1823 /* alts_unseal_privacy_integrity_crypter.cc in Sources */,
+				OBJ_1824 /* frame_handler.cc in Sources */,
+				OBJ_1825 /* alts_handshaker_client.cc in Sources */,
+				OBJ_1826 /* alts_handshaker_service_api.cc in Sources */,
+				OBJ_1827 /* alts_handshaker_service_api_util.cc in Sources */,
+				OBJ_1828 /* alts_tsi_event.cc in Sources */,
+				OBJ_1829 /* alts_tsi_handshaker.cc in Sources */,
+				OBJ_1830 /* alts_tsi_utils.cc in Sources */,
+				OBJ_1831 /* altscontext.pb.c in Sources */,
+				OBJ_1832 /* handshaker.pb.c in Sources */,
+				OBJ_1833 /* transport_security_common.pb.c in Sources */,
+				OBJ_1834 /* transport_security_common_api.cc in Sources */,
+				OBJ_1835 /* alts_grpc_integrity_only_record_protocol.cc in Sources */,
+				OBJ_1836 /* alts_grpc_privacy_integrity_record_protocol.cc in Sources */,
+				OBJ_1837 /* alts_grpc_record_protocol_common.cc in Sources */,
+				OBJ_1838 /* alts_iovec_record_protocol.cc in Sources */,
+				OBJ_1839 /* alts_zero_copy_grpc_protector.cc in Sources */,
+				OBJ_1840 /* alts_transport_security.cc in Sources */,
+				OBJ_1841 /* fake_transport_security.cc in Sources */,
+				OBJ_1842 /* ssl_session_boringssl.cc in Sources */,
+				OBJ_1843 /* ssl_session_cache.cc in Sources */,
+				OBJ_1844 /* ssl_session_openssl.cc in Sources */,
+				OBJ_1845 /* ssl_transport_security.cc in Sources */,
+				OBJ_1846 /* transport_security.cc in Sources */,
+				OBJ_1847 /* transport_security_adapter.cc in Sources */,
+				OBJ_1848 /* transport_security_grpc.cc in Sources */,
+				OBJ_1849 /* pb_common.c in Sources */,
+				OBJ_1850 /* pb_decode.c in Sources */,
+				OBJ_1851 /* pb_encode.c in Sources */,
+			);
+		};
+		OBJ_1925 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			files = (
+				OBJ_1926 /* ByteBuffer.swift in Sources */,
+				OBJ_1927 /* Call.swift in Sources */,
+				OBJ_1928 /* CallError.swift in Sources */,
+				OBJ_1929 /* CallResult.swift in Sources */,
+				OBJ_1930 /* Channel.swift in Sources */,
+				OBJ_1931 /* ChannelArgument.swift in Sources */,
+				OBJ_1932 /* CompletionQueue.swift in Sources */,
+				OBJ_1933 /* Handler.swift in Sources */,
+				OBJ_1934 /* Metadata.swift in Sources */,
+				OBJ_1935 /* Mutex.swift in Sources */,
+				OBJ_1936 /* Operation.swift in Sources */,
+				OBJ_1937 /* OperationGroup.swift in Sources */,
+				OBJ_1938 /* Roots.swift in Sources */,
+				OBJ_1939 /* Server.swift in Sources */,
+				OBJ_1940 /* ServerStatus.swift in Sources */,
+				OBJ_1941 /* gRPC.swift in Sources */,
+				OBJ_1942 /* ClientCall.swift in Sources */,
+				OBJ_1943 /* ClientCallBidirectionalStreaming.swift in Sources */,
+				OBJ_1944 /* ClientCallClientStreaming.swift in Sources */,
+				OBJ_1945 /* ClientCallServerStreaming.swift in Sources */,
+				OBJ_1946 /* ClientCallUnary.swift in Sources */,
+				OBJ_1947 /* RPCError.swift in Sources */,
+				OBJ_1948 /* ServerSession.swift in Sources */,
+				OBJ_1949 /* ServerSessionBidirectionalStreaming.swift in Sources */,
+				OBJ_1950 /* ServerSessionClientStreaming.swift in Sources */,
+				OBJ_1951 /* ServerSessionServerStreaming.swift in Sources */,
+				OBJ_1952 /* ServerSessionUnary.swift in Sources */,
+				OBJ_1953 /* ServiceClient.swift in Sources */,
+				OBJ_1954 /* ServiceProvider.swift in Sources */,
+				OBJ_1955 /* ServiceServer.swift in Sources */,
+				OBJ_1956 /* StreamReceiving.swift in Sources */,
+				OBJ_1957 /* StreamSending.swift in Sources */,
+			);
+		};
+		OBJ_2012 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			files = (
+				OBJ_2013 /* AnyMessageStorage.swift in Sources */,
+				OBJ_2014 /* AnyUnpackError.swift in Sources */,
+				OBJ_2015 /* BinaryDecoder.swift in Sources */,
+				OBJ_2016 /* BinaryDecodingError.swift in Sources */,
+				OBJ_2017 /* BinaryDecodingOptions.swift in Sources */,
+				OBJ_2018 /* BinaryDelimited.swift in Sources */,
+				OBJ_2019 /* BinaryEncoder.swift in Sources */,
+				OBJ_2020 /* BinaryEncodingError.swift in Sources */,
+				OBJ_2021 /* BinaryEncodingSizeVisitor.swift in Sources */,
+				OBJ_2022 /* BinaryEncodingVisitor.swift in Sources */,
+				OBJ_2023 /* CustomJSONCodable.swift in Sources */,
+				OBJ_2024 /* Decoder.swift in Sources */,
+				OBJ_2025 /* DoubleFormatter.swift in Sources */,
+				OBJ_2026 /* Enum.swift in Sources */,
+				OBJ_2027 /* ExtensibleMessage.swift in Sources */,
+				OBJ_2028 /* ExtensionFieldValueSet.swift in Sources */,
+				OBJ_2029 /* ExtensionFields.swift in Sources */,
+				OBJ_2030 /* ExtensionMap.swift in Sources */,
+				OBJ_2031 /* FieldTag.swift in Sources */,
+				OBJ_2032 /* FieldTypes.swift in Sources */,
+				OBJ_2033 /* Google_Protobuf_Any+Extensions.swift in Sources */,
+				OBJ_2034 /* Google_Protobuf_Any+Registry.swift in Sources */,
+				OBJ_2035 /* Google_Protobuf_Duration+Extensions.swift in Sources */,
+				OBJ_2036 /* Google_Protobuf_FieldMask+Extensions.swift in Sources */,
+				OBJ_2037 /* Google_Protobuf_ListValue+Extensions.swift in Sources */,
+				OBJ_2038 /* Google_Protobuf_Struct+Extensions.swift in Sources */,
+				OBJ_2039 /* Google_Protobuf_Timestamp+Extensions.swift in Sources */,
+				OBJ_2040 /* Google_Protobuf_Value+Extensions.swift in Sources */,
+				OBJ_2041 /* Google_Protobuf_Wrappers+Extensions.swift in Sources */,
+				OBJ_2042 /* HashVisitor.swift in Sources */,
+				OBJ_2043 /* Internal.swift in Sources */,
+				OBJ_2044 /* JSONDecoder.swift in Sources */,
+				OBJ_2045 /* JSONDecodingError.swift in Sources */,
+				OBJ_2046 /* JSONDecodingOptions.swift in Sources */,
+				OBJ_2047 /* JSONEncoder.swift in Sources */,
+				OBJ_2048 /* JSONEncodingError.swift in Sources */,
+				OBJ_2049 /* JSONEncodingVisitor.swift in Sources */,
+				OBJ_2050 /* JSONMapEncodingVisitor.swift in Sources */,
+				OBJ_2051 /* JSONScanner.swift in Sources */,
+				OBJ_2052 /* MathUtils.swift in Sources */,
+				OBJ_2053 /* Message+AnyAdditions.swift in Sources */,
+				OBJ_2054 /* Message+BinaryAdditions.swift in Sources */,
+				OBJ_2055 /* Message+JSONAdditions.swift in Sources */,
+				OBJ_2056 /* Message+JSONArrayAdditions.swift in Sources */,
+				OBJ_2057 /* Message+TextFormatAdditions.swift in Sources */,
+				OBJ_2058 /* Message.swift in Sources */,
+				OBJ_2059 /* MessageExtension.swift in Sources */,
+				OBJ_2060 /* NameMap.swift in Sources */,
+				OBJ_2061 /* ProtoNameProviding.swift in Sources */,
+				OBJ_2062 /* ProtobufAPIVersionCheck.swift in Sources */,
+				OBJ_2063 /* ProtobufMap.swift in Sources */,
+				OBJ_2064 /* SelectiveVisitor.swift in Sources */,
+				OBJ_2065 /* SimpleExtensionMap.swift in Sources */,
+				OBJ_2066 /* StringUtils.swift in Sources */,
+				OBJ_2067 /* TextFormatDecoder.swift in Sources */,
+				OBJ_2068 /* TextFormatDecodingError.swift in Sources */,
+				OBJ_2069 /* TextFormatEncoder.swift in Sources */,
+				OBJ_2070 /* TextFormatEncodingVisitor.swift in Sources */,
+				OBJ_2071 /* TextFormatScanner.swift in Sources */,
+				OBJ_2072 /* TimeUtils.swift in Sources */,
+				OBJ_2073 /* UnknownStorage.swift in Sources */,
+				OBJ_2074 /* Varint.swift in Sources */,
+				OBJ_2075 /* Version.swift in Sources */,
+				OBJ_2076 /* Visitor.swift in Sources */,
+				OBJ_2077 /* WireFormat.swift in Sources */,
+				OBJ_2078 /* ZigZag.swift in Sources */,
+				OBJ_2079 /* any.pb.swift in Sources */,
+				OBJ_2080 /* api.pb.swift in Sources */,
+				OBJ_2081 /* duration.pb.swift in Sources */,
+				OBJ_2082 /* empty.pb.swift in Sources */,
+				OBJ_2083 /* field_mask.pb.swift in Sources */,
+				OBJ_2084 /* source_context.pb.swift in Sources */,
+				OBJ_2085 /* struct.pb.swift in Sources */,
+				OBJ_2086 /* timestamp.pb.swift in Sources */,
+				OBJ_2087 /* type.pb.swift in Sources */,
+				OBJ_2088 /* wrappers.pb.swift in Sources */,
+			);
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		OBJ_1854 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = SwiftGRPC::BoringSSL /* BoringSSL */;
+		};
+		OBJ_1962 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = SwiftProtobuf::SwiftProtobuf /* SwiftProtobuf */;
+		};
+		OBJ_1963 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = SwiftGRPC::CgRPC /* CgRPC */;
+		};
+		OBJ_1964 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = SwiftGRPC::BoringSSL /* BoringSSL */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		OBJ_1175 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "c++11";
+				DEFINES_MODULE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Sources/BoringSSL/include",
+					"$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--1071467962839356487",
+				);
+				INFOPLIST_FILE = "SwiftGRPC-Carthage.xcodeproj/BoringSSL_Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-lz",
+				);
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = BoringSSL;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				TARGET_NAME = BoringSSL;
+			};
+			name = Debug;
+		};
+		OBJ_1176 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "c++11";
+				DEFINES_MODULE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Sources/BoringSSL/include",
+					"$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--1071467962839356487",
+				);
+				INFOPLIST_FILE = "SwiftGRPC-Carthage.xcodeproj/BoringSSL_Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-lz",
+				);
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = BoringSSL;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				TARGET_NAME = BoringSSL;
+			};
+			name = Release;
+		};
+		OBJ_1495 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "c++11";
+				DEFINES_MODULE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Sources/CgRPC/include",
+					"$(SRCROOT)/Sources/BoringSSL/include",
+					"$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--1071467962839356487",
+				);
+				INFOPLIST_FILE = "SwiftGRPC-Carthage.xcodeproj/CgRPC_Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-lz",
+				);
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = CgRPC;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				TARGET_NAME = CgRPC;
+			};
+			name = Debug;
+		};
+		OBJ_1496 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "c++11";
+				DEFINES_MODULE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Sources/CgRPC/include",
+					"$(SRCROOT)/Sources/BoringSSL/include",
+					"$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--1071467962839356487",
+				);
+				INFOPLIST_FILE = "SwiftGRPC-Carthage.xcodeproj/CgRPC_Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-lz",
+				);
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = CgRPC;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				TARGET_NAME = CgRPC;
+			};
+			name = Release;
+		};
+		OBJ_1923 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Sources/CgRPC/include",
+					"$(SRCROOT)/Sources/BoringSSL/include",
+					"$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--1071467962839356487",
+					"$(SRCROOT)/SwiftGRPC-Carthage.xcodeproj/GeneratedModuleMap/BoringSSL",
+				);
+				INFOPLIST_FILE = "SwiftGRPC-Carthage.xcodeproj/SwiftGRPC_Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-lz",
+				);
+				OTHER_SWIFT_FLAGS = "$(inherited) -Xcc -fmodule-map-file=$(SRCROOT)/Sources/CgRPC/include/module.modulemap -Xcc -fmodule-map-file=$(SRCROOT)/SwiftGRPC-Carthage.xcodeproj/GeneratedModuleMap/BoringSSL/module.modulemap";
+				PRODUCT_BUNDLE_IDENTIFIER = SwiftGRPC;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = SwiftGRPC;
+			};
+			name = Debug;
+		};
+		OBJ_1924 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Sources/CgRPC/include",
+					"$(SRCROOT)/Sources/BoringSSL/include",
+					"$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--1071467962839356487",
+					"$(SRCROOT)/SwiftGRPC-Carthage.xcodeproj/GeneratedModuleMap/BoringSSL",
+				);
+				INFOPLIST_FILE = "SwiftGRPC-Carthage.xcodeproj/SwiftGRPC_Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-lz",
+				);
+				OTHER_SWIFT_FLAGS = "$(inherited) -Xcc -fmodule-map-file=$(SRCROOT)/Sources/CgRPC/include/module.modulemap -Xcc -fmodule-map-file=$(SRCROOT)/SwiftGRPC-Carthage.xcodeproj/GeneratedModuleMap/BoringSSL/module.modulemap";
+				PRODUCT_BUNDLE_IDENTIFIER = SwiftGRPC;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = SwiftGRPC;
+			};
+			name = Release;
+		};
+		OBJ_2010 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = "SwiftGRPC-Carthage.xcodeproj/SwiftProtobuf_Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = SwiftProtobuf;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = SwiftProtobuf;
+			};
+			name = Debug;
+		};
+		OBJ_2011 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = "SwiftGRPC-Carthage.xcodeproj/SwiftProtobuf_Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = SwiftProtobuf;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = SwiftProtobuf;
+			};
+			name = Release;
+		};
+		OBJ_3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_SWIFT_FLAGS = "-DXcode";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		OBJ_4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_OPTIMIZATION_LEVEL = s;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_SWIFT_FLAGS = "-DXcode";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		OBJ_1174 /* Build configuration list for PBXNativeTarget "BoringSSL" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_1175 /* Debug */,
+				OBJ_1176 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_1494 /* Build configuration list for PBXNativeTarget "CgRPC" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_1495 /* Debug */,
+				OBJ_1496 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_1922 /* Build configuration list for PBXNativeTarget "SwiftGRPC" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_1923 /* Debug */,
+				OBJ_1924 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_2 /* Build configuration list for PBXProject "SwiftGRPC-Carthage" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_3 /* Debug */,
+				OBJ_4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_2009 /* Build configuration list for PBXNativeTarget "SwiftProtobuf" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_2010 /* Debug */,
+				OBJ_2011 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = OBJ_1 /* Project object */;
+}

--- a/SwiftGRPC-Carthage.xcodeproj/xcshareddata/xcschemes/SwiftGRPC-Carthage-Package.xcscheme
+++ b/SwiftGRPC-Carthage.xcodeproj/xcshareddata/xcschemes/SwiftGRPC-Carthage-Package.xcscheme
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme LastUpgradeVersion = "9999" version = "1.3">
+  <BuildAction parallelizeBuildables = "YES" buildImplicitDependencies = "YES">
+    <BuildActionEntries>
+      <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
+        <BuildableReference
+          BuildableIdentifier = "primary"
+          BuildableName = "'$(TARGET_NAME)'"
+          BlueprintName = "Echo"
+          ReferencedContainer = "container:SwiftGRPC-Carthage.xcodeproj">
+        </BuildableReference>
+      </BuildActionEntry>
+      <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
+        <BuildableReference
+          BuildableIdentifier = "primary"
+          BuildableName = "'$(TARGET_NAME)'"
+          BlueprintName = "protoc-gen-swift"
+          ReferencedContainer = "container:SwiftGRPC-Carthage.xcodeproj">
+        </BuildableReference>
+      </BuildActionEntry>
+      <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
+        <BuildableReference
+          BuildableIdentifier = "primary"
+          BuildableName = "'$(TARGET_NAME)'"
+          BlueprintName = "Simple"
+          ReferencedContainer = "container:SwiftGRPC-Carthage.xcodeproj">
+        </BuildableReference>
+      </BuildActionEntry>
+      <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
+        <BuildableReference
+          BuildableIdentifier = "primary"
+          BuildableName = "'lib$(TARGET_NAME)'"
+          BlueprintName = "SwiftProtobufPluginLibrary"
+          ReferencedContainer = "container:SwiftGRPC-Carthage.xcodeproj">
+        </BuildableReference>
+      </BuildActionEntry>
+      <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
+        <BuildableReference
+          BuildableIdentifier = "primary"
+          BuildableName = "'lib$(TARGET_NAME)'"
+          BlueprintName = "Commander"
+          ReferencedContainer = "container:SwiftGRPC-Carthage.xcodeproj">
+        </BuildableReference>
+      </BuildActionEntry>
+      <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
+        <BuildableReference
+          BuildableIdentifier = "primary"
+          BuildableName = "'lib$(TARGET_NAME)'"
+          BlueprintName = "CgRPC"
+          ReferencedContainer = "container:SwiftGRPC-Carthage.xcodeproj">
+        </BuildableReference>
+      </BuildActionEntry>
+      <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
+        <BuildableReference
+          BuildableIdentifier = "primary"
+          BuildableName = "'$(TARGET_NAME)'"
+          BlueprintName = "RootsEncoder"
+          ReferencedContainer = "container:SwiftGRPC-Carthage.xcodeproj">
+        </BuildableReference>
+      </BuildActionEntry>
+      <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
+        <BuildableReference
+          BuildableIdentifier = "primary"
+          BuildableName = "'lib$(TARGET_NAME)'"
+          BlueprintName = "SwiftGRPC"
+          ReferencedContainer = "container:SwiftGRPC-Carthage.xcodeproj">
+        </BuildableReference>
+      </BuildActionEntry>
+      <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
+        <BuildableReference
+          BuildableIdentifier = "primary"
+          BuildableName = "'lib$(TARGET_NAME)'"
+          BlueprintName = "BoringSSL"
+          ReferencedContainer = "container:SwiftGRPC-Carthage.xcodeproj">
+        </BuildableReference>
+      </BuildActionEntry>
+      <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
+        <BuildableReference
+          BuildableIdentifier = "primary"
+          BuildableName = "'lib$(TARGET_NAME)'"
+          BlueprintName = "SwiftProtobuf"
+          ReferencedContainer = "container:SwiftGRPC-Carthage.xcodeproj">
+        </BuildableReference>
+      </BuildActionEntry>
+      <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
+        <BuildableReference
+          BuildableIdentifier = "primary"
+          BuildableName = "'$(TARGET_NAME)'"
+          BlueprintName = "protoc-gen-swiftgrpc"
+          ReferencedContainer = "container:SwiftGRPC-Carthage.xcodeproj">
+        </BuildableReference>
+      </BuildActionEntry>
+    </BuildActionEntries>
+  </BuildAction>
+  <TestAction
+    buildConfiguration = "Debug"
+    selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+    selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+    shouldUseLaunchSchemeArgsEnv = "YES"
+    codeCoverageEnabled = "NO">
+    <Testables>
+    <TestableReference
+      skipped = "NO">
+      <BuildableReference
+        BuildableIdentifier = "primary"
+        BuildableName = "'$(TARGET_NAME)'"
+        BlueprintName = "SwiftGRPCTests"
+        ReferencedContainer = "container:SwiftGRPC-Carthage.xcodeproj">
+      </BuildableReference>
+    </TestableReference>
+    </Testables>
+  </TestAction>
+</Scheme>

--- a/SwiftGRPC-Carthage.xcodeproj/xcshareddata/xcschemes/xcschememanagement.plist
+++ b/SwiftGRPC-Carthage.xcodeproj/xcshareddata/xcschemes/xcschememanagement.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>SchemeUserState</key>
+  <dict>
+    <key>SwiftGRPC-Carthage-Package.xcscheme</key>
+    <dict></dict>
+  </dict>
+  <key>SuppressBuildableAutocreation</key>
+  <dict></dict>
+</dict>
+</plist>

--- a/add-swift-resolve-prebuild-phase.rb
+++ b/add-swift-resolve-prebuild-phase.rb
@@ -1,0 +1,15 @@
+require 'xcodeproj'
+project_path = './SwiftGRPC-Carthage.xcodeproj'
+project = Xcodeproj::Project.open(project_path)
+
+swift_protobuf_target = project.targets.select { |target| target.name == "SwiftProtobuf" }[0]
+swift_protobuf_build_phases = swift_protobuf_target.build_phases
+
+swift_protobuf_target.new_shell_script_build_phase
+
+new_script_phase = swift_protobuf_build_phases.pop
+new_script_phase.shell_script = "swift package resolve"
+
+swift_protobuf_build_phases.unshift(new_script_phase)
+
+project.save

--- a/fix-project-settings.rb
+++ b/fix-project-settings.rb
@@ -1,5 +1,5 @@
 require 'xcodeproj'
-project_path = './SwiftGRPC.xcodeproj'
+project_path = ARGV[0]
 project = Xcodeproj::Project.open(project_path)
 
 project.main_group.uses_tabs = '0'

--- a/remove-unwanted-targets-for-carthage.rb
+++ b/remove-unwanted-targets-for-carthage.rb
@@ -1,0 +1,23 @@
+require 'xcodeproj'
+project_path = ARGV[0]
+project = Xcodeproj::Project.open(project_path)
+
+carthage_targets = ["BoringSSL", "CgRPC", "SwiftGRPC", "SwiftProtobuf"]
+targets_to_remove = []
+
+project.targets.each do |target|
+  if !carthage_targets.include?(target.name)
+    targets_to_remove << target
+  else
+    puts target.name
+    target.build_configurations.each do |config|
+      config.build_settings["IPHONEOS_DEPLOYMENT_TARGET"] = "9.0"
+    end
+  end
+end
+
+targets_to_remove.each do |target|
+  target.remove_from_project
+end
+
+project.save


### PR DESCRIPTION
Opening the work for #13.

Note that there are very few changes in the build system: most of this PR is about archiving the project `SwiftGRPC-Carthage.xcodeproj` that is generated by `make project-carthage`.

The issue here is that it won't work unless `make` is run (and versioned).

Trying the PR:

1. Pull this branch
2. Run `carthage build --no-skip-current` and observe that it fails because files are missing
3. Run `make`
4. Run `carthage build --no-skip-current` again, and see that it works this time.