### PR TITLE
Remove unexported executables from products

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,10 @@ protoc-gen-grpc-swift:
 	${SWIFT_BUILD} --product protoc-gen-grpc-swift
 
 interop-test-runner:
-	${SWIFT_BUILD} --product InteroperabilityTestRunner
+	${SWIFT_BUILD} --target InteroperabilityTestRunner
 
 interop-backoff-test-runner:
-	${SWIFT_BUILD} --product ConnectionBackoffInteropTestRunner
+	${SWIFT_BUILD} --target ConnectionBackoffInteropTestRunner
 
 ### Xcodeproj and LinuxMain
 

--- a/Package.swift
+++ b/Package.swift
@@ -21,10 +21,6 @@ let package = Package(
   name: "GRPC",
   products: [
     .library(name: "GRPC", targets: ["GRPC"]),
-    .executable(name: "InteroperabilityTestRunner", targets: ["GRPCInteroperabilityTests"]),
-    .executable(name: "ConnectionBackoffInteropTestRunner", targets: ["GRPCConnectionBackoffInteropTest"]),
-    .executable(name: "PerformanceTestRunner", targets: ["GRPCPerformanceTests"]),
-    .executable(name: "Echo", targets: ["Echo"]),
     .executable(name: "protoc-gen-grpc-swift", targets: ["protoc-gen-grpc-swift"]),
   ],
   dependencies: [


### PR DESCRIPTION
Motivation:

From https://developer.apple.com/documentation/swift_packages/product

> Executable
> Use an executable product to vend an executable target.
> Use this only if you want to make the executable available to clients.

Several executable products are not meant to be made available to
clients, but rather exist for internal integration or performance tests.
Further, most of these products are not namespaced and have generic names.
The code-generator product, `protoc-gen-grpc-swift`, appears to be the
only executable intended for export and it is already appropriately
namespaced.

Modifications:

Unexport the executable products that are not intended for use by clients.
Change the `Makefile` to reference the executable targets rather than their
derived products.

Result:

Fewer potential namespace conflicts. This fixed #591.