### PR TITLE
Bump required version of NIOSSL

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "26586835fd327f754efdebe3b9869f1e6f7cc298",
-          "version": "2.6.1"
+          "revision": "790827800d6af12ca6a8b1dca7a9072606fd2a1e",
+          "version": "2.7.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
     // HTTP2 via SwiftNIO
     .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.5.0"),
     // TLS via SwiftNIO
-    .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.0.0"),
+    .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.4.0"),
     // Support for Network.framework where possible. Note: from 1.0.2 the package
     // is essentially an empty import on platforms where it isn't supported.
     .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.0.2"),

--- a/Sources/GRPCInteroperabilityTestsImplementation/InteroperabilityTestCredentials.swift
+++ b/Sources/GRPCInteroperabilityTestsImplementation/InteroperabilityTestCredentials.swift
@@ -28,7 +28,7 @@ public struct InteroperabilityTestCredentials {
 
   /// Self signed gRPC interoperability test CA certificate.
   public static let caCertificate = try! NIOSSLCertificate(
-    buffer: Array(caCertificatePem.utf8CString),
+    bytes: .init(caCertificatePem.utf8),
     format: .pem)
 
   /// gRPC interoperability test server certificate.
@@ -36,7 +36,7 @@ public struct InteroperabilityTestCredentials {
   /// Note: the specification refers to the certificate and key as "server1", this name is carried
   /// across here.
   public static let server1Certificate = try! NIOSSLCertificate(
-    buffer: Array(server1CertificatePem.utf8CString),
+    bytes: .init(server1CertificatePem.utf8),
     format: .pem)
 
   /// gRPC interoperability test server private key.
@@ -44,7 +44,7 @@ public struct InteroperabilityTestCredentials {
   /// Note: the specification refers to the certificate and key as "server1", this name is carried
   /// across here.
   public static let server1Key = try! NIOSSLPrivateKey(
-    buffer: Array(server1KeyPem.utf8CString),
+    bytes: .init(server1KeyPem.utf8),
     format: .pem)
 
   private static let caCertificatePem = """

--- a/Sources/GRPCSampleData/GRPCSwiftCertificate.swift
+++ b/Sources/GRPCSampleData/GRPCSwiftCertificate.swift
@@ -23,26 +23,26 @@ public struct SampleCertificate {
   public var notAfter: Date
 
   public static let ca = SampleCertificate(
-    certificate: try! NIOSSLCertificate(buffer: Array(caCert.utf8CString), format: .pem),
+    certificate: try! NIOSSLCertificate(bytes: .init(caCert.utf8), format: .pem),
     commonName: "foo",
     // 22/07/2024 16:32:23
     notAfter: Date(timeIntervalSince1970: 1721662343.0))
 
   public static let server = SampleCertificate(
-    certificate: try! NIOSSLCertificate(buffer: Array(serverCert.utf8CString), format: .pem),
+    certificate: try! NIOSSLCertificate(bytes: .init(serverCert.utf8), format: .pem),
     commonName: "localhost",
     // 22/07/2024 16:32:23
     notAfter: Date(timeIntervalSince1970: 1721662343.0))
 
   public static let exampleServer = SampleCertificate(
-    certificate: try! NIOSSLCertificate(buffer: Array(exampleServerCert.utf8CString), format: .pem),
+    certificate: try! NIOSSLCertificate(bytes: .init(exampleServerCert.utf8), format: .pem),
     commonName: "example.com",
     // 22/07/2024 16:43:12
     notAfter: Date(timeIntervalSince1970: 1721662992.0)
   )
 
   public static let client = SampleCertificate(
-    certificate: try! NIOSSLCertificate(buffer: Array(clientCert.utf8CString), format: .pem),
+    certificate: try! NIOSSLCertificate(bytes: .init(clientCert.utf8), format: .pem),
     commonName: "localhost",
     // 22/07/2024 16:32:23
     notAfter: Date(timeIntervalSince1970: 1721662343.0))
@@ -59,9 +59,9 @@ extension SampleCertificate {
 public struct SamplePrivateKey {
   private init() { }
 
-  public static let server = try! NIOSSLPrivateKey(buffer: Array(serverKey.utf8CString), format: .pem)
-  public static let exampleServer = try! NIOSSLPrivateKey(buffer: Array(exampleServerKey.utf8CString), format: .pem)
-  public static let client = try! NIOSSLPrivateKey(buffer: Array(clientKey.utf8CString), format: .pem)
+  public static let server = try! NIOSSLPrivateKey(bytes: .init(serverKey.utf8), format: .pem)
+  public static let exampleServer = try! NIOSSLPrivateKey(bytes: .init(exampleServerKey.utf8), format: .pem)
+  public static let client = try! NIOSSLPrivateKey(bytes: .init(clientKey.utf8), format: .pem)
 }
 
 // MARK: - Certificates and private keys


### PR DESCRIPTION
Motivation:

Prior to NIOSSL 2.4 it was possible to silently drop some certificates
from a PEM bundle when loading from a file or buffer. These APIs were
deprecated in 2.4 and our usage of them was causing compiler warnings.

Modifications:

Set the minimum version of NIOSSL to 2.4; update usage to the new APIs.

Result:

Fewer compiler warnings.