### PR TITLE
Add ability to manually shut down channels

### DIFF
--- a/Examples/SimpleXcode/Simple/Document.swift
+++ b/Examples/SimpleXcode/Simple/Document.swift
@@ -144,16 +144,17 @@ class Document: NSDocument {
         if !self.isRunning() {
           break
         }
-        let method = (i < steps) ? "/hello" : "/quit"
-        let call = self.channel.makeCall(method)
-
-        let metadata = try! Metadata([
-          "x": "xylophone",
-          "y": "yu",
-          "z": "zither"
-        ])
 
         do {
+          let method = (i < steps) ? "/hello" : "/quit"
+          let call = try self.channel.makeCall(method)
+
+          let metadata = try Metadata([
+            "x": "xylophone",
+            "y": "yu",
+            "z": "zither"
+          ])
+
           try call.start(.unary,
                          metadata: metadata,
                          message: messageData) { callResult in

--- a/Sources/Examples/Simple/main.swift
+++ b/Sources/Examples/Simple/main.swift
@@ -30,7 +30,7 @@ func client() throws {
 
     let method = (i < steps - 1) ? "/hello" : "/quit"
     print("calling " + method)
-    let call = try! c.makeCall(method)
+    let call = try c.makeCall(method)
 
     let metadata = try Metadata([
       "x": "xylophone",
@@ -38,7 +38,7 @@ func client() throws {
       "z": "zither"
     ])
 
-    try! call.start(.unary, metadata: metadata, message: message) {
+    try call.start(.unary, metadata: metadata, message: message) {
       response in
       print("status:", response.statusCode)
       print("statusMessage:", response.statusMessage!)

--- a/Sources/Examples/Simple/main.swift
+++ b/Sources/Examples/Simple/main.swift
@@ -30,7 +30,7 @@ func client() throws {
 
     let method = (i < steps - 1) ? "/hello" : "/quit"
     print("calling " + method)
-    let call = c.makeCall(method)
+    let call = try! c.makeCall(method)
 
     let metadata = try Metadata([
       "x": "xylophone",

--- a/Sources/SwiftGRPC/Core/Channel.swift
+++ b/Sources/SwiftGRPC/Core/Channel.swift
@@ -18,6 +18,16 @@ import CgRPC
 #endif
 import Foundation
 
+/// Used to hold weak references to objects since `NSHashTable<T>.weakObjects()` isn't available on Linux.
+/// If/when this type becomes available on Linux, this should be replaced.
+private final class WeakReference<T: AnyObject> {
+  private(set) weak var value: T?
+
+  init(value: T) {
+    self.value = value
+  }
+}
+
 /// A gRPC Channel
 public class Channel {
   private let mutex = Mutex()
@@ -184,15 +194,5 @@ public class Channel {
       self.activeCalls = self.activeCalls.filter { $0.value != nil }
     }
     self.scheduleActiveCallCleanUp()
-  }
-}
-
-/// Used to hold weak references to objects since `NSHashTable<T>.weakObjects()` isn't available on Linux.
-/// If/when this type becomes available on Linux, this should be replaced.
-private final class WeakReference<T: AnyObject> {
-  weak var value: T?
-
-  init(value: T) {
-    self.value = value
   }
 }

--- a/Sources/SwiftGRPC/Runtime/ClientCall.swift
+++ b/Sources/SwiftGRPC/Runtime/ClientCall.swift
@@ -13,27 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import Dispatch
-import Foundation
 import SwiftProtobuf
 
 public protocol ClientCall: class {
   static var method: String { get }
-  
+
   /// Cancel the call.
   func cancel()
 }
 
-open class ClientCallBase: ClientCall {
+open class ClientCallBase {
   open class var method: String { fatalError("needs to be overridden") }
 
   public let call: Call
 
   /// Create a call.
-  public init(_ channel: Channel) {
-    call = channel.makeCall(type(of: self).method)
+  public init(_ channel: Channel) throws {
+    self.call = try channel.makeCall(type(of: self).method)
   }
-  
-  public func cancel() { call.cancel() }
+}
+
+extension ClientCallBase: ClientCall {
+  public func cancel() {
+    self.call.cancel()
+  }
 }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -22,6 +22,7 @@ XCTMain([
   testCase(gRPCTests.allTests),
   testCase(ChannelArgumentTests.allTests),
   testCase(ChannelConnectivityTests.allTests),
+  testCase(ChannelShutdownTests.allTests),
   testCase(ClientCancellingTests.allTests),
   testCase(ClientTestExample.allTests),
   testCase(ClientTimeoutTests.allTests),

--- a/Tests/SwiftGRPCTests/ChannelShutdownTests.swift
+++ b/Tests/SwiftGRPCTests/ChannelShutdownTests.swift
@@ -42,9 +42,8 @@ extension ChannelShutdownTests {
     let call = try! self.client.channel.makeCall("foo")
     self.client.channel.shutdown()
 
-    XCTAssertThrowsError(try call.receiveMessage(completion: { _ in })) { error in
+    XCTAssertThrowsError(try call.receiveMessage { _ in }) { error in
       XCTAssertEqual(.completionQueueShutdown, error as? CallError)
-      XCTAssertNotNil(self.client.channel)
     }
   }
 
@@ -54,7 +53,6 @@ extension ChannelShutdownTests {
 
     XCTAssertThrowsError(try call.close()) { error in
       XCTAssertEqual(.completionQueueShutdown, error as? CallError)
-      XCTAssertNotNil(self.client.channel)
     }
   }
 
@@ -62,9 +60,8 @@ extension ChannelShutdownTests {
     let call = try! self.client.channel.makeCall("foo")
     self.client.channel.shutdown()
 
-    XCTAssertThrowsError(try call.closeAndReceiveMessage(completion: { _ in })) { error in
+    XCTAssertThrowsError(try call.closeAndReceiveMessage { _ in }) { error in
       XCTAssertEqual(.completionQueueShutdown, error as? CallError)
-      XCTAssertNotNil(self.client.channel)
     }
   }
 
@@ -74,7 +71,6 @@ extension ChannelShutdownTests {
 
     XCTAssertThrowsError(try call.sendMessage(data: Data())) { error in
       XCTAssertEqual(.completionQueueShutdown, error as? CallError)
-      XCTAssertNotNil(self.client.channel)
     }
   }
 

--- a/Tests/SwiftGRPCTests/ChannelShutdownTests.swift
+++ b/Tests/SwiftGRPCTests/ChannelShutdownTests.swift
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2018, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@testable import SwiftGRPC
+import XCTest
+
+final class ChannelShutdownTests: BasicEchoTestCase {
+  static var allTests: [(String, (ChannelShutdownTests) -> () throws -> Void)] {
+    return [
+      ("testThrowsWhenCreatingCallWithAlreadyShutDownChannel", testThrowsWhenCreatingCallWithAlreadyShutDownChannel),
+      ("testCallReceiveThrowsWhenChannelIsShutDown", testCallReceiveThrowsWhenChannelIsShutDown),
+      ("testCallCloseThrowsWhenChannelIsShutDown", testCallCloseThrowsWhenChannelIsShutDown),
+      ("testCallCloseAndReceiveThrowsWhenChannelIsShutDown", testCallCloseAndReceiveThrowsWhenChannelIsShutDown),
+      ("testCallSendThrowsWhenChannelIsShutDown", testCallSendThrowsWhenChannelIsShutDown),
+      ("testCancelsActiveCallWhenShutdownIsCalled", testCancelsActiveCallWhenShutdownIsCalled),
+    ]
+  }
+}
+
+extension ChannelShutdownTests {
+  func testThrowsWhenCreatingCallWithAlreadyShutDownChannel() {
+    self.client.channel.shutdown()
+
+    XCTAssertThrowsError(try self.client.channel.makeCall("foobar")) { error in
+      XCTAssertEqual(.alreadyShutdown, error as? Channel.Error)
+    }
+  }
+
+  func testCallReceiveThrowsWhenChannelIsShutDown() {
+    let call = try! self.client.channel.makeCall("foo")
+    self.client.channel.shutdown()
+
+    XCTAssertThrowsError(try call.receiveMessage(completion: { _ in })) { error in
+      XCTAssertEqual(.completionQueueShutdown, error as? CallError)
+      XCTAssertNotNil(self.client.channel)
+    }
+  }
+
+  func testCallCloseThrowsWhenChannelIsShutDown() {
+    let call = try! self.client.channel.makeCall("foo")
+    self.client.channel.shutdown()
+
+    XCTAssertThrowsError(try call.close()) { error in
+      XCTAssertEqual(.completionQueueShutdown, error as? CallError)
+      XCTAssertNotNil(self.client.channel)
+    }
+  }
+
+  func testCallCloseAndReceiveThrowsWhenChannelIsShutDown() {
+    let call = try! self.client.channel.makeCall("foo")
+    self.client.channel.shutdown()
+
+    XCTAssertThrowsError(try call.closeAndReceiveMessage(completion: { _ in })) { error in
+      XCTAssertEqual(.completionQueueShutdown, error as? CallError)
+      XCTAssertNotNil(self.client.channel)
+    }
+  }
+
+  func testCallSendThrowsWhenChannelIsShutDown() {
+    let call = try! self.client.channel.makeCall("foo")
+    self.client.channel.shutdown()
+
+    XCTAssertThrowsError(try call.sendMessage(data: Data())) { error in
+      XCTAssertEqual(.completionQueueShutdown, error as? CallError)
+      XCTAssertNotNil(self.client.channel)
+    }
+  }
+
+  func testCancelsActiveCallWhenShutdownIsCalled() {
+    let errorExpectation = self.expectation(description: "error is returned to call when channel is shut down")
+    let call = try! self.client.channel.makeCall("foo")
+
+    try! call.receiveMessage { result in
+      XCTAssertFalse(result.success)
+      errorExpectation.fulfill()
+    }
+
+    self.client.channel.shutdown()
+    self.waitForExpectations(timeout: 0.1)
+
+    XCTAssertThrowsError(try call.close()) { error in
+      XCTAssertEqual(.completionQueueShutdown, error as? CallError)
+    }
+  }
+}

--- a/Tests/SwiftGRPCTests/GRPCTests.swift
+++ b/Tests/SwiftGRPCTests/GRPCTests.swift
@@ -177,7 +177,7 @@ func callUnary(channel: Channel) throws {
 func callUnaryIndividual(channel: Channel, message: Data, shouldSucceed: Bool) throws {
   let sem = DispatchSemaphore(value: 0)
   let method = hello
-  let call = channel.makeCall(method)
+  let call = try channel.makeCall(method)
   let metadata = try Metadata(initialClientMetadata)
   try call.start(.unary, metadata: metadata, message: message) {
     response in
@@ -228,7 +228,7 @@ func callServerStream(channel: Channel) throws {
 
   let sem = DispatchSemaphore(value: 0)
   let method = helloServerStream
-  let call = channel.makeCall(method)
+  let call = try channel.makeCall(method)
   try call.start(.serverStreaming, metadata: metadata, message: message) {
     response in
 
@@ -270,7 +270,7 @@ func callBiDiStream(channel: Channel) throws {
 
   let sem = DispatchSemaphore(value: 0)
   let method = helloBiDiStream
-  let call = channel.makeCall(method)
+  let call = try channel.makeCall(method)
   try call.start(.bidiStreaming, metadata: metadata, message: nil) {
     response in
 


### PR DESCRIPTION
Addresses https://github.com/grpc/grpc-swift/issues/198.

It's currently not possible to manually shut down a gRPC channel, which means that the only way to shut down a channel is to deallocate it. This requirement is a bit fragile for cases where a consumer wants to manually shut down a channel, since it requires confidence that nothing else is holding a strong reference to the channel.

This PR:
- Adds a `shutdown` function to `Channel`, allowing consumers to arbitrarily shut down connections
- Cancels all existing calls that are using the channel upon shutdown
- Validates that existing calls will throw errors when attempting to read/write from a previously shut down channel
- Ensures creating new calls using previously shut down channels will result in the initializer throwing (already handled by code generators)

This change is increasingly relevant because consumers will need to shut down channels and restart them to help mitigate issues when switching between wifi/cellular as mentioned here: https://github.com/grpc/grpc-swift/issues/337.