### PR TITLE
Use EmbeddedChannel for client timeout tests

### DIFF
--- a/Sources/GRPC/ClientCalls/BaseClientCall.swift
+++ b/Sources/GRPC/ClientCalls/BaseClientCall.swift
@@ -168,20 +168,17 @@ extension BaseClientCall: ClientCall {
 /// - Parameter requestID: The request ID used for this call. If `callOptions` specifies a
 ///   non-nil `reqeuestIDHeader` then this request ID will be added to the headers with the
 ///   specified header name.
-internal func makeRequestHead(path: String, host: String?, callOptions: CallOptions, requestID: String) -> HTTPRequestHead {
+internal func makeRequestHead(path: String, host: String, callOptions: CallOptions, requestID: String) -> HTTPRequestHead {
   var headers: HTTPHeaders = [
     "content-type": "application/grpc",
     // Used to detect incompatible proxies, as per https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests
     "te": "trailers",
     //! FIXME: Add a more specific user-agent, see: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#user-agents
     "user-agent": "grpc-swift-nio",
+    // We're dealing with HTTP/1; the NIO HTTP2ToHTTP1Codec replaces "host" with ":authority".
+    "host": host,
     GRPCHeaderName.acceptEncoding: CompressionMechanism.acceptEncodingHeader,
   ]
-
-  if let host = host {
-    // We're dealing with HTTP/1; the NIO HTTP2ToHTTP1Codec replaces "host" with ":authority".
-    headers.add(name: "host", value: host)
-  }
 
   if callOptions.timeout != .infinite {
     headers.add(name: GRPCHeaderName.timeout, value: String(describing: callOptions.timeout))


### PR DESCRIPTION
Motivation:

The ClientTimeoutTests were often flakey as they relied on waiting
for specified times instead of reacting to signals.

Modifications:

Provide an internal init for ClientConnection which uses an
EmbeddedChannel. Rewrite the ClientTimeoutTests to make use of
this change.

Result:

ClientTimeoutTests are more reliable.