### PR TITLE
Update linux/mac versions for CI

### DIFF
--- a/.travis-install.sh
+++ b/.travis-install.sh
@@ -28,16 +28,19 @@
 cd
 mkdir -p local
 
+SWIFT_VERSION=5.0.2
+PROTOBUF_VERSION=3.9.1
+
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-  PROTOC_URL=https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-osx-x86_64.zip
+  PROTOC_URL=https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/protoc-${PROTOBUF_VERSION}-osx-x86_64.zip
 else
   # Install swift
-  SWIFT_URL=https://swift.org/builds/swift-5.0-release/ubuntu1404/swift-5.0-RELEASE/swift-5.0-RELEASE-ubuntu14.04.tar.gz
+  SWIFT_URL=https://swift.org/builds/swift-${SWIFT_VERSION}-release/ubuntu1804/swift-${SWIFT_VERSION}-RELEASE/swift-${SWIFT_VERSION}-RELEASE-ubuntu18.04.tar.gz
   echo $SWIFT_URL
   curl -fSsL $SWIFT_URL -o swift.tar.gz
   tar -xzf swift.tar.gz --strip-components=2 --directory=local
 
-  PROTOC_URL=https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip
+  PROTOC_URL=https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/protoc-${PROTOBUF_VERSION}-linux-x86_64.zip
 fi
 
 # Install protoc

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,10 @@ cache:
     - .build/checkouts
     - .build/repositories
 
-# Use Ubuntu 14.04
-dist: trusty
+# Use Ubuntu 18.04
+dist: bionic
 
-osx_image: xcode10.2
+osx_image: xcode10.3
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,15 +35,7 @@ sudo: false
 addons:
   apt:
     packages:
-      - clang-3.8
-      - lldb-3.8
-      - libicu-dev
-      - libtool
-      - libcurl4-openssl-dev
-      - libbsd-dev
       - build-essential
-      - libssl-dev
-      - uuid-dev
       - curl
       - unzip
 


### PR DESCRIPTION
Motivation:

The CI is using an old version of Ubuntu and Xcode. We should build
using more up-to-date versions.

Modifications:

- Update the Ubuntu to 18.04
- Update Xcode to 10.3
- Update Swift to 5.0.2
- Update protobuf to 3.9.1

Result:

CI builds on newer platforms with newer dependencies.