### PR TITLE
Disable logging in tests for CI only

### DIFF
--- a/Tests/GRPCTests/LengthPrefixedMessageReaderTests.swift
+++ b/Tests/GRPCTests/LengthPrefixedMessageReaderTests.swift
@@ -20,11 +20,16 @@ import NIO
 import Logging
 
 class LengthPrefixedMessageReaderTests: GRPCTestCase {
-  var reader = LengthPrefixedMessageReader(
-    mode: .client,
-    compressionMechanism: .none,
-    logger: Logger(label: "io.grpc.testing")
-  )
+  var reader: LengthPrefixedMessageReader!
+
+  override func setUp() {
+    super.setUp()
+    self.reader = LengthPrefixedMessageReader(
+      mode: .client,
+      compressionMechanism: .none,
+      logger: Logger(label: "io.grpc.testing")
+    )
+  }
 
   var allocator = ByteBufferAllocator()
 


### PR DESCRIPTION
Motivation:

It's often useful to have logging output when running tests, however,
Travis will fail the job if we log too much.

Modifications:

Enable logging in tests only of the "CI" environment variable does not
equal "true".

Result:

Logging can be disabled by the environment.