### PR TITLE
Fix typos in README

### DIFF
--- a/Sources/GRPC/Server.swift
+++ b/Sources/GRPC/Server.swift
@@ -210,16 +210,6 @@ extension Server {
       self.tls = tls
     }
   }
-
-  /// The TLS configuration for a connection.
-  public struct TLSConfiguration {
-    /// The SSL context to use.
-    public var sslContext: NIOSSLContext
-
-    public init(sslContext: NIOSSLContext) {
-      self.sslContext = sslContext
-    }
-  }
 }
 
 fileprivate extension Server.Configuration {


### PR DESCRIPTION
Motivation:

Parts of the README were outdated and incorrect.

Modifications:

Update the README to correct known typographic errors. Update the
section on TLS since it was incorrect.

Removed old TLS code the README referred to but could not be used.

Result:

More helpful README