### PR TITLE
Allow "FileNaming" option to be set via CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ separated from the output directory by a colon.
 | `Async` |  `true`/`false` | `true` | Whether to generate asynchronous code |
 | `Sync` |  `true`/`false` | `true` | Whether to generate synchronous code |
 | `TestStubs` |  `true`/`false` | `false` | Whether to generate test stub code |
+| `FileNaming` | `FullPath`/`PathToUnderscores`/`DropPath` | `FullPath` | How to handle the naming of generated sources |
 
 Example:
 

--- a/Sources/protoc-gen-swiftgrpc/main.swift
+++ b/Sources/protoc-gen-swiftgrpc/main.swift
@@ -55,18 +55,16 @@ func splitPath(pathname: String) -> (dir: String, base: String, suffix: String) 
   return (dir: dir, base: base, suffix: suffix)
 }
 
-enum OutputNaming: String {
+enum FileNaming: String {
   case FullPath
   case PathToUnderscores
   case DropPath
 }
 
-var outputNamingOption: OutputNaming = .FullPath // temporarily hard-coded
-
-func outputFileName(component: String, fileDescriptor: FileDescriptor) -> String {
+func outputFileName(component: String, fileDescriptor: FileDescriptor, fileNamingOption: FileNaming) -> String {
   let ext = "." + component + ".swift"
   let pathParts = splitPath(pathname: fileDescriptor.name)
-  switch outputNamingOption {
+  switch fileNamingOption {
   case .FullPath:
     return pathParts.dir + pathParts.base + ext
   case .PathToUnderscores:
@@ -80,11 +78,11 @@ func outputFileName(component: String, fileDescriptor: FileDescriptor) -> String
 
 var generatedFiles: [String: Int] = [:]
 
-func uniqueOutputFileName(component: String, fileDescriptor: FileDescriptor) -> String {
-  let defaultName = outputFileName(component: component, fileDescriptor: fileDescriptor)
+func uniqueOutputFileName(component: String, fileDescriptor: FileDescriptor, fileNamingOption: FileNaming) -> String {
+  let defaultName = outputFileName(component: component, fileDescriptor: fileDescriptor, fileNamingOption: fileNamingOption)
   if let count = generatedFiles[defaultName] {
     generatedFiles[defaultName] = count + 1
-    return outputFileName(component: "\(count)." + component, fileDescriptor: fileDescriptor)
+    return outputFileName(component: "\(count)." + component, fileDescriptor: fileDescriptor, fileNamingOption: fileNamingOption)
   } else {
     generatedFiles[defaultName] = 1
     return defaultName
@@ -108,7 +106,7 @@ func main() throws {
   // process each .proto file separately
   for fileDescriptor in descriptorSet.files {
     if fileDescriptor.services.count > 0 {
-      let grpcFileName = uniqueOutputFileName(component: "grpc", fileDescriptor: fileDescriptor)
+      let grpcFileName = uniqueOutputFileName(component: "grpc", fileDescriptor: fileDescriptor, fileNamingOption: options.fileNaming)
       let grpcGenerator = Generator(fileDescriptor, options: options)
       var grpcFile = Google_Protobuf_Compiler_CodeGeneratorResponse.File()
       grpcFile.name = grpcFileName

--- a/Sources/protoc-gen-swiftgrpc/options.swift
+++ b/Sources/protoc-gen-swiftgrpc/options.swift
@@ -59,6 +59,7 @@ final class GeneratorOptions {
   private(set) var generateTestStubs = false
   private(set) var generateNIOImplementation = false
   private(set) var protoToModuleMappings = ProtoFileToModuleMappings()
+  private(set) var fileNaming = FileNaming.FullPath
 
   init(parameter: String?) throws {
     for pair in GeneratorOptions.parseParameter(string: parameter) {
@@ -121,6 +122,13 @@ final class GeneratorOptions {
               message: "Parameter 'ProtoPathModuleMappings=\(pair.value)'",
               error: e)
           }
+        }
+
+      case "FileNaming":
+        if let value = FileNaming(rawValue: pair.value) {
+          fileNaming = value
+        } else {
+          throw GenerationError.invalidParameterValue(name: pair.key, value: pair.value)
         }
 
       default:


### PR DESCRIPTION
Adds the `FileNaming` option to the CLI args for the grpc-swift protoc plugin.

This was requested in issue #321.