### PR TITLE
Mark unary async calls as @discardableResult.

### DIFF
--- a/Sources/Examples/Echo/Generated/echo.grpc.swift
+++ b/Sources/Examples/Echo/Generated/echo.grpc.swift
@@ -119,6 +119,7 @@ internal protocol Echo_EchoService: ServiceClient {
   /// Synchronous. Unary.
   func get(_ request: Echo_EchoRequest, metadata customMetadata: Metadata) throws -> Echo_EchoResponse
   /// Asynchronous. Unary.
+  @discardableResult
   func get(_ request: Echo_EchoRequest, metadata customMetadata: Metadata, completion: @escaping (Echo_EchoResponse?, CallResult) -> Void) throws -> Echo_EchoGetCall
 
   /// Asynchronous. Server-streaming.
@@ -144,6 +145,7 @@ internal extension Echo_EchoService {
     return try self.get(request, metadata: self.metadata)
   }
   /// Asynchronous. Unary.
+  @discardableResult
   func get(_ request: Echo_EchoRequest, completion: @escaping (Echo_EchoResponse?, CallResult) -> Void) throws -> Echo_EchoGetCall {
     return try self.get(request, metadata: self.metadata, completion: completion)
   }
@@ -172,6 +174,7 @@ internal final class Echo_EchoServiceClient: ServiceClientBase, Echo_EchoService
       .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
+  @discardableResult
   internal func get(_ request: Echo_EchoRequest, metadata customMetadata: Metadata, completion: @escaping (Echo_EchoResponse?, CallResult) -> Void) throws -> Echo_EchoGetCall {
     return try Echo_EchoGetCallBase(channel)
       .start(request: request, metadata: customMetadata, completion: completion)
@@ -211,6 +214,7 @@ class Echo_EchoServiceTestStub: ServiceClientTestStubBase, Echo_EchoService {
     defer { getResponses.removeFirst() }
     return getResponses.first!
   }
+  @discardableResult
   func get(_ request: Echo_EchoRequest, metadata customMetadata: Metadata, completion: @escaping (Echo_EchoResponse?, CallResult) -> Void) throws -> Echo_EchoGetCall {
     fatalError("not implemented")
   }

--- a/Sources/protoc-gen-swiftgrpc/Generator-Client.swift
+++ b/Sources/protoc-gen-swiftgrpc/Generator-Client.swift
@@ -175,6 +175,7 @@ extension Generator {
         }
         if asynchronousCode {
           println("/// Asynchronous. Unary.")
+	  println("@discardableResult")
           println("func \(methodFunctionName)(_ request: \(methodInputName), metadata customMetadata: Metadata, completion: @escaping (\(methodOutputName)?, CallResult) -> Void) throws -> \(callName)")
         }
       case .serverStreaming:
@@ -217,6 +218,7 @@ extension Generator {
         }
         if asynchronousCode {
           println("/// Asynchronous. Unary.")
+	  println("@discardableResult")
           println("func \(methodFunctionName)(_ request: \(methodInputName), completion: @escaping (\(methodOutputName)?, CallResult) -> Void) throws -> \(callName) {")
           indent()
           println("return try self.\(methodFunctionName)(request, metadata: self.metadata, completion: completion)")
@@ -272,6 +274,7 @@ extension Generator {
         }
         if asynchronousCode {
           println("/// Asynchronous. Unary.")
+	  println("@discardableResult")
           println("\(access) func \(methodFunctionName)(_ request: \(methodInputName), metadata customMetadata: Metadata, completion: @escaping (\(methodOutputName)?, CallResult) -> Void) throws -> \(callName) {")
           indent()
           println("return try \(callName)Base(channel)")
@@ -340,6 +343,7 @@ extension Generator {
         println("return \(methodFunctionName)Responses.first!")
         outdent()
         println("}")
+	println("@discardableResult")
         println("func \(methodFunctionName)(_ request: \(methodInputName), metadata customMetadata: Metadata, completion: @escaping (\(methodOutputName)?, CallResult) -> Void) throws -> \(callName) {")
         indent()
         println("fatalError(\"not implemented\")")

--- a/Sources/protoc-gen-swiftgrpc/Generator-Client.swift
+++ b/Sources/protoc-gen-swiftgrpc/Generator-Client.swift
@@ -175,7 +175,7 @@ extension Generator {
         }
         if asynchronousCode {
           println("/// Asynchronous. Unary.")
-	  println("@discardableResult")
+          println("@discardableResult")
           println("func \(methodFunctionName)(_ request: \(methodInputName), metadata customMetadata: Metadata, completion: @escaping (\(methodOutputName)?, CallResult) -> Void) throws -> \(callName)")
         }
       case .serverStreaming:
@@ -218,7 +218,7 @@ extension Generator {
         }
         if asynchronousCode {
           println("/// Asynchronous. Unary.")
-	  println("@discardableResult")
+          println("@discardableResult")
           println("func \(methodFunctionName)(_ request: \(methodInputName), completion: @escaping (\(methodOutputName)?, CallResult) -> Void) throws -> \(callName) {")
           indent()
           println("return try self.\(methodFunctionName)(request, metadata: self.metadata, completion: completion)")
@@ -274,7 +274,7 @@ extension Generator {
         }
         if asynchronousCode {
           println("/// Asynchronous. Unary.")
-	  println("@discardableResult")
+          println("@discardableResult")
           println("\(access) func \(methodFunctionName)(_ request: \(methodInputName), metadata customMetadata: Metadata, completion: @escaping (\(methodOutputName)?, CallResult) -> Void) throws -> \(callName) {")
           indent()
           println("return try \(callName)Base(channel)")
@@ -343,7 +343,7 @@ extension Generator {
         println("return \(methodFunctionName)Responses.first!")
         outdent()
         println("}")
-	println("@discardableResult")
+        println("@discardableResult")
         println("func \(methodFunctionName)(_ request: \(methodInputName), metadata customMetadata: Metadata, completion: @escaping (\(methodOutputName)?, CallResult) -> Void) throws -> \(callName) {")
         indent()
         println("fatalError(\"not implemented\")")


### PR DESCRIPTION
The result is only necessary if you need cancellation.