### PR TITLE
Use "swift run" for interop tests in CI

### DIFF
--- a/.travis-script.sh
+++ b/.travis-script.sh
@@ -86,7 +86,6 @@ make_project() {
 
 run_interop_tests() {
   echo -en 'travis_fold:start:test.interop_tests\\r'
-  make interop-test-runner
   INTEROP_TEST_SERVER_PORT=8080
 
   # interop_server should be on $PATH
@@ -116,7 +115,7 @@ run_interop_tests() {
   # Run the tests; logs are written to stderr, capture them per-test.
   for test in "${TESTS[@]}"; do
     info "Running $test"
-    $BUILD_OUTPUT/InteroperabilityTestRunner run_test \
+    swift run GRPCInteroperabilityTests run_test \
       "localhost" \
       "$INTEROP_TEST_SERVER_PORT" \
       "$test" \
@@ -133,7 +132,6 @@ run_interop_tests() {
 
 run_interop_reconnect_test() {
   echo -en 'travis_fold:start:test.interop_reconnect\\r'
-  make interop-backoff-test-runner
   INTEROP_TEST_SERVER_CONTROL_PORT=8081
   INTEROP_TEST_SERVER_RETRY_PORT=8082
 
@@ -149,7 +147,7 @@ run_interop_reconnect_test() {
 
   info "Running connection backoff interop test"
   # Run the test; logs are written to stderr, redirect them to a file.
-  ${BUILD_OUTPUT}/ConnectionBackoffInteropTestRunner \
+  swift run GRPCConnectionBackoffInteropTest \
     ${INTEROP_TEST_SERVER_CONTROL_PORT} \
     ${INTEROP_TEST_SERVER_RETRY_PORT} \
       2> "interop.connection_backoff.log"

--- a/.travis-script.sh
+++ b/.travis-script.sh
@@ -115,10 +115,8 @@ run_interop_tests() {
   # Run the tests; logs are written to stderr, capture them per-test.
   for test in "${TESTS[@]}"; do
     info "Running $test"
-    swift run GRPCInteroperabilityTests run_test \
-      "localhost" \
-      "$INTEROP_TEST_SERVER_PORT" \
-      "$test" \
+    make interop-test-runner \
+      TEST_ARGS="run_test localhost $INTEROP_TEST_SERVER_PORT $test" \
         2> "interop.$test.log"
     success "PASSED $test"
   done
@@ -147,9 +145,8 @@ run_interop_reconnect_test() {
 
   info "Running connection backoff interop test"
   # Run the test; logs are written to stderr, redirect them to a file.
-  swift run GRPCConnectionBackoffInteropTest \
-    ${INTEROP_TEST_SERVER_CONTROL_PORT} \
-    ${INTEROP_TEST_SERVER_RETRY_PORT} \
+  make interop-backoff-test-runner \
+    TEST_ARGS="${INTEROP_TEST_SERVER_CONTROL_PORT} ${INTEROP_TEST_SERVER_RETRY_PORT}" \
       2> "interop.connection_backoff.log"
   success "connection backoff interop test PASSED"
 

--- a/Makefile
+++ b/Makefile
@@ -25,12 +25,6 @@ protoc-gen-swift:
 protoc-gen-grpc-swift:
 	${SWIFT_BUILD} --product protoc-gen-grpc-swift
 
-interop-test-runner:
-	${SWIFT_BUILD} --target InteroperabilityTestRunner
-
-interop-backoff-test-runner:
-	${SWIFT_BUILD} --target ConnectionBackoffInteropTestRunner
-
 ### Xcodeproj and LinuxMain
 
 project: ${XCODEPROJ}

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ SWIFT_BUILD_CONFIGURATION:=debug
 SWIFT_FLAGS:=--build-path=${SWIFT_BUILD_PATH} --configuration=${SWIFT_BUILD_CONFIGURATION}
 
 SWIFT_BUILD:=${SWIFT} build ${SWIFT_FLAGS}
+SWIFT_RUN:=${SWIFT} run ${SWIFT_FLAGS}
 SWIFT_TEST:=${SWIFT} test ${SWIFT_FLAGS}
 SWIFT_PACKAGE:=${SWIFT} package ${SWIFT_FLAGS}
 
@@ -24,6 +25,14 @@ protoc-gen-swift:
 
 protoc-gen-grpc-swift:
 	${SWIFT_BUILD} --product protoc-gen-grpc-swift
+
+.PHONY:
+interop-test-runner:
+	${SWIFT_RUN} GRPCInteroperabilityTests ${TEST_ARGS}
+
+.PHONY:
+interop-backoff-test-runner:
+	${SWIFT_RUN} GRPCConnectionBackoffInteropTest ${TEST_ARGS}
 
 ### Xcodeproj and LinuxMain
 


### PR DESCRIPTION
Motivation:

60205adb (#592) cleared up the product namespace by removing executables
which were not meant to be exposed to clients. However the post-merge CI
failed (i.e. interop tests) because the executable targets no longer
exist. This was missed because the CI for the PR was still able to build
the targets and because the products had different names to the targets.

Modifications:

Use 'swift run' in the CI script used after merging PRs.

Result:

Interop tests should be runnable when a PR is merged.