### PR TITLE
Transmission type parameters for sync/async code generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ separated from the output directory by a colon.
 | `Visibility` | `Internal`/`Public` | `Internal` | ACL of generated code |
 | `Server` |  `true`/`false` | `true` | Whether to generate server code |
 | `Client` |  `true`/`false` | `true` | Whether to generate client code |
+| `Async` |  `true`/`false` | `true` | Whether to generate asynchronous code |
+| `Sync` |  `true`/`false` | `true` | Whether to generate synchronous code |
 | `TestStubs` |  `true`/`false` | `false` | Whether to generate test stub code |
 
 Example:

--- a/Sources/protoc-gen-swiftgrpc/Generator.swift
+++ b/Sources/protoc-gen-swiftgrpc/Generator.swift
@@ -81,7 +81,8 @@ class Generator {
     if options.generateClient {
       for service in file.services {
         self.service = service
-        printClient()
+        printClient(asynchronousCode: options.generateAsynchronous,
+                    synchronousCode: options.generateSynchronous)
       }
     }
     println()

--- a/Sources/protoc-gen-swiftgrpc/options.swift
+++ b/Sources/protoc-gen-swiftgrpc/options.swift
@@ -49,6 +49,8 @@ final class GeneratorOptions {
   private(set) var visibility = Visibility.internal
   private(set) var generateServer = true
   private(set) var generateClient = true
+  private(set) var generateAsynchronous = true
+  private(set) var generateSynchronous = true
   private(set) var generateTestStubs = false
 
   init(parameter: String?) throws {
@@ -71,6 +73,20 @@ final class GeneratorOptions {
       case "Client":
         if let value = Bool(pair.value) {
           generateClient = value
+        } else {
+          throw GenerationError.invalidParameterValue(name: pair.key, value: pair.value)
+        }
+        
+      case "Async":
+        if let value = Bool(pair.value) {
+          generateAsynchronous = value
+        } else {
+          throw GenerationError.invalidParameterValue(name: pair.key, value: pair.value)
+        }
+        
+      case "Sync":
+        if let value = Bool(pair.value) {
+          generateSynchronous = value
         } else {
           throw GenerationError.invalidParameterValue(name: pair.key, value: pair.value)
         }


### PR DESCRIPTION
These changes will improve the files generated by `swiftgrpc_out` where the user wants to opt out of e.g. synchronous code for the client.

Example:

    $ protoc <your proto> --swiftgrpc_out=Client=true,Server=false,Sync=false:.
