### PR TITLE
Add Server.Configuration

### DIFF
--- a/Sources/GRPC/LoggingServerErrorDelegate.swift
+++ b/Sources/GRPC/LoggingServerErrorDelegate.swift
@@ -16,7 +16,9 @@
 import Foundation
 
 public class LoggingServerErrorDelegate: ServerErrorDelegate {
-  public init() {}
+  public static let shared = LoggingServerErrorDelegate()
+
+  private init() {}
 
   public func observeLibraryError(_ error: Error) {
     print("[grpc-server][\(Date())] library: \(error)")

--- a/Sources/GRPCPerformanceTests/main.swift
+++ b/Sources/GRPCPerformanceTests/main.swift
@@ -363,15 +363,16 @@ Group { group in
       privateKeyPath: privateKeyPath,
       server: true)
 
+    let configuration = Server.Configuration(
+      target: .hostAndPort(host, port),
+      eventLoopGroup: group,
+      serviceProviders: [EchoProvider()],
+      tlsConfiguration: sslContext.map { .init(sslContext: $0) })
+
     let server: Server
 
     do {
-      server = try Server.start(
-        hostname: host,
-        port: port,
-        eventLoopGroup: group,
-        serviceProviders: [EchoProvider()],
-        tls: sslContext.map { .custom($0) } ?? .none).wait()
+      server = try Server.start(configuration: configuration).wait()
     } catch {
       print("unable to start server: \(error)")
       exit(1)

--- a/Tests/GRPCTests/ClientTLSFailureTests.swift
+++ b/Tests/GRPCTests/ClientTLSFailureTests.swift
@@ -60,14 +60,16 @@ class ClientTLSFailureTests: XCTestCase {
 
   override func setUp() {
     self.serverEventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-    self.server = try! Server.start(
-      hostname: "localhost",
-      port: 0,
+    let sslContext = try! NIOSSLContext(configuration: self.defaultServerTLSConfiguration)
+
+    let configuration = Server.Configuration(
+      target: .hostAndPort("localhost", 0),
       eventLoopGroup: self.serverEventLoopGroup,
       serviceProviders: [EchoProvider()],
       errorDelegate: nil,
-      tls: .custom(try NIOSSLContext(configuration: defaultServerTLSConfiguration))
-    ).wait()
+      tlsConfiguration: .init(sslContext: sslContext))
+
+    self.server = try! Server.start(configuration: configuration).wait()
 
     self.port = self.server.channel.localAddress?.port
 

--- a/Tests/GRPCTests/ServerWebTests.swift
+++ b/Tests/GRPCTests/ServerWebTests.swift
@@ -45,7 +45,7 @@ class ServerWebTests: EchoTestCaseBase {
   }
 
   private func sendOverHTTP1(rpcMethod: String, message: String?, handler: @escaping (Data?, Error?) -> Void) {
-    let serverURL = URL(string: "http://localhost:5050/echo.Echo/\(rpcMethod)")!
+    let serverURL = URL(string: "http://localhost:\(self.port!)/echo.Echo/\(rpcMethod)")!
     var request = URLRequest(url: serverURL)
     request.httpMethod = "POST"
     request.setValue("application/grpc-web-text", forHTTPHeaderField: "content-type")


### PR DESCRIPTION
Motivation:

We added Configuration to the ClientConnection to make it simpler to
create new connections. We should have the equivalent for Server.

Modification:

Added a Configuration for Server similar to
ClientConnection.Configuration. This also made it possible to add
support for NIOTS for the server.

Result:

Configuring a server is easier and they can now use NIOTS.