### PR TITLE
Cut a 0.6.0 release due to the breaking changes in SwiftProtobuf 1.1

### DIFF
--- a/SwiftGRPC.podspec
+++ b/SwiftGRPC.podspec
@@ -11,7 +11,7 @@
 
 Pod::Spec.new do |s|
   s.name = 'SwiftGRPC'
-  s.version = '0.5.1'
+  s.version = '0.6.0'
   s.license     = { :type => 'Apache License, Version 2.0',
                     :text => <<-LICENSE
                       Copyright 2018, gRPC Authors. All rights reserved.


### PR DESCRIPTION
Fixes #302.