### PR TITLE
Remove unnecessary "#if swift" code paths

### DIFF
--- a/Sources/SwiftGRPCNIO/CompressionMechanism.swift
+++ b/Sources/SwiftGRPCNIO/CompressionMechanism.swift
@@ -20,7 +20,7 @@ public enum CompressionError: Error {
 }
 
 /// The mechanism to use for message compression.
-public enum CompressionMechanism: String {
+public enum CompressionMechanism: String, CaseIterable {
   // No compression was indicated.
   case none
 
@@ -70,12 +70,3 @@ public enum CompressionMechanism: String {
       .joined(separator: ", ")
   }()
 }
-
-#if swift(>=4.2)
-extension CompressionMechanism: CaseIterable {}
-//! FIXME: Remove this code once the CI is updated to 4.2.
-#else
-extension CompressionMechanism {
-  public static let allCases: [CompressionMechanism] = [.none, .identity, .gzip, .deflate, .snappy, .unknown]
-}
-#endif

--- a/Sources/SwiftGRPCNIO/HTTP1ToRawGRPCServerCodec.swift
+++ b/Sources/SwiftGRPCNIO/HTTP1ToRawGRPCServerCodec.swift
@@ -203,14 +203,7 @@ extension HTTP1ToRawGRPCServerCodec: ChannelOutboundHandler {
         // Store the response into an independent buffer. We can't return the message directly as
         // it needs to be aggregated with all the responses plus the trailers, in order to have
         // the base64 response properly encoded in a single byte stream.
-        #if swift(>=4.2)
         messageWriter.write(messageBytes, into: &self.responseTextBuffer, usingCompression: .none)
-        #else
-        // Write into a temporary buffer to avoid: "error: cannot pass immutable value as inout argument: 'self' is immutable"
-        var responseBuffer = context.channel.allocator.buffer(capacity: LengthPrefixedMessageWriter.metadataLength)
-        messageWriter.write(messageBytes, into: &responseBuffer, usingCompression: .none)
-        responseTextBuffer.writeBuffer(&responseBuffer)
-        #endif
 
         // Since we stored the written data, mark the write promise as successful so that the
         // ServerStreaming provider continues sending the data.


### PR DESCRIPTION
- This branch requires Swift 5 as a minimum; as such this code is now redundant.