### PR TITLE
Run CI on Swift 5.1 and Swift 5.0

### DIFF
--- a/.travis-install.sh
+++ b/.travis-install.sh
@@ -32,8 +32,6 @@
 # Update .travis.yml if this changes.
 BIN_CACHE="$HOME"/bin_cache
 
-# Only applies to Linux, we get Swift from Xcode on macOS.
-SWIFT_VERSION=5.0.2
 PROTOBUF_VERSION=3.9.1
 # We need this to build gRPC C++ for the interop test server(s).
 BAZEL_VERSION=0.28.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,26 +20,40 @@ jobs:
     # Tests for each PR.
     - &tests
       stage: "Test"
-      name: "Ubuntu 18.04"
+      name: "Ubuntu 18.04 (Swift 5.1)"
       os: linux
       dist: bionic
       script: ./.travis-script.sh
-      env: RUN_INTEROP_TESTS=false
+      env: RUN_INTEROP_TESTS=false SWIFT_VERSION=5.1
     - <<: *tests
-      name: "macOS (Xcode 10.3)"
+      name: "Ubuntu 18.04 (Swift 5.0)"
+      env: RUN_INTEROP_TESTS=false SWIFT_VERSION=5.0.3
+    - <<: *tests
+      name: "Xcode 11 (Swift 5.1)"
+      os: osx
+      osx_image: xcode11
+    - <<: *tests
+      name: "Xcode 10.3 (Swift 5.0)"
       os: osx
       osx_image: xcode10.3
     # Interop Tests.
     - &interop_tests
       stage: "Interoperability Tests"
       # Linux
-      name: "Ubuntu 18.04"
+      name: "Ubuntu 18.04 (Swift 5.1)"
       os: linux
       dist: bionic
       script: ./.travis-script.sh
       env: RUN_INTEROP_TESTS=true
     - <<: *interop_tests
-      name: "macOS (Xcode 10.3)"
+      name: "Ubuntu 18.04 (Swift 5.0)"
+      env: RUN_INTEROP_TESTS=true SWIFT_VERSION=5.0.3
+    - <<: *interop_tests
+      name: "Xcode 11 (Swift 5.1)"
+      os: osx
+      osx_image: xcode11
+    - <<: *interop_tests
+      name: "Xcode 10.3 (Swift 5.0)"
       os: osx
       osx_image: xcode10.3
 


### PR DESCRIPTION
Motivation:

Xcode 11 and Swift 5.1 have now been released, our CI should be updated
accordingly.

Modifications:

- Add Swift 5.1 targets for linux and macOS
- Bump Swift 5 Linux version from 5.0.2 to 5.0.3

Result:

CI runs on Swift 5.1 and Swift 5.0