### PR TITLE
Carthage: support from iOS 9.0 

### DIFF
--- a/SwiftGRPC-Carthage.xcodeproj/project.pbxproj
+++ b/SwiftGRPC-Carthage.xcodeproj/project.pbxproj
@@ -2172,18 +2172,18 @@
 		OBJ_1160 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				SwiftGRPC::Echo::Product /* Echo */,
-				SwiftProtobuf::protoc-gen-swift::Product /* protoc-gen-swift */,
 				SwiftGRPC::RootsEncoder::Product /* RootsEncoder */,
-				SwiftGRPC::Simple::Product /* Simple */,
 				SwiftProtobuf::SwiftProtobufPluginLibrary::Product /* SwiftProtobufPluginLibrary.framework */,
-				SwiftGRPC::SwiftGRPCTests::Product /* SwiftGRPCTests.xctest */,
 				SwiftGRPC::SwiftGRPC::Product /* SwiftGRPC.framework */,
-				SwiftGRPC::BoringSSL::Product /* BoringSSL.framework */,
-				Commander::Commander::Product /* Commander.framework */,
-				SwiftGRPC::CgRPC::Product /* CgRPC.framework */,
 				SwiftProtobuf::SwiftProtobuf::Product /* SwiftProtobuf.framework */,
+				SwiftGRPC::BoringSSL::Product /* BoringSSL.framework */,
+				SwiftProtobuf::protoc-gen-swift::Product /* protoc-gen-swift */,
+				SwiftGRPC::Echo::Product /* Echo */,
+				SwiftGRPC::Simple::Product /* Simple */,
+				Commander::Commander::Product /* Commander.framework */,
 				SwiftGRPC::protoc-gen-swiftgrpc::Product /* protoc-gen-swiftgrpc */,
+				SwiftGRPC::SwiftGRPCTests::Product /* SwiftGRPCTests.xctest */,
+				SwiftGRPC::CgRPC::Product /* CgRPC.framework */,
 			);
 			name = Products;
 			path = "";
@@ -4371,7 +4371,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = OBJ_2009 /* Build configuration list for PBXNativeTarget "SwiftProtobuf" */;
 			buildPhases = (
-				31CD0F748721B9677E261D1D /* ShellScript */,
+				9787213439CCFC4B91A030CE /* ShellScript */,
 				OBJ_2012 /* Sources */,
 				OBJ_2089 /* Frameworks */,
 			);
@@ -4412,7 +4412,7 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		31CD0F748721B9677E261D1D /* ShellScript */ = {
+		9787213439CCFC4B91A030CE /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -5264,6 +5264,7 @@
 					"$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--1071467962839356487",
 				);
 				INFOPLIST_FILE = "SwiftGRPC-Carthage.xcodeproj/BoringSSL_Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = (
@@ -5296,6 +5297,7 @@
 					"$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--1071467962839356487",
 				);
 				INFOPLIST_FILE = "SwiftGRPC-Carthage.xcodeproj/BoringSSL_Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = (
@@ -5329,6 +5331,7 @@
 					"$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--1071467962839356487",
 				);
 				INFOPLIST_FILE = "SwiftGRPC-Carthage.xcodeproj/CgRPC_Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = (
@@ -5362,6 +5365,7 @@
 					"$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--1071467962839356487",
 				);
 				INFOPLIST_FILE = "SwiftGRPC-Carthage.xcodeproj/CgRPC_Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = (
@@ -5393,6 +5397,7 @@
 					"$(SRCROOT)/SwiftGRPC-Carthage.xcodeproj/GeneratedModuleMap/BoringSSL",
 				);
 				INFOPLIST_FILE = "SwiftGRPC-Carthage.xcodeproj/SwiftGRPC_Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = (
@@ -5425,6 +5430,7 @@
 					"$(SRCROOT)/SwiftGRPC-Carthage.xcodeproj/GeneratedModuleMap/BoringSSL",
 				);
 				INFOPLIST_FILE = "SwiftGRPC-Carthage.xcodeproj/SwiftGRPC_Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = (
@@ -5451,6 +5457,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "SwiftGRPC-Carthage.xcodeproj/SwiftProtobuf_Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
@@ -5474,6 +5481,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "SwiftGRPC-Carthage.xcodeproj/SwiftProtobuf_Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";

--- a/SwiftGRPC-Carthage.xcodeproj/xcshareddata/xcschemes/SwiftGRPC-Carthage-Package.xcscheme
+++ b/SwiftGRPC-Carthage.xcodeproj/xcshareddata/xcschemes/SwiftGRPC-Carthage-Package.xcscheme
@@ -5,8 +5,16 @@
       <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
         <BuildableReference
           BuildableIdentifier = "primary"
-          BuildableName = "'$(TARGET_NAME)'"
-          BlueprintName = "Echo"
+          BuildableName = "'lib$(TARGET_NAME)'"
+          BlueprintName = "SwiftGRPC"
+          ReferencedContainer = "container:SwiftGRPC-Carthage.xcodeproj">
+        </BuildableReference>
+      </BuildActionEntry>
+      <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
+        <BuildableReference
+          BuildableIdentifier = "primary"
+          BuildableName = "'lib$(TARGET_NAME)'"
+          BlueprintName = "SwiftProtobuf"
           ReferencedContainer = "container:SwiftGRPC-Carthage.xcodeproj">
         </BuildableReference>
       </BuildActionEntry>
@@ -22,23 +30,7 @@
         <BuildableReference
           BuildableIdentifier = "primary"
           BuildableName = "'$(TARGET_NAME)'"
-          BlueprintName = "Simple"
-          ReferencedContainer = "container:SwiftGRPC-Carthage.xcodeproj">
-        </BuildableReference>
-      </BuildActionEntry>
-      <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
-        <BuildableReference
-          BuildableIdentifier = "primary"
-          BuildableName = "'lib$(TARGET_NAME)'"
-          BlueprintName = "SwiftProtobufPluginLibrary"
-          ReferencedContainer = "container:SwiftGRPC-Carthage.xcodeproj">
-        </BuildableReference>
-      </BuildActionEntry>
-      <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
-        <BuildableReference
-          BuildableIdentifier = "primary"
-          BuildableName = "'lib$(TARGET_NAME)'"
-          BlueprintName = "Commander"
+          BlueprintName = "Echo"
           ReferencedContainer = "container:SwiftGRPC-Carthage.xcodeproj">
         </BuildableReference>
       </BuildActionEntry>
@@ -62,14 +54,6 @@
         <BuildableReference
           BuildableIdentifier = "primary"
           BuildableName = "'lib$(TARGET_NAME)'"
-          BlueprintName = "SwiftGRPC"
-          ReferencedContainer = "container:SwiftGRPC-Carthage.xcodeproj">
-        </BuildableReference>
-      </BuildActionEntry>
-      <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
-        <BuildableReference
-          BuildableIdentifier = "primary"
-          BuildableName = "'lib$(TARGET_NAME)'"
           BlueprintName = "BoringSSL"
           ReferencedContainer = "container:SwiftGRPC-Carthage.xcodeproj">
         </BuildableReference>
@@ -77,8 +61,16 @@
       <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
         <BuildableReference
           BuildableIdentifier = "primary"
+          BuildableName = "'$(TARGET_NAME)'"
+          BlueprintName = "Simple"
+          ReferencedContainer = "container:SwiftGRPC-Carthage.xcodeproj">
+        </BuildableReference>
+      </BuildActionEntry>
+      <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
+        <BuildableReference
+          BuildableIdentifier = "primary"
           BuildableName = "'lib$(TARGET_NAME)'"
-          BlueprintName = "SwiftProtobuf"
+          BlueprintName = "Commander"
           ReferencedContainer = "container:SwiftGRPC-Carthage.xcodeproj">
         </BuildableReference>
       </BuildActionEntry>
@@ -87,6 +79,14 @@
           BuildableIdentifier = "primary"
           BuildableName = "'$(TARGET_NAME)'"
           BlueprintName = "protoc-gen-swiftgrpc"
+          ReferencedContainer = "container:SwiftGRPC-Carthage.xcodeproj">
+        </BuildableReference>
+      </BuildActionEntry>
+      <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
+        <BuildableReference
+          BuildableIdentifier = "primary"
+          BuildableName = "'lib$(TARGET_NAME)'"
+          BlueprintName = "SwiftProtobufPluginLibrary"
           ReferencedContainer = "container:SwiftGRPC-Carthage.xcodeproj">
         </BuildableReference>
       </BuildActionEntry>

--- a/remove-unwanted-targets-for-carthage.rb
+++ b/remove-unwanted-targets-for-carthage.rb
@@ -9,7 +9,6 @@ project.targets.each do |target|
   if !carthage_targets.include?(target.name)
     targets_to_remove << target
   else
-    puts target.name
     target.build_configurations.each do |config|
       config.build_settings["IPHONEOS_DEPLOYMENT_TARGET"] = "9.0"
     end


### PR DESCRIPTION
As described at the end of #282, the current master gets `IPHONEOS_DEPLOYMENT_TARGET` set to 11.4 by default. I believe 9.0 is more reasonable (mainly because my project targets 9.0, so that's negociable).

Unfortunatly, I messed up in #282 and got [the change](https://github.com/grpc/grpc-swift/compare/master...JonasVautherin:support-ios-9?expand=1#diff-ec55bd13fd5a9fcbffc88ce21fdfcd33R13) merged without having the versioned `xcodeproj` updated. This PR fixes this.

Also, it shows what kind of maintenance comes from supporting Carthage: running `make project-carthage` generates the `xcodeproj` again. And unfortunately, it is not deterministic. So this PR only adds a bunch of `IPHONEOS_DEPLOYMENT_TARGET = 9.0;` to the `xcodeproj`, but still the order of the objects in the project file changes -_-.

I have been testing this PR by building with Carthage and integrating the resulting frameworks in a project that was otherwise failing because of the deployment target. I still get error #272, but that's not in the scope of this PR.