### PR TITLE
Generate ClientCallUnary test stubs.

### DIFF
--- a/Sources/Examples/Echo/Generated/echo.grpc.swift
+++ b/Sources/Examples/Echo/Generated/echo.grpc.swift
@@ -31,6 +31,10 @@ fileprivate final class Echo_EchoGetCallBase: ClientCallUnaryBase<Echo_EchoReque
   override class var method: String { return "/echo.Echo/Get" }
 }
 
+class Echo_EchoGetCallTestStub: ClientCallUnaryTestStub<Echo_EchoRequest, Echo_EchoResponse>, Echo_EchoGetCall {
+  override class var method: String { return "/echo.Echo/Get" }
+}
+
 internal protocol Echo_EchoExpandCall: ClientCallServerStreaming {
   /// Do not call this directly, call `receive()` in the protocol extension below instead.
   func _receive(timeout: DispatchTime) throws -> Echo_EchoResponse?

--- a/Sources/Examples/Echo/Generated/echo.grpc.swift
+++ b/Sources/Examples/Echo/Generated/echo.grpc.swift
@@ -31,7 +31,7 @@ fileprivate final class Echo_EchoGetCallBase: ClientCallUnaryBase<Echo_EchoReque
   override class var method: String { return "/echo.Echo/Get" }
 }
 
-class Echo_EchoGetCallTestStub: ClientCallUnaryTestStub<Echo_EchoRequest, Echo_EchoResponse>, Echo_EchoGetCall {
+class Echo_EchoGetCallTestStub: ClientCallUnaryTestStub, Echo_EchoGetCall {
   override class var method: String { return "/echo.Echo/Get" }
 }
 

--- a/Sources/SwiftGRPC/Runtime/ClientCallUnary.swift
+++ b/Sources/SwiftGRPC/Runtime/ClientCallUnary.swift
@@ -58,7 +58,7 @@ open class ClientCallUnaryBase<InputType: Message, OutputType: Message>: ClientC
 }
 
 /// Simple fake implementation of `ClientCallUnary`.
-open class ClientCallUnaryTestStub<InputType: Message, OutputType: Message>: ClientCallUnary {
+open class ClientCallUnaryTestStub: ClientCallUnary {
   open class var method: String { fatalError("needs to be overridden") }
 
   open func cancel() {}

--- a/Sources/SwiftGRPC/Runtime/ClientCallUnary.swift
+++ b/Sources/SwiftGRPC/Runtime/ClientCallUnary.swift
@@ -56,3 +56,10 @@ open class ClientCallUnaryBase<InputType: Message, OutputType: Message>: ClientC
     return self
   }
 }
+
+/// Simple fake implementation of `ClientCallUnary`.
+open class ClientCallUnaryTestStub<InputType: Message, OutputType: Message>: ClientCallUnary {
+  open class var method: String { fatalError("needs to be overridden") }
+
+  open func cancel() {}
+}

--- a/Sources/protoc-gen-swiftgrpc/Generator-Client.swift
+++ b/Sources/protoc-gen-swiftgrpc/Generator-Client.swift
@@ -68,7 +68,7 @@ extension Generator {
     println("}")
     if options.generateTestStubs {
       println()
-      println("class \(callName)TestStub: ClientCallUnaryTestStub<\(methodInputName), \(methodOutputName)>, \(callName) {")
+      println("class \(callName)TestStub: ClientCallUnaryTestStub, \(callName) {")
       indent()
       println("override class var method: String { return \(methodPath) }")
       outdent()

--- a/Sources/protoc-gen-swiftgrpc/Generator-Client.swift
+++ b/Sources/protoc-gen-swiftgrpc/Generator-Client.swift
@@ -66,6 +66,14 @@ extension Generator {
     println("override class var method: String { return \(methodPath) }")
     outdent()
     println("}")
+    if options.generateTestStubs {
+      println()
+      println("class \(callName)TestStub: ClientCallUnaryTestStub<\(methodInputName), \(methodOutputName)>, \(callName) {")
+      indent()
+      println("override class var method: String { return \(methodPath) }")
+      outdent()
+      println("}")
+    }
     println()
   }
 


### PR DESCRIPTION
This simplifies testing for async calls, e.g. a failing request could
be simulated with something like:
```
  override func get(_ request: Echo_EchoRequest, metadata customMetadata: Metadata, completion: @escaping (Echo_EchoResponse?, CallResult) -> Void) throws -> Echo_EchoGetCall {
    completion(nil, .error(statusCode: .notFound))
    return Echo_EchoGetCallTestStub()
  }
```