### PR TITLE
Add missing bracket in NaturalLanguage example

### DIFF
--- a/Examples/Google/NaturalLanguage/Sources/main.swift
+++ b/Examples/Google/NaturalLanguage/Sources/main.swift
@@ -37,9 +37,9 @@ func makeServiceClient(host: String,
       let configuration = GRPCClientConnection.Configuration(
         target: .hostAndPort(host, port),
         eventLoopGroup: eventLoopGroup,
-        tlsConfiguration: .init(sslContext: try makeClientTLS())
+        tlsConfiguration: .init(sslContext: try makeClientTLS()))
 
-      try GRPCClientConnection.start(configuration)
+      GRPCClientConnection.start(configuration)
         .map { client in
           Google_Cloud_Language_V1_LanguageServiceServiceClient(connection: client)
         }.cascade(to: promise)


### PR DESCRIPTION
This was broken in #479 but it wasn't picked up because it isn't a target in the main `Package.swift`.