### PR TITLE
Add the connection backoff interop test

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
   products: [
     .library(name: "GRPC", targets: ["GRPC"]),
     .executable(name: "InteroperabilityTestRunner", targets: ["GRPCInteroperabilityTests"]),
+    .executable(name: "ConnectionBackoffInteropTestRunner", targets: ["GRPCConnectionBackoffInteropTest"]),
     .executable(name: "PerformanceTestRunner", targets: ["GRPCPerformanceTests"]),
     .executable(name: "Echo", targets: ["Echo"]),
   ],
@@ -106,6 +107,15 @@ let package = Package(
       dependencies: [
         "GRPCInteroperabilityTestsImplementation",
         "Commander"
+      ]
+    ),
+
+    // The connection backoff interoperability test.
+    .target(
+      name: "GRPCConnectionBackoffInteropTest",
+      dependencies: [
+        "GRPC",
+        "GRPCInteroperabilityTestModels",
       ]
     ),
 

--- a/Sources/GRPC/ClientCalls/BaseClientCall.swift
+++ b/Sources/GRPC/ClientCalls/BaseClientCall.swift
@@ -110,6 +110,7 @@ open class BaseClientCall<RequestMessage: Message, ResponseMessage: Message> {
     }
 
     self.createStreamChannel()
+    self.responseHandler.scheduleTimeout(eventLoop: connection.eventLoop)
   }
 
   /// Creates and configures an HTTP/2 stream channel. The `self.subchannel` future will hold the

--- a/Sources/GRPCConnectionBackoffInteropTest/README.md
+++ b/Sources/GRPCConnectionBackoffInteropTest/README.md
@@ -1,0 +1,22 @@
+# gRPC Connection Backoff Interoperability Test
+
+This module implements the gRPC connection backoff interoperability test as
+described in the [specification][interop-test].
+
+## Running the Test
+
+The C++ interoperability test server implements the required server and should
+be targeted when running this test. It is available in the main [gRPC
+repository][grpc-repo] and may be built using `bazel` (`bazel build
+test/cpp/interop:reconnect_interop_server`) or one of the other options for
+[building the C++ source][grpc-cpp-build].
+
+1. Start the server: `./path/to/server --control_port=8080 --retry_port=8081`
+1. Start the test: `swift run ConnectionBackoffInteropTestRunner 8080 8081`
+
+The test takes **approximately 10 minutes to complete** and logs are written to
+`stderr`.
+
+[interop-test]: https://github.com/grpc/grpc/blob/master/doc/connection-backoff-interop-test-description.md
+[grpc-cpp-build]: https://github.com/grpc/grpc/blob/master/BUILDING.md
+[grpc-repo]: https://github.com/grpc/grpc.git

--- a/Sources/GRPCConnectionBackoffInteropTest/main.swift
+++ b/Sources/GRPCConnectionBackoffInteropTest/main.swift
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2019, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Foundation
+import GRPC
+import GRPCInteroperabilityTestModels
+import NIO
+import Logging
+
+let args = CommandLine.arguments
+guard args.count == 3, let controlPort = Int(args[1]), let retryPort = Int(args[2]) else {
+  print("Usage: \(args[0]) <server_control_port> <server_retry_port>")
+  exit(1)
+}
+
+// Notes from the test procedure are inline.
+// See: https://github.com/grpc/grpc/blob/master/doc/connection-backoff-interop-test-description.md
+
+// MARK: - Setup
+
+// Reduce stdout noise.
+LoggingSystem.bootstrap(StreamLogHandler.standardError)
+
+let group = MultiThreadedEventLoopGroup(numberOfThreads: 2)
+defer {
+  try! group.syncShutdownGracefully()
+}
+
+// The client must connect to the control port without TLS.
+let controlConfig = ClientConnection.Configuration(
+  target: .hostAndPort("localhost", controlPort),
+  eventLoopGroup: group,
+  connectionBackoff: .init()
+)
+
+// The client must connect to the retry port with TLS.
+let retryConfig = ClientConnection.Configuration(
+  target: .hostAndPort("localhost", retryPort),
+  eventLoopGroup: group,
+  tls: .init(),
+  connectionBackoff: .init()
+)
+
+// MARK: - Test Procedure
+
+print("Starting connection backoff interoperability test...")
+
+// 1. Call 'Start' on server control port with a large deadline or no deadline, wait for it to
+//    finish and check it succeeded.
+let controlConnection = ClientConnection(configuration: controlConfig)
+let controlClient = Grpc_Testing_ReconnectServiceServiceClient(connection: controlConnection)
+print("Control 'Start' call started")
+let controlStart = controlClient.start(.init(), callOptions: .init(timeout: .infinite))
+let controlStartStatus = try controlStart.status.wait()
+assert(controlStartStatus.code == .ok, "Control Start rpc failed: \(controlStartStatus.code)")
+print("Control 'Start' call succeeded")
+
+// 2. Initiate a channel connection to server retry port, which should perform reconnections with
+//    proper backoffs. A convenient way to achieve this is to call 'Start' with a deadline of 540s.
+//    The rpc should fail with deadline exceeded.
+print("Retry 'Start' call started")
+let retryConnection = ClientConnection(configuration: retryConfig)
+let retryClient = Grpc_Testing_ReconnectServiceServiceClient(
+  connection: retryConnection,
+  defaultCallOptions: CallOptions(timeout: try! .seconds(540))
+)
+let retryStart = retryClient.start(.init())
+// We expect this to take some time!
+let retryStartStatus = try retryStart.status.wait()
+assert(retryStartStatus.code == .deadlineExceeded,
+       "Retry Start rpc status was not 'deadlineExceeded': \(retryStartStatus.code)")
+print("Retry 'Start' call terminated with expected status")
+
+// 3. Call 'Stop' on server control port and check it succeeded.
+print("Control 'Stop' call started")
+let controlStop = controlClient.stop(.init())
+let controlStopStatus = try controlStop.status.wait()
+assert(controlStopStatus.code == .ok, "Control Stop rpc failed: \(controlStopStatus.code)")
+print("Control 'Stop' call succeeded")
+
+// 4. Check the response to see whether the server thinks the backoffs passed the test.
+let controlResponse = try controlStop.response.wait()
+assert(controlResponse.passed, "TEST FAILED")
+print("TEST PASSED")
+
+// MARK: - Tear down
+
+// Close the connections.
+
+// We expect close to fail on the retry connection because the channel should never be successfully
+// started.
+try? retryConnection.close().wait()
+try controlConnection.close().wait()


### PR DESCRIPTION
Motivation:

We'd like our implementation to be compliant with the gRPC
specification. Passing the interop tests is an important part of this,
yet we don't have an implementation of the connectivity backoff test.

Modifications:

- Implement the connectivity backoff test.
- Fixes a bug where call timeouts would not be respected if the
  connection had not been established.
- Fixes a bug where the connection could be re-established after calling
  shutdown.

Result:

Our connection backoff code has better test coverage; fewer bugs.