### PR TITLE
SR-10128 workaround

### DIFF
--- a/Sources/SwiftGRPCNIO/ClientCalls/BaseClientCall.swift
+++ b/Sources/SwiftGRPCNIO/ClientCalls/BaseClientCall.swift
@@ -83,6 +83,12 @@ extension BaseClientCall: ClientCall {
     return self.clientChannelHandler.statusPromise.futureResult
   }
 
+  // Workaround for: https://bugs.swift.org/browse/SR-10128
+  // Once resolved this can become a default implementation on `ClientCall`.
+  public var trailingMetadata: EventLoopFuture<HTTPHeaders> {
+    return status.map { $0.trailingMetadata }
+  }
+
   public func cancel() {
     self.client.channel.eventLoop.execute {
       self.subchannel.whenSuccess { channel in

--- a/Sources/SwiftGRPCNIO/ClientCalls/BaseClientCall.swift
+++ b/Sources/SwiftGRPCNIO/ClientCalls/BaseClientCall.swift
@@ -84,7 +84,7 @@ extension BaseClientCall: ClientCall {
   }
 
   // Workaround for: https://bugs.swift.org/browse/SR-10128
-  // Once resolved this can become a default implementation on `ClientCall`.
+  // TODO: Make this a default implementation on `ClientCall` when SR-10128 is resolved.
   public var trailingMetadata: EventLoopFuture<HTTPHeaders> {
     return status.map { $0.trailingMetadata }
   }

--- a/Sources/SwiftGRPCNIO/ClientCalls/ClientCall.swift
+++ b/Sources/SwiftGRPCNIO/ClientCalls/ClientCall.swift
@@ -54,12 +54,6 @@ public protocol ClientCall {
   func cancel()
 }
 
-extension ClientCall {
-  public var trailingMetadata: EventLoopFuture<HTTPHeaders> {
-    return status.map { $0.trailingMetadata }
-  }
-}
-
 /// A `ClientCall` with request streaming; i.e. client-streaming and bidirectional-streaming.
 public protocol StreamingRequestClientCall: ClientCall {
   /// Sends a message to the service.

--- a/Sources/SwiftGRPCNIO/HTTPProtocolSwitcher.swift
+++ b/Sources/SwiftGRPCNIO/HTTPProtocolSwitcher.swift
@@ -82,8 +82,13 @@ extension HTTPProtocolSwitcher: ChannelInboundHandler {
     let result = regex.firstMatch(in: preamble, options: [], range: range)!
 
     let versionRange = result.range(at: 1)
-    let start = String.UTF16Index(encodedOffset: versionRange.location)
-    let end = String.UTF16Index(encodedOffset: versionRange.location + versionRange.length)
+    #if swift(>=5.0)
+    let start = String.Index(utf16Offset: versionRange.location, in: preamble)
+    let end = String.Index(utf16Offset: versionRange.location + versionRange.length, in: preamble)
+    #else
+    let start = String.UTF16View.Index(encodedOffset: versionRange.location)
+    let end = String.UTF16View.Index(encodedOffset: versionRange.location + versionRange.length)
+    #endif
 
     switch String(preamble.utf16[start..<end])! {
     case "1":


### PR DESCRIPTION
- Workaround to avoid Swift 5 compiler crash: https://bugs.swift.org/browse/SR-10128
- Handles Swift 5 `String` API deprecation: https://github.com/apple/swift-evolution/blob/master/proposals/0241-string-index-explicit-encoding-offset.md

