### PR TITLE
Make ConnectivityObserver class final

### DIFF
--- a/Sources/SwiftGRPC/Core/Channel.swift
+++ b/Sources/SwiftGRPC/Core/Channel.swift
@@ -135,7 +135,7 @@ private extension Channel {
   final class ConnectivityObserver {
     private let completionQueue: CompletionQueue
     private let underlyingChannel: UnsafeMutableRawPointer
-    private let underlyingCompletionQueue: UnsafeMutableRawPointer = cgrpc_completion_queue_create_for_next()
+    private let underlyingCompletionQueue: UnsafeMutableRawPointer
     private let callback: (ConnectivityState) -> Void
     private var lastState: ConnectivityState
     private var hasBeenShutdown = false
@@ -143,6 +143,7 @@ private extension Channel {
 
     init(underlyingChannel: UnsafeMutableRawPointer, currentState: ConnectivityState, callback: @escaping (ConnectivityState) -> ()) {
       self.underlyingChannel = underlyingChannel
+      self.underlyingCompletionQueue = cgrpc_completion_queue_create_for_next()
       self.completionQueue = CompletionQueue(underlyingCompletionQueue: self.underlyingCompletionQueue, name: "Connectivity State")
       self.callback = callback
       self.lastState = currentState

--- a/Sources/SwiftGRPC/Core/Channel.swift
+++ b/Sources/SwiftGRPC/Core/Channel.swift
@@ -132,10 +132,10 @@ public class Channel {
 }
 
 private extension Channel {
-  class ConnectivityObserver {
+  final class ConnectivityObserver {
     private let completionQueue: CompletionQueue
     private let underlyingChannel: UnsafeMutableRawPointer
-    private let underlyingCompletionQueue: UnsafeMutableRawPointer
+    private let underlyingCompletionQueue: UnsafeMutableRawPointer = cgrpc_completion_queue_create_for_next()
     private let callback: (ConnectivityState) -> Void
     private var lastState: ConnectivityState
     private var hasBeenShutdown = false
@@ -143,7 +143,6 @@ private extension Channel {
 
     init(underlyingChannel: UnsafeMutableRawPointer, currentState: ConnectivityState, callback: @escaping (ConnectivityState) -> ()) {
       self.underlyingChannel = underlyingChannel
-      self.underlyingCompletionQueue = cgrpc_completion_queue_create_for_next()
       self.completionQueue = CompletionQueue(underlyingCompletionQueue: self.underlyingCompletionQueue, name: "Connectivity State")
       self.callback = callback
       self.lastState = currentState


### PR DESCRIPTION
This is `private` to the file and will never be subclassed. I believe updating it with the `final` annotation will make this clearer to readers.