### PR TITLE
Disable static stdlib linking.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ all:
 	cp .build/debug/protoc-gen-swiftgrpc .
 
 plugin:
-	swift build --product protoc-gen-swift -c release -Xswiftc -static-stdlib
-	swift build --product protoc-gen-swiftgrpc -c release -Xswiftc -static-stdlib
+	swift build --product protoc-gen-swift -c release
+	swift build --product protoc-gen-swiftgrpc -c release
 	cp .build/release/protoc-gen-swift .
 	cp .build/release/protoc-gen-swiftgrpc .
 


### PR DESCRIPTION
Disable static stdlib linking for our protoc plugins.

Motivation:

Seems like these cause some issues these days; let's see if our users can confirm that removing this flag helps.

Modifications:

Remove the ` -Xswiftc -static-stdlib` compiler flags.

Result:

The plugins will build correctly with both Swift 5 and Swift 5.1.