### PR TITLE
Add MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,17 @@
+This page lists all active maintainers of this repository. If you were a
+maintainer and would like to add your name to the Emeritus list, please send us a
+PR.
+
+See [GOVERNANCE.md](https://github.com/grpc/grpc-community/blob/master/governance.md)
+for governance guidelines and how to become a maintainer.
+See [CONTRIBUTING.md](https://github.com/grpc/grpc-community/blob/master/CONTRIBUTING.md)
+for general contribution guidelines.
+
+## Maintainers (in alphabetical order)
+- [glbrntt](https://github.com/glbrntt), Apple Inc.
+- [MrMage](https://github.com/MrMage), Timing
+- [rebello95](https://github.com/rebello95), Lyft, Inc.
+- [timburks](https://github.com/timburks), Google LLC
+
+## Emeritus Maintainers (in alphabetical order)
+- (none)


### PR DESCRIPTION
Reviewers please check for accuracy.

This is in response to the following request:
<hr>
Hi Tim,

I am preparing to make gRPC a CNCF graduated project. One of the requirements is to have a publicly available list of maintainers. Can you please add a MAINTAINERS.md file in grpc-swift repo listing the current and past maintainers in [this format](https://github.com/grpc/grpc-go/blob/master/MAINTAINERS.md)?

Maintainers are the ones who have write access to the repo. In grpc-swift repo, there are three external maintainers too. Please add their company info. We decided not to add email info.

Thanks,
Srini