### PR TITLE
Call `.writeAndFlush` in two more places

### DIFF
--- a/Sources/SwiftGRPCNIO/GRPCChannelHandler.swift
+++ b/Sources/SwiftGRPCNIO/GRPCChannelHandler.swift
@@ -53,8 +53,8 @@ extension GRPCChannelHandler: ChannelInboundHandler {
     switch requestPart {
     case .head(let requestHead):
       guard let callHandler = getCallHandler(channel: ctx.channel, requestHead: requestHead) else {
-          errorCaught(ctx: ctx, error: GRPCError.server(.unimplementedMethod(requestHead.uri)))
-          return
+        errorCaught(ctx: ctx, error: GRPCError.server(.unimplementedMethod(requestHead.uri)))
+        return
       }
 
       let codec = callHandler.makeGRPCServerCodec()
@@ -69,7 +69,7 @@ extension GRPCChannelHandler: ChannelInboundHandler {
           // handler doesn't have the data to determine whether headers should be returned, as it is
           // this handler that checks whether the stub for the requested Service/Method is implemented.
           // This likely signals that the architecture for these handlers could be improved.
-          ctx.write(self.wrapOutboundOut(.headers(HTTPHeaders())), promise: nil)
+          ctx.writeAndFlush(self.wrapOutboundOut(.headers(HTTPHeaders())), promise: nil)
         }
       }
 

--- a/Sources/SwiftGRPCNIO/ServerCallContexts/UnaryResponseCallContext.swift
+++ b/Sources/SwiftGRPCNIO/ServerCallContexts/UnaryResponseCallContext.swift
@@ -50,7 +50,7 @@ open class UnaryResponseCallContextImpl<ResponseMessage: Message>: UnaryResponse
         // Send the response provided to the promise.
         //! FIXME: It would be nicer to chain sending the status onto a successful write, but for some reason the
         //  "write message" future doesn't seem to get fulfilled?
-        self.channel.write(NIOAny(WrappedResponse.message(responseMessage)), promise: nil)
+        self.channel.writeAndFlush(NIOAny(WrappedResponse.message(responseMessage)), promise: nil)
         
         return self.responseStatus
       }


### PR DESCRIPTION
@glbrntt 

This is the highest level where we can flush, and I think sending the initial status and the single response for unary calls is a point where we should definitely flush. (We also flush after each message for server-streaming calls.)