### PR TITLE
Add environment flag for BoringSSL/OpenSSL on MacOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,16 +26,16 @@ var packageDependencies: [Package.Dependency] = [
 var cGRPCDependencies: [Target.Dependency] = []
 
 #if os(Linux)
-// On Linux, Foundation links with openssl, so we'll need to use that instead of BoringSSL.
-// See https://github.com/apple/swift-nio-ssl/issues/16#issuecomment-392705505 for details.
 let isLinux = true
 #else
 let isLinux = false
 #endif 
 
+// On Linux, Foundation links with openssl, so we'll need to use that instead of BoringSSL.
+// See https://github.com/apple/swift-nio-ssl/issues/16#issuecomment-392705505 for details.
 // swift build doesn't pass -Xswiftc flags to dependencies, so here using an environment variable
 // is easiest.
-if ProcessInfo.processInfo.environment.keys.contains("GRPC_USE_OPENSSL") || isLinux {
+if isLinux || ProcessInfo.processInfo.environment.keys.contains("GRPC_USE_OPENSSL") {
   packageDependencies.append(.package(url: "https://github.com/apple/swift-nio-ssl-support.git", from: "1.0.0"))
 } else {
   cGRPCDependencies.append("BoringSSL")

--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 import PackageDescription
+import Foundation
 
 var packageDependencies: [Package.Dependency] = [
   .package(url: "https://github.com/apple/swift-protobuf.git", .upToNextMinor(from: "1.1.1")),
@@ -23,13 +24,22 @@ var packageDependencies: [Package.Dependency] = [
 ]
 
 var cGRPCDependencies: [Target.Dependency] = []
+
 #if os(Linux)
 // On Linux, Foundation links with openssl, so we'll need to use that instead of BoringSSL.
 // See https://github.com/apple/swift-nio-ssl/issues/16#issuecomment-392705505 for details.
-packageDependencies.append(.package(url: "https://github.com/apple/swift-nio-ssl-support.git", from: "1.0.0"))
+let isLinux = true
 #else
-cGRPCDependencies.append("BoringSSL")
-#endif
+let isLinux = false
+#endif 
+
+// swift build doesn't pass -Xswiftc flags to dependencies, so here using an environment variable
+// is easiest.
+if !ProcessInfo.processInfo.environment.keys.contains("GRPC_USE_OPENSSL") && !isLinux {
+  cGRPCDependencies.append("BoringSSL")
+} else {
+  packageDependencies.append(.package(url: "https://github.com/apple/swift-nio-ssl-support.git", from: "1.0.0"))
+}
 
 let package = Package(
   name: "SwiftGRPC",

--- a/Package.swift
+++ b/Package.swift
@@ -35,10 +35,10 @@ let isLinux = false
 
 // swift build doesn't pass -Xswiftc flags to dependencies, so here using an environment variable
 // is easiest.
-if !ProcessInfo.processInfo.environment.keys.contains("GRPC_USE_OPENSSL") && !isLinux {
-  cGRPCDependencies.append("BoringSSL")
-} else {
+if ProcessInfo.processInfo.environment.keys.contains("GRPC_USE_OPENSSL") || isLinux {
   packageDependencies.append(.package(url: "https://github.com/apple/swift-nio-ssl-support.git", from: "1.0.0"))
+} else {
+  cGRPCDependencies.append("BoringSSL")
 }
 
 let package = Package(


### PR DESCRIPTION
Sometimes one wants to use dependencies that rely on OpenSSL, and for those times updating build scripts is easier than forking projects.

This change adjusts the behavior of the OpenSSL vs BoringSSL selection in Package.swift.  If you're not on Linux and the environment variable `GRPC_USE_OPENSSL`  is present, it will use OpenSSL. If not it will use BoringSSL as usual.