### PR TITLE
Use protoToModuleMappings in input/output names.

### DIFF
--- a/Sources/protoc-gen-swiftgrpc/Generator-Names.swift
+++ b/Sources/protoc-gen-swiftgrpc/Generator-Names.swift
@@ -17,11 +17,6 @@ import Foundation
 import SwiftProtobuf
 import SwiftProtobufPluginLibrary
 
-// Transform .some.package_name.FooBarRequest -> Some_PackageName_FooBarRequest
-internal func protoMessageName(_ descriptor: SwiftProtobufPluginLibrary.Descriptor) -> String {
-  return SwiftProtobufNamer().fullName(message: descriptor)
-}
-
 internal func nameForPackageService(_ file: FileDescriptor,
                                     _ service: ServiceDescriptor) -> String {
   if !file.package.isEmpty {
@@ -73,11 +68,11 @@ extension Generator {
   }
 
   internal var methodInputName: String {
-    return protoMessageName(method.inputType)
+    return protobufNamer.fullName(message: method.inputType)
   }
 
   internal var methodOutputName: String {
-    return protoMessageName(method.outputType)
+    return protobufNamer.fullName(message: method.outputType)
   }
   
   internal var servicePath: String {

--- a/Sources/protoc-gen-swiftgrpc/Generator.swift
+++ b/Sources/protoc-gen-swiftgrpc/Generator.swift
@@ -23,10 +23,15 @@ class Generator {
   internal var service: ServiceDescriptor! // context during generation
   internal var method: MethodDescriptor!   // context during generation
 
+  internal let protobufNamer: SwiftProtobufNamer
+
   init(_ file:FileDescriptor, options:GeneratorOptions) {
     self.file = file
     self.options = options
     self.printer = CodePrinter()
+    self.protobufNamer =  SwiftProtobufNamer(
+      currentFile: file,
+      protoFileToModuleMappings:  options.protoToModuleMappings)
     printMain()
   }
   

--- a/Sources/protoc-gen-swiftgrpc/Generator.swift
+++ b/Sources/protoc-gen-swiftgrpc/Generator.swift
@@ -25,13 +25,13 @@ class Generator {
 
   internal let protobufNamer: SwiftProtobufNamer
 
-  init(_ file:FileDescriptor, options:GeneratorOptions) {
+  init(_ file: FileDescriptor, options: GeneratorOptions) {
     self.file = file
     self.options = options
     self.printer = CodePrinter()
-    self.protobufNamer =  SwiftProtobufNamer(
+    self.protobufNamer = SwiftProtobufNamer(
       currentFile: file,
-      protoFileToModuleMappings:  options.protoToModuleMappings)
+      protoFileToModuleMappings: options.protoToModuleMappings)
     printMain()
   }
   


### PR DESCRIPTION
Type ambiguities can arise if the proto module mappings are not factored
in. For example, if a message named `Version` is defined in a separate
module, and used in a unary call the generated generic arguments
`ClientCallUnaryBase<Version, Version>` are ambiguous:

```
SwiftProtobuf.Version:1:15: note: found this candidate
public struct Version {
              ^
some_module.Version:1:15: note: found this candidate
public struct Version {
```