### PR TITLE
Add support for RPC status

### DIFF
--- a/Sources/CgRPC/shim/cgrpc.h
+++ b/Sources/CgRPC/shim/cgrpc.h
@@ -240,6 +240,7 @@ void cgrpc_metadata_array_unref_fields(cgrpc_metadata_array *array);
 size_t cgrpc_metadata_array_get_count(cgrpc_metadata_array *array);
 char *cgrpc_metadata_array_copy_key_at_index(cgrpc_metadata_array *array, size_t index);
 char *cgrpc_metadata_array_copy_value_at_index(cgrpc_metadata_array *array, size_t index);
+cgrpc_byte_buffer *cgrpc_metadata_array_copy_data_value_at_index(cgrpc_metadata_array *array, size_t index);
 void cgrpc_metadata_array_move_metadata(cgrpc_metadata_array *dest, cgrpc_metadata_array *src);
 cgrpc_metadata_array *cgrpc_metadata_array_copy(cgrpc_metadata_array *src);
 void cgrpc_metadata_array_append_metadata(cgrpc_metadata_array *metadata, const char *key, const char *value);

--- a/Sources/CgRPC/shim/metadata.c
+++ b/Sources/CgRPC/shim/metadata.c
@@ -60,6 +60,11 @@ char *cgrpc_metadata_array_copy_value_at_index(cgrpc_metadata_array *array, size
   return str;
 }
 
+cgrpc_byte_buffer *cgrpc_metadata_array_copy_data_value_at_index(cgrpc_metadata_array *array, size_t index) {
+  size_t length = GRPC_SLICE_LENGTH(array->metadata[index].value);
+  return cgrpc_byte_buffer_create_by_copying_data(GRPC_SLICE_START_PTR(array->metadata[index].value), length);
+}
+
 void cgrpc_metadata_array_move_metadata(cgrpc_metadata_array *destination,
                                         cgrpc_metadata_array *source) {
   destination->count = source->count;

--- a/Sources/SwiftGRPC/Core/Metadata.swift
+++ b/Sources/SwiftGRPC/Core/Metadata.swift
@@ -80,7 +80,16 @@ public class Metadata {
     defer { cgrpc_free_copied_string(valueData) }
     return String(cString: valueData, encoding: String.Encoding.utf8)
   }
-  
+
+  public func data(forKey key: String) -> Data? {
+    for index in 0..<count() {
+      guard self.key(index) == key else { continue }
+      let byteBuffer = ByteBuffer(underlyingByteBuffer: cgrpc_metadata_array_copy_data_value_at_index(underlyingArray, index))
+      return byteBuffer.data()
+    }
+    return nil
+  }
+
   public func add(key: String, value: String) throws {
     if !ownsFields {
       throw Error.doesNotOwnFields

--- a/Sources/SwiftGRPC/Core/Metadata.swift
+++ b/Sources/SwiftGRPC/Core/Metadata.swift
@@ -81,15 +81,6 @@ public class Metadata {
     return String(cString: valueData, encoding: String.Encoding.utf8)
   }
 
-  public func data(forKey key: String) -> Data? {
-    for index in 0..<count() {
-      guard self.key(index) == key else { continue }
-      let byteBuffer = ByteBuffer(underlyingByteBuffer: cgrpc_metadata_array_copy_data_value_at_index(underlyingArray, index))
-      return byteBuffer.data()
-    }
-    return nil
-  }
-
   public func add(key: String, value: String) throws {
     if !ownsFields {
       throw Error.doesNotOwnFields
@@ -136,6 +127,15 @@ extension Metadata {
       return self.value(i)
     }
     
+    return nil
+  }
+
+  public func data(forKey key: String) -> Data? {
+    for index in 0..<count() {
+      guard self.key(index) == key else { continue }
+      let byteBuffer = ByteBuffer(underlyingByteBuffer: cgrpc_metadata_array_copy_data_value_at_index(underlyingArray, index))
+      return byteBuffer.data()
+    }
     return nil
   }
 }

--- a/Tests/SwiftGRPCTests/MetadataTests.swift
+++ b/Tests/SwiftGRPCTests/MetadataTests.swift
@@ -28,4 +28,9 @@ class MetadataTests: XCTestCase {
     let metadata = try! Metadata(["foo": "bar"])
     XCTAssertEqual(["foo": "bar"], metadata.copy().dictionaryRepresentation)
   }
+
+  func testExtractData() {
+    let metadata = try! Metadata(["foo": "bar"])
+    XCTAssertEqual("bar".data(using: .utf8), metadata.data(forKey: "foo"))
+  }
 }


### PR DESCRIPTION
This closes #258 

The new changes provide a way for consumer of `grpc-swift` to get access to the data stored in the `grpc-status-details-bin` of metadata. 

Here's how to use it in the consumer app:
```
// Register message types that could be returned in the details field of Status
Google_Protobuf_Any.register(messageType: CustomError.self)

_ = try service.doSomething(request) { response, result in
  result.trailingMetadata?.status?.details // will contain a list of messages that carry the error details
}
```