### PR TITLE
Add public init to client call unary stubs.

### DIFF
--- a/Sources/SwiftGRPC/Runtime/ClientCallUnary.swift
+++ b/Sources/SwiftGRPC/Runtime/ClientCallUnary.swift
@@ -61,5 +61,7 @@ open class ClientCallUnaryBase<InputType: Message, OutputType: Message>: ClientC
 open class ClientCallUnaryTestStub: ClientCallUnary {
   open class var method: String { fatalError("needs to be overridden") }
 
+  public init() {}
+
   open func cancel() {}
 }


### PR DESCRIPTION
Currently initializing test stubs from a different module fails.