### PR TITLE
Update Swift packages

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "790827800d6af12ca6a8b1dca7a9072606fd2a1e",
-          "version": "2.7.0"
+          "revision": "32760eae40e6b7cb81d4d543bb0a9f548356d9a2",
+          "version": "2.7.1"
         }
       },
       {


### PR DESCRIPTION
Motivation:

One of interop test cases may hang prior to NIO 2.7.1 causing the CI to
fail.

Modifications:

Update Package.resolved so that NIO 2.7.1, which contains a fix for the
aforementioned bug, is used.

Result:

Interop tests are less likely to hang.