### PR TITLE
Remove '###' from git commit template section headers

### DIFF
--- a/dev/git.commit.template
+++ b/dev/git.commit.template
@@ -1,14 +1,14 @@
 One line description of your change
 
-### Motivation:
+Motivation:
 
 Explain here the context, and why you're making that change.
 What is the problem you're trying to solve.
 
-### Modifications:
+Modifications:
 
 Describe the modifications you've done.
 
-### Result:
+Result:
 
 After your change, what will change.


### PR DESCRIPTION
Motivation:

It seems like git removes any lines starting with a `#`, so we'd lose
lines from commits following the template.

Modifications:

Remove the Markdown formatting from the commit template.

Result:

Commits using our template won't have lines removed by git.