### PR TITLE
[WIP] Add support for Carthage through xcodegen

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,1 @@
+github "apple/swift-protobuf" ~> 1.1.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,0 +1,1 @@
+github "apple/swift-protobuf" "1.2.0"

--- a/project.yml
+++ b/project.yml
@@ -1,0 +1,54 @@
+name: SwiftGRPC-XcodeGen
+options:
+  bundleIdPrefix: "io.grpc"
+  deploymentTarget: 
+    iOS: 10.0
+  indentWidth: 2
+  tabWidth: 2
+  usesTabs: false
+targets:
+  SwiftGRPC:
+    platform: [iOS]
+    settings:
+      SWIFT_VERSION: 4
+    scheme: {}
+    sources:
+      - Sources/SwiftGRPC
+    info:
+      path: Sources/SwiftGRPC/Info.plist
+    dependencies:
+      - target: BoringSSL_$platform
+      - target: CgRPC_$platform
+      - carthage: SwiftProtobuf
+    type: framework
+  BoringSSL:
+    platform: [iOS]
+    settings:
+      SWIFT_VERSION: 4
+      HEADER_SEARCH_PATHS:
+        $(SRCROOT)/Sources/BoringSSL/include
+    scheme: {}
+    sources:
+        - path: Sources/BoringSSL
+          headerVisibility: project
+          excludes: "README.md"
+    info:
+      path: Sources/BoringSSL/Info.plist
+    type: framework
+  CgRPC:
+    platform: [iOS]
+    settings:
+      SWIFT_VERSION: 4
+      HEADER_SEARCH_PATHS:
+        $(inherited)
+        $(SRCROOT)/Sources/BoringSSL/include
+        $(SRCROOT)/Sources/CgRPC/include
+    scheme: {}
+    sources: 
+      - path: Sources/CgRPC
+        headerVisibility: project
+    info:
+      path: Sources/CgRPC/Info.plist
+    dependencies:
+      - target: BoringSSL_$platform
+    type: framework


### PR DESCRIPTION
Trying to implement a solution for #329.

FYI: @MrMage, @sbarow, @ishkawa

I get an error saying:

```
Showing All Messages
:-1: Multiple commands produce '/Users/jones/Library/Developer/Xcode/DerivedData/SwiftGRPC-XcodeGen-gohnuovawbgognemswwzuzdzqfeh/Build/Products/Debug-iphonesimulator/BoringSSL.framework/Headers/internal.h':
1) Target 'BoringSSL_iOS' (project 'SwiftGRPC-XcodeGen') has copy command from '/tmp/test_xcodegen/grpc-swift/Sources/BoringSSL/crypto/bio/internal.h' to '/Users/jones/Library/Developer/Xcode/DerivedData/SwiftGRPC-XcodeGen-gohnuovawbgognemswwzuzdzqfeh/Build/Products/Debug-iphonesimulator/BoringSSL.framework/Headers/internal.h'
2) Target 'BoringSSL_iOS' (project 'SwiftGRPC-XcodeGen') has copy command from '/tmp/test_xcodegen/grpc-swift/Sources/BoringSSL/crypto/bytestring/internal.h' to '/Users/jones/Library/Developer/Xcode/DerivedData/SwiftGRPC-XcodeGen-gohnuovawbgognemswwzuzdzqfeh/Build/Products/Debug-iphonesimulator/BoringSSL.framework/Headers/internal.h'
...
[and a lot more similar ones]
```

I'm stuck there, I have absolutely no idea what's happening.