### PR TITLE
Rename GRPCNIO to PlatformSupport

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ logical cores on your system.
 We also `wait` for the server to start before setting up a client.
 
 ```swift
-let serverEventLoopGroup = GRPCNIO.makeEventLoopGroup(numberOfThreads: 1)
+let serverEventLoopGroup = PlatformSupport.makeEventLoopGroup(numberOfThreads: 1)
 let configuration = Server.Configuration(
   target: .hostAndPort(address, port),
   eventLoopGroup: serverEventLoopGroup,
@@ -226,7 +226,7 @@ means to make gRPC calls via a generated client. Note that
 `Echo_EchoServiceClient` is the client we generated from `echo.proto`.
 
 ```swift
-let clientEventLoopGroup = GRPCNIO.makeEventLoopGroup(loopCount: 1)
+let clientEventLoopGroup = PlatformSupport.makeEventLoopGroup(loopCount: 1)
 let configuration = ClientConnection.Configuration(
   target: .hostAndPort(host, port),
   eventLoopGroup: clientEventLoopGroup
@@ -421,7 +421,7 @@ gRPC Swift provides a helper method to provide the correct `EventLoopGroup`
 based on the network preference:
 
 ```swift
-GRPCNIO.makeEventLoopGroup(loopCount:networkPreference:) -> EventLoopGroup
+PlatformSupport.makeEventLoopGroup(loopCount:networkPreference:) -> EventLoopGroup
 ```
 
 Here `networkPreference` defaults to `.best`, which chooses the

--- a/Sources/GRPC/ClientConnection.swift
+++ b/Sources/GRPC/ClientConnection.swift
@@ -332,7 +332,7 @@ extension ClientConnection {
     timeout: TimeInterval?,
     logger: Logger
   ) -> ClientBootstrapProtocol {
-    let bootstrap = GRPCNIO.makeClientBootstrap(group: group)
+    let bootstrap = PlatformSupport.makeClientBootstrap(group: group)
       // Enable SO_REUSEADDR and TCP_NODELAY.
       .channelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
       .channelOption(ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)

--- a/Sources/GRPC/PlatformSupport.swift
+++ b/Sources/GRPC/PlatformSupport.swift
@@ -56,14 +56,14 @@ extension NetworkPreference {
     case .best:
       #if canImport(Network)
       guard #available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *) else {
-        GRPCNIO.logger.critical("Network.framework can be imported but is not supported on this platform")
+        PlatformSupport.logger.critical("Network.framework can be imported but is not supported on this platform")
         // This is gated by the availability of `.networkFramework` so should never happen.
         fatalError(".networkFramework is being used on an unsupported platform")
       }
-      GRPCNIO.logger.info("'best' NetworkImplementation is .networkFramework")
+      PlatformSupport.logger.info("'best' NetworkImplementation is .networkFramework")
       return .networkFramework
       #else
-      GRPCNIO.logger.info("'best' NetworkImplementation is .posix")
+      PlatformSupport.logger.info("'best' NetworkImplementation is .posix")
       return .posix
       #endif
 
@@ -120,7 +120,7 @@ extension NIOTSListenerBootstrap: ServerBootstrapProtocol {}
 
 // MARK: - Bootstrap / EventLoopGroup helpers
 
-public enum GRPCNIO {
+public enum PlatformSupport {
   static let logger = Logger(subsystem: .nio)
 
   /// Makes a new event loop group based on the network preference.

--- a/Sources/GRPC/Server.swift
+++ b/Sources/GRPC/Server.swift
@@ -93,7 +93,7 @@ import NIOSSL
 public final class Server {
   /// Makes and configures a `ServerBootstrap` using the provided configuration.
   public class func makeBootstrap(configuration: Configuration) -> ServerBootstrapProtocol {
-    let bootstrap = GRPCNIO.makeServerBootstrap(group: configuration.eventLoopGroup)
+    let bootstrap = PlatformSupport.makeServerBootstrap(group: configuration.eventLoopGroup)
 
     // Backlog is only available on `ServerBootstrap`.
     if bootstrap is ServerBootstrap {

--- a/Sources/GRPC/Shims.swift
+++ b/Sources/GRPC/Shims.swift
@@ -32,3 +32,6 @@ extension Server.Configuration {
     return nil
   }
 }
+
+@available(*, deprecated, renamed: "PlatformSupport")
+public enum GRPCNIO {}

--- a/Tests/GRPCTests/BasicEchoTestCase.swift
+++ b/Tests/GRPCTests/BasicEchoTestCase.swift
@@ -144,14 +144,14 @@ class EchoTestCaseBase: GRPCTestCase {
 
   override func setUp() {
     super.setUp()
-    self.serverEventLoopGroup = GRPCNIO.makeEventLoopGroup(
+    self.serverEventLoopGroup = PlatformSupport.makeEventLoopGroup(
       loopCount: 1,
       networkPreference: self.networkPreference)
     self.server = try! self.makeServer()
 
     self.port = self.server.channel.localAddress!.port!
 
-    self.clientEventLoopGroup = GRPCNIO.makeEventLoopGroup(
+    self.clientEventLoopGroup = PlatformSupport.makeEventLoopGroup(
       loopCount: 1,
       networkPreference: self.networkPreference)
     self.client = try! self.makeEchoClient(port: self.port)


### PR DESCRIPTION
Motivation:

We were never really satisfied with the name "GRPCNIO" for the
namespace with functions to provide event loop groups
and bootstraps for NIO and NIOTS in a platform-agnostic way.

Modifications:

Rename GRPCNIO to PlatformSupport, add an availability attribute
to GRPCNIO to make it easier for users to update their code after
the renaming.

Result:

Slightly better naming.