### PR TITLE
Fix building for 32-bit architectures. Fix Int overflow.

### DIFF
--- a/Sources/GRPC/GRPCTimeout.swift
+++ b/Sources/GRPC/GRPCTimeout.swift
@@ -46,7 +46,7 @@ public struct GRPCTimeout: CustomStringConvertible, Equatable {
 
     // See "Timeout" in https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests
     let description = "\(amount)\(unit.rawValue)"
-    let nanoseconds = Int64(amount) * Int64(unit.asNanoseconds)
+    let nanoseconds = Int64(amount) * unit.asNanoseconds
 
     return GRPCTimeout(nanoseconds: nanoseconds, description: description)
   }
@@ -133,7 +133,7 @@ private enum GRPCTimeoutUnit: String {
   case microseconds = "u"
   case nanoseconds = "n"
 
-  internal var asNanoseconds: Int {
+  internal var asNanoseconds: Int64 {
     switch self {
     case .hours:
       return 60 * 60 * 1000 * 1000 * 1000


### PR DESCRIPTION
## What
Fix possible `Int` overflow when building for 32-bit architectures by increasing the size to `Int64`.
See related issue https://github.com/grpc/grpc-swift/issues/534

## Why
The build is failing and overflow issues are possible

## Affected Areas
Timestamp generation in `GRPCTimeout.swift`