### PR TITLE
Enforce request cardinality for unary-request calls also for the case of zero request messages being sent.

### DIFF
--- a/Sources/SwiftGRPCNIO/CallHandlers/BaseCallHandler.swift
+++ b/Sources/SwiftGRPCNIO/CallHandlers/BaseCallHandler.swift
@@ -19,7 +19,7 @@ public class BaseCallHandler<RequestMessage: Message, ResponseMessage: Message>:
   /// Called when the client has half-closed the stream, indicating that they won't send any further data.
   ///
   /// Overridden by subclasses if the "end-of-stream" event is relevant.
-  public func endOfStreamReceived() { }
+  public func endOfStreamReceived() throws { }
 
   /// Whether this handler can still write messages to the client.
   private var serverCanWrite = true
@@ -60,7 +60,11 @@ extension BaseCallHandler: ChannelInboundHandler {
       }
 
     case .end:
-      endOfStreamReceived()
+      do {
+        try endOfStreamReceived()
+      } catch {
+        self.errorCaught(ctx: ctx, error: error)
+      }
     }
   }
 }

--- a/Sources/SwiftGRPCNIO/CallHandlers/BaseCallHandler.swift
+++ b/Sources/SwiftGRPCNIO/CallHandlers/BaseCallHandler.swift
@@ -46,7 +46,7 @@ extension BaseCallHandler: ChannelInboundHandler {
   /// return a status with code `.internalError`.
   public func errorCaught(ctx: ChannelHandlerContext, error: Error) {
     errorDelegate?.observe(error)
-    
+
     let transformed = errorDelegate?.transform(error) ?? error
     let status = (transformed as? GRPCStatusTransformable)?.asGRPCStatus() ?? GRPCStatus.processingError
     sendErrorStatus(status)

--- a/Sources/SwiftGRPCNIO/CallHandlers/BidirectionalStreamingCallHandler.swift
+++ b/Sources/SwiftGRPCNIO/CallHandlers/BidirectionalStreamingCallHandler.swift
@@ -36,7 +36,7 @@ public class BidirectionalStreamingCallHandler<RequestMessage: Message, Response
     }
   }
 
-  public override func endOfStreamReceived() {
+  public override func endOfStreamReceived() throws {
     eventObserver?.whenSuccess { observer in
       observer(.end)
     }

--- a/Sources/SwiftGRPCNIO/CallHandlers/BidirectionalStreamingCallHandler.swift
+++ b/Sources/SwiftGRPCNIO/CallHandlers/BidirectionalStreamingCallHandler.swift
@@ -41,4 +41,8 @@ public class BidirectionalStreamingCallHandler<RequestMessage: Message, Response
       observer(.end)
     }
   }
+  
+  override func sendErrorStatus(_ status: GRPCStatus) {
+    context?.statusPromise.fail(error: status)
+  }
 }

--- a/Sources/SwiftGRPCNIO/CallHandlers/ClientStreamingCallHandler.swift
+++ b/Sources/SwiftGRPCNIO/CallHandlers/ClientStreamingCallHandler.swift
@@ -35,7 +35,7 @@ public class ClientStreamingCallHandler<RequestMessage: Message, ResponseMessage
     }
   }
   
-  public override func endOfStreamReceived() {
+  public override func endOfStreamReceived() throws {
     eventObserver?.whenSuccess { observer in
       observer(.end)
     }

--- a/Sources/SwiftGRPCNIO/CallHandlers/ClientStreamingCallHandler.swift
+++ b/Sources/SwiftGRPCNIO/CallHandlers/ClientStreamingCallHandler.swift
@@ -40,4 +40,8 @@ public class ClientStreamingCallHandler<RequestMessage: Message, ResponseMessage
       observer(.end)
     }
   }
+  
+  override func sendErrorStatus(_ status: GRPCStatus) {
+    context?.responsePromise.fail(error: status)
+  }
 }

--- a/Sources/SwiftGRPCNIO/CallHandlers/ServerStreamingCallHandler.swift
+++ b/Sources/SwiftGRPCNIO/CallHandlers/ServerStreamingCallHandler.swift
@@ -28,7 +28,7 @@ public class ServerStreamingCallHandler<RequestMessage: Message, ResponseMessage
   public override func processMessage(_ message: RequestMessage) throws {
     guard let eventObserver = self.eventObserver,
       let context = self.context else {
-        throw GRPCError.server(.requestCardinalityViolation)
+        throw GRPCError.server(.requestCardinalityViolationTooMany)
     }
 
     let resultFuture = eventObserver(message)
@@ -36,5 +36,11 @@ public class ServerStreamingCallHandler<RequestMessage: Message, ResponseMessage
       // Fulfill the status promise with whatever status the framework user has provided.
       .cascade(promise: context.statusPromise)
     self.eventObserver = nil
+  }
+  
+  public override func endOfStreamReceived() throws {
+    if self.eventObserver != nil {
+      throw GRPCError.server(.requestCardinalityViolationTooFew)
+    }
   }
 }

--- a/Sources/SwiftGRPCNIO/CallHandlers/ServerStreamingCallHandler.swift
+++ b/Sources/SwiftGRPCNIO/CallHandlers/ServerStreamingCallHandler.swift
@@ -43,4 +43,8 @@ public class ServerStreamingCallHandler<RequestMessage: Message, ResponseMessage
       throw GRPCError.server(.requestCardinalityViolationTooFewRequests)
     }
   }
+  
+  override func sendErrorStatus(_ status: GRPCStatus) {
+    context?.statusPromise.fail(error: status)
+  }
 }

--- a/Sources/SwiftGRPCNIO/CallHandlers/ServerStreamingCallHandler.swift
+++ b/Sources/SwiftGRPCNIO/CallHandlers/ServerStreamingCallHandler.swift
@@ -40,7 +40,7 @@ public class ServerStreamingCallHandler<RequestMessage: Message, ResponseMessage
   
   public override func endOfStreamReceived() throws {
     if self.eventObserver != nil {
-      throw GRPCError.server(.tooFewRequests)
+      throw GRPCError.server(.noRequestsButOneExpected)
     }
   }
   

--- a/Sources/SwiftGRPCNIO/CallHandlers/ServerStreamingCallHandler.swift
+++ b/Sources/SwiftGRPCNIO/CallHandlers/ServerStreamingCallHandler.swift
@@ -28,7 +28,7 @@ public class ServerStreamingCallHandler<RequestMessage: Message, ResponseMessage
   public override func processMessage(_ message: RequestMessage) throws {
     guard let eventObserver = self.eventObserver,
       let context = self.context else {
-        throw GRPCError.server(.requestCardinalityViolationTooMany)
+        throw GRPCError.server(.requestCardinalityViolationTooManyRequests)
     }
 
     let resultFuture = eventObserver(message)
@@ -40,7 +40,7 @@ public class ServerStreamingCallHandler<RequestMessage: Message, ResponseMessage
   
   public override func endOfStreamReceived() throws {
     if self.eventObserver != nil {
-      throw GRPCError.server(.requestCardinalityViolationTooFew)
+      throw GRPCError.server(.requestCardinalityViolationTooFewRequests)
     }
   }
 }

--- a/Sources/SwiftGRPCNIO/CallHandlers/ServerStreamingCallHandler.swift
+++ b/Sources/SwiftGRPCNIO/CallHandlers/ServerStreamingCallHandler.swift
@@ -28,7 +28,7 @@ public class ServerStreamingCallHandler<RequestMessage: Message, ResponseMessage
   public override func processMessage(_ message: RequestMessage) throws {
     guard let eventObserver = self.eventObserver,
       let context = self.context else {
-        throw GRPCError.server(.requestCardinalityViolationTooManyRequests)
+        throw GRPCError.server(.tooManyRequests)
     }
 
     let resultFuture = eventObserver(message)
@@ -40,7 +40,7 @@ public class ServerStreamingCallHandler<RequestMessage: Message, ResponseMessage
   
   public override func endOfStreamReceived() throws {
     if self.eventObserver != nil {
-      throw GRPCError.server(.requestCardinalityViolationTooFewRequests)
+      throw GRPCError.server(.tooFewRequests)
     }
   }
   

--- a/Sources/SwiftGRPCNIO/CallHandlers/UnaryCallHandler.swift
+++ b/Sources/SwiftGRPCNIO/CallHandlers/UnaryCallHandler.swift
@@ -29,7 +29,7 @@ public class UnaryCallHandler<RequestMessage: Message, ResponseMessage: Message>
   public override func processMessage(_ message: RequestMessage) throws {
     guard let eventObserver = self.eventObserver,
       let context = self.context else {
-      throw GRPCError.server(.requestCardinalityViolationTooManyRequests)
+      throw GRPCError.server(.tooManyRequests)
     }
     
     let resultFuture = eventObserver(message)
@@ -41,7 +41,7 @@ public class UnaryCallHandler<RequestMessage: Message, ResponseMessage: Message>
   
   public override func endOfStreamReceived() throws {
     if self.eventObserver != nil {
-      throw GRPCError.server(.requestCardinalityViolationTooFewRequests)
+      throw GRPCError.server(.tooFewRequests)
     }
   }
   

--- a/Sources/SwiftGRPCNIO/CallHandlers/UnaryCallHandler.swift
+++ b/Sources/SwiftGRPCNIO/CallHandlers/UnaryCallHandler.swift
@@ -41,7 +41,7 @@ public class UnaryCallHandler<RequestMessage: Message, ResponseMessage: Message>
   
   public override func endOfStreamReceived() throws {
     if self.eventObserver != nil {
-      throw GRPCError.server(.tooFewRequests)
+      throw GRPCError.server(.noRequestsButOneExpected)
     }
   }
   

--- a/Sources/SwiftGRPCNIO/CallHandlers/UnaryCallHandler.swift
+++ b/Sources/SwiftGRPCNIO/CallHandlers/UnaryCallHandler.swift
@@ -29,7 +29,7 @@ public class UnaryCallHandler<RequestMessage: Message, ResponseMessage: Message>
   public override func processMessage(_ message: RequestMessage) throws {
     guard let eventObserver = self.eventObserver,
       let context = self.context else {
-      throw GRPCError.server(.requestCardinalityViolationTooMany)
+      throw GRPCError.server(.requestCardinalityViolationTooManyRequests)
     }
     
     let resultFuture = eventObserver(message)
@@ -41,7 +41,7 @@ public class UnaryCallHandler<RequestMessage: Message, ResponseMessage: Message>
   
   public override func endOfStreamReceived() throws {
     if self.eventObserver != nil {
-      throw GRPCError.server(.requestCardinalityViolationTooFew)
+      throw GRPCError.server(.requestCardinalityViolationTooFewRequests)
     }
   }
 }

--- a/Sources/SwiftGRPCNIO/CallHandlers/UnaryCallHandler.swift
+++ b/Sources/SwiftGRPCNIO/CallHandlers/UnaryCallHandler.swift
@@ -44,4 +44,8 @@ public class UnaryCallHandler<RequestMessage: Message, ResponseMessage: Message>
       throw GRPCError.server(.requestCardinalityViolationTooFewRequests)
     }
   }
+  
+  override func sendErrorStatus(_ status: GRPCStatus) {
+    context?.responsePromise.fail(error: status)
+  }
 }

--- a/Sources/SwiftGRPCNIO/CallHandlers/UnaryCallHandler.swift
+++ b/Sources/SwiftGRPCNIO/CallHandlers/UnaryCallHandler.swift
@@ -29,7 +29,7 @@ public class UnaryCallHandler<RequestMessage: Message, ResponseMessage: Message>
   public override func processMessage(_ message: RequestMessage) throws {
     guard let eventObserver = self.eventObserver,
       let context = self.context else {
-      throw GRPCError.server(.requestCardinalityViolation)
+      throw GRPCError.server(.requestCardinalityViolationTooMany)
     }
     
     let resultFuture = eventObserver(message)
@@ -37,5 +37,11 @@ public class UnaryCallHandler<RequestMessage: Message, ResponseMessage: Message>
       // Fulfill the response promise with whatever response (or error) the framework user has provided.
       .cascade(promise: context.responsePromise)
     self.eventObserver = nil
+  }
+  
+  public override func endOfStreamReceived() throws {
+    if self.eventObserver != nil {
+      throw GRPCError.server(.requestCardinalityViolationTooFew)
+    }
   }
 }

--- a/Sources/SwiftGRPCNIO/GRPCError.swift
+++ b/Sources/SwiftGRPCNIO/GRPCError.swift
@@ -88,10 +88,10 @@ public enum GRPCServerError: Error, Equatable {
   case responseProtoSerializationFailure
 
   /// Zero requests were sent for a unary-request call.
-  case requestCardinalityViolationTooFew
+  case requestCardinalityViolationTooFewRequests
   
   /// More than one request was sent for a unary-request call.
-  case requestCardinalityViolationTooMany
+  case requestCardinalityViolationTooManyRequests
 
   /// The server received a message when it was not in a writable state.
   case serverNotWritable
@@ -146,10 +146,10 @@ extension GRPCServerError: GRPCStatusTransformable {
     case .responseProtoSerializationFailure:
       return GRPCStatus(code: .internalError, message: "could not serialize response proto")
 
-    case .requestCardinalityViolationTooFew:
+    case .requestCardinalityViolationTooFewRequests:
       return GRPCStatus(code: .unimplemented, message: "request cardinality violation; method requires exactly one request but client sent none")
       
-    case .requestCardinalityViolationTooMany:
+    case .requestCardinalityViolationTooManyRequests:
       return GRPCStatus(code: .unimplemented, message: "request cardinality violation; method requires exactly one request but client sent more")
 
     case .serverNotWritable:

--- a/Sources/SwiftGRPCNIO/GRPCError.swift
+++ b/Sources/SwiftGRPCNIO/GRPCError.swift
@@ -87,8 +87,11 @@ public enum GRPCServerError: Error, Equatable {
   /// It was not possible to serialize the response protobuf.
   case responseProtoSerializationFailure
 
+  /// Zero requests were sent for a unary-request call.
+  case requestCardinalityViolationTooFew
+  
   /// More than one request was sent for a unary-request call.
-  case requestCardinalityViolation
+  case requestCardinalityViolationTooMany
 
   /// The server received a message when it was not in a writable state.
   case serverNotWritable
@@ -143,7 +146,10 @@ extension GRPCServerError: GRPCStatusTransformable {
     case .responseProtoSerializationFailure:
       return GRPCStatus(code: .internalError, message: "could not serialize response proto")
 
-    case .requestCardinalityViolation:
+    case .requestCardinalityViolationTooFew:
+      return GRPCStatus(code: .unimplemented, message: "request cardinality violation; method requires exactly one request but client sent none")
+      
+    case .requestCardinalityViolationTooMany:
       return GRPCStatus(code: .unimplemented, message: "request cardinality violation; method requires exactly one request but client sent more")
 
     case .serverNotWritable:

--- a/Sources/SwiftGRPCNIO/GRPCError.swift
+++ b/Sources/SwiftGRPCNIO/GRPCError.swift
@@ -88,10 +88,10 @@ public enum GRPCServerError: Error, Equatable {
   case responseProtoSerializationFailure
 
   /// Zero requests were sent for a unary-request call.
-  case requestCardinalityViolationTooFewRequests
+  case tooFewRequests
   
   /// More than one request was sent for a unary-request call.
-  case requestCardinalityViolationTooManyRequests
+  case tooManyRequests
 
   /// The server received a message when it was not in a writable state.
   case serverNotWritable
@@ -146,10 +146,10 @@ extension GRPCServerError: GRPCStatusTransformable {
     case .responseProtoSerializationFailure:
       return GRPCStatus(code: .internalError, message: "could not serialize response proto")
 
-    case .requestCardinalityViolationTooFewRequests:
+    case .tooFewRequests:
       return GRPCStatus(code: .unimplemented, message: "request cardinality violation; method requires exactly one request but client sent none")
       
-    case .requestCardinalityViolationTooManyRequests:
+    case .tooManyRequests:
       return GRPCStatus(code: .unimplemented, message: "request cardinality violation; method requires exactly one request but client sent more")
 
     case .serverNotWritable:

--- a/Sources/SwiftGRPCNIO/GRPCError.swift
+++ b/Sources/SwiftGRPCNIO/GRPCError.swift
@@ -88,7 +88,7 @@ public enum GRPCServerError: Error, Equatable {
   case responseProtoSerializationFailure
 
   /// Zero requests were sent for a unary-request call.
-  case tooFewRequests
+  case noRequestsButOneExpected
   
   /// More than one request was sent for a unary-request call.
   case tooManyRequests
@@ -146,7 +146,7 @@ extension GRPCServerError: GRPCStatusTransformable {
     case .responseProtoSerializationFailure:
       return GRPCStatus(code: .internalError, message: "could not serialize response proto")
 
-    case .tooFewRequests:
+    case .noRequestsButOneExpected:
       return GRPCStatus(code: .unimplemented, message: "request cardinality violation; method requires exactly one request but client sent none")
       
     case .tooManyRequests:


### PR DESCRIPTION
Otherwise, the server will never respond to a call that gets closed without the client sending a response.

In addition, we introduce a method `sendErrorStatus` (happy to discuss naming) on `BaseCallHandler` that sends an error status to the client while ensuring that all call context promises are fulfilled. This method is required (and needs to be overridden) because only the concrete call subclass knows which promises need to be fulfilled.