### PR TITLE
Revert to Apache 2.0 license verbatim [skip ci]

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,14 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        https://www.apache.org/licenses/
+                        http://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
    1. Definitions.
 
       "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
       "Licensor" shall mean the copyright owner or entity authorized by
       the copyright owner that is granting the License.
@@ -86,6 +87,7 @@
       granted to You under this License for that Work shall terminate
       as of the date such litigation is filed.
 
+   4. Redistribution. You may reproduce and distribute copies of the
       Work or Derivative Works thereof in any medium, with or without
       modifications, and in Source or Object form, provided that You
       meet the following conditions:
@@ -103,6 +105,7 @@
           the Derivative Works; and
 
       (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
           include a readable copy of the attribution notices contained
           within such NOTICE file, excluding those notices that do not
           pertain to any part of the Derivative Works, in at least one
@@ -120,7 +123,9 @@
 
       You may add Your own copyright statement to Your modifications and
       may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
       for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
       the conditions stated in this License.
 
    5. Submission of Contributions. Unless You explicitly state otherwise,
@@ -171,13 +176,24 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2016-2017 gRPC authors.
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       https://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Replaced the license with the verbatim contents of the canonical license URL:
https://www.apache.org/licenses/LICENSE-2.0.txt

The license seems to be missing random lines, the entire paragraph at the end,
and should not be replacing the template with a specific copyright as this is the
license, not a copyright statement for the project. Each file has a copyright
statement at the top.