### PR TITLE
Make the backoff infinite

### DIFF
--- a/Sources/GRPC/ClientConnection.swift
+++ b/Sources/GRPC/ClientConnection.swift
@@ -467,15 +467,14 @@ extension ClientConnection {
     ///     on debug builds.
     /// - Parameter connectivityStateDelegate: A connectivity state delegate, defaulting to `nil`.
     /// - Parameter tlsConfiguration: TLS configuration, defaulting to `nil`.
-    /// - Parameter connectionBackoff: The connection backoff configuration to use, defaulting
-    ///     to `nil`.
+    /// - Parameter connectionBackoff: The connection backoff configuration to use.
     public init(
       target: ConnectionTarget,
       eventLoopGroup: EventLoopGroup,
       errorDelegate: ClientErrorDelegate? = DebugOnlyLoggingClientErrorDelegate.shared,
       connectivityStateDelegate: ConnectivityStateDelegate? = nil,
       tls: Configuration.TLS? = nil,
-      connectionBackoff: ConnectionBackoff? = nil
+      connectionBackoff: ConnectionBackoff? = ConnectionBackoff()
     ) {
       self.target = target
       self.eventLoopGroup = eventLoopGroup

--- a/Sources/GRPC/ConnectionBackoff.swift
+++ b/Sources/GRPC/ConnectionBackoff.swift
@@ -90,16 +90,8 @@ public class ConnectionBackoffIterator: IteratorProtocol {
   /// compute it on-the-fly.
   private var initialElement: Element?
 
-  /// Whether or not we should make another element.
-  private var shouldMakeNextElement: Bool {
-    return self.unjitteredBackoff < self.connectionBackoff.maximumBackoff
-  }
-
   /// Returns the next pair of connection timeout and backoff (in that order) to use should the
   /// connection attempt fail.
-  ///
-  /// The iterator will stop producing values _after_ the unjittered backoff is greater than or
-  /// equal to the maximum backoff set in the configuration used to create this iterator.
   public func next() -> Element? {
     if let initial = self.initialElement {
       self.initialElement = nil
@@ -109,12 +101,8 @@ public class ConnectionBackoffIterator: IteratorProtocol {
     }
   }
 
-  /// Produces the next element to return, or `nil` if no more elements should be made.
-  private func makeNextElement() -> Element? {
-    guard self.shouldMakeNextElement else {
-      return nil
-    }
-
+  /// Produces the next element to return.
+  private func makeNextElement() -> Element {
     let unjittered = self.unjitteredBackoff * self.connectionBackoff.multiplier
     self.unjitteredBackoff = min(unjittered, self.connectionBackoff.maximumBackoff)
 

--- a/Tests/GRPCTests/ClientTLSFailureTests.swift
+++ b/Tests/GRPCTests/ClientTLSFailureTests.swift
@@ -58,7 +58,9 @@ class ClientTLSFailureTests: GRPCTestCase {
     return .init(
       target: .hostAndPort("localhost", self.port),
       eventLoopGroup: self.clientEventLoopGroup,
-      tls: tls
+      tls: tls,
+      // No need to retry connecting.
+      connectionBackoff: nil
     )
   }
 

--- a/Tests/GRPCTests/XCTestManifests.swift
+++ b/Tests/GRPCTests/XCTestManifests.swift
@@ -47,7 +47,6 @@ extension ClientConnectionBackoffTests {
     static let __allTests__ClientConnectionBackoffTests = [
         ("testClientConnectionFailsWithNoBackoff", testClientConnectionFailsWithNoBackoff),
         ("testClientEventuallyConnects", testClientEventuallyConnects),
-        ("testClientEventuallyTimesOut", testClientEventuallyTimesOut),
         ("testClientReconnectsAutomatically", testClientReconnectsAutomatically),
     ]
 }


### PR DESCRIPTION
Motivation:

The gRPC backoff continues ad infinitum (it is capped at a maximum
timeout instead of growing exponentially forever). Our backoff
terminates once it reaches the maximum backoff.

Modifications:

- Remove the upper limit on backoff generation so it is produced infinitely.
- Remove a test which is no longer relevant.
- Enable backoff by default

Result:

Client will try connecting until the user calls `close()`