### PR TITLE
Update Travis script

### DIFF
--- a/.travis-script.sh
+++ b/.travis-script.sh
@@ -117,8 +117,9 @@ run_interop_tests() {
   for test in "${TESTS[@]}"; do
     info "Running $test"
     $BUILD_OUTPUT/InteroperabilityTestRunner run_test \
-      --test_case "$test" \
-      --server_port $INTEROP_TEST_SERVER_PORT \
+      "localhost" \
+      "$INTEROP_TEST_SERVER_PORT" \
+      "$test" \
         2> "interop.$test.log"
     success "PASSED $test"
   done

--- a/Sources/GRPCInteroperabilityTests/main.swift
+++ b/Sources/GRPCInteroperabilityTests/main.swift
@@ -99,7 +99,7 @@ enum Command {
     let command = args.removeFirst()
     switch command {
     case "start_server":
-      guard (args.count == 2 || args.count == 3),
+      guard (args.count == 1 || args.count == 2),
         let port = args.popLast().flatMap(Int.init),
         let useTLS = Command.parseTLSArg(args.popLast())
         else {


### PR DESCRIPTION
Motivation:

Recently the CLI parsing library was dropped in favour of our own CLI
parsing. However, the CI script for running interop tests was not
updated.

Modifications:

Update the CI script to run interop tests. Also update an off-by-one
error in the server CLI parsing that forced users to provide an optional
argument.

Result:

CI shouldn't error because of CLI failures.