### PR TITLE
Bump podspec to 0.5.1

### DIFF
--- a/SwiftGRPC.podspec
+++ b/SwiftGRPC.podspec
@@ -11,7 +11,7 @@
 
 Pod::Spec.new do |s|
   s.name = 'SwiftGRPC'
-  s.version = '0.5.0'
+  s.version = '0.5.1'
   s.license     = { :type => 'Apache License, Version 2.0',
                     :text => <<-LICENSE
                       Copyright 2018, gRPC Authors. All rights reserved.


### PR DESCRIPTION
We should issue a new release which includes https://github.com/grpc/grpc-swift/pull/289 (the fix for https://github.com/grpc/grpc-swift/issues/288).