### PR TITLE
import FoundationNetworking if possible

### DIFF
--- a/Tests/GRPCTests/ServerWebTests.swift
+++ b/Tests/GRPCTests/ServerWebTests.swift
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import NIO
 @testable import GRPC
 import EchoModel


### PR DESCRIPTION
Motivation:

On Swift 5.1 for Linux, `URLSession` has moved to a new
`FoundationNetworking` module.

Modifications:

Import the module when it's present.

Result:

grpc-swift compiles on Swift 5.1 for Linux