### PR TITLE
Refactor channel connectivity to avoid multiple spin loops

### DIFF
--- a/Sources/SwiftGRPC/Core/Channel.swift
+++ b/Sources/SwiftGRPC/Core/Channel.swift
@@ -95,7 +95,9 @@ public class Channel {
   }
 
   deinit {
-    self.connectivityObserver?.shutdown()
+    self.mutex.synchronize {
+      self.connectivityObserver?.shutdown()
+    }
     cgrpc_channel_destroy(self.underlyingChannel)
     self.completionQueue.shutdown()
   }

--- a/Sources/SwiftGRPC/Core/Channel.swift
+++ b/Sources/SwiftGRPC/Core/Channel.swift
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 #if SWIFT_PACKAGE
-  import CgRPC
-  import Dispatch
+import CgRPC
+import Dispatch
 #endif
 import Foundation
 
@@ -23,18 +23,16 @@ import Foundation
 public class Channel {
   /// Pointer to underlying C representation
   private let underlyingChannel: UnsafeMutableRawPointer
-
   /// Completion queue for channel call operations
   private let completionQueue: CompletionQueue
+  /// Observer for connectivity state changes.
+  private lazy var connectivityObserver = ConnectivityObserver(underlyingChannel: self.underlyingChannel)
 
   /// Timeout for new calls
   public var timeout: TimeInterval = 600.0
 
   /// Default host to use for new calls
   public var host: String
-
-  /// Connectivity state observers
-  private var connectivityObservers: [ConnectivityObserver] = []
 
   /// Initializes a gRPC channel
   ///
@@ -47,12 +45,12 @@ public class Channel {
     let argumentWrappers = arguments.map { $0.toCArg() }
 
     underlyingChannel = withExtendedLifetime(argumentWrappers) {
-        var argumentValues = argumentWrappers.map { $0.wrapped }
-        if secure {
-          return cgrpc_channel_create_secure(address, kRootCertificates, nil, nil, &argumentValues, Int32(arguments.count))
-        } else {
-          return cgrpc_channel_create(address, &argumentValues, Int32(arguments.count))
-        }
+      var argumentValues = argumentWrappers.map { $0.wrapped }
+      if secure {
+        return cgrpc_channel_create_secure(address, kRootCertificates, nil, nil, &argumentValues, Int32(arguments.count))
+      } else {
+        return cgrpc_channel_create(address, &argumentValues, Int32(arguments.count))
+      }
     }
     completionQueue = CompletionQueue(underlyingCompletionQueue: cgrpc_channel_completion_queue(underlyingChannel), name: "Client")
     completionQueue.run() // start a loop that watches the channel's completion queue
@@ -66,10 +64,10 @@ public class Channel {
     gRPC.initialize()
     host = googleAddress
     let argumentWrappers = arguments.map { $0.toCArg() }
-    
+
     underlyingChannel = withExtendedLifetime(argumentWrappers) {
-        var argumentValues = argumentWrappers.map { $0.wrapped }
-        return cgrpc_channel_create_google(googleAddress, &argumentValues, Int32(arguments.count))
+      var argumentValues = argumentWrappers.map { $0.wrapped }
+      return cgrpc_channel_create_google(googleAddress, &argumentValues, Int32(arguments.count))
     }
 
     completionQueue = CompletionQueue(underlyingCompletionQueue: cgrpc_channel_completion_queue(underlyingChannel), name: "Client")
@@ -89,15 +87,15 @@ public class Channel {
     let argumentWrappers = arguments.map { $0.toCArg() }
 
     underlyingChannel = withExtendedLifetime(argumentWrappers) {
-        var argumentValues = argumentWrappers.map { $0.wrapped }
-        return cgrpc_channel_create_secure(address, certificates, clientCertificates, clientKey, &argumentValues, Int32(arguments.count))
+      var argumentValues = argumentWrappers.map { $0.wrapped }
+      return cgrpc_channel_create_secure(address, certificates, clientCertificates, clientKey, &argumentValues, Int32(arguments.count))
     }
     completionQueue = CompletionQueue(underlyingCompletionQueue: cgrpc_channel_completion_queue(underlyingChannel), name: "Client")
     completionQueue.run() // start a loop that watches the channel's completion queue
   }
 
   deinit {
-    connectivityObservers.forEach { $0.shutdown() }
+    connectivityObserver.shutdown()
     cgrpc_channel_destroy(underlyingChannel)
     completionQueue.shutdown()
   }
@@ -109,7 +107,7 @@ public class Channel {
   /// - Parameter timeout: a timeout value in seconds
   /// - Returns: a Call object that can be used to perform the request
   public func makeCall(_ method: String, host: String = "", timeout: TimeInterval? = nil) -> Call {
-    let host = (host == "") ? self.host : host
+    let host = host.isEmpty ? self.host : host
     let timeout = timeout ?? self.timeout
     let underlyingCall = cgrpc_channel_create_call(underlyingChannel, method, host, timeout)!
     return Call(underlyingCall: underlyingCall, owned: true, completionQueue: completionQueue)
@@ -126,8 +124,8 @@ public class Channel {
   /// Subscribe to connectivity state changes
   ///
   /// - Parameter callback: block executed every time a new connectivity state is detected
-  public func subscribe(callback: @escaping (ConnectivityState) -> Void) {
-    connectivityObservers.append(ConnectivityObserver(underlyingChannel: underlyingChannel, currentState: connectivityState(), callback: callback))
+  public func addConnectivityObserver(callback: @escaping (ConnectivityState) -> Void) {
+    connectivityObserver.addConnectivityObserver(callback: callback)
   }
 }
 
@@ -136,18 +134,16 @@ private extension Channel {
     private let completionQueue: CompletionQueue
     private let underlyingChannel: UnsafeMutableRawPointer
     private let underlyingCompletionQueue: UnsafeMutableRawPointer
-    private let callback: (ConnectivityState) -> Void
-    private var lastState: ConnectivityState
+    private var callbacks = [(ConnectivityState) -> Void]()
     private var hasBeenShutdown = false
-    private let stateMutex: Mutex = Mutex()
+    private let stateMutex = Mutex()
 
-    init(underlyingChannel: UnsafeMutableRawPointer, currentState: ConnectivityState, callback: @escaping (ConnectivityState) -> ()) {
+    init(underlyingChannel: UnsafeMutableRawPointer) {
       self.underlyingChannel = underlyingChannel
       self.underlyingCompletionQueue = cgrpc_completion_queue_create_for_next()
-      self.completionQueue = CompletionQueue(underlyingCompletionQueue: self.underlyingCompletionQueue, name: "Connectivity State")
-      self.callback = callback
-      self.lastState = currentState
-      run()
+      self.completionQueue = CompletionQueue(underlyingCompletionQueue: self.underlyingCompletionQueue,
+                                             name: "Connectivity State")
+      self.run()
     }
 
     deinit {
@@ -156,19 +152,20 @@ private extension Channel {
 
     private func run() {
       let spinloopThreadQueue = DispatchQueue(label: "SwiftGRPC.ConnectivityObserver.run.spinloopThread")
-
+      var lastState = ConnectivityState(cgrpc_channel_check_connectivity_state(self.underlyingChannel, 0))
       spinloopThreadQueue.async {
         while true  {
-          guard (self.stateMutex.synchronize{ !self.hasBeenShutdown }) else {
+          guard (self.stateMutex.synchronize { !self.hasBeenShutdown }) else {
             return
           }
-            
-          guard let underlyingState = self.lastState.underlyingState else { return }
+
+          guard let underlyingState = lastState.underlyingState else { return }
 
           let deadline: TimeInterval = 0.2
-          cgrpc_channel_watch_connectivity_state(self.underlyingChannel, self.underlyingCompletionQueue, underlyingState, deadline, nil)
+          cgrpc_channel_watch_connectivity_state(self.underlyingChannel, self.underlyingCompletionQueue,
+                                                 underlyingState, deadline, nil)
+
           let event = self.completionQueue.wait(timeout: deadline)
-          
           guard (self.stateMutex.synchronize{ !self.hasBeenShutdown }) else {
             return
           }
@@ -176,11 +173,12 @@ private extension Channel {
           switch event.type {
           case .complete:
             let newState = ConnectivityState(cgrpc_channel_check_connectivity_state(self.underlyingChannel, 0))
+            guard newState != lastState else { continue }
 
-            if newState != self.lastState {
-              self.callback(newState)
+            lastState = newState
+            self.stateMutex.synchronize {
+              self.callbacks.forEach { callback in callback(newState) }
             }
-            self.lastState = newState
 
           case .queueShutdown:
             return
@@ -189,6 +187,12 @@ private extension Channel {
             continue
           }
         }
+      }
+    }
+
+    func addConnectivityObserver(callback: @escaping (ConnectivityState) -> Void) {
+      self.stateMutex.synchronize {
+        self.callbacks.append(callback)
       }
     }
 

--- a/Sources/SwiftGRPC/Core/ChannelConnectivityObserver.swift
+++ b/Sources/SwiftGRPC/Core/ChannelConnectivityObserver.swift
@@ -70,7 +70,7 @@ extension Channel {
                                                  underlyingState, deadline, nil)
 
           let event = self.completionQueue.wait(timeout: deadline)
-          guard (self.mutex.synchronize{ !self.hasBeenShutdown }) else {
+          guard (self.mutex.synchronize { !self.hasBeenShutdown }) else {
             return
           }
 

--- a/Sources/SwiftGRPC/Core/ChannelConnectivityObserver.swift
+++ b/Sources/SwiftGRPC/Core/ChannelConnectivityObserver.swift
@@ -38,7 +38,7 @@ extension Channel {
     }
 
     deinit {
-      shutdown()
+      self.shutdown()
     }
 
     private func run() {
@@ -88,10 +88,10 @@ extension Channel {
     }
 
     func shutdown() {
-      mutex.synchronize {
-        hasBeenShutdown = true
+      self.mutex.synchronize {
+        self.hasBeenShutdown = true
       }
-      completionQueue.shutdown()
+      self.completionQueue.shutdown()
     }
   }
 }

--- a/Sources/SwiftGRPC/Core/ChannelConnectivityObserver.swift
+++ b/Sources/SwiftGRPC/Core/ChannelConnectivityObserver.swift
@@ -79,10 +79,9 @@ extension Channel {
             let newState = ConnectivityState(cgrpc_channel_check_connectivity_state(self.underlyingChannel, 0))
             guard newState != lastState else { continue }
 
+            let callbacks = self.mutex.synchronize { Array(self.callbacks) }
             lastState = newState
-            self.mutex.synchronize {
-              self.callbacks.forEach { callback in callback(newState) }
-            }
+            callbacks.forEach { callback in callback(newState) }
 
           case .queueShutdown:
             return

--- a/Sources/SwiftGRPC/Core/ChannelConnectivityObserver.swift
+++ b/Sources/SwiftGRPC/Core/ChannelConnectivityObserver.swift
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2016, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#if SWIFT_PACKAGE
+import CgRPC
+import Dispatch
+#endif
+import Foundation
+
+extension Channel {
+  /// Provides an interface for observing the connectivity of a given channel.
+  final class ConnectivityObserver {
+    private let completionQueue: CompletionQueue
+    private let underlyingChannel: UnsafeMutableRawPointer
+    private let underlyingCompletionQueue: UnsafeMutableRawPointer
+    private var callbacks = [(ConnectivityState) -> Void]()
+    private var hasBeenShutdown = false
+    private let stateMutex = Mutex()
+
+    init(underlyingChannel: UnsafeMutableRawPointer) {
+      self.underlyingChannel = underlyingChannel
+      self.underlyingCompletionQueue = cgrpc_completion_queue_create_for_next()
+      self.completionQueue = CompletionQueue(underlyingCompletionQueue: self.underlyingCompletionQueue,
+                                             name: "Connectivity State")
+      self.run()
+    }
+
+    deinit {
+      shutdown()
+    }
+
+    private func run() {
+      let spinloopThreadQueue = DispatchQueue(label: "SwiftGRPC.ConnectivityObserver.run.spinloopThread")
+      var lastState = ConnectivityState(cgrpc_channel_check_connectivity_state(self.underlyingChannel, 0))
+      spinloopThreadQueue.async {
+        while true  {
+          guard (self.stateMutex.synchronize { !self.hasBeenShutdown }) else {
+            return
+          }
+
+          guard let underlyingState = lastState.underlyingState else { return }
+
+          let deadline: TimeInterval = 0.2
+          cgrpc_channel_watch_connectivity_state(self.underlyingChannel, self.underlyingCompletionQueue,
+                                                 underlyingState, deadline, nil)
+
+          let event = self.completionQueue.wait(timeout: deadline)
+          guard (self.stateMutex.synchronize{ !self.hasBeenShutdown }) else {
+            return
+          }
+
+          switch event.type {
+          case .complete:
+            let newState = ConnectivityState(cgrpc_channel_check_connectivity_state(self.underlyingChannel, 0))
+            guard newState != lastState else { continue }
+
+            lastState = newState
+            self.stateMutex.synchronize {
+              self.callbacks.forEach { callback in callback(newState) }
+            }
+
+          case .queueShutdown:
+            return
+
+          default:
+            continue
+          }
+        }
+      }
+    }
+
+    func addConnectivityObserver(callback: @escaping (ConnectivityState) -> Void) {
+      self.stateMutex.synchronize {
+        self.callbacks.append(callback)
+      }
+    }
+
+    func shutdown() {
+      stateMutex.synchronize {
+        hasBeenShutdown = true
+      }
+      completionQueue.shutdown()
+    }
+  }
+}

--- a/Sources/SwiftGRPC/Core/ChannelConnectivityObserver.swift
+++ b/Sources/SwiftGRPC/Core/ChannelConnectivityObserver.swift
@@ -49,9 +49,11 @@ extension Channel {
 
     func shutdown() {
       self.mutex.synchronize {
+        guard !self.hasBeenShutdown else { return }
+
         self.hasBeenShutdown = true
+        self.completionQueue.shutdown()
       }
-      self.completionQueue.shutdown()
     }
 
     // MARK: - Private

--- a/Tests/SwiftGRPCTests/ChannelConnectivityTests.swift
+++ b/Tests/SwiftGRPCTests/ChannelConnectivityTests.swift
@@ -49,13 +49,14 @@ extension ChannelConnectivityTests {
   }
 
   func testMultipleConnectivityObserversAreCalled() {
-    let completionHandlerExpectation = expectation(description: "completion handler called")
+    // Linux doesn't yet support `assertForOverFulfill` or `expectedFulfillmentCount`, and since these are
+    // called multiple times, we can't use expectations. https://bugs.swift.org/browse/SR-6249
     var firstObserverCalled = false
     var secondObserverCalled = false
-
     client.channel.addConnectivityObserver { _ in firstObserverCalled = true }
     client.channel.addConnectivityObserver { _ in secondObserverCalled = true }
 
+    let completionHandlerExpectation = expectation(description: "completion handler called")
     _ = try! client.expand(Echo_EchoRequest(text: "foo bar baz foo bar baz")) { _ in
       completionHandlerExpectation.fulfill()
     }


### PR DESCRIPTION
The current Swift implementation of the gRPC channel's connectivity observer spins up a new ConnectivityObserver instance which then starts a new "spin loop" thread and continually runs, observing changes to the underlying gRPC Core channel's connectivity and piping those back through a callback closure. This means that there's a new spin loop spun up for each observer for each channel.

We can avoid having to spin up multiple spin loops for each observer (keeping only 0 or 1 per channel) by allowing a single ConnectivityObserver instance to pipe changes back to multiple callbacks.