### PR TITLE
Call renaming

### DIFF
--- a/Sources/Examples/Echo/Generated/echo.grpc.swift
+++ b/Sources/Examples/Echo/Generated/echo.grpc.swift
@@ -30,7 +30,7 @@ import SwiftProtobuf
 /// Usage: instantiate Echo_EchoServiceClient, then call methods of this protocol to make API calls.
 internal protocol Echo_EchoService {
   func get(_ request: Echo_EchoRequest, callOptions: CallOptions?) -> UnaryCall<Echo_EchoRequest, Echo_EchoResponse>
-  func expand(_ request: Echo_EchoRequest, callOptions: CallOptions?, handler: @escaping (Echo_EchoResponse) -> Void) -> ServerStreamingClientCall<Echo_EchoRequest, Echo_EchoResponse>
+  func expand(_ request: Echo_EchoRequest, callOptions: CallOptions?, handler: @escaping (Echo_EchoResponse) -> Void) -> ServerStreamingCall<Echo_EchoRequest, Echo_EchoResponse>
   func collect(callOptions: CallOptions?) -> ClientStreamingClientCall<Echo_EchoRequest, Echo_EchoResponse>
   func update(callOptions: CallOptions?, handler: @escaping (Echo_EchoResponse) -> Void) -> BidirectionalStreamingClientCall<Echo_EchoRequest, Echo_EchoResponse>
 }
@@ -68,8 +68,8 @@ internal final class Echo_EchoServiceClient: GRPCServiceClient, Echo_EchoService
   ///   - request: Request to send to Expand.
   ///   - callOptions: Call options; `self.defaultCallOptions` is used if `nil`.
   ///   - handler: A closure called when each response is received from the server.
-  /// - Returns: A `ServerStreamingClientCall` with futures for the metadata and status.
-  internal func expand(_ request: Echo_EchoRequest, callOptions: CallOptions? = nil, handler: @escaping (Echo_EchoResponse) -> Void) -> ServerStreamingClientCall<Echo_EchoRequest, Echo_EchoResponse> {
+  /// - Returns: A `ServerStreamingCall` with futures for the metadata and status.
+  internal func expand(_ request: Echo_EchoRequest, callOptions: CallOptions? = nil, handler: @escaping (Echo_EchoResponse) -> Void) -> ServerStreamingCall<Echo_EchoRequest, Echo_EchoResponse> {
     return self.makeServerStreamingCall(path: self.path(forMethod: "Expand"),
                                         request: request,
                                         callOptions: callOptions ?? self.defaultCallOptions,

--- a/Sources/Examples/Echo/Generated/echo.grpc.swift
+++ b/Sources/Examples/Echo/Generated/echo.grpc.swift
@@ -29,7 +29,7 @@ import SwiftProtobuf
 
 /// Usage: instantiate Echo_EchoServiceClient, then call methods of this protocol to make API calls.
 internal protocol Echo_EchoService {
-  func get(_ request: Echo_EchoRequest, callOptions: CallOptions?) -> UnaryClientCall<Echo_EchoRequest, Echo_EchoResponse>
+  func get(_ request: Echo_EchoRequest, callOptions: CallOptions?) -> UnaryCall<Echo_EchoRequest, Echo_EchoResponse>
   func expand(_ request: Echo_EchoRequest, callOptions: CallOptions?, handler: @escaping (Echo_EchoResponse) -> Void) -> ServerStreamingClientCall<Echo_EchoRequest, Echo_EchoResponse>
   func collect(callOptions: CallOptions?) -> ClientStreamingClientCall<Echo_EchoRequest, Echo_EchoResponse>
   func update(callOptions: CallOptions?, handler: @escaping (Echo_EchoResponse) -> Void) -> BidirectionalStreamingClientCall<Echo_EchoRequest, Echo_EchoResponse>
@@ -55,8 +55,8 @@ internal final class Echo_EchoServiceClient: GRPCServiceClient, Echo_EchoService
   /// - Parameters:
   ///   - request: Request to send to Get.
   ///   - callOptions: Call options; `self.defaultCallOptions` is used if `nil`.
-  /// - Returns: A `UnaryClientCall` with futures for the metadata, status and response.
-  internal func get(_ request: Echo_EchoRequest, callOptions: CallOptions? = nil) -> UnaryClientCall<Echo_EchoRequest, Echo_EchoResponse> {
+  /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
+  internal func get(_ request: Echo_EchoRequest, callOptions: CallOptions? = nil) -> UnaryCall<Echo_EchoRequest, Echo_EchoResponse> {
     return self.makeUnaryCall(path: self.path(forMethod: "Get"),
                               request: request,
                               callOptions: callOptions ?? self.defaultCallOptions)

--- a/Sources/Examples/Echo/Generated/echo.grpc.swift
+++ b/Sources/Examples/Echo/Generated/echo.grpc.swift
@@ -32,7 +32,7 @@ internal protocol Echo_EchoService {
   func get(_ request: Echo_EchoRequest, callOptions: CallOptions?) -> UnaryCall<Echo_EchoRequest, Echo_EchoResponse>
   func expand(_ request: Echo_EchoRequest, callOptions: CallOptions?, handler: @escaping (Echo_EchoResponse) -> Void) -> ServerStreamingCall<Echo_EchoRequest, Echo_EchoResponse>
   func collect(callOptions: CallOptions?) -> ClientStreamingCall<Echo_EchoRequest, Echo_EchoResponse>
-  func update(callOptions: CallOptions?, handler: @escaping (Echo_EchoResponse) -> Void) -> BidirectionalStreamingClientCall<Echo_EchoRequest, Echo_EchoResponse>
+  func update(callOptions: CallOptions?, handler: @escaping (Echo_EchoResponse) -> Void) -> BidirectionalStreamingCall<Echo_EchoRequest, Echo_EchoResponse>
 }
 
 internal final class Echo_EchoServiceClient: GRPCServiceClient, Echo_EchoService {
@@ -98,7 +98,7 @@ internal final class Echo_EchoServiceClient: GRPCServiceClient, Echo_EchoService
   ///   - callOptions: Call options; `self.defaultCallOptions` is used if `nil`.
   ///   - handler: A closure called when each response is received from the server.
   /// - Returns: A `ClientStreamingCall` with futures for the metadata and status.
-  internal func update(callOptions: CallOptions? = nil, handler: @escaping (Echo_EchoResponse) -> Void) -> BidirectionalStreamingClientCall<Echo_EchoRequest, Echo_EchoResponse> {
+  internal func update(callOptions: CallOptions? = nil, handler: @escaping (Echo_EchoResponse) -> Void) -> BidirectionalStreamingCall<Echo_EchoRequest, Echo_EchoResponse> {
     return self.makeBidirectionalStreamingCall(path: self.path(forMethod: "Update"),
                                                callOptions: callOptions ?? self.defaultCallOptions,
                                                handler: handler)

--- a/Sources/Examples/Echo/Generated/echo.grpc.swift
+++ b/Sources/Examples/Echo/Generated/echo.grpc.swift
@@ -31,7 +31,7 @@ import SwiftProtobuf
 internal protocol Echo_EchoService {
   func get(_ request: Echo_EchoRequest, callOptions: CallOptions?) -> UnaryCall<Echo_EchoRequest, Echo_EchoResponse>
   func expand(_ request: Echo_EchoRequest, callOptions: CallOptions?, handler: @escaping (Echo_EchoResponse) -> Void) -> ServerStreamingCall<Echo_EchoRequest, Echo_EchoResponse>
-  func collect(callOptions: CallOptions?) -> ClientStreamingClientCall<Echo_EchoRequest, Echo_EchoResponse>
+  func collect(callOptions: CallOptions?) -> ClientStreamingCall<Echo_EchoRequest, Echo_EchoResponse>
   func update(callOptions: CallOptions?, handler: @escaping (Echo_EchoResponse) -> Void) -> BidirectionalStreamingClientCall<Echo_EchoRequest, Echo_EchoResponse>
 }
 
@@ -83,8 +83,8 @@ internal final class Echo_EchoServiceClient: GRPCServiceClient, Echo_EchoService
   ///
   /// - Parameters:
   ///   - callOptions: Call options; `self.defaultCallOptions` is used if `nil`.
-  /// - Returns: A `ClientStreamingClientCall` with futures for the metadata, status and response.
-  internal func collect(callOptions: CallOptions? = nil) -> ClientStreamingClientCall<Echo_EchoRequest, Echo_EchoResponse> {
+  /// - Returns: A `ClientStreamingCall` with futures for the metadata, status and response.
+  internal func collect(callOptions: CallOptions? = nil) -> ClientStreamingCall<Echo_EchoRequest, Echo_EchoResponse> {
     return self.makeClientStreamingCall(path: self.path(forMethod: "Collect"),
                                         callOptions: callOptions ?? self.defaultCallOptions)
   }
@@ -97,7 +97,7 @@ internal final class Echo_EchoServiceClient: GRPCServiceClient, Echo_EchoService
   /// - Parameters:
   ///   - callOptions: Call options; `self.defaultCallOptions` is used if `nil`.
   ///   - handler: A closure called when each response is received from the server.
-  /// - Returns: A `ClientStreamingClientCall` with futures for the metadata and status.
+  /// - Returns: A `ClientStreamingCall` with futures for the metadata and status.
   internal func update(callOptions: CallOptions? = nil, handler: @escaping (Echo_EchoResponse) -> Void) -> BidirectionalStreamingClientCall<Echo_EchoRequest, Echo_EchoResponse> {
     return self.makeBidirectionalStreamingCall(path: self.path(forMethod: "Update"),
                                                callOptions: callOptions ?? self.defaultCallOptions,

--- a/Sources/GRPC/ClientCalls/BidirectionalStreamingCall.swift
+++ b/Sources/GRPC/ClientCalls/BidirectionalStreamingCall.swift
@@ -26,7 +26,7 @@ import NIO
 /// - `initialMetadata`: the initial metadata returned from the server,
 /// - `status`: the status of the gRPC call after it has ended,
 /// - `trailingMetadata`: any metadata returned from the server alongside the `status`.
-public final class BidirectionalStreamingClientCall<RequestMessage: Message, ResponseMessage: Message>
+public final class BidirectionalStreamingCall<RequestMessage: Message, ResponseMessage: Message>
   : BaseClientCall<RequestMessage, ResponseMessage>,
     StreamingRequestClientCall {
   private var messageQueue: EventLoopFuture<Void>

--- a/Sources/GRPC/ClientCalls/ClientStreamingCall.swift
+++ b/Sources/GRPC/ClientCalls/ClientStreamingCall.swift
@@ -27,7 +27,7 @@ import NIO
 /// - `response`: the response from the call,
 /// - `status`: the status of the gRPC call after it has ended,
 /// - `trailingMetadata`: any metadata returned from the server alongside the `status`.
-public final class ClientStreamingClientCall<RequestMessage: Message, ResponseMessage: Message>
+public final class ClientStreamingCall<RequestMessage: Message, ResponseMessage: Message>
   : BaseClientCall<RequestMessage, ResponseMessage>,
     StreamingRequestClientCall,
     UnaryResponseClientCall {

--- a/Sources/GRPC/ClientCalls/ServerStreamingCall.swift
+++ b/Sources/GRPC/ClientCalls/ServerStreamingCall.swift
@@ -23,7 +23,7 @@ import NIO
 /// - `initialMetadata`: the initial metadata returned from the server,
 /// - `status`: the status of the gRPC call after it has ended,
 /// - `trailingMetadata`: any metadata returned from the server alongside the `status`.
-public final class ServerStreamingClientCall<RequestMessage: Message, ResponseMessage: Message>: BaseClientCall<RequestMessage, ResponseMessage> {
+public final class ServerStreamingCall<RequestMessage: Message, ResponseMessage: Message>: BaseClientCall<RequestMessage, ResponseMessage> {
   public init(connection: ClientConnection, path: String, request: RequestMessage, callOptions: CallOptions, errorDelegate: ClientErrorDelegate?, handler: @escaping (ResponseMessage) -> Void) {
     let responseHandler = GRPCClientStreamingResponseChannelHandler(
       initialMetadataPromise: connection.channel.eventLoop.makePromise(),

--- a/Sources/GRPC/ClientCalls/UnaryCall.swift
+++ b/Sources/GRPC/ClientCalls/UnaryCall.swift
@@ -26,7 +26,7 @@ import NIOHTTP2
 /// - `response`: the response from the unary call,
 /// - `status`: the status of the gRPC call after it has ended,
 /// - `trailingMetadata`: any metadata returned from the server alongside the `status`.
-public final class UnaryClientCall<RequestMessage: Message, ResponseMessage: Message>
+public final class UnaryCall<RequestMessage: Message, ResponseMessage: Message>
   : BaseClientCall<RequestMessage, ResponseMessage>,
     UnaryResponseClientCall {
   public let response: EventLoopFuture<ResponseMessage>

--- a/Sources/GRPC/GRPCClient.swift
+++ b/Sources/GRPC/GRPCClient.swift
@@ -46,8 +46,8 @@ extension GRPCClient {
     callOptions: CallOptions? = nil,
     responseType: Response.Type = Response.self,
     handler: @escaping (Response) -> Void
-  ) -> ServerStreamingClientCall<Request, Response> {
-    return ServerStreamingClientCall(
+  ) -> ServerStreamingCall<Request, Response> {
+    return ServerStreamingCall(
       connection: self.connection,
       path: path,
       request: request,

--- a/Sources/GRPC/GRPCClient.swift
+++ b/Sources/GRPC/GRPCClient.swift
@@ -75,8 +75,8 @@ extension GRPCClient {
     requestType: Request.Type = Request.self,
     responseType: Response.Type = Response.self,
     handler: @escaping (Response) -> Void
-  ) -> BidirectionalStreamingClientCall<Request, Response> {
-    return BidirectionalStreamingClientCall(
+  ) -> BidirectionalStreamingCall<Request, Response> {
+    return BidirectionalStreamingCall(
       connection: self.connection,
       path: path,
       callOptions: callOptions ?? self.defaultCallOptions,

--- a/Sources/GRPC/GRPCClient.swift
+++ b/Sources/GRPC/GRPCClient.swift
@@ -31,8 +31,8 @@ extension GRPCClient {
     request: Request,
     callOptions: CallOptions? = nil,
     responseType: Response.Type = Response.self
-  ) -> UnaryClientCall<Request, Response> {
-    return UnaryClientCall(
+  ) -> UnaryCall<Request, Response> {
+    return UnaryCall(
       connection: self.connection,
       path: path,
       request: request,

--- a/Sources/GRPC/GRPCClient.swift
+++ b/Sources/GRPC/GRPCClient.swift
@@ -61,8 +61,8 @@ extension GRPCClient {
     callOptions: CallOptions? = nil,
     requestType: Request.Type = Request.self,
     responseType: Response.Type = Response.self
-  ) -> ClientStreamingClientCall<Request, Response> {
-    return ClientStreamingClientCall(
+  ) -> ClientStreamingCall<Request, Response> {
+    return ClientStreamingCall(
       connection: self.connection,
       path: path,
       callOptions: callOptions ?? self.defaultCallOptions,

--- a/Sources/GRPCInteroperabilityTests/protos/Generated/test.grpc.swift
+++ b/Sources/GRPCInteroperabilityTests/protos/Generated/test.grpc.swift
@@ -32,7 +32,7 @@ public protocol Grpc_Testing_TestServiceService {
   func emptyCall(_ request: Grpc_Testing_Empty, callOptions: CallOptions?) -> UnaryCall<Grpc_Testing_Empty, Grpc_Testing_Empty>
   func unaryCall(_ request: Grpc_Testing_SimpleRequest, callOptions: CallOptions?) -> UnaryCall<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse>
   func cacheableUnaryCall(_ request: Grpc_Testing_SimpleRequest, callOptions: CallOptions?) -> UnaryCall<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse>
-  func streamingOutputCall(_ request: Grpc_Testing_StreamingOutputCallRequest, callOptions: CallOptions?, handler: @escaping (Grpc_Testing_StreamingOutputCallResponse) -> Void) -> ServerStreamingClientCall<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>
+  func streamingOutputCall(_ request: Grpc_Testing_StreamingOutputCallRequest, callOptions: CallOptions?, handler: @escaping (Grpc_Testing_StreamingOutputCallResponse) -> Void) -> ServerStreamingCall<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>
   func streamingInputCall(callOptions: CallOptions?) -> ClientStreamingClientCall<Grpc_Testing_StreamingInputCallRequest, Grpc_Testing_StreamingInputCallResponse>
   func fullDuplexCall(callOptions: CallOptions?, handler: @escaping (Grpc_Testing_StreamingOutputCallResponse) -> Void) -> BidirectionalStreamingClientCall<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>
   func halfDuplexCall(callOptions: CallOptions?, handler: @escaping (Grpc_Testing_StreamingOutputCallResponse) -> Void) -> BidirectionalStreamingClientCall<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>
@@ -96,8 +96,8 @@ public final class Grpc_Testing_TestServiceServiceClient: GRPCServiceClient, Grp
   ///   - request: Request to send to StreamingOutputCall.
   ///   - callOptions: Call options; `self.defaultCallOptions` is used if `nil`.
   ///   - handler: A closure called when each response is received from the server.
-  /// - Returns: A `ServerStreamingClientCall` with futures for the metadata and status.
-  public func streamingOutputCall(_ request: Grpc_Testing_StreamingOutputCallRequest, callOptions: CallOptions? = nil, handler: @escaping (Grpc_Testing_StreamingOutputCallResponse) -> Void) -> ServerStreamingClientCall<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse> {
+  /// - Returns: A `ServerStreamingCall` with futures for the metadata and status.
+  public func streamingOutputCall(_ request: Grpc_Testing_StreamingOutputCallRequest, callOptions: CallOptions? = nil, handler: @escaping (Grpc_Testing_StreamingOutputCallResponse) -> Void) -> ServerStreamingCall<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse> {
     return self.makeServerStreamingCall(path: self.path(forMethod: "StreamingOutputCall"),
                                         request: request,
                                         callOptions: callOptions ?? self.defaultCallOptions,

--- a/Sources/GRPCInteroperabilityTests/protos/Generated/test.grpc.swift
+++ b/Sources/GRPCInteroperabilityTests/protos/Generated/test.grpc.swift
@@ -33,7 +33,7 @@ public protocol Grpc_Testing_TestServiceService {
   func unaryCall(_ request: Grpc_Testing_SimpleRequest, callOptions: CallOptions?) -> UnaryCall<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse>
   func cacheableUnaryCall(_ request: Grpc_Testing_SimpleRequest, callOptions: CallOptions?) -> UnaryCall<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse>
   func streamingOutputCall(_ request: Grpc_Testing_StreamingOutputCallRequest, callOptions: CallOptions?, handler: @escaping (Grpc_Testing_StreamingOutputCallResponse) -> Void) -> ServerStreamingCall<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>
-  func streamingInputCall(callOptions: CallOptions?) -> ClientStreamingClientCall<Grpc_Testing_StreamingInputCallRequest, Grpc_Testing_StreamingInputCallResponse>
+  func streamingInputCall(callOptions: CallOptions?) -> ClientStreamingCall<Grpc_Testing_StreamingInputCallRequest, Grpc_Testing_StreamingInputCallResponse>
   func fullDuplexCall(callOptions: CallOptions?, handler: @escaping (Grpc_Testing_StreamingOutputCallResponse) -> Void) -> BidirectionalStreamingClientCall<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>
   func halfDuplexCall(callOptions: CallOptions?, handler: @escaping (Grpc_Testing_StreamingOutputCallResponse) -> Void) -> BidirectionalStreamingClientCall<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>
   func unimplementedCall(_ request: Grpc_Testing_Empty, callOptions: CallOptions?) -> UnaryCall<Grpc_Testing_Empty, Grpc_Testing_Empty>
@@ -111,8 +111,8 @@ public final class Grpc_Testing_TestServiceServiceClient: GRPCServiceClient, Grp
   ///
   /// - Parameters:
   ///   - callOptions: Call options; `self.defaultCallOptions` is used if `nil`.
-  /// - Returns: A `ClientStreamingClientCall` with futures for the metadata, status and response.
-  public func streamingInputCall(callOptions: CallOptions? = nil) -> ClientStreamingClientCall<Grpc_Testing_StreamingInputCallRequest, Grpc_Testing_StreamingInputCallResponse> {
+  /// - Returns: A `ClientStreamingCall` with futures for the metadata, status and response.
+  public func streamingInputCall(callOptions: CallOptions? = nil) -> ClientStreamingCall<Grpc_Testing_StreamingInputCallRequest, Grpc_Testing_StreamingInputCallResponse> {
     return self.makeClientStreamingCall(path: self.path(forMethod: "StreamingInputCall"),
                                         callOptions: callOptions ?? self.defaultCallOptions)
   }
@@ -125,7 +125,7 @@ public final class Grpc_Testing_TestServiceServiceClient: GRPCServiceClient, Grp
   /// - Parameters:
   ///   - callOptions: Call options; `self.defaultCallOptions` is used if `nil`.
   ///   - handler: A closure called when each response is received from the server.
-  /// - Returns: A `ClientStreamingClientCall` with futures for the metadata and status.
+  /// - Returns: A `ClientStreamingCall` with futures for the metadata and status.
   public func fullDuplexCall(callOptions: CallOptions? = nil, handler: @escaping (Grpc_Testing_StreamingOutputCallResponse) -> Void) -> BidirectionalStreamingClientCall<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse> {
     return self.makeBidirectionalStreamingCall(path: self.path(forMethod: "FullDuplexCall"),
                                                callOptions: callOptions ?? self.defaultCallOptions,
@@ -140,7 +140,7 @@ public final class Grpc_Testing_TestServiceServiceClient: GRPCServiceClient, Grp
   /// - Parameters:
   ///   - callOptions: Call options; `self.defaultCallOptions` is used if `nil`.
   ///   - handler: A closure called when each response is received from the server.
-  /// - Returns: A `ClientStreamingClientCall` with futures for the metadata and status.
+  /// - Returns: A `ClientStreamingCall` with futures for the metadata and status.
   public func halfDuplexCall(callOptions: CallOptions? = nil, handler: @escaping (Grpc_Testing_StreamingOutputCallResponse) -> Void) -> BidirectionalStreamingClientCall<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse> {
     return self.makeBidirectionalStreamingCall(path: self.path(forMethod: "HalfDuplexCall"),
                                                callOptions: callOptions ?? self.defaultCallOptions,

--- a/Sources/GRPCInteroperabilityTests/protos/Generated/test.grpc.swift
+++ b/Sources/GRPCInteroperabilityTests/protos/Generated/test.grpc.swift
@@ -34,8 +34,8 @@ public protocol Grpc_Testing_TestServiceService {
   func cacheableUnaryCall(_ request: Grpc_Testing_SimpleRequest, callOptions: CallOptions?) -> UnaryCall<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse>
   func streamingOutputCall(_ request: Grpc_Testing_StreamingOutputCallRequest, callOptions: CallOptions?, handler: @escaping (Grpc_Testing_StreamingOutputCallResponse) -> Void) -> ServerStreamingCall<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>
   func streamingInputCall(callOptions: CallOptions?) -> ClientStreamingCall<Grpc_Testing_StreamingInputCallRequest, Grpc_Testing_StreamingInputCallResponse>
-  func fullDuplexCall(callOptions: CallOptions?, handler: @escaping (Grpc_Testing_StreamingOutputCallResponse) -> Void) -> BidirectionalStreamingClientCall<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>
-  func halfDuplexCall(callOptions: CallOptions?, handler: @escaping (Grpc_Testing_StreamingOutputCallResponse) -> Void) -> BidirectionalStreamingClientCall<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>
+  func fullDuplexCall(callOptions: CallOptions?, handler: @escaping (Grpc_Testing_StreamingOutputCallResponse) -> Void) -> BidirectionalStreamingCall<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>
+  func halfDuplexCall(callOptions: CallOptions?, handler: @escaping (Grpc_Testing_StreamingOutputCallResponse) -> Void) -> BidirectionalStreamingCall<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>
   func unimplementedCall(_ request: Grpc_Testing_Empty, callOptions: CallOptions?) -> UnaryCall<Grpc_Testing_Empty, Grpc_Testing_Empty>
 }
 
@@ -126,7 +126,7 @@ public final class Grpc_Testing_TestServiceServiceClient: GRPCServiceClient, Grp
   ///   - callOptions: Call options; `self.defaultCallOptions` is used if `nil`.
   ///   - handler: A closure called when each response is received from the server.
   /// - Returns: A `ClientStreamingCall` with futures for the metadata and status.
-  public func fullDuplexCall(callOptions: CallOptions? = nil, handler: @escaping (Grpc_Testing_StreamingOutputCallResponse) -> Void) -> BidirectionalStreamingClientCall<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse> {
+  public func fullDuplexCall(callOptions: CallOptions? = nil, handler: @escaping (Grpc_Testing_StreamingOutputCallResponse) -> Void) -> BidirectionalStreamingCall<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse> {
     return self.makeBidirectionalStreamingCall(path: self.path(forMethod: "FullDuplexCall"),
                                                callOptions: callOptions ?? self.defaultCallOptions,
                                                handler: handler)
@@ -141,7 +141,7 @@ public final class Grpc_Testing_TestServiceServiceClient: GRPCServiceClient, Grp
   ///   - callOptions: Call options; `self.defaultCallOptions` is used if `nil`.
   ///   - handler: A closure called when each response is received from the server.
   /// - Returns: A `ClientStreamingCall` with futures for the metadata and status.
-  public func halfDuplexCall(callOptions: CallOptions? = nil, handler: @escaping (Grpc_Testing_StreamingOutputCallResponse) -> Void) -> BidirectionalStreamingClientCall<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse> {
+  public func halfDuplexCall(callOptions: CallOptions? = nil, handler: @escaping (Grpc_Testing_StreamingOutputCallResponse) -> Void) -> BidirectionalStreamingCall<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse> {
     return self.makeBidirectionalStreamingCall(path: self.path(forMethod: "HalfDuplexCall"),
                                                callOptions: callOptions ?? self.defaultCallOptions,
                                                handler: handler)

--- a/Sources/GRPCInteroperabilityTests/protos/Generated/test.grpc.swift
+++ b/Sources/GRPCInteroperabilityTests/protos/Generated/test.grpc.swift
@@ -29,14 +29,14 @@ import SwiftProtobuf
 
 /// Usage: instantiate Grpc_Testing_TestServiceServiceClient, then call methods of this protocol to make API calls.
 public protocol Grpc_Testing_TestServiceService {
-  func emptyCall(_ request: Grpc_Testing_Empty, callOptions: CallOptions?) -> UnaryClientCall<Grpc_Testing_Empty, Grpc_Testing_Empty>
-  func unaryCall(_ request: Grpc_Testing_SimpleRequest, callOptions: CallOptions?) -> UnaryClientCall<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse>
-  func cacheableUnaryCall(_ request: Grpc_Testing_SimpleRequest, callOptions: CallOptions?) -> UnaryClientCall<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse>
+  func emptyCall(_ request: Grpc_Testing_Empty, callOptions: CallOptions?) -> UnaryCall<Grpc_Testing_Empty, Grpc_Testing_Empty>
+  func unaryCall(_ request: Grpc_Testing_SimpleRequest, callOptions: CallOptions?) -> UnaryCall<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse>
+  func cacheableUnaryCall(_ request: Grpc_Testing_SimpleRequest, callOptions: CallOptions?) -> UnaryCall<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse>
   func streamingOutputCall(_ request: Grpc_Testing_StreamingOutputCallRequest, callOptions: CallOptions?, handler: @escaping (Grpc_Testing_StreamingOutputCallResponse) -> Void) -> ServerStreamingClientCall<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>
   func streamingInputCall(callOptions: CallOptions?) -> ClientStreamingClientCall<Grpc_Testing_StreamingInputCallRequest, Grpc_Testing_StreamingInputCallResponse>
   func fullDuplexCall(callOptions: CallOptions?, handler: @escaping (Grpc_Testing_StreamingOutputCallResponse) -> Void) -> BidirectionalStreamingClientCall<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>
   func halfDuplexCall(callOptions: CallOptions?, handler: @escaping (Grpc_Testing_StreamingOutputCallResponse) -> Void) -> BidirectionalStreamingClientCall<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>
-  func unimplementedCall(_ request: Grpc_Testing_Empty, callOptions: CallOptions?) -> UnaryClientCall<Grpc_Testing_Empty, Grpc_Testing_Empty>
+  func unimplementedCall(_ request: Grpc_Testing_Empty, callOptions: CallOptions?) -> UnaryCall<Grpc_Testing_Empty, Grpc_Testing_Empty>
 }
 
 public final class Grpc_Testing_TestServiceServiceClient: GRPCServiceClient, Grpc_Testing_TestServiceService {
@@ -59,8 +59,8 @@ public final class Grpc_Testing_TestServiceServiceClient: GRPCServiceClient, Grp
   /// - Parameters:
   ///   - request: Request to send to EmptyCall.
   ///   - callOptions: Call options; `self.defaultCallOptions` is used if `nil`.
-  /// - Returns: A `UnaryClientCall` with futures for the metadata, status and response.
-  public func emptyCall(_ request: Grpc_Testing_Empty, callOptions: CallOptions? = nil) -> UnaryClientCall<Grpc_Testing_Empty, Grpc_Testing_Empty> {
+  /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
+  public func emptyCall(_ request: Grpc_Testing_Empty, callOptions: CallOptions? = nil) -> UnaryCall<Grpc_Testing_Empty, Grpc_Testing_Empty> {
     return self.makeUnaryCall(path: self.path(forMethod: "EmptyCall"),
                               request: request,
                               callOptions: callOptions ?? self.defaultCallOptions)
@@ -71,8 +71,8 @@ public final class Grpc_Testing_TestServiceServiceClient: GRPCServiceClient, Grp
   /// - Parameters:
   ///   - request: Request to send to UnaryCall.
   ///   - callOptions: Call options; `self.defaultCallOptions` is used if `nil`.
-  /// - Returns: A `UnaryClientCall` with futures for the metadata, status and response.
-  public func unaryCall(_ request: Grpc_Testing_SimpleRequest, callOptions: CallOptions? = nil) -> UnaryClientCall<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse> {
+  /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
+  public func unaryCall(_ request: Grpc_Testing_SimpleRequest, callOptions: CallOptions? = nil) -> UnaryCall<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse> {
     return self.makeUnaryCall(path: self.path(forMethod: "UnaryCall"),
                               request: request,
                               callOptions: callOptions ?? self.defaultCallOptions)
@@ -83,8 +83,8 @@ public final class Grpc_Testing_TestServiceServiceClient: GRPCServiceClient, Grp
   /// - Parameters:
   ///   - request: Request to send to CacheableUnaryCall.
   ///   - callOptions: Call options; `self.defaultCallOptions` is used if `nil`.
-  /// - Returns: A `UnaryClientCall` with futures for the metadata, status and response.
-  public func cacheableUnaryCall(_ request: Grpc_Testing_SimpleRequest, callOptions: CallOptions? = nil) -> UnaryClientCall<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse> {
+  /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
+  public func cacheableUnaryCall(_ request: Grpc_Testing_SimpleRequest, callOptions: CallOptions? = nil) -> UnaryCall<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse> {
     return self.makeUnaryCall(path: self.path(forMethod: "CacheableUnaryCall"),
                               request: request,
                               callOptions: callOptions ?? self.defaultCallOptions)
@@ -152,8 +152,8 @@ public final class Grpc_Testing_TestServiceServiceClient: GRPCServiceClient, Grp
   /// - Parameters:
   ///   - request: Request to send to UnimplementedCall.
   ///   - callOptions: Call options; `self.defaultCallOptions` is used if `nil`.
-  /// - Returns: A `UnaryClientCall` with futures for the metadata, status and response.
-  public func unimplementedCall(_ request: Grpc_Testing_Empty, callOptions: CallOptions? = nil) -> UnaryClientCall<Grpc_Testing_Empty, Grpc_Testing_Empty> {
+  /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
+  public func unimplementedCall(_ request: Grpc_Testing_Empty, callOptions: CallOptions? = nil) -> UnaryCall<Grpc_Testing_Empty, Grpc_Testing_Empty> {
     return self.makeUnaryCall(path: self.path(forMethod: "UnimplementedCall"),
                               request: request,
                               callOptions: callOptions ?? self.defaultCallOptions)
@@ -163,7 +163,7 @@ public final class Grpc_Testing_TestServiceServiceClient: GRPCServiceClient, Grp
 
 /// Usage: instantiate Grpc_Testing_UnimplementedServiceServiceClient, then call methods of this protocol to make API calls.
 public protocol Grpc_Testing_UnimplementedServiceService {
-  func unimplementedCall(_ request: Grpc_Testing_Empty, callOptions: CallOptions?) -> UnaryClientCall<Grpc_Testing_Empty, Grpc_Testing_Empty>
+  func unimplementedCall(_ request: Grpc_Testing_Empty, callOptions: CallOptions?) -> UnaryCall<Grpc_Testing_Empty, Grpc_Testing_Empty>
 }
 
 public final class Grpc_Testing_UnimplementedServiceServiceClient: GRPCServiceClient, Grpc_Testing_UnimplementedServiceService {
@@ -186,8 +186,8 @@ public final class Grpc_Testing_UnimplementedServiceServiceClient: GRPCServiceCl
   /// - Parameters:
   ///   - request: Request to send to UnimplementedCall.
   ///   - callOptions: Call options; `self.defaultCallOptions` is used if `nil`.
-  /// - Returns: A `UnaryClientCall` with futures for the metadata, status and response.
-  public func unimplementedCall(_ request: Grpc_Testing_Empty, callOptions: CallOptions? = nil) -> UnaryClientCall<Grpc_Testing_Empty, Grpc_Testing_Empty> {
+  /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
+  public func unimplementedCall(_ request: Grpc_Testing_Empty, callOptions: CallOptions? = nil) -> UnaryCall<Grpc_Testing_Empty, Grpc_Testing_Empty> {
     return self.makeUnaryCall(path: self.path(forMethod: "UnimplementedCall"),
                               request: request,
                               callOptions: callOptions ?? self.defaultCallOptions)
@@ -197,8 +197,8 @@ public final class Grpc_Testing_UnimplementedServiceServiceClient: GRPCServiceCl
 
 /// Usage: instantiate Grpc_Testing_ReconnectServiceServiceClient, then call methods of this protocol to make API calls.
 public protocol Grpc_Testing_ReconnectServiceService {
-  func start(_ request: Grpc_Testing_ReconnectParams, callOptions: CallOptions?) -> UnaryClientCall<Grpc_Testing_ReconnectParams, Grpc_Testing_Empty>
-  func stop(_ request: Grpc_Testing_Empty, callOptions: CallOptions?) -> UnaryClientCall<Grpc_Testing_Empty, Grpc_Testing_ReconnectInfo>
+  func start(_ request: Grpc_Testing_ReconnectParams, callOptions: CallOptions?) -> UnaryCall<Grpc_Testing_ReconnectParams, Grpc_Testing_Empty>
+  func stop(_ request: Grpc_Testing_Empty, callOptions: CallOptions?) -> UnaryCall<Grpc_Testing_Empty, Grpc_Testing_ReconnectInfo>
 }
 
 public final class Grpc_Testing_ReconnectServiceServiceClient: GRPCServiceClient, Grpc_Testing_ReconnectServiceService {
@@ -221,8 +221,8 @@ public final class Grpc_Testing_ReconnectServiceServiceClient: GRPCServiceClient
   /// - Parameters:
   ///   - request: Request to send to Start.
   ///   - callOptions: Call options; `self.defaultCallOptions` is used if `nil`.
-  /// - Returns: A `UnaryClientCall` with futures for the metadata, status and response.
-  public func start(_ request: Grpc_Testing_ReconnectParams, callOptions: CallOptions? = nil) -> UnaryClientCall<Grpc_Testing_ReconnectParams, Grpc_Testing_Empty> {
+  /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
+  public func start(_ request: Grpc_Testing_ReconnectParams, callOptions: CallOptions? = nil) -> UnaryCall<Grpc_Testing_ReconnectParams, Grpc_Testing_Empty> {
     return self.makeUnaryCall(path: self.path(forMethod: "Start"),
                               request: request,
                               callOptions: callOptions ?? self.defaultCallOptions)
@@ -233,8 +233,8 @@ public final class Grpc_Testing_ReconnectServiceServiceClient: GRPCServiceClient
   /// - Parameters:
   ///   - request: Request to send to Stop.
   ///   - callOptions: Call options; `self.defaultCallOptions` is used if `nil`.
-  /// - Returns: A `UnaryClientCall` with futures for the metadata, status and response.
-  public func stop(_ request: Grpc_Testing_Empty, callOptions: CallOptions? = nil) -> UnaryClientCall<Grpc_Testing_Empty, Grpc_Testing_ReconnectInfo> {
+  /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
+  public func stop(_ request: Grpc_Testing_Empty, callOptions: CallOptions? = nil) -> UnaryCall<Grpc_Testing_Empty, Grpc_Testing_ReconnectInfo> {
     return self.makeUnaryCall(path: self.path(forMethod: "Stop"),
                               request: request,
                               callOptions: callOptions ?? self.defaultCallOptions)

--- a/Sources/protoc-gen-swiftgrpc/Generator-Client.swift
+++ b/Sources/protoc-gen-swiftgrpc/Generator-Client.swift
@@ -33,7 +33,7 @@ extension Generator {
       self.method = method
       switch streamingType(method) {
       case .unary:
-        println("func \(methodFunctionName)(_ request: \(methodInputName), callOptions: CallOptions?) -> UnaryClientCall<\(methodInputName), \(methodOutputName)>")
+        println("func \(methodFunctionName)(_ request: \(methodInputName), callOptions: CallOptions?) -> UnaryCall<\(methodInputName), \(methodOutputName)>")
 
       case .serverStreaming:
         println("func \(methodFunctionName)(_ request: \(methodInputName), callOptions: CallOptions?, handler: @escaping (\(methodOutputName)) -> Void) -> ServerStreamingClientCall<\(methodInputName), \(methodOutputName)>")
@@ -78,8 +78,8 @@ extension Generator {
         printParameters()
         printRequestParameter()
         printCallOptionsParameter()
-        println("/// - Returns: A `UnaryClientCall` with futures for the metadata, status and response.")
-        println("\(access) func \(methodFunctionName)(_ request: \(methodInputName), callOptions: CallOptions? = nil) -> UnaryClientCall<\(methodInputName), \(methodOutputName)> {")
+        println("/// - Returns: A `UnaryCall` with futures for the metadata, status and response.")
+        println("\(access) func \(methodFunctionName)(_ request: \(methodInputName), callOptions: CallOptions? = nil) -> UnaryCall<\(methodInputName), \(methodOutputName)> {")
         indent()
         println("return self.makeUnaryCall(path: self.path(forMethod: \"\(method.name)\"),")
         println("                          request: request,")

--- a/Sources/protoc-gen-swiftgrpc/Generator-Client.swift
+++ b/Sources/protoc-gen-swiftgrpc/Generator-Client.swift
@@ -42,7 +42,7 @@ extension Generator {
         println("func \(methodFunctionName)(callOptions: CallOptions?) -> ClientStreamingCall<\(methodInputName), \(methodOutputName)>")
 
       case .bidirectionalStreaming:
-        println("func \(methodFunctionName)(callOptions: CallOptions?, handler: @escaping (\(methodOutputName)) -> Void) -> BidirectionalStreamingClientCall<\(methodInputName), \(methodOutputName)>")
+        println("func \(methodFunctionName)(callOptions: CallOptions?, handler: @escaping (\(methodOutputName)) -> Void) -> BidirectionalStreamingCall<\(methodInputName), \(methodOutputName)>")
       }
     }
     outdent()
@@ -128,7 +128,7 @@ extension Generator {
         printCallOptionsParameter()
         printHandlerParameter()
         println("/// - Returns: A `ClientStreamingCall` with futures for the metadata and status.")
-        println("\(access) func \(methodFunctionName)(callOptions: CallOptions? = nil, handler: @escaping (\(methodOutputName)) -> Void) -> BidirectionalStreamingClientCall<\(methodInputName), \(methodOutputName)> {")
+        println("\(access) func \(methodFunctionName)(callOptions: CallOptions? = nil, handler: @escaping (\(methodOutputName)) -> Void) -> BidirectionalStreamingCall<\(methodInputName), \(methodOutputName)> {")
         indent()
         println("return self.makeBidirectionalStreamingCall(path: self.path(forMethod: \"\(method.name)\"),")
         println("                                           callOptions: callOptions ?? self.defaultCallOptions,")

--- a/Sources/protoc-gen-swiftgrpc/Generator-Client.swift
+++ b/Sources/protoc-gen-swiftgrpc/Generator-Client.swift
@@ -39,7 +39,7 @@ extension Generator {
         println("func \(methodFunctionName)(_ request: \(methodInputName), callOptions: CallOptions?, handler: @escaping (\(methodOutputName)) -> Void) -> ServerStreamingCall<\(methodInputName), \(methodOutputName)>")
 
       case .clientStreaming:
-        println("func \(methodFunctionName)(callOptions: CallOptions?) -> ClientStreamingClientCall<\(methodInputName), \(methodOutputName)>")
+        println("func \(methodFunctionName)(callOptions: CallOptions?) -> ClientStreamingCall<\(methodInputName), \(methodOutputName)>")
 
       case .bidirectionalStreaming:
         println("func \(methodFunctionName)(callOptions: CallOptions?, handler: @escaping (\(methodOutputName)) -> Void) -> BidirectionalStreamingClientCall<\(methodInputName), \(methodOutputName)>")
@@ -111,8 +111,8 @@ extension Generator {
         println("///")
         printParameters()
         printCallOptionsParameter()
-        println("/// - Returns: A `ClientStreamingClientCall` with futures for the metadata, status and response.")
-        println("\(access) func \(methodFunctionName)(callOptions: CallOptions? = nil) -> ClientStreamingClientCall<\(methodInputName), \(methodOutputName)> {")
+        println("/// - Returns: A `ClientStreamingCall` with futures for the metadata, status and response.")
+        println("\(access) func \(methodFunctionName)(callOptions: CallOptions? = nil) -> ClientStreamingCall<\(methodInputName), \(methodOutputName)> {")
         indent()
         println("return self.makeClientStreamingCall(path: self.path(forMethod: \"\(method.name)\"),")
         println("                                    callOptions: callOptions ?? self.defaultCallOptions)")
@@ -127,7 +127,7 @@ extension Generator {
         printParameters()
         printCallOptionsParameter()
         printHandlerParameter()
-        println("/// - Returns: A `ClientStreamingClientCall` with futures for the metadata and status.")
+        println("/// - Returns: A `ClientStreamingCall` with futures for the metadata and status.")
         println("\(access) func \(methodFunctionName)(callOptions: CallOptions? = nil, handler: @escaping (\(methodOutputName)) -> Void) -> BidirectionalStreamingClientCall<\(methodInputName), \(methodOutputName)> {")
         indent()
         println("return self.makeBidirectionalStreamingCall(path: self.path(forMethod: \"\(method.name)\"),")

--- a/Sources/protoc-gen-swiftgrpc/Generator-Client.swift
+++ b/Sources/protoc-gen-swiftgrpc/Generator-Client.swift
@@ -36,7 +36,7 @@ extension Generator {
         println("func \(methodFunctionName)(_ request: \(methodInputName), callOptions: CallOptions?) -> UnaryCall<\(methodInputName), \(methodOutputName)>")
 
       case .serverStreaming:
-        println("func \(methodFunctionName)(_ request: \(methodInputName), callOptions: CallOptions?, handler: @escaping (\(methodOutputName)) -> Void) -> ServerStreamingClientCall<\(methodInputName), \(methodOutputName)>")
+        println("func \(methodFunctionName)(_ request: \(methodInputName), callOptions: CallOptions?, handler: @escaping (\(methodOutputName)) -> Void) -> ServerStreamingCall<\(methodInputName), \(methodOutputName)>")
 
       case .clientStreaming:
         println("func \(methodFunctionName)(callOptions: CallOptions?) -> ClientStreamingClientCall<\(methodInputName), \(methodOutputName)>")
@@ -94,8 +94,8 @@ extension Generator {
         printRequestParameter()
         printCallOptionsParameter()
         printHandlerParameter()
-        println("/// - Returns: A `ServerStreamingClientCall` with futures for the metadata and status.")
-        println("\(access) func \(methodFunctionName)(_ request: \(methodInputName), callOptions: CallOptions? = nil, handler: @escaping (\(methodOutputName)) -> Void) -> ServerStreamingClientCall<\(methodInputName), \(methodOutputName)> {")
+        println("/// - Returns: A `ServerStreamingCall` with futures for the metadata and status.")
+        println("\(access) func \(methodFunctionName)(_ request: \(methodInputName), callOptions: CallOptions? = nil, handler: @escaping (\(methodOutputName)) -> Void) -> ServerStreamingCall<\(methodInputName), \(methodOutputName)> {")
         indent()
         println("return self.makeServerStreamingCall(path: self.path(forMethod: \"\(method.name)\"),")
         println("                                    request: request,")


### PR DESCRIPTION
Remove "Client" from all the client calls:
- `{Unary,{Server,Client,Bidirectional}Streaming}ClientCall` -> `{Unary,{Server,Client,Bidirectional}Streaming}Call` 