### PR TITLE
avoid conformance error surfacing when SwiftUI Preview builds tests

### DIFF
--- a/Sources/GRPCInteroperabilityTestsCLI/main.swift
+++ b/Sources/GRPCInteroperabilityTestsCLI/main.swift
@@ -79,30 +79,6 @@ func exitOnThrow<T>(block: () throws -> T) -> T {
   }
 }
 
-// MARK: - Optional extensions for Commander
-
-// "Commander" doesn't allow us to have no value for an `Option` and using a sentinel value to
-// indicate a lack of value isn't very Swift-y when we have `Optional`.
-
-extension Optional: CustomStringConvertible where Wrapped: ArgumentConvertible {
-  public var description: String {
-    guard let value = self else {
-      return "None"
-    }
-    return "Some(\(value))"
-  }
-}
-
-extension Optional: ArgumentConvertible where Wrapped: ArgumentConvertible {
-  public init(parser: ArgumentParser) throws {
-    if let wrapped = parser.shift() as? Wrapped {
-      self = wrapped
-    } else {
-      self = .none
-    }
-  }
-}
-
 // MARK: - Command line options and "main".
 
 let serverHostOption = Option(


### PR DESCRIPTION
```
conflicting conformance of 'Optional<Wrapped>' to protocol 'CustomStringConvertible'; there cannot be more than one conformance, even with different conditional bounds

----------------------------------------

Failed to build the scheme "swiftgrpc": Compile /Volumes/DerivedData-ramdisk/DerivedData/aduu-swift-ccwvbioiqcuclleyjznkpzajipeb/SourcePackages/checkouts/grpc-swift/Sources/GRPCInteroperabilityTestsCLI/main.swift:
/Volumes/DerivedData-ramdisk/DerivedData/aduu-swift-ccwvbioiqcuclleyjznkpzajipeb/SourcePackages/checkouts/grpc-swift/Sources/GRPCInteroperabilityTestsCLI/main.swift:87:21: error: conflicting conformance of 'Optional<Wrapped>' to protocol 'CustomStringConvertible'; there cannot be more than one conformance, even with different conditional bounds
extension Optional: CustomStringConvertible where Wrapped: ArgumentConvertible {
                    ^
Commander.Optional<τ_0_0>:1:11: note: 'Optional<Wrapped>' declares conformance to protocol 'CustomStringConvertible' here
extension Optional : CustomStringConvertible where Wrapped : CustomStringConvertible {
          ^
/Volumes/DerivedData-ramdisk/DerivedData/aduu-swift-ccwvbioiqcuclleyjznkpzajipeb/SourcePackages/checkouts/grpc-swift/Sources/GRPCInteroperabilityTestsCLI/main.swift:96:21: warning: conformance of 'Optional<Wrapped>' to protocol 'ArgumentConvertible' was already stated in the protocol's module 'Commander'
extension Optional: ArgumentConvertible where Wrapped: ArgumentConvertible {
                    ^
/Volumes/DerivedData-ramdisk/DerivedData/aduu-swift-ccwvbioiqcuclleyjznkpzajipeb/SourcePackages/checkouts/grpc-swift/Sources/GRPCInteroperabilityTestsCLI/main.swift:97:10: note: initializer 'init(parser:)' will not be used to satisfy the conformance to 'ArgumentConvertible'
  public init(parser: ArgumentParser) throws {
         ^
Commander.Optional<τ_0_0>:1:11: note: 'Optional<Wrapped>' declares conformance to protocol 'ArgumentConvertible' here
extension Optional : Commander.ArgumentConvertible where Wrapped : Commander.ArgumentConvertible {
          ^
```

This conformance error comes up when using SwiftUI previews, clicking Continue/Retry to show the Preview. Removing the offending conformance makes the Preview work correctly.

I don't know whether more is required for this though.

[This forum post](https://forums.swift.org/t/conditional-conformance-collisions/18023/4) suggests to use use wrapper types or some such to avoid this kind of issue. I don't know whether anyone would want to do that.