### PR TITLE
Fix interoperability tests.

### DIFF
--- a/.travis-script.sh
+++ b/.travis-script.sh
@@ -116,7 +116,7 @@ run_interop_tests() {
   # Run the tests; logs are written to stderr, capture them per-test.
   for test in "${TESTS[@]}"; do
     info "Running $test"
-    $BUILD_OUTPUT/InteroperabilityTestRunner run_test \
+    $BUILD_OUTPUT/GRPCInteroperabilityTests run_test \
       "localhost" \
       "$INTEROP_TEST_SERVER_PORT" \
       "$test" \
@@ -149,7 +149,7 @@ run_interop_reconnect_test() {
 
   info "Running connection backoff interop test"
   # Run the test; logs are written to stderr, redirect them to a file.
-  ${BUILD_OUTPUT}/ConnectionBackoffInteropTestRunner \
+  ${BUILD_OUTPUT}/GRPCConnectionBackoffInteropTest \
     ${INTEROP_TEST_SERVER_CONTROL_PORT} \
     ${INTEROP_TEST_SERVER_RETRY_PORT} \
       2> "interop.connection_backoff.log"

--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,10 @@ protoc-gen-grpc-swift:
 	${SWIFT_BUILD} --product protoc-gen-grpc-swift
 
 interop-test-runner:
-	${SWIFT_BUILD} --target InteroperabilityTestRunner
+	${SWIFT_BUILD} --product GRPCInteroperabilityTests
 
 interop-backoff-test-runner:
-	${SWIFT_BUILD} --target ConnectionBackoffInteropTestRunner
+	${SWIFT_BUILD} --product GRPCConnectionBackoffInteropTest
 
 ### Xcodeproj and LinuxMain
 


### PR DESCRIPTION
Motivation:

In 60205ad I changed the Makefile to use `--target` instead of
`--product` to build the interoperability tests. However, it turns out
this only builds the objects and doesn't link the final executable.

Modifications:

Use `--product` to build the interoperability tests again.

Result:

The build is fixed.