### PR TITLE
CI improvements: faster, log folding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,4 +57,4 @@ script:
   - echo -en 'travis_fold:start:make.test-plugin\\r' && make test-plugin && echo -en 'travis_fold:end:make.test-plugin\\r'
   - echo -en 'travis_fold:start:make.test-echo\\r' && make test-echo && echo -en 'travis_fold:end:make.test-echo\\r'
   - echo -en 'travis_fold:start:make.xcodebuild\\r' && if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then make xcodebuild; fi && echo -en 'travis_fold:end:make.xcodebuild\\r'
-  - echo -en 'travis_fold:start:make.build-carthage\\r' && if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then make clean && travis_wait 40 make build-carthage; fi && echo -en 'travis_fold:end:make.build-carthage\\r'
+  - echo -en 'travis_fold:start:make.build-carthage\\r' && if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then make clean && travis_wait 40 make build-carthage-debug; fi && echo -en 'travis_fold:end:make.build-carthage\\r'

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,5 +56,5 @@ script:
   - echo -en 'travis_fold:start:make.test\\r' && make test && echo -en 'travis_fold:end:make.test\\r'
   - echo -en 'travis_fold:start:make.test-plugin\\r' && make test-plugin && echo -en 'travis_fold:end:make.test-plugin\\r'
   - echo -en 'travis_fold:start:make.test-echo\\r' && make test-echo && echo -en 'travis_fold:end:make.test-echo\\r'
-  - echo -en 'travis_fold:start:make.xcodebuild\\r' && if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then make xcodebuild; fi && echo -en 'travis_fold:end:make.xcodebuild\\r'
-  - echo -en 'travis_fold:start:make.build-carthage\\r' && if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then make clean && travis_wait 40 make build-carthage-debug; fi && echo -en 'travis_fold:end:make.build-carthage\\r'
+  - echo -en 'travis_fold:start:make.project\\r' && if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then make project; fi && echo -en 'travis_fold:end:make.project\\r'
+  - echo -en 'travis_fold:start:make.build-carthage\\r' && if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then make clean && make build-carthage-debug; fi && echo -en 'travis_fold:end:make.build-carthage\\r'

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,13 +49,12 @@ addons:
 
 install: ./.travis-install.sh
 
-script: 
-  - export PATH=$HOME/local/bin:$PATH
-  - export LD_LIBRARY_PATH=$HOME/local/lib
-  - swift package -v resolve
-  - make all
-  - make test
-  - make test-plugin
-  - make test-echo
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then make xcodebuild; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then make clean && travis_wait 40 make build-carthage; fi
+script:
+  - echo -en 'travis_fold:start:script.environment\\r' && export PATH=$HOME/local/bin:$PATH && export LD_LIBRARY_PATH=$HOME/local/lib && echo -en 'travis_fold:end:script.environment\\r'
+  - echo -en 'travis_fold:start:swift.resolve-deps\\r' && swift package -v resolve && echo -en 'travis_fold:end:swift.resolve-deps\\r'
+  - echo -en 'travis_fold:start:make.all\\r' && make all && echo -en 'travis_fold:end:make.all\\r'
+  - echo -en 'travis_fold:start:make.test\\r' && make test && echo -en 'travis_fold:end:make.test\\r'
+  - echo -en 'travis_fold:start:make.test-plugin\\r' && make test-plugin && echo -en 'travis_fold:end:make.test-plugin\\r'
+  - echo -en 'travis_fold:start:make.test-echo\\r' && make test-echo && echo -en 'travis_fold:end:make.test-echo\\r'
+  - echo -en 'travis_fold:start:make.xcodebuild\\r' && if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then make xcodebuild; fi && echo -en 'travis_fold:end:make.xcodebuild\\r'
+  - echo -en 'travis_fold:start:make.build-carthage\\r' && if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then make clean && travis_wait 40 make build-carthage; fi && echo -en 'travis_fold:end:make.build-carthage\\r'

--- a/Makefile
+++ b/Makefile
@@ -44,11 +44,15 @@ xcodebuild: project
 build-carthage:
 	carthage build --no-skip-current
 
+build-carthage-debug:
+	carthage build --no-skip-current --configuration Debug --platform iOS, macOS
+
 clean:
 	-rm -rf Packages
 	-rm -rf .build build
 	-rm -rf SwiftGRPC.xcodeproj
 	-rm -rf Package.pins Package.resolved
 	-rm -rf protoc-gen-swift protoc-gen-swiftgrpc
-	-cd Examples/Echo/PackageManager && make clean
-	-cd Examples/Simple/PackageManager && make clean
+	-cd Examples/Google/Datastore && make clean
+	-cd Examples/Google/NaturalLanguage && make clean
+	-cd Examples/Google/Spanner && make clean


### PR DESCRIPTION
Our build times have increased to ~25 minutes after integrating Carthage. This PR reduces them back to 14 minutes by switching Carthage builds to the Debug configuration and only building macOS/iOS. 

**For further improvements, I have also removed the `xcodebuild` step, given that that is essentially done by `carthage build` anyway.**

Also fixed `make clean` and added folding for Travis logs.