### PR TITLE
Run CI on both Swift 4.2 and 5, and fix Swift 5 warning

### DIFF
--- a/.travis-install.sh
+++ b/.travis-install.sh
@@ -18,10 +18,10 @@
 #
 # Install dependencies that aren't available as Ubuntu packages (or already present on macOS).
 #
-# Everything goes into $HOME/local. 
+# Everything goes into $HOME/local.
 #
-# Scripts should add 
-# - $HOME/local/bin to PATH 
+# Scripts should add
+# - $HOME/local/bin to PATH
 # - $HOME/local/lib to LD_LIBRARY_PATH
 #
 
@@ -32,9 +32,9 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
   PROTOC_URL=https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-osx-x86_64.zip
 else
   # Install swift
-  SWIFT_URL=https://swift.org/builds/swift-4.1.1-release/ubuntu1404/swift-4.1.1-RELEASE/swift-4.1.1-RELEASE-ubuntu14.04.tar.gz
+  SWIFT_URL=https://swift.org/builds/swift-5.0-release/ubuntu1404/swift-5.0-RELEASE/swift-5.0-RELEASE-ubuntu14.04.tar.gz
   echo $SWIFT_URL
-  curl -fSsL $SWIFT_URL -o swift.tar.gz 
+  curl -fSsL $SWIFT_URL -o swift.tar.gz
   tar -xzf swift.tar.gz --strip-components=2 --directory=local
 
   PROTOC_URL=https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip

--- a/.travis-install.sh
+++ b/.travis-install.sh
@@ -28,11 +28,11 @@
 cd
 mkdir -p local
 
-if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
   PROTOC_URL=https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-osx-x86_64.zip
 else
   # Install swift
-  SWIFT_URL=https://swift.org/builds/swift-5.0-release/ubuntu1404/swift-5.0-RELEASE/swift-5.0-RELEASE-ubuntu14.04.tar.gz
+  SWIFT_URL=https://swift.org/builds/swift-${SWIFT_VERSION}-release/ubuntu1404/swift-${SWIFT_VERSION}-RELEASE/swift-${SWIFT_VERSION}-RELEASE-ubuntu14.04.tar.gz
   echo $SWIFT_URL
   curl -fSsL $SWIFT_URL -o swift.tar.gz
   tar -xzf swift.tar.gz --strip-components=2 --directory=local

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,27 +16,28 @@
 # Travis CI build file for Swift gRPC.
 
 matrix:
-  os:
-    - linux
-      osx_image: xcode10
-      env:
-        - SWIFT_VERSION=4.2
-        - MAJOR_VERSION=4.2
-    - osx
-      osx_image: xcode10
-      env:
-        - SWIFT_VERSION=4.2
-        - MAJOR_VERSION=4.2
-    - linux
-      osx_image: xcode10.2
-      env:
-        - SWIFT_VERSION=5.0
-        - MAJOR_VERSION=5
-    - osx
-      osx_image: xcode10.2
-      env:
-        - SWIFT_VERSION=5.0
-        - MAJOR_VERSION=5
+  include:
+    os:
+      - linux
+        osx_image: xcode10
+        env:
+          - SWIFT_VERSION=4.2
+          - MAJOR_VERSION=4.2
+      - osx
+        osx_image: xcode10
+        env:
+          - SWIFT_VERSION=4.2
+          - MAJOR_VERSION=4.2
+      - linux
+        osx_image: xcode10.2
+        env:
+          - SWIFT_VERSION=5.0
+          - MAJOR_VERSION=5
+      - osx
+        osx_image: xcode10.2
+        env:
+          - SWIFT_VERSION=5.0
+          - MAJOR_VERSION=5
 
 cache:
   apt: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,25 @@
 
 os:
   - linux
+    osx_image: xcode10
+    env:
+      - SWIFT_VERSION=4.2
+      - MAJOR_VERSION=4.2
   - osx
+    osx_image: xcode10
+    env:
+      - SWIFT_VERSION=4.2
+      - MAJOR_VERSION=4.2
+  - linux
+    osx_image: xcode10.2
+    env:
+      - SWIFT_VERSION=5.0
+      - MAJOR_VERSION=5
+  - osx
+    osx_image: xcode10.2
+    env:
+      - SWIFT_VERSION=5.0
+      - MAJOR_VERSION=5
 
 cache:
   apt: true
@@ -28,8 +46,6 @@ cache:
 # Use Ubuntu 14.04
 dist: trusty
 
-osx_image: xcode9.3
-
 sudo: false
 
 addons:
@@ -37,14 +53,14 @@ addons:
     sources:
       - sourceline: 'ppa:ondrej/apache2'  # for libnghttp2-dev
     packages:
-      - clang-3.8 
-      - lldb-3.8 
-      - libicu-dev 
-      - libtool 
-      - libcurl4-openssl-dev 
-      - libbsd-dev 
-      - build-essential 
-      - libssl-dev 
+      - clang-3.8
+      - lldb-3.8
+      - libicu-dev
+      - libtool
+      - libcurl4-openssl-dev
+      - libbsd-dev
+      - build-essential
+      - libssl-dev
       - uuid-dev
       - curl
       - unzip

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,17 +18,15 @@
 matrix:
   include:
     - os: linux
-      osx_image: xcode10
       env:
         - SWIFT_VERSION=4.2
         - MAJOR_VERSION=4.2
     - os: osx
-      osx_image: xcode10
+      osx_image: xcode10.2
       env:
         - SWIFT_VERSION=4.2
         - MAJOR_VERSION=4.2
     - os: linux
-      osx_image: xcode10.2
       env:
         - SWIFT_VERSION=5.0
         - MAJOR_VERSION=5

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,27 +17,26 @@
 
 matrix:
   include:
-    os:
-      - linux
-        osx_image: xcode10
-        env:
-          - SWIFT_VERSION=4.2
-          - MAJOR_VERSION=4.2
-      - osx
-        osx_image: xcode10
-        env:
-          - SWIFT_VERSION=4.2
-          - MAJOR_VERSION=4.2
-      - linux
-        osx_image: xcode10.2
-        env:
-          - SWIFT_VERSION=5.0
-          - MAJOR_VERSION=5
-      - osx
-        osx_image: xcode10.2
-        env:
-          - SWIFT_VERSION=5.0
-          - MAJOR_VERSION=5
+    - os: linux
+      osx_image: xcode10
+      env:
+        - SWIFT_VERSION=4.2
+        - MAJOR_VERSION=4.2
+    - os: osx
+      osx_image: xcode10
+      env:
+        - SWIFT_VERSION=4.2
+        - MAJOR_VERSION=4.2
+    - os: linux
+      osx_image: xcode10.2
+      env:
+        - SWIFT_VERSION=5.0
+        - MAJOR_VERSION=5
+    - os: osx
+      osx_image: xcode10.2
+      env:
+        - SWIFT_VERSION=5.0
+        - MAJOR_VERSION=5
 
 cache:
   apt: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,27 +15,28 @@
 #
 # Travis CI build file for Swift gRPC.
 
-os:
-  - linux
-    osx_image: xcode10
-    env:
-      - SWIFT_VERSION=4.2
-      - MAJOR_VERSION=4.2
-  - osx
-    osx_image: xcode10
-    env:
-      - SWIFT_VERSION=4.2
-      - MAJOR_VERSION=4.2
-  - linux
-    osx_image: xcode10.2
-    env:
-      - SWIFT_VERSION=5.0
-      - MAJOR_VERSION=5
-  - osx
-    osx_image: xcode10.2
-    env:
-      - SWIFT_VERSION=5.0
-      - MAJOR_VERSION=5
+matrix:
+  os:
+    - linux
+      osx_image: xcode10
+      env:
+        - SWIFT_VERSION=4.2
+        - MAJOR_VERSION=4.2
+    - osx
+      osx_image: xcode10
+      env:
+        - SWIFT_VERSION=4.2
+        - MAJOR_VERSION=4.2
+    - linux
+      osx_image: xcode10.2
+      env:
+        - SWIFT_VERSION=5.0
+        - MAJOR_VERSION=5
+    - osx
+      osx_image: xcode10.2
+      env:
+        - SWIFT_VERSION=5.0
+        - MAJOR_VERSION=5
 
 cache:
   apt: true

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:4.2
 /*
  * Copyright 2017, gRPC Authors All rights reserved.
  *
@@ -95,5 +95,6 @@ let package = Package(
     .testTarget(name: "SwiftGRPCTests", dependencies: ["SwiftGRPC"]),
     .testTarget(name: "SwiftGRPCNIOTests", dependencies: ["SwiftGRPC", "SwiftGRPCNIO"])
   ],
+  swiftLanguageVersions: [.v4, .v4_2, .version("5")],
   cLanguageStandard: .gnu11,
   cxxLanguageStandard: .cxx11)

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.0
 /*
  * Copyright 2017, gRPC Authors All rights reserved.
  *

--- a/README.md
+++ b/README.md
@@ -167,8 +167,8 @@ Original SwiftGRPC issue: https://github.com/grpc/grpc-swift/issues/337.
 grpc-swift depends on Swift, Xcode, and swift-protobuf. We are currently
 testing with the following versions:
 
-- Xcode 9.1
-- Swift 4.0
+- Xcode 10.0 / 10.2
+- Swift 4.2 / 5.0
 - swift-protobuf 1.3.1
 
 ## `SwiftGRPCNIO` package

--- a/Sources/SwiftGRPC/Core/ByteBuffer.swift
+++ b/Sources/SwiftGRPC/Core/ByteBuffer.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #if SWIFT_PACKAGE
-  import CgRPC
+import CgRPC
 #endif
 import Foundation
 
@@ -35,10 +35,16 @@ public class ByteBuffer {
   ///
   /// - Parameter data: the data to store in the buffer
   public init(data: Data) {
+#if swift(>=5.0)
     self.underlyingByteBuffer = data.withUnsafeBytes { bytes in
       let buffer = bytes.bindMemory(to: UInt8.self).baseAddress
       return cgrpc_byte_buffer_create_by_copying_data(buffer, data.count)
     }
+#else
+    self.underlyingByteBuffer = data.withUnsafeBytes { bytes in
+      return cgrpc_byte_buffer_create_by_copying_data(bytes, data.count)
+    }
+#endif
   }
 
   deinit {

--- a/Sources/SwiftGRPC/Core/ByteBuffer.swift
+++ b/Sources/SwiftGRPC/Core/ByteBuffer.swift
@@ -16,7 +16,7 @@
 #if SWIFT_PACKAGE
   import CgRPC
 #endif
-import Foundation // for String.Encoding
+import Foundation
 
 /// Representation of raw data that may be sent and received using gRPC
 public class ByteBuffer {
@@ -35,11 +35,10 @@ public class ByteBuffer {
   ///
   /// - Parameter data: the data to store in the buffer
   public init(data: Data) {
-    var underlyingByteBuffer: UnsafeMutableRawPointer?
-    data.withUnsafeBytes { bytes in
-      underlyingByteBuffer = cgrpc_byte_buffer_create_by_copying_data(bytes, data.count)
+    self.underlyingByteBuffer = data.withUnsafeBytes { bytes in
+      let buffer = bytes.bindMemory(to: UInt8.self).baseAddress
+      return cgrpc_byte_buffer_create_by_copying_data(buffer, data.count)
     }
-    self.underlyingByteBuffer = underlyingByteBuffer!
   }
 
   deinit {


### PR DESCRIPTION
Fixes a warning when compiling with Swift 5:

> 'withUnsafeBytes' is deprecated: use `withUnsafeBytes<R>(…)

Also updates CI to run tests on both Swift 4.2 and Swift 5.0.