### PR TITLE
Use user events for timing out and cancelling client calls

### DIFF
--- a/Sources/SwiftGRPCNIO/GRPCDelegatingErrorHandler.swift
+++ b/Sources/SwiftGRPCNIO/GRPCDelegatingErrorHandler.swift
@@ -31,7 +31,7 @@ public class GRPCDelegatingErrorHandler: ChannelInboundHandler {
   public func errorCaught(context: ChannelHandlerContext, error: Error) {
     if let delegate = self.delegate {
       let grpcError = (error as? GRPCError) ?? .unknown(error, origin: .client)
-      delegate.didCatchError(grpcError.error, file: grpcError.file, line: grpcError.line)
+      delegate.didCatchError(grpcError.wrappedError, file: grpcError.file, line: grpcError.line)
     }
     context.close(promise: nil)
   }

--- a/Sources/SwiftGRPCNIO/GRPCError.swift
+++ b/Sources/SwiftGRPCNIO/GRPCError.swift
@@ -21,7 +21,7 @@ public struct GRPCError: Error, GRPCStatusTransformable {
   public enum Origin { case client, server }
 
   /// The underlying error thrown by framework.
-  public let error: Error
+  public let wrappedError: Error
 
   /// The origin of the error.
   public let origin: Origin
@@ -33,11 +33,11 @@ public struct GRPCError: Error, GRPCStatusTransformable {
   public let line: Int
 
   public func asGRPCStatus() -> GRPCStatus {
-    return (error as? GRPCStatusTransformable)?.asGRPCStatus() ?? .processingError
+    return (wrappedError as? GRPCStatusTransformable)?.asGRPCStatus() ?? .processingError
   }
 
   private init(_ error: Error, origin: Origin, file: StaticString, line: Int) {
-    self.error = error
+    self.wrappedError = error
     self.origin = origin
     self.file = file
     self.line = line

--- a/Sources/SwiftGRPCNIO/GRPCTLSVerificationHandler.swift
+++ b/Sources/SwiftGRPCNIO/GRPCTLSVerificationHandler.swift
@@ -55,7 +55,7 @@ public class GRPCTLSVerificationHandler: ChannelInboundHandler, RemovableChannel
 
     if let delegate = self.delegate {
       let grpcError = (error as? GRPCError) ?? GRPCError.unknown(error, origin: .client)
-      delegate.didCatchError(grpcError.error, file: grpcError.file, line: grpcError.line)
+      delegate.didCatchError(grpcError.wrappedError, file: grpcError.file, line: grpcError.line)
     }
 
     verificationPromise.fail(error)

--- a/Tests/SwiftGRPCNIOTests/GRPCChannelHandlerResponseCapturingTestCase.swift
+++ b/Tests/SwiftGRPCNIOTests/GRPCChannelHandlerResponseCapturingTestCase.swift
@@ -21,11 +21,11 @@ class CollectingServerErrorDelegate: ServerErrorDelegate {
   }
 
   var asGRPCServerErrors: [GRPCServerError]? {
-    return (self.asGRPCErrors?.map { $0.error }) as? [GRPCServerError]
+    return (self.asGRPCErrors?.map { $0.wrappedError }) as? [GRPCServerError]
   }
 
   var asGRPCCommonErrors: [GRPCCommonError]? {
-    return (self.asGRPCErrors?.map { $0.error }) as? [GRPCCommonError]
+    return (self.asGRPCErrors?.map { $0.wrappedError }) as? [GRPCCommonError]
   }
 
   func observeLibraryError(_ error: Error) {

--- a/Tests/SwiftGRPCNIOTests/LengthPrefixedMessageReaderTests.swift
+++ b/Tests/SwiftGRPCNIOTests/LengthPrefixedMessageReaderTests.swift
@@ -195,7 +195,7 @@ class LengthPrefixedMessageReaderTests: XCTestCase {
     reader.append(buffer: &buffer)
 
     XCTAssertThrowsError(try reader.nextMessage()) { error in
-      XCTAssertEqual(.unsupportedCompressionMechanism("unknown"), (error as? GRPCError)?.error as? GRPCCommonError)
+      XCTAssertEqual(.unsupportedCompressionMechanism("unknown"), (error as? GRPCError)?.wrappedError as? GRPCCommonError)
     }
   }
 
@@ -208,7 +208,7 @@ class LengthPrefixedMessageReaderTests: XCTestCase {
     reader.append(buffer: &buffer)
 
     XCTAssertThrowsError(try reader.nextMessage()) { error in
-      XCTAssertEqual(.unexpectedCompression, (error as? GRPCError)?.error as? GRPCCommonError)
+      XCTAssertEqual(.unexpectedCompression, (error as? GRPCError)?.wrappedError as? GRPCCommonError)
     }
   }
 

--- a/Tests/SwiftGRPCNIOTests/NIOBasicEchoTestCase.swift
+++ b/Tests/SwiftGRPCNIOTests/NIOBasicEchoTestCase.swift
@@ -71,7 +71,7 @@ extension TransportSecurity {
 
     case .anonymousClient, .mutualAuthentication:
       return .forServer(certificateChain: [.certificate(self.serverCert)],
-                        privateKey: .privateKey(SamplePrivateKey.server), 
+                        privateKey: .privateKey(SamplePrivateKey.server),
                         trustRoots: .certificates ([self.caCert]),
                         applicationProtocols: GRPCApplicationProtocolIdentifier.allCases.map { $0.rawValue })
     }

--- a/Tests/SwiftGRPCNIOTests/NIOClientTLSFailureTests.swift
+++ b/Tests/SwiftGRPCNIOTests/NIOClientTLSFailureTests.swift
@@ -92,7 +92,7 @@ class NIOClientTLSFailureTests: XCTestCase {
     let connectionExpectation = self.makeClientConnectionExpectation()
 
     connection.assertError(fulfill: connectionExpectation) { error in
-      let clientError = (error as? GRPCError)?.error as? GRPCClientError
+      let clientError = (error as? GRPCError)?.wrappedError as? GRPCClientError
       XCTAssertEqual(clientError, .applicationLevelProtocolNegotiationFailed)
     }
 


### PR DESCRIPTION
- Use user events for timing out and cancelling calls
- Cancelling a call is now no longer treated as an error
- `GRPCError.error` was renamed to `GRPCError.wrappedError`