### PR TITLE
Remove unused 'serverHandler' parameter for generated server code

### DIFF
--- a/Sources/Examples/Echo/Generated/echo.grpc.swift
+++ b/Sources/Examples/Echo/Generated/echo.grpc.swift
@@ -119,7 +119,7 @@ extension Echo_EchoProvider {
 
   /// Determines, calls and returns the appropriate request handler, depending on the request's method.
   /// Returns nil for methods not handled by this service.
-  internal func handleMethod(_ methodName: String, request: HTTPRequestHead, serverHandler: GRPCChannelHandler, channel: Channel, errorDelegate: ServerErrorDelegate?) -> GRPCCallHandler? {
+  internal func handleMethod(_ methodName: String, request: HTTPRequestHead, channel: Channel, errorDelegate: ServerErrorDelegate?) -> GRPCCallHandler? {
     switch methodName {
     case "Get":
       return UnaryCallHandler(channel: channel, request: request, errorDelegate: errorDelegate) { context in

--- a/Sources/Examples/Echo/RUNME
+++ b/Sources/Examples/Echo/RUNME
@@ -4,4 +4,4 @@
 #
 protoc echo.proto \
     --swift_out=Generated \
-    --swiftgrpc_out=Client=false,Server=true,NIO=true:Generated
+    --swiftgrpc_out=Client=true,Server=true:Generated

--- a/Sources/GRPC/GRPCChannelHandler.swift
+++ b/Sources/GRPC/GRPCChannelHandler.swift
@@ -34,7 +34,7 @@ public protocol CallHandlerProvider: class {
 
   /// Determines, calls and returns the appropriate request handler (`GRPCCallHandler`), depending on the request's
   /// method. Returns nil for methods not handled by this service.
-  func handleMethod(_ methodName: String, request: HTTPRequestHead, serverHandler: GRPCChannelHandler, channel: Channel, errorDelegate: ServerErrorDelegate?) -> GRPCCallHandler?
+  func handleMethod(_ methodName: String, request: HTTPRequestHead, channel: Channel, errorDelegate: ServerErrorDelegate?) -> GRPCCallHandler?
 }
 
 /// Listens on a newly-opened HTTP2 subchannel and yields to the sub-handler matching a call, if available.
@@ -107,7 +107,7 @@ extension GRPCChannelHandler: ChannelInboundHandler, RemovableChannelHandler {
     let uriComponents = requestHead.uri.components(separatedBy: "/")
     guard uriComponents.count >= 3 && uriComponents[0].isEmpty,
       let providerForServiceName = servicesByName[uriComponents[1]],
-      let callHandler = providerForServiceName.handleMethod(uriComponents[2], request: requestHead, serverHandler: self, channel: channel, errorDelegate: errorDelegate) else {
+      let callHandler = providerForServiceName.handleMethod(uriComponents[2], request: requestHead, channel: channel, errorDelegate: errorDelegate) else {
         return nil
     }
     return callHandler

--- a/Sources/GRPCInteroperabilityTests/protos/Generated/test.grpc.swift
+++ b/Sources/GRPCInteroperabilityTests/protos/Generated/test.grpc.swift
@@ -258,7 +258,7 @@ extension Grpc_Testing_TestServiceProvider {
 
   /// Determines, calls and returns the appropriate request handler, depending on the request's method.
   /// Returns nil for methods not handled by this service.
-  public func handleMethod(_ methodName: String, request: HTTPRequestHead, serverHandler: GRPCChannelHandler, channel: Channel, errorDelegate: ServerErrorDelegate?) -> GRPCCallHandler? {
+  public func handleMethod(_ methodName: String, request: HTTPRequestHead, channel: Channel, errorDelegate: ServerErrorDelegate?) -> GRPCCallHandler? {
     switch methodName {
     case "EmptyCall":
       return UnaryCallHandler(channel: channel, request: request, errorDelegate: errorDelegate) { context in
@@ -318,7 +318,7 @@ extension Grpc_Testing_UnimplementedServiceProvider {
 
   /// Determines, calls and returns the appropriate request handler, depending on the request's method.
   /// Returns nil for methods not handled by this service.
-  public func handleMethod(_ methodName: String, request: HTTPRequestHead, serverHandler: GRPCChannelHandler, channel: Channel, errorDelegate: ServerErrorDelegate?) -> GRPCCallHandler? {
+  public func handleMethod(_ methodName: String, request: HTTPRequestHead, channel: Channel, errorDelegate: ServerErrorDelegate?) -> GRPCCallHandler? {
     switch methodName {
     case "UnimplementedCall":
       return UnaryCallHandler(channel: channel, request: request, errorDelegate: errorDelegate) { context in
@@ -343,7 +343,7 @@ extension Grpc_Testing_ReconnectServiceProvider {
 
   /// Determines, calls and returns the appropriate request handler, depending on the request's method.
   /// Returns nil for methods not handled by this service.
-  public func handleMethod(_ methodName: String, request: HTTPRequestHead, serverHandler: GRPCChannelHandler, channel: Channel, errorDelegate: ServerErrorDelegate?) -> GRPCCallHandler? {
+  public func handleMethod(_ methodName: String, request: HTTPRequestHead, channel: Channel, errorDelegate: ServerErrorDelegate?) -> GRPCCallHandler? {
     switch methodName {
     case "Start":
       return UnaryCallHandler(channel: channel, request: request, errorDelegate: errorDelegate) { context in

--- a/Sources/protoc-gen-swiftgrpc/Generator-Server.swift
+++ b/Sources/protoc-gen-swiftgrpc/Generator-Server.swift
@@ -49,7 +49,7 @@ extension Generator {
     println()
     println("/// Determines, calls and returns the appropriate request handler, depending on the request's method.")
     println("/// Returns nil for methods not handled by this service.")
-    println("\(access) func handleMethod(_ methodName: String, request: HTTPRequestHead, serverHandler: GRPCChannelHandler, channel: Channel, errorDelegate: ServerErrorDelegate?) -> GRPCCallHandler? {")
+    println("\(access) func handleMethod(_ methodName: String, request: HTTPRequestHead, channel: Channel, errorDelegate: ServerErrorDelegate?) -> GRPCCallHandler? {")
     indent()
     println("switch methodName {")
     for method in service.methods {


### PR DESCRIPTION
Motivation:

The `handleMethod` of `CallHandlerProvider` took a serverHandler
parameter which was unused.

Modifications:

Remove the unused parameter from the protocol, codegen, and re-ran
codegen for Echo and interop tests.

Result:

Fewer unused parameters.