### PR TITLE
Fix a compiler warning.

### DIFF
--- a/Sources/CgRPC/include/grpc/grpc_security.h
+++ b/Sources/CgRPC/include/grpc/grpc_security.h
@@ -632,7 +632,7 @@ typedef struct grpc_tls_credentials_options grpc_tls_credentials_options;
 
 /** Create an empty TLS credentials options. It is used for
  *  experimental purpose for now and subject to change. */
-GRPCAPI grpc_tls_credentials_options* grpc_tls_credentials_options_create();
+GRPCAPI grpc_tls_credentials_options* grpc_tls_credentials_options_create(void);
 
 /** Set grpc_ssl_client_certificate_request_type field in credentials options
     with the provided type. options should not be NULL.
@@ -674,7 +674,7 @@ GRPCAPI int grpc_tls_credentials_options_set_server_authorization_check_config(
 
 /** Create an empty grpc_tls_key_materials_config instance.
  *  It is used for experimental purpose for now and subject to change. */
-GRPCAPI grpc_tls_key_materials_config* grpc_tls_key_materials_config_create();
+GRPCAPI grpc_tls_key_materials_config* grpc_tls_key_materials_config_create(void);
 
 /** Set grpc_tls_key_materials_config instance with provided a TLS certificate.
     config will take the ownership of pem_root_certs and pem_key_cert_pairs.


### PR DESCRIPTION
This is a backport of https://github.com/grpc/grpc/pull/18915, as I do not have the bandwidth to upgrade the whole codebase to gRPC 1.22 right now.