### PR TITLE
Update minimum Swift NIO version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
   dependencies: [
     // GRPC dependencies:
     // Main SwiftNIO package
-    .package(url: "https://github.com/apple/swift-nio.git", from: "2.2.0"),
+    .package(url: "https://github.com/apple/swift-nio.git", from: "2.7.1"),
     // HTTP2 via SwiftNIO
     .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.5.0"),
     // TLS via SwiftNIO

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ necessary targets:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/grpc/grpc-swift.git", from: "1.0.0-alpha.1")
+  .package(url: "https://github.com/grpc/grpc-swift.git", from: "1.0.0-alpha.5")
 ]
 ```
 


### PR DESCRIPTION
Motivation:

The minimum NIO version is quite old and there have been a number of bug
fixes since which have fixed issues we've seen in gRPC. We should
enforce users to use a newer version so that they will not see these
issues.

Modifications:

- Update our minimum NIO version to 2.7.1.
- Also bump gRPC alpha version in README

Result:

NIO is more up-to-date.