### PR TITLE
Several fixes to the example projects.

### DIFF
--- a/Examples/Cocoapods/NaturalLanguage/NaturalLanguage.xcodeproj/project.pbxproj
+++ b/Examples/Cocoapods/NaturalLanguage/NaturalLanguage.xcodeproj/project.pbxproj
@@ -103,7 +103,6 @@
 				D353015B2097A4DC00727A88 /* Frameworks */,
 				D353015C2097A4DC00727A88 /* Resources */,
 				C656FB9F83FB17EE3625C732 /* [CP] Embed Pods Frameworks */,
-				80E1BDF830F9EEC4C0FFA0DA /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -177,28 +176,13 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		80E1BDF830F9EEC4C0FFA0DA /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-NaturalLanguage/Pods-NaturalLanguage-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		C656FB9F83FB17EE3625C732 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-NaturalLanguage/Pods-NaturalLanguage-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-NaturalLanguage/Pods-NaturalLanguage-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/BoringSSL/openssl.framework",
 				"${BUILT_PRODUCTS_DIR}/SwiftGRPC/SwiftGRPC.framework",
 				"${BUILT_PRODUCTS_DIR}/SwiftProtobuf/SwiftProtobuf.framework",
@@ -215,7 +199,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-NaturalLanguage/Pods-NaturalLanguage-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-NaturalLanguage/Pods-NaturalLanguage-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/Examples/Cocoapods/NaturalLanguage/NaturalLanguage/AppDelegate.swift
+++ b/Examples/Cocoapods/NaturalLanguage/NaturalLanguage/AppDelegate.swift
@@ -34,7 +34,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     signal(UIColor.yellow);
     // Prepare the API client.
     service = Google_Cloud_Language_V1_LanguageServiceServiceClient(address: "language.googleapis.com")
-    service.metadata = Metadata(["x-goog-api-key": GOOGLE_API_KEY])
+    service.metadata = try! Metadata(["x-goog-api-key": GOOGLE_API_KEY])
     // Call the API.
     var document = Google_Cloud_Language_V1_Document()
     document.type = .plainText

--- a/Examples/EchoXcode/Echo.xcodeproj/project.pbxproj
+++ b/Examples/EchoXcode/Echo.xcodeproj/project.pbxproj
@@ -14,75 +14,11 @@
 		D35C9FAE1D74B079000443CD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D35C9FAD1D74B079000443CD /* Assets.xcassets */; };
 		D35C9FB11D74B079000443CD /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = D35C9FAF1D74B079000443CD /* MainMenu.xib */; };
 		D35C9FC81D74B0C1000443CD /* EchoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35C9FC71D74B0C1000443CD /* EchoViewController.swift */; };
-		D36AB73D1F58DF10007D7184 /* BoringSSL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D36AB7281F58DEDB007D7184 /* BoringSSL.framework */; };
-		D36AB73E1F58DF10007D7184 /* CgRPC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D36AB7261F58DEDB007D7184 /* CgRPC.framework */; };
-		D36AB7401F58DF10007D7184 /* SwiftGRPC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D36AB72A1F58DEDB007D7184 /* SwiftGRPC.framework */; };
-		D36AB7411F58DF10007D7184 /* SwiftProtobuf.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D36AB7341F58DEDB007D7184 /* SwiftProtobuf.framework */; };
 		D3971E211D89132E001A0B3F /* ssl.key in Resources */ = {isa = PBXBuildFile; fileRef = D3971E201D89132E001A0B3F /* ssl.key */; };
 		D3BFE28C1D87A45D00A648D8 /* ssl.crt in Resources */ = {isa = PBXBuildFile; fileRef = D3BFE28B1D87A45D00A648D8 /* ssl.crt */; };
 /* End PBXBuildFile section */
 
-/* Begin PBXContainerItemProxy section */
-		D315DEEB1EE8B29B007670CE /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D315DEDF1EE8B29A007670CE /* SwiftProtobuf.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = "_____Product_ProtobufTestSuite_macOS";
-			remoteInfo = SwiftProtobufTestSuite_macOS;
-		};
-		D315DEED1EE8B29B007670CE /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D315DEDF1EE8B29A007670CE /* SwiftProtobuf.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = "_____Product_Protobuf_iOS";
-			remoteInfo = SwiftProtobuf_iOS;
-		};
-		D315DEEF1EE8B29B007670CE /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D315DEDF1EE8B29A007670CE /* SwiftProtobuf.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = "_____Product_ProtobufTestSuite_iOS";
-			remoteInfo = SwiftProtobufTestSuite_iOS;
-		};
-		D315DEF11EE8B29B007670CE /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D315DEDF1EE8B29A007670CE /* SwiftProtobuf.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = F44F936F1DAEA53900BC5B85;
-			remoteInfo = SwiftProtobuf_tvOS;
-		};
-		D315DEF31EE8B29B007670CE /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D315DEDF1EE8B29A007670CE /* SwiftProtobuf.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = F44F939F1DAEA7C500BC5B85;
-			remoteInfo = SwiftProtobufTestSuite_tvOS;
-		};
-		D315DEF51EE8B29B007670CE /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D315DEDF1EE8B29A007670CE /* SwiftProtobuf.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = F44F93FE1DAEB13F00BC5B85;
-			remoteInfo = SwiftProtobuf_watchOS;
-		};
-		D315DEF71EE8B2C1007670CE /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D315DEDF1EE8B29A007670CE /* SwiftProtobuf.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = "______Target_Protobuf";
-			remoteInfo = SwiftProtobuf_macOS;
-		};
-		D36AB7331F58DEDB007D7184 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D315DEDF1EE8B29A007670CE /* SwiftProtobuf.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = "_____Product_Protobuf_macOS";
-			remoteInfo = SwiftProtobuf_macOS;
-		};
-/* End PBXContainerItemProxy section */
-
 /* Begin PBXFileReference section */
-		D315DEDF1EE8B29A007670CE /* SwiftProtobuf.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SwiftProtobuf.xcodeproj; path = "../../third_party/swift-protobuf/SwiftProtobuf.xcodeproj"; sourceTree = "<group>"; };
 		D353581D1E219963007FA223 /* echo.grpc.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = echo.grpc.swift; path = ../../Sources/Examples/Echo/Generated/echo.grpc.swift; sourceTree = "<group>"; };
 		D353581E1E219963007FA223 /* echo.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = echo.pb.swift; path = ../../Sources/Examples/Echo/Generated/echo.pb.swift; sourceTree = "<group>"; };
 		D35358241E219980007FA223 /* EchoProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = EchoProvider.swift; path = ../../Sources/Examples/Echo/EchoProvider.swift; sourceTree = "<group>"; };
@@ -101,28 +37,17 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D36AB73D1F58DF10007D7184 /* BoringSSL.framework in Frameworks */,
-				D36AB73E1F58DF10007D7184 /* CgRPC.framework in Frameworks */,
-				D36AB7401F58DF10007D7184 /* gRPC.framework in Frameworks */,
-				D36AB7411F58DF10007D7184 /* SwiftProtobuf.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		D315DEE01EE8B29A007670CE /* Products */ = {
+		65F3F130213563CB00471BFC /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				D36AB7341F58DEDB007D7184 /* SwiftProtobuf.framework */,
-				D315DEEC1EE8B29B007670CE /* SwiftProtobufTests.xctest */,
-				D315DEEE1EE8B29B007670CE /* SwiftProtobuf.framework */,
-				D315DEF01EE8B29B007670CE /* SwiftProtobufTests.xctest */,
-				D315DEF21EE8B29B007670CE /* SwiftProtobuf.framework */,
-				D315DEF41EE8B29B007670CE /* SwiftProtobufTests.xctest */,
-				D315DEF61EE8B29B007670CE /* SwiftProtobuf.framework */,
 			);
-			name = Products;
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		D35358231E219971007FA223 /* Generated */ = {
@@ -137,11 +62,11 @@
 		D35C9F9F1D74B079000443CD = {
 			isa = PBXGroup;
 			children = (
-				D315DEDF1EE8B29A007670CE /* SwiftProtobuf.xcodeproj */,
 				D35C9FAA1D74B079000443CD /* Echo */,
 				D35358231E219971007FA223 /* Generated */,
 				D35358241E219980007FA223 /* EchoProvider.swift */,
 				D35C9FA91D74B079000443CD /* Products */,
+				65F3F130213563CB00471BFC /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -167,18 +92,6 @@
 			path = Echo;
 			sourceTree = "<group>";
 		};
-		D36AB7191F58DEDB007D7184 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				D36AB7221F58DEDB007D7184 /* zlib-example */,
-				D36AB7261F58DEDB007D7184 /* CgRPC.framework */,
-				D36AB7281F58DEDB007D7184 /* BoringSSL.framework */,
-				D36AB72A1F58DEDB007D7184 /* gRPC.framework */,
-				D36AB72C1F58DEDB007D7184 /* gRPCTests.xctest */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -193,15 +106,12 @@
 			buildRules = (
 			);
 			dependencies = (
-				D36AB7361F58DF02007D7184 /* PBXTargetDependency */,
 				D36AB7381F58DF02007D7184 /* PBXTargetDependency */,
 				D36AB73A1F58DF02007D7184 /* PBXTargetDependency */,
 				D36AB73C1F58DF02007D7184 /* PBXTargetDependency */,
-				D315DEFA1EE8B2C7007670CE /* PBXTargetDependency */,
 				D315DEFC1EE8B2C7007670CE /* PBXTargetDependency */,
 				D315DEFE1EE8B2C7007670CE /* PBXTargetDependency */,
 				D315DF001EE8B2C7007670CE /* PBXTargetDependency */,
-				D315DEF81EE8B2C1007670CE /* PBXTargetDependency */,
 			);
 			name = Echo;
 			productName = Echo;
@@ -236,73 +146,12 @@
 			mainGroup = D35C9F9F1D74B079000443CD;
 			productRefGroup = D35C9FA91D74B079000443CD /* Products */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = D36AB7191F58DEDB007D7184 /* Products */;
-				},
-				{
-					ProductGroup = D315DEE01EE8B29A007670CE /* Products */;
-					ProjectRef = D315DEDF1EE8B29A007670CE /* SwiftProtobuf.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				D35C9FA71D74B079000443CD /* Echo */,
 			);
 		};
 /* End PBXProject section */
-
-/* Begin PBXReferenceProxy section */
-		D315DEEC1EE8B29B007670CE /* SwiftProtobufTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = SwiftProtobufTests.xctest;
-			remoteRef = D315DEEB1EE8B29B007670CE /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		D315DEEE1EE8B29B007670CE /* SwiftProtobuf.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = SwiftProtobuf.framework;
-			remoteRef = D315DEED1EE8B29B007670CE /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		D315DEF01EE8B29B007670CE /* SwiftProtobufTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = SwiftProtobufTests.xctest;
-			remoteRef = D315DEEF1EE8B29B007670CE /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		D315DEF21EE8B29B007670CE /* SwiftProtobuf.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = SwiftProtobuf.framework;
-			remoteRef = D315DEF11EE8B29B007670CE /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		D315DEF41EE8B29B007670CE /* SwiftProtobufTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = SwiftProtobufTests.xctest;
-			remoteRef = D315DEF31EE8B29B007670CE /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		D315DEF61EE8B29B007670CE /* SwiftProtobuf.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = SwiftProtobuf.framework;
-			remoteRef = D315DEF51EE8B29B007670CE /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		D36AB7341F58DEDB007D7184 /* SwiftProtobuf.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = SwiftProtobuf.framework;
-			remoteRef = D36AB7331F58DEDB007D7184 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		D35C9FA61D74B079000443CD /* Resources */ = {
@@ -334,11 +183,6 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		D315DEF81EE8B2C1007670CE /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = SwiftProtobuf_macOS;
-			targetProxy = D315DEF71EE8B2C1007670CE /* PBXContainerItemProxy */;
-		};
 		D315DEFC1EE8B2C7007670CE /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = CgRPC;
@@ -354,17 +198,14 @@
 		D36AB7381F58DF02007D7184 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = CgRPC;
-			targetProxy = D36AB7371F58DF02007D7184 /* PBXContainerItemProxy */;
 		};
 		D36AB73A1F58DF02007D7184 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = BoringSSL;
-			targetProxy = D36AB7391F58DF02007D7184 /* PBXContainerItemProxy */;
 		};
 		D36AB73C1F58DF02007D7184 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = gRPC;
-			targetProxy = D36AB73B1F58DF02007D7184 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/Examples/EchoXcode/README.md
+++ b/Examples/EchoXcode/README.md
@@ -6,5 +6,5 @@ on the gRPC Xcode project, which requires a local build of the
 gRPC Core C library. To build that, please run "make" in the
 root of your gRPC distribution. Next use Xcode's "Add Files..."
 command to add the SwiftGRPC.xcodeproj to your project and
-then add the gRPC, CgRPC, and BoringSSL libraries
-to the target dependencies of "Echo".
+then add the gRPC, CgRPC, BoringSSL, and SwiftProtobuf
+libraries to the target dependencies of "Echo".

--- a/Examples/SimpleXcode/README.md
+++ b/Examples/SimpleXcode/README.md
@@ -11,8 +11,8 @@ on the gRPC Xcode project, which requires a local build of the
 gRPC Core C library. To build that, please run "make" in the
 root of your gRPC distribution. Next use Xcode's "Add Files..."
 command to add the SwiftGRPC.xcodeproj to your project and
-then add the CzLib, gRPC, CgRPC, and BoringSSL libraries
-to the target dependencies of "Simple".
+then add the gRPC, CgRPC, and BoringSSL libraries to the target
+dependencies of "Simple".
 
 When running the app, use the "New" menu option to create new
 gRPC sessions. Configure each session using the host and port

--- a/Examples/SimpleXcode/Simple.xcodeproj/project.pbxproj
+++ b/Examples/SimpleXcode/Simple.xcodeproj/project.pbxproj
@@ -7,22 +7,15 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		020BF449F4DC160FFEA59281 /* Pods_Simple.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1637F1B5EB217163B05C09F6 /* Pods_Simple.framework */; };
 		D30D735B1D565E4400F90CCB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30D735A1D565E4400F90CCB /* AppDelegate.swift */; };
 		D30D735D1D565E4400F90CCB /* Document.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30D735C1D565E4400F90CCB /* Document.swift */; };
 		D30D73601D565E4400F90CCB /* Document.xib in Resources */ = {isa = PBXBuildFile; fileRef = D30D735E1D565E4400F90CCB /* Document.xib */; };
 		D30D73621D565E4400F90CCB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D30D73611D565E4400F90CCB /* Assets.xcassets */; };
 		D30D73651D565E4400F90CCB /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = D30D73631D565E4400F90CCB /* MainMenu.xib */; };
-		D394EF271F58DBA300E99633 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
-		D394EF281F58DBA300E99633 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
-		D394EF291F58DBA300E99633 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
-		D394EF2A1F58DBA300E99633 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		1637F1B5EB217163B05C09F6 /* Pods_Simple.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Simple.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		82FBE46939E735B1F797924F /* Pods-Simple.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Simple.release.xcconfig"; path = "Pods/Target Support Files/Pods-Simple/Pods-Simple.release.xcconfig"; sourceTree = "<group>"; };
-		92FB91401821C52F1D137A51 /* Pods-Simple.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Simple.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Simple/Pods-Simple.debug.xcconfig"; sourceTree = "<group>"; };
 		D30D73571D565E4400F90CCB /* Simple.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Simple.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D30D735A1D565E4400F90CCB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		D30D735C1D565E4400F90CCB /* Document.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Document.swift; sourceTree = "<group>"; };
@@ -37,11 +30,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D394EF271F58DBA300E99633 /* BuildFile in Frameworks */,
-				D394EF281F58DBA300E99633 /* BuildFile in Frameworks */,
-				D394EF291F58DBA300E99633 /* BuildFile in Frameworks */,
-				D394EF2A1F58DBA300E99633 /* BuildFile in Frameworks */,
-				020BF449F4DC160FFEA59281 /* Pods_Simple.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -56,21 +44,11 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		42235A567C9D88F028BC9FBB /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				92FB91401821C52F1D137A51 /* Pods-Simple.debug.xcconfig */,
-				82FBE46939E735B1F797924F /* Pods-Simple.release.xcconfig */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
 		D30D734E1D565E4400F90CCB = {
 			isa = PBXGroup;
 			children = (
 				D30D73591D565E4400F90CCB /* Simple */,
 				D30D73581D565E4400F90CCB /* Products */,
-				42235A567C9D88F028BC9FBB /* Pods */,
 				3410CF2A0B1DA40CBD2960DB /* Frameworks */,
 			);
 			sourceTree = "<group>";
@@ -96,13 +74,6 @@
 			path = Simple;
 			sourceTree = "<group>";
 		};
-		D394EF0B1F58DB7A00E99633 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -110,21 +81,16 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = D30D73691D565E4400F90CCB /* Build configuration list for PBXNativeTarget "Simple" */;
 			buildPhases = (
-				D0F766A5DE10BD0BBB1D0BED /* [CP] Check Pods Manifest.lock */,
 				D30D73531D565E4400F90CCB /* Sources */,
 				D30D73541D565E4400F90CCB /* Frameworks */,
 				D30D73551D565E4400F90CCB /* Resources */,
-				65570F4D3F2AC86016E847D3 /* [CP] Embed Pods Frameworks */,
-				F67FAAFE297D1C22F4F94B88 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				D394EF201F58DB9800E99633 /* PBXTargetDependency */,
 				D394EF221F58DB9800E99633 /* PBXTargetDependency */,
 				D394EF241F58DB9800E99633 /* PBXTargetDependency */,
 				D394EF261F58DB9800E99633 /* PBXTargetDependency */,
-				D3E1EA811EE8B0120024A93A /* PBXTargetDependency */,
 				D3E1EA831EE8B0120024A93A /* PBXTargetDependency */,
 				D3E1EA7F1EE8B00C0024A93A /* PBXTargetDependency */,
 				D3E1EA7D1EE8B0070024A93A /* PBXTargetDependency */,
@@ -166,11 +132,6 @@
 			mainGroup = D30D734E1D565E4400F90CCB;
 			productRefGroup = D30D73581D565E4400F90CCB /* Products */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = D394EF0B1F58DB7A00E99633 /* Products */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				D30D73561D565E4400F90CCB /* Simple */,
@@ -190,57 +151,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		65570F4D3F2AC86016E847D3 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Simple/Pods-Simple-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		D0F766A5DE10BD0BBB1D0BED /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Simple-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		F67FAAFE297D1C22F4F94B88 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Simple/Pods-Simple-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		D30D73531D565E4400F90CCB /* Sources */ = {
@@ -403,7 +313,6 @@
 		};
 		D30D736A1D565E4400F90CCB /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 92FB91401821C52F1D137A51 /* Pods-Simple.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -417,7 +326,6 @@
 		};
 		D30D736B1D565E4400F90CCB /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 82FBE46939E735B1F797924F /* Pods-Simple.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;

--- a/Examples/SimpleXcode/Simple/AppDelegate.swift
+++ b/Examples/SimpleXcode/Simple/AppDelegate.swift
@@ -20,7 +20,7 @@ import SwiftGRPC
 class AppDelegate: NSObject, NSApplicationDelegate {
   func applicationDidFinishLaunching(_: Notification) {
     gRPC.initialize()
-    print("GRPC version", gRPC.version())
+    print("GRPC version", gRPC.version)
   }
 
   func applicationWillTerminate(_: Notification) {


### PR DESCRIPTION
- Added a `try!` in Examples/Cocoapods/NaturalLanguage/NaturalLanguage/AppDelegate.swift
- Ran `pod install` in Examples/Cocoapods/NaturalLange, causing a minor update to that project
- Removed existing references to SwiftProtobuf and SwiftGRPC from EchoXcode.xcodeproj (the user should add these manually)
- Removed existing references to SwiftGRPC from SimpleXcode.xcodeproj (the user should add these manually)
- Removed CocoaPods references from SimpleXcode.xcodeproj (that project isn't using CocoaPods)
- Updated READMEs

I am afraid the "Google" samples are still broken because of a compiler error in https://github.com/swift-server/http (might be new with Swift 4.2).