### PR TITLE
Getting initialMetadata at the beginning of streaming

### DIFF
--- a/Sources/SwiftGRPC/Core/Call.swift
+++ b/Sources/SwiftGRPC/Core/Call.swift
@@ -132,15 +132,16 @@ public class Call {
                                  operations: [
                                   .sendInitialMetadata(metadata.copy()),
                                   .sendMessage(ByteBuffer(data:message)),
-                                  .receiveInitialMetadata,
+                                  .receiveInitialMetadata
                                   ],
                                  completion: completion != nil
                                   ? { op in completion?(CallResult(op)) }
                                   : nil))
       try perform(OperationGroup(call: self,
-                                 operations: [.sendCloseFromClient,
-                                              .receiveStatusOnClient,
-                                              ],
+                                 operations: [
+                                  .sendCloseFromClient,
+                                  .receiveStatusOnClient
+                                  ],
                                  completion: completion != nil
                                   ? { op in completion?(CallResult(op)) }
                                   : nil))

--- a/Sources/SwiftGRPC/Core/Call.swift
+++ b/Sources/SwiftGRPC/Core/Call.swift
@@ -141,7 +141,9 @@ public class Call {
                                   .sendInitialMetadata(metadata.copy()),
                                   .receiveInitialMetadata
                                   ],
-                                 completion: nil))
+                                 completion: completion != nil
+                                  ? { op in completion?(CallResult(op)) }
+                                  : nil))
       try perform(OperationGroup(call: self,
                                  operations: [.receiveStatusOnClient],
                                  completion: completion != nil


### PR DESCRIPTION
I needed to get data from initialMetada at the beginning of streaming(bidirectional and server) in order to see progress, but I couldn't do it.