### PR TITLE
Add a swift_versions flag to the Podspec.

### DIFF
--- a/SwiftGRPC.podspec
+++ b/SwiftGRPC.podspec
@@ -32,6 +32,7 @@ Pod::Spec.new do |s|
   s.authors  = { 'The gRPC contributors' => 'grpc-packages@google.com' }
   s.source = { :git => 'https://github.com/grpc/grpc-swift.git', :tag => s.version }
 
+  s.swift_versions = [4.2]
   s.requires_arc = true
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'


### PR DESCRIPTION
This squelches a warning in the Podspec before releasing the 0.9.1 tag.

The following warnings will still remain in the Podspec:

```
    - WARN  | xcodebuild:  /Users/daniel/Library/Developer/Xcode/DerivedData/App-ekzxujpqpbynmreaqbbxjewuznea/Build/Products/Release-iphonesimulator/gRPC-Core/grpc.framework/Headers/grpc_security.h:635:74: warning: this function declaration is not a prototype [-Wstrict-prototypes]
    - WARN  | xcodebuild:  /Users/daniel/Library/Developer/Xcode/DerivedData/App-ekzxujpqpbynmreaqbbxjewuznea/Build/Products/Release-iphonesimulator/gRPC-Core/grpc.framework/Headers/grpc_security.h:677:76: warning: this function declaration is not a prototype [-Wstrict-prototypes]
    - WARN  | [OSX] xcodebuild:  /Users/daniel/Library/Developer/Xcode/DerivedData/App-ekzxujpqpbynmreaqbbxjewuznea/Build/Products/Release/gRPC-Core/grpc.framework/Headers/grpc_security.h:635:74: warning: this function declaration is not a prototype [-Wstrict-prototypes]
    - WARN  | [OSX] xcodebuild:  /Users/daniel/Library/Developer/Xcode/DerivedData/App-ekzxujpqpbynmreaqbbxjewuznea/Build/Products/Release/gRPC-Core/grpc.framework/Headers/grpc_security.h:677:76: warning: this function declaration is not a prototype [-Wstrict-prototypes]
    - WARN  | [tvOS] xcodebuild:  /Users/daniel/Library/Developer/Xcode/DerivedData/App-ekzxujpqpbynmreaqbbxjewuznea/Build/Products/Release-appletvsimulator/gRPC-Core/grpc.framework/Headers/grpc_security.h:635:74: warning: this function declaration is not a prototype [-Wstrict-prototypes]
    - WARN  | [tvOS] xcodebuild:  /Users/daniel/Library/Developer/Xcode/DerivedData/App-ekzxujpqpbynmreaqbbxjewuznea/Build/Products/Release-appletvsimulator/gRPC-Core/grpc.framework/Headers/grpc_security.h:677:76: warning: this function declaration is not a prototype [-Wstrict-prototypes]
```

These are fixed in #499, but as the Podspec directly pulls in its own copy of gRPC-Core, the CocoaPods variant does not benefit from that fix. Unfortunately, I do not have the time to upgrade this whole project to gRPC-Core 1.22 right now, however.