### PR TITLE
Notify state change for initial state

### DIFF
--- a/Sources/SwiftGRPC/Core/ClientNetworkMonitor.swift
+++ b/Sources/SwiftGRPC/Core/ClientNetworkMonitor.swift
@@ -149,8 +149,8 @@ open class ClientNetworkMonitor {
       let isUsingWifi = !flags.contains(.isWWAN)
       let isReachable = flags.contains(.reachable)
 
-      let notifyForWifi = self.isUsingWifi != nil && self.isUsingWifi != isUsingWifi
-      let notifyForReachable = self.isReachable != nil && self.isReachable != isReachable
+      let notifyForWifi = self.isUsingWifi != isUsingWifi
+      let notifyForReachable = self.isReachable != isReachable
 
       self.isUsingWifi = isUsingWifi
       self.isReachable = isReachable


### PR DESCRIPTION
Hi. :hand:

I fixed state notification logic in `ClientNetworkMonitor`.

In the initial state of the `ClientNetworkMonitor` instance, the internal `reachabilityDidChange(with:)` is called, but if `isUsingWifi` or `isReachable` is nil, `callBack` is not called.  
In addition, `SCNetworkReachabilityCallBack` will then notify `SCNetworkReachabilityFlags`, but `callBack` will not be called because of comparing the values.
Was this implementation intentionally?

```swift
let notifyForWifi = self.isUsingWifi != nil && self.isUsingWifi != isUsingWifi
let notifyForReachable = self.isReachable != nil && self.isReachable != isReachable
```

I think `callback` should be called anytime because `SCNetworkReachabilitySetCallback` notifies the first state. 
[Reachability.swift](https://github.com/ashleymills/Reachability.swift), a typical Reachability framework, also execute status notifications for the first state. Please [see](https://github.com/ashleymills/Reachability.swift/blob/master/Sources/Reachability.swift) here for the details.