### PR TITLE
Refactor some properties shared by all server-side call contexts into a common `ServerCallContext` protocol …

### DIFF
--- a/Sources/SwiftGRPCNIO/ServerCallContexts/ServerCallContext.swift
+++ b/Sources/SwiftGRPCNIO/ServerCallContexts/ServerCallContext.swift
@@ -3,11 +3,18 @@ import SwiftProtobuf
 import NIO
 import NIOHTTP1
 
-/// Base class providing data provided to the framework user for all server calls.
-open class ServerCallContext {
+/// Protocol declaring a minimum set of properties exposed by *all* types of call contexts.
+public protocol ServerCallContext: class {
   /// The event loop this call is served on.
-  public let eventLoop: EventLoop
+  var eventLoop: EventLoop { get }
+  
   /// Generic metadata provided with this request.
+  var request: HTTPRequestHead { get }
+}
+
+/// Base class providing data provided to the framework user for all server calls.
+open class ServerCallContextBase: ServerCallContext {
+  public let eventLoop: EventLoop
   public let request: HTTPRequestHead
   
   public init(eventLoop: EventLoop, request: HTTPRequestHead) {

--- a/Sources/SwiftGRPCNIO/ServerCallContexts/StreamingResponseCallContext.swift
+++ b/Sources/SwiftGRPCNIO/ServerCallContexts/StreamingResponseCallContext.swift
@@ -8,7 +8,7 @@ import NIOHTTP1
 /// - When `statusPromise` is fulfilled, the call is closed and the provided status transmitted.
 /// - If `statusPromise` is failed and the error is of type `GRPCStatus`, that error will be returned to the client.
 /// - For other errors, `GRPCStatus.processingError` is returned to the client.
-open class StreamingResponseCallContext<ResponseMessage: Message>: ServerCallContext {
+open class StreamingResponseCallContext<ResponseMessage: Message>: ServerCallContextBase {
   public typealias WrappedResponse = GRPCServerResponsePart<ResponseMessage>
   
   public let statusPromise: EventLoopPromise<GRPCStatus>

--- a/Sources/SwiftGRPCNIO/ServerCallContexts/UnaryResponseCallContext.swift
+++ b/Sources/SwiftGRPCNIO/ServerCallContexts/UnaryResponseCallContext.swift
@@ -31,7 +31,7 @@ open class UnaryResponseCallContext<ResponseMessage: Message>: ServerCallContext
 /// be fulfilled by the user.
 ///
 /// We can use a protocol (instead of an abstract base class) here because removing the generic `responsePromise` field
-/// lets us avoid associated-type requirements on the protol.
+/// lets us avoid associated-type requirements on the protocol.
 public protocol StatusOnlyCallContext: ServerCallContext {
   var responseStatus: GRPCStatus { get set }
 }

--- a/Sources/SwiftGRPCNIO/ServerCallContexts/UnaryResponseCallContext.swift
+++ b/Sources/SwiftGRPCNIO/ServerCallContexts/UnaryResponseCallContext.swift
@@ -11,7 +11,7 @@ import NIOHTTP1
 ///
 /// For unary calls, the response is not actually provided by fulfilling `responsePromise`, but instead by completing
 /// the future returned by `UnaryCallHandler.EventObserver`.
-open class UnaryResponseCallContext<ResponseMessage: Message>: ServerCallContext, StatusOnlyCallContext {
+open class UnaryResponseCallContext<ResponseMessage: Message>: ServerCallContextBase, StatusOnlyCallContext {
   public typealias WrappedResponse = GRPCServerResponsePart<ResponseMessage>
   
   public let responsePromise: EventLoopPromise<ResponseMessage>
@@ -32,10 +32,7 @@ open class UnaryResponseCallContext<ResponseMessage: Message>: ServerCallContext
 ///
 /// We can use a protocol (instead of an abstract base class) here because removing the generic `responsePromise` field
 /// lets us avoid associated-type requirements on the protol.
-public protocol StatusOnlyCallContext {
-  var eventLoop: EventLoop { get }
-  var request: HTTPRequestHead { get }
-  
+public protocol StatusOnlyCallContext: ServerCallContext {
   var responseStatus: GRPCStatus { get set }
 }
 


### PR DESCRIPTION
… , while renaming the existing `ServerCallContext` class to `ServerCallContextBase`.

Motivation: As opposed to all three other call types, unary calls are not passed an instance of the previous `ServerCallContext` class, but rather of the `StatusOnlyCallContext` protocol. If one wanted to create a method that uses only a call's event loop and request headers but wants to process all *four* types of calls, that was not possible before. With this change, such a method could simply accept an instance of `ServerCallContext`, which the call arguments provided to all four methods now conform to.