### PR TITLE
Update CI for Swift 5

### DIFF
--- a/.travis-install.sh
+++ b/.travis-install.sh
@@ -18,10 +18,10 @@
 #
 # Install dependencies that aren't available as Ubuntu packages (or already present on macOS).
 #
-# Everything goes into $HOME/local. 
+# Everything goes into $HOME/local.
 #
-# Scripts should add 
-# - $HOME/local/bin to PATH 
+# Scripts should add
+# - $HOME/local/bin to PATH
 # - $HOME/local/lib to LD_LIBRARY_PATH
 #
 
@@ -32,9 +32,9 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
   PROTOC_URL=https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-osx-x86_64.zip
 else
   # Install swift
-  SWIFT_URL=https://swift.org/builds/swift-4.1.1-release/ubuntu1404/swift-4.1.1-RELEASE/swift-4.1.1-RELEASE-ubuntu14.04.tar.gz
+  SWIFT_URL=https://swift.org/builds/swift-5.0-branch/ubuntu1404/swift-5.0-DEVELOPMENT-SNAPSHOT-2019-03-10-a/swift-5.0-DEVELOPMENT-SNAPSHOT-2019-03-10-a-ubuntu14.04.tar.gz
   echo $SWIFT_URL
-  curl -fSsL $SWIFT_URL -o swift.tar.gz 
+  curl -fSsL $SWIFT_URL -o swift.tar.gz
   tar -xzf swift.tar.gz --strip-components=2 --directory=local
 
   PROTOC_URL=https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ cache:
 # Use Ubuntu 14.04
 dist: trusty
 
-osx_image: xcode9.3
+osx_image: xcode10.2
 
 sudo: false
 
@@ -37,14 +37,14 @@ addons:
     sources:
       - sourceline: 'ppa:ondrej/apache2'  # for libnghttp2-dev
     packages:
-      - clang-3.8 
-      - lldb-3.8 
-      - libicu-dev 
-      - libtool 
-      - libcurl4-openssl-dev 
-      - libbsd-dev 
-      - build-essential 
-      - libssl-dev 
+      - clang-3.8
+      - lldb-3.8
+      - libicu-dev
+      - libtool
+      - libcurl4-openssl-dev
+      - libbsd-dev
+      - build-essential
+      - libssl-dev
       - uuid-dev
       - curl
       - unzip


### PR DESCRIPTION
- Update macOS image to xcode10.2 (this is Beta 2: https://blog.travis-ci.com/2019-02-12-xcode-10-2-beta-2-is-now-available)
- Update Swift snapshot for Linux to 5.0 development (2019-03-10)