### PR TITLE
Improve the documentation on building the `protoc` plugins and add a `make plugin` option.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,13 @@ all:
 	swift build $(CFLAGS)
 	cp .build/debug/protoc-gen-swift .
 	cp .build/debug/protoc-gen-swiftgrpc .
-	
+
+plugin:
+	swift build $(CFLAGS) --product protoc-gen-swift -c release -Xswiftc -static-stdlib
+	swift build $(CFLAGS) --product protoc-gen-swiftgrpc -c release -Xswiftc -static-stdlib
+	cp .build/release/protoc-gen-swift .
+	cp .build/release/protoc-gen-swiftgrpc .
+
 project:
 	swift package $(CFLAGS) generate-xcodeproj --output SwiftGRPC.xcodeproj
 	@-ruby fix-project-settings.rb SwiftGRPC.xcodeproj || echo "Consider running 'sudo gem install xcodeproj' to automatically set correct indentation settings for the generated project."

--- a/README.md
+++ b/README.md
@@ -71,15 +71,17 @@ generate the necessary support code.
 Binary releases of `protoc`, the Protocol Buffer Compiler, are
 available on [GitHub](https://github.com/google/protobuf/releases).
 
-To build the plugins, run `make` in the main directory.
+To build the plugins, run `make plugin` in the main directory.
 This uses the Swift Package Manager to build both of the necessary
 plugins: `protoc-gen-swift`, which generates Protocol Buffer support code
 and `protoc-gen-swiftgrpc`, which generates gRPC interface code.
 
+To install these plugins, just copy the two executables (`protoc-gen-swift` and `protoc-gen-swiftgrpc`) that show up in the main directory into a directory that is part of your `PATH` environment variable.
+
 ### Using the plugins
 
 To use the plugins, `protoc` and both plugins should be in your
-search path. Invoke them with commands like the following:
+search path (see above). Invoke them with commands like the following:
 
     protoc <your proto files> \
         --swift_out=. \


### PR DESCRIPTION
`make plugin` also statically links the Swift standard library, which should avoid crashes when users update their Swift toolchain.