### PR TITLE
Fix deprecation warnings

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "32760eae40e6b7cb81d4d543bb0a9f548356d9a2",
-          "version": "2.7.1"
+          "revision": "9201908b54578aa33f1d1826a5a680aca8991843",
+          "version": "2.8.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
         "state": {
           "branch": null,
-          "revision": "86ce1dcd0df501401eb1a0d445dbd90aaad84a64",
-          "version": "1.5.0"
+          "revision": "790cf6fd2b899e0b10cf462389556475ead81dbf",
+          "version": "1.6.1"
         }
       },
       {

--- a/Sources/GRPC/ClientConnection.swift
+++ b/Sources/GRPC/ClientConnection.swift
@@ -562,6 +562,6 @@ fileprivate extension TimeAmount {
   ///
   /// - Parameter timeInterval: The amount of time in seconds
   static func seconds(timeInterval: TimeInterval) -> TimeAmount {
-    return .nanoseconds(TimeAmount.Value(timeInterval * 1_000_000_000))
+    return .nanoseconds(Int64(timeInterval * 1_000_000_000))
   }
 }

--- a/Tests/GRPCTests/ServerThrowingTests.swift
+++ b/Tests/GRPCTests/ServerThrowingTests.swift
@@ -49,7 +49,7 @@ class ImmediateThrowingEchoProvider: Echo_EchoProvider {
 
 extension EventLoop {
   func makeFailedFuture<T>(_ error: Error, delay: TimeInterval) -> EventLoopFuture<T> {
-    return self.scheduleTask(in: .nanoseconds(TimeAmount.Value(delay * 1000 * 1000 * 1000))) { () }.futureResult
+    return self.scheduleTask(in: .nanoseconds(Int64(delay * 1000 * 1000 * 1000))) { () }.futureResult
       .flatMapThrowing { _ -> T in throw error }
   }
 }


### PR DESCRIPTION
Motivation:

NIO 2.8.0 deprecated 'TimeAmount.Value' in favour of using 'Int64'
directly. This caused unnecessary warnings.

Modifications:

Replace usages of 'TimeAmount.Value' with 'Int64'.

Result:

- No more warnings.
- 'TimeAmount.Value' was 'Int64' before it was deprecated, so no
  functional changes.