### PR TITLE
Update makeRequestHead to use add(contentsOf:)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "b2be49ada3d2cf3824e038505be32230d6e62893",
-          "version": "2.1.1"
+          "revision": "ed50f8a41ece8db20afa8d1188fc0960f95263df",
+          "version": "2.2.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ var packageDependencies: [Package.Dependency] = [
 
   // SwiftGRPCNIO dependencies:
   // Main SwiftNIO package
-  .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
+  .package(url: "https://github.com/apple/swift-nio.git", from: "2.2.0"),
   // HTTP2 via SwiftNIO
   .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.2.0"),
   // TLS via SwiftNIO


### PR DESCRIPTION
Using `add(contentsOf:)` reduces the number of allocations when adding to the headers, particularly if the user passes a large number of custom metadata headers.