### PR TITLE
Provide a channel handler using the client state machine

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
     // Main SwiftNIO package
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.7.1"),
     // HTTP2 via SwiftNIO
-    .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.5.0"),
+    .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.6.0"),
     // TLS via SwiftNIO
     .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.4.0"),
     // Support for Network.framework where possible.

--- a/Sources/GRPC/GRPCClientChannelHandler.swift
+++ b/Sources/GRPC/GRPCClientChannelHandler.swift
@@ -1,0 +1,374 @@
+/*
+ * Copyright 2019, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import NIO
+import NIOHTTP1
+import NIOHPACK
+import NIOHTTP2
+import SwiftProtobuf
+import Logging
+
+// TODO: rename GRPCClientRequestPart2 to GRPCClientRequestPart once this is in-place.
+/// A gRPC client request message part.
+public enum GRPCClientRequestPart2<Request: Message> {
+  /// The 'head' of the request, that is, information about the initiation of the RPC.
+  case head(GRPCRequestHead)
+
+  /// A deserialized request message to send to the server.
+  case request(Request)
+
+  /// Indicates that the client does not intend to send any further messages.
+  case end
+}
+
+public struct GRPCRequestHead {
+  public var scheme: String
+  public var path: String
+  public var host: String
+  public var options: CallOptions
+  public var requestID: String
+
+  public init(scheme: String, path: String, host: String, options: CallOptions, requestID: String) {
+    self.scheme = scheme
+    self.path = path
+    self.host = host
+    self.options = options
+    self.requestID = requestID
+  }
+}
+
+// TODO: rename GRPCClientResponsePart2 to GRPCClientResponsePart once this is in-place.
+/// A gRPC client response message part.
+public enum GRPCClientResponsePart2<Response: Message> {
+  /// Metadata received as the server acknowledges the RPC.
+  case initialMetadata(HPACKHeaders)
+
+  /// A deserialized response message received from the server.
+  case response(Response)
+
+  /// The metadata received at the end of the RPC.
+  case trailingMetadata(HPACKHeaders)
+
+  /// The final status of the RPC.
+  case status(GRPCStatus)
+}
+
+/// The type of gRPC call.
+public enum GRPCCallType {
+  /// Unary: a single request and a single response.
+  case unary
+
+  /// Client streaming: many requests and a single response.
+  case clientStreaming
+
+  /// Server streaming: a single request and many responses.
+  case serverStreaming
+
+  /// Bidirectional streaming: many request and many responses.
+  case bidirectionalStreaming
+}
+
+// MARK: - GRPCClientChannelHandler
+
+/// A channel handler for gRPC clients which translates HTTP/2 frames into gRPC messages.
+///
+/// This channel handler should typically be used in conjunction with another handler which
+/// reads the parsed `GRPCClientResponsePart2<Response>` messages and surfaces them to the caller
+/// in some fashion. Note that for unary and client streaming RPCs this handler will only emit at
+/// most one response message.
+///
+/// This handler relies heavily on the `GRPCClientStateMachine` to manage the state of the request
+/// and response streams, which share a single HTTP/2 stream for transport.
+///
+/// Typical usage of this handler is with a `HTTP2StreamMultiplexer` from SwiftNIO HTTP2:
+///
+/// ```
+/// let multiplexer: HTTP2StreamMultiplexer = // ...
+/// multiplexer.createStreamChannel(promise: nil) { (channel, streamID) in
+///   let clientChannelHandler = GRPCClientChannelHandler<Request, Response>(
+///     streamID: streamID,
+///     callType: callType,
+///     logger: logger
+///   )
+///   return channel.pipeline.addHandler(clientChannelHandler)
+/// }
+/// ```
+public final class GRPCClientChannelHandler<Request: Message, Response: Message> {
+  let logger: Logger
+  let streamID: HTTP2StreamID
+  var stateMachine: GRPCClientStateMachine<Request, Response>
+
+  /// Creates a new gRPC channel handler for clients to translate HTTP/2 frames to gRPC messages.
+  ///
+  /// - Parameters:
+  ///   - streamID: The ID of the HTTP/2 stream that this handler will read and write HTTP/2
+  ///     frames on.
+  ///   - callType: Type of RPC call being made.
+  ///   - logger: Logger.
+  public init(streamID: HTTP2StreamID, callType: GRPCCallType, logger: Logger) {
+    self.streamID = streamID
+    self.logger = logger
+    switch callType {
+    case .unary:
+      self.stateMachine = .init(requestArity: .one, responseArity: .one, logger: logger)
+    case .clientStreaming:
+      self.stateMachine = .init(requestArity: .many, responseArity: .one, logger: logger)
+    case .serverStreaming:
+      self.stateMachine = .init(requestArity: .one, responseArity: .many, logger: logger)
+    case .bidirectionalStreaming:
+      self.stateMachine = .init(requestArity: .many, responseArity: .many, logger: logger)
+    }
+  }
+}
+
+// MARK: - GRPCClientChannelHandler: Inbound
+extension GRPCClientChannelHandler: ChannelInboundHandler {
+  public typealias InboundIn = HTTP2Frame
+  public typealias InboundOut = GRPCClientResponsePart2<Response>
+
+  public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+    let frame = self.unwrapInboundIn(data)
+    switch frame.payload {
+    case .headers(let content):
+      self.readHeaders(content: content, context: context)
+
+    case .data(let content):
+      self.readData(content: content, context: context)
+
+    // We don't need to handle other frame type, just drop them instead.
+    default:
+      // TODO: synthesise a more precise `GRPCStatus` from RST_STREAM frames in accordance
+      // with: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#errors
+      break
+    }
+  }
+
+  /// Read the content from an HTTP/2 HEADERS frame received from the server.
+  ///
+  /// We can receive headers in two cases:
+  /// - when the RPC is being acknowledged, and
+  /// - when the RPC is being terminated.
+  ///
+  /// It is also possible for the RPC to be acknowledged and terminated at the same time, the
+  /// specification refers to this as a "Trailers-Only" response.
+  ///
+  /// - Parameter content: Content of the headers frame.
+  /// - Parameter context: Channel handler context.
+  private func readHeaders(content: HTTP2Frame.FramePayload.Headers, context: ChannelHandlerContext) {
+    // In the case of a "Trailers-Only" response there's no guarantee that end-of-stream will be set
+    // on the headers frame: end stream may be sent on an empty data frame as well. If the headers
+    // contain a gRPC status code then they must be for a "Trailers-Only" response.
+    if content.endStream || content.headers.contains(name: GRPCHeaderName.statusCode) {
+      // We have the headers, pass them to the next handler:
+      context.fireChannelRead(self.wrapInboundOut(.trailingMetadata(content.headers)))
+
+      // Are they valid headers?
+      let result = self.stateMachine.receiveEndOfResponseStream(content.headers).mapError { error -> GRPCError in
+        // The headers aren't valid so let's figure out a reasonable error to forward:
+        switch error {
+        case .invalidContentType:
+          return .client(.invalidContentType)
+        case .invalidHTTPStatus(let status):
+          return .client(.invalidHTTPStatus(status))
+        case .invalidHTTPStatusWithGRPCStatus(let status):
+          return .client(.invalidHTTPStatusWithGRPCStatus(status))
+        case .invalidState:
+          return .client(.invalidState("invalid state parsing headers as trailers-only response"))
+        }
+      }
+
+      // Okay, what should we tell the next handler?
+      switch result {
+      case .success(let status):
+        context.fireChannelRead(self.wrapInboundOut(.status(status)))
+      case .failure(let error):
+        context.fireErrorCaught(error)
+      }
+    } else {
+      // "Normal" response headers, but are they valid?
+      let result = self.stateMachine.receiveResponseHeaders(content.headers).mapError { error -> GRPCError in
+        // The headers aren't valid so let's figure out a reasonable error to forward:
+        switch error {
+        case .invalidContentType:
+          return .client(.invalidContentType)
+        case .invalidHTTPStatus(let status):
+          return .client(.invalidHTTPStatus(status))
+        case .unsupportedMessageEncoding(let encoding):
+          return .client(.unsupportedCompressionMechanism(encoding))
+        case .invalidState:
+          return .client(.invalidState("invalid state parsing headers as trailers-only response"))
+        }
+      }
+
+      // Okay, what should we tell the next handler?
+      switch result {
+      case .success:
+        context.fireChannelRead(self.wrapInboundOut(.initialMetadata(content.headers)))
+      case .failure(let error):
+        context.fireErrorCaught(error)
+      }
+    }
+  }
+
+  /// Reads the content from an HTTP/2 DATA frame received from the server and buffers the bytes
+  /// necessary to deserialize a message (or messages).
+  ///
+  /// - Parameter content: Content of the data frame.
+  /// - Parameter context: Channel handler context.
+  private func readData(content: HTTP2Frame.FramePayload.Data, context: ChannelHandlerContext) {
+    // Note: this is replicated from NIO's HTTP2ToHTTP1ClientCodec.
+    guard case .byteBuffer(var buffer) = content.data else {
+      preconditionFailure("Received DATA frame with non-ByteBuffer IOData")
+    }
+
+    // Do we have bytes to read? If there are no bytes to read then we can't do anything. This may
+    // happen if the end-of-stream flag is not set on the trailing headers frame (i.e. the one
+    // containing the gRPC status code) and an additional empty data frame is sent with the
+    // end-of-stream flag set.
+    guard buffer.readableBytes > 0 else {
+      return
+    }
+
+    // Feed the buffer into the state machine.
+    let result = self.stateMachine.receiveResponseBuffer(&buffer).mapError { error -> GRPCError in
+      switch error {
+      case .cardinalityViolation:
+        return .client(.responseCardinalityViolation)
+      case .deserializationFailed, .leftOverBytes:
+        return .client(.responseProtoDeserializationFailure)
+      case .invalidState:
+        return .client(.invalidState("invalid state when parsing data as a response message"))
+      }
+    }
+
+    // Did we get any messages?
+    switch result {
+    case .success(let messages):
+      // Awesome: we got some messages. The state machine guarantees we only get at most a single
+      // message for unary and client-streaming RPCs.
+      for message in messages {
+        context.fireChannelRead(self.wrapInboundOut(.response(message)))
+      }
+    case .failure(let error):
+      context.fireErrorCaught(error)
+    }
+  }
+}
+
+// MARK: - GRPCClientChannelHandler: Outbound
+extension GRPCClientChannelHandler: ChannelOutboundHandler {
+  public typealias OutboundIn = GRPCClientRequestPart2<Request>
+  public typealias OutboundOut = HTTP2Frame
+
+  public func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+    switch self.unwrapOutboundIn(data) {
+    case .head(let requestHead):
+      // Feed the request into the state machine:
+      let result = self.stateMachine.sendRequestHeaders(
+        scheme: requestHead.scheme,
+        host: requestHead.host,
+        path: requestHead.path,
+        options: requestHead.options,
+        requestID: requestHead.requestID
+      )
+
+      switch result {
+      case .success(let headers):
+        // Great, we're clear to write the some headers. Create an appropriate frame and write it.
+        let frame = HTTP2Frame(streamID: self.streamID, payload: .headers(.init(headers: headers)))
+        context.write(self.wrapOutboundOut(frame), promise: promise)
+
+      case .failure(let sendRequestHeadersError):
+        switch sendRequestHeadersError {
+        case .invalidState:
+          // This is bad: we need to trigger an error and close.
+          promise?.fail(sendRequestHeadersError)
+          context.fireErrorCaught(GRPCError.client(.invalidState("unable to initiate RPC")))
+        }
+      }
+
+    case .request(let request):
+      // Feed the request message into the state machine:
+      let result = self.stateMachine.sendRequest(request, allocator: context.channel.allocator)
+      switch result {
+      case .success(let buffer):
+        // We're clear to send a message; wrap it up in an HTTP/2 frame.
+        let frame = HTTP2Frame(
+          streamID: self.streamID,
+          payload: .data(.init(data: .byteBuffer(buffer)))
+        )
+        context.write(self.wrapOutboundOut(frame), promise: promise)
+
+      case .failure(let writeError):
+        switch writeError {
+        case .cardinalityViolation:
+          // This is fine: we can ignore the request.
+          promise?.fail(writeError)
+
+        case .serializationFailed:
+          // This is bad: we need to trigger an error and close.
+          promise?.fail(writeError)
+          context.fireErrorCaught(GRPCError.client(.requestProtoSerializationFailure))
+
+        case .invalidState:
+          promise?.fail(writeError)
+          context.fireErrorCaught(GRPCError.client(.invalidState("unable to write message")))
+        }
+      }
+
+    case .end:
+      // Okay: can we close the request stream?
+      switch self.stateMachine.sendEndOfRequestStream() {
+      case .success(()):
+        // We can, great, send an empty DATA frame with end-stream set.
+        let empty = context.channel.allocator.buffer(capacity: 0)
+        let frame = HTTP2Frame(
+          streamID: self.streamID,
+          payload: .data(.init(data: .byteBuffer(empty), endStream: true))
+        )
+        context.write(self.wrapOutboundOut(frame), promise: promise)
+
+      case .failure(let error):
+        // We can't close, but why?
+        switch error {
+        case .alreadyClosed:
+          // This is fine: we can just ignore it.
+          promise?.fail(error)
+
+        case .invalidState:
+          // This is bad: we need to trigger an error and close.
+          promise?.fail(error)
+          context.fireErrorCaught(GRPCError.client(.invalidState("unable to close request stream")))
+        }
+      }
+    }
+  }
+
+  public func triggerUserOutboundEvent(
+    context: ChannelHandlerContext,
+    event: Any,
+    promise: EventLoopPromise<Void>?
+  ) {
+    if let userEvent = event as? GRPCClientUserEvent {
+      switch userEvent {
+      case .cancelled:
+        context.fireErrorCaught(GRPCClientError.cancelledByClient)
+        context.close(mode: .all, promise: promise)
+      }
+    } else {
+      context.triggerUserOutboundEvent(event, promise: promise)
+    }
+  }
+}

--- a/Sources/GRPC/GRPCClientStateMachine.swift
+++ b/Sources/GRPC/GRPCClientStateMachine.swift
@@ -16,6 +16,7 @@
 import Foundation
 import NIO
 import NIOHTTP1
+import NIOHPACK
 import Logging
 import SwiftProtobuf
 
@@ -24,16 +25,26 @@ enum ReceiveResponseHeadError: Error, Equatable {
   case invalidContentType
 
   /// The HTTP response status from the server was not 200 OK.
-  case invalidHTTPStatus(HTTPResponseStatus)
+  case invalidHTTPStatus(HTTPResponseStatus?)
 
   /// The encoding used by the server is not supported.
-  case unsupportedMessageEncoding
+  case unsupportedMessageEncoding(String)
 
   /// An invalid state was encountered. This is a serious implementation error.
   case invalidState
 }
 
 enum ReceiveEndOfResponseStreamError: Error {
+  /// The 'content-type' header was missing or the value is not supported by this implementation.
+  case invalidContentType
+
+  /// The HTTP response status from the server was not 200 OK.
+  case invalidHTTPStatus(HTTPResponseStatus?)
+
+  /// The HTTP response status from the server was not 200 OK but the "grpc-status" header contained
+  /// a valid value.
+  case invalidHTTPStatusWithGRPCStatus(GRPCStatus)
+
   /// An invalid state was encountered. This is a serious implementation error.
   case invalidState
 }
@@ -192,13 +203,15 @@ struct GRPCClientStateMachine<Request: Message, Response: Message> {
   /// - Parameter path: The path of the RPC (e.g. '/echo.Echo/Collect').
   /// - Parameter options: Options for this RPC.
   /// - Parameter requestID: The unique ID of this request used for logging.
-  mutating func sendRequestHead(
+  mutating func sendRequestHeaders(
+    scheme: String,
     host: String,
     path: String,
     options: CallOptions,
     requestID: String
-  ) -> Result<HTTPRequestHead, SendRequestHeadersError> {
-    return self.state.sendRequestHead(
+  ) -> Result<HPACKHeaders, SendRequestHeadersError> {
+    return self.state.sendRequestHeaders(
+      scheme: scheme,
       host: host,
       path: path,
       options: options,
@@ -273,11 +286,11 @@ struct GRPCClientStateMachine<Request: Message, Response: Message> {
   /// - `.clientClosedServerClosed`
   /// Doing so will result in a `.invalidState` error.
   ///
-  /// - Parameter responseHead: The response head received from the server.
-  mutating func receiveResponseHead(
-    _ responseHead: HTTPResponseHead
-  ) -> Result<HTTPHeaders, ReceiveResponseHeadError> {
-    return self.state.receiveResponseHead(responseHead, logger: self.logger)
+  /// - Parameter headers: The headers received from the server.
+  mutating func receiveResponseHeaders(
+    _ headers: HPACKHeaders
+  ) -> Result<Void, ReceiveResponseHeadError> {
+    return self.state.receiveResponseHeaders(headers, logger: self.logger)
   }
 
   /// Read a response buffer from the server and return any decoded messages.
@@ -329,27 +342,37 @@ struct GRPCClientStateMachine<Request: Message, Response: Message> {
   ///
   /// - Parameter trailers: The trailers to parse.
   mutating func receiveEndOfResponseStream(
-    _ trailers: HTTPHeaders
+    _ trailers: HPACKHeaders
   ) -> Result<GRPCStatus, ReceiveEndOfResponseStreamError> {
     return self.state.receiveEndOfResponseStream(trailers)
   }
 }
 
 extension GRPCClientStateMachine.State {
-  /// See `GRPCClientStateMachine.sendRequestHead(host:path:options:requestID)`.
-  mutating func sendRequestHead(
+  /// See `GRPCClientStateMachine.sendRequestHeaders(host:path:options:requestID)`.
+  mutating func sendRequestHeaders(
+    scheme: String,
     host: String,
     path: String,
     options: CallOptions,
     requestID: String
-  ) -> Result<HTTPRequestHead, SendRequestHeadersError> {
-    let result: Result<HTTPRequestHead, SendRequestHeadersError>
+  ) -> Result<HPACKHeaders, SendRequestHeadersError> {
+    let result: Result<HPACKHeaders, SendRequestHeadersError>
 
     switch self {
-    case let .clientIdleServerIdle(pendingWriteState, readArity):
-      let head = self.makeRequestHead(host: host, path: path, options: options, requestID: requestID)
-      result = .success(head)
-      self = .clientActiveServerIdle(writeState: pendingWriteState.makeWriteState(), readArity: readArity)
+    case let .clientIdleServerIdle(pendingWriteState, responseArity):
+      let headers = self.makeRequestHeaders(
+        scheme: scheme,
+        host: host,
+        path: path,
+        options: options,
+        requestID: requestID
+      )
+      result = .success(headers)
+      self = .clientActiveServerIdle(
+        writeState: pendingWriteState.makeWriteState(),
+        readArity: responseArity
+      )
 
     case .clientActiveServerIdle,
          .clientClosedServerIdle,
@@ -415,30 +438,22 @@ extension GRPCClientStateMachine.State {
     return result
   }
 
-  /// See `GRPCClientStateMachine.receiveResponseHead(_:)`.
-  mutating func receiveResponseHead(
-    _ responseHead: HTTPResponseHead,
+  /// See `GRPCClientStateMachine.receiveResponseHeaders(_:)`.
+  mutating func receiveResponseHeaders(
+    _ headers: HPACKHeaders,
     logger: Logger
-  ) -> Result<HTTPHeaders, ReceiveResponseHeadError> {
-    let result: Result<HTTPHeaders, ReceiveResponseHeadError>
+  ) -> Result<Void, ReceiveResponseHeadError> {
+    let result: Result<Void, ReceiveResponseHeadError>
 
     switch self {
     case let .clientActiveServerIdle(writeState, readArity):
-      switch self.parseResponseHead(responseHead, responseArity: readArity, logger: logger) {
-      case .success(let readState):
+      result = self.parseResponseHeaders(headers, arity: readArity, logger: logger).map { readState in
         self = .clientActiveServerActive(writeState: writeState, readState: readState)
-        result = .success(responseHead.headers)
-      case .failure(let error):
-        result = .failure(error)
       }
 
     case let .clientClosedServerIdle(readArity):
-      switch self.parseResponseHead(responseHead, responseArity: readArity, logger: logger) {
-      case .success(let readState):
+      result = self.parseResponseHeaders(headers, arity: readArity, logger: logger).map { readState in
         self = .clientClosedServerActive(readState: readState)
-        result = .success(responseHead.headers)
-      case .failure(let error):
-        result = .failure(error)
       }
 
     case .clientIdleServerIdle,
@@ -478,27 +493,32 @@ extension GRPCClientStateMachine.State {
 
   /// See `GRPCClientStateMachine.receiveEndOfResponseStream(_:)`.
   mutating func receiveEndOfResponseStream(
-    _ trailers: HTTPHeaders
+    _ trailers: HPACKHeaders
   ) -> Result<GRPCStatus, ReceiveEndOfResponseStreamError> {
-     let result: Result<GRPCStatus, ReceiveEndOfResponseStreamError>
+    let result: Result<GRPCStatus, ReceiveEndOfResponseStreamError>
 
-     switch self {
-     case .clientActiveServerActive,
-          .clientActiveServerIdle,
-          .clientClosedServerIdle,
-          .clientClosedServerActive:
-       result = .success(self.parseTrailers(trailers))
-       self = .clientClosedServerClosed
+    switch self {
+    case .clientActiveServerIdle,
+         .clientClosedServerIdle:
+      result = self.parseTrailersOnly(trailers).map { status in
+        self = .clientClosedServerClosed
+        return status
+      }
 
-     case .clientIdleServerIdle,
-          .clientClosedServerClosed:
+    case .clientActiveServerActive,
+         .clientClosedServerActive:
+      result = .success(self.parseTrailers(trailers))
+      self = .clientClosedServerClosed
+
+    case .clientIdleServerIdle,
+         .clientClosedServerClosed:
       result = .failure(.invalidState)
-     }
+    }
 
-     return result
-   }
+    return result
+  }
 
-  /// Makes the request head (`Request-Headers` in the specification) used to initiate an RPC
+  /// Makes the request headers (`Request-Headers` in the specification) used to initiate an RPC
   /// call.
   ///
   /// See: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests
@@ -507,19 +527,23 @@ extension GRPCClientStateMachine.State {
   /// - Parameter options: Any options related to the call.
   /// - Parameter requestID: A request ID associated with the call. An additional header will be
   ///     added using this value if `options.requestIDHeader` is specified.
-  private func makeRequestHead(
+  private func makeRequestHeaders(
+    scheme: String,
     host: String,
     path: String,
     options: CallOptions,
     requestID: String
-  ) -> HTTPRequestHead {
+  ) -> HPACKHeaders {
     // Note: we don't currently set the 'grpc-encoding' header, if we do we will need to feed that
     // encoded into the message writer.
-    var headers: HTTPHeaders = [
-      "content-type": "application/grpc",
+    var headers: HPACKHeaders = [
+      ":method": options.cacheable ? "GET" : "POST",
+      ":path": path,
+      ":authority": host,
+      ":scheme": scheme,
+      "content-type": "application/grpc+proto",
       "te": "trailers",  // Used to detect incompatible proxies, part of the gRPC specification.
-      "user-agent": "grpc-swift-nio",  // TODO: Add a more specific user-agent.
-      "host": host,  // NIO's HTTP2ToHTTP1Codec replaces "host" with ":authority"
+      "user-agent": "grpc-swift-nio",  //  TODO: Add a more specific user-agent.
     ]
 
     // Add the timeout header, if a timeout was specified.
@@ -528,30 +552,25 @@ extension GRPCClientStateMachine.State {
     }
 
     // Add user-defined custom metadata: this should come after the call definition headers.
-    headers.add(contentsOf: options.customMetadata)
+    headers.add(contentsOf: options.customMetadata.map { ($0.name, $0.value) })
 
     // Add a tracing header if the user specified it.
     if let headerName = options.requestIDHeader {
       headers.add(name: headerName, value: requestID)
     }
 
-    return HTTPRequestHead(
-      version: HTTPVersion(major: 2, minor: 0),
-      method: options.cacheable ? .GET : .POST,
-      uri: path,
-      headers: headers
-    )
+    return headers
   }
 
-  /// Parses the response head ("Response-Headers" in the specification) from server into
+  /// Parses the response headers ("Response-Headers" in the specification) from the server into
   /// a `ReadState`.
   ///
   /// See: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#responses
   ///
   /// - Parameter headers: The headers to parse.
-  private func parseResponseHead(
-    _ head: HTTPResponseHead,
-    responseArity: MessageArity,
+  private func parseResponseHeaders(
+    _ headers: HPACKHeaders,
+    arity: MessageArity,
     logger: Logger
   ) -> Result<ReadState, ReceiveResponseHeadError> {
     // From: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#responses
@@ -560,23 +579,28 @@ extension GRPCClientStateMachine.State {
     // responses as well as a variety of non-GRPC content-types and to omit Status & Status-Message.
     // Implementations must synthesize a Status & Status-Message to propagate to the application
     // layer when this occurs."
-    guard head.status == .ok else {
-      return .failure(.invalidHTTPStatus(head.status))
+    let statusHeader = headers[":status"].first
+    let responseStatus = statusHeader.flatMap(Int.init).map { code in
+      HTTPResponseStatus(statusCode: code)
+    } ?? .preconditionFailed
+
+    guard responseStatus == .ok else {
+      return .failure(.invalidHTTPStatus(responseStatus))
     }
 
-    guard head.headers["content-type"].first?.starts(with: "application/grpc") ?? false else {
+    guard headers["content-type"].first.flatMap(ContentType.init) != nil else {
       return .failure(.invalidContentType)
     }
 
     // What compression mechanism is the server using, if any?
-    let compression = CompressionMechanism(value: head.headers[GRPCHeaderName.encoding].first)
+    let compression = CompressionMechanism(value: headers[GRPCHeaderName.encoding].first)
 
     // From: https://github.com/grpc/grpc/blob/master/doc/compression.md
     //
     // "If a server sent data which is compressed by an algorithm that is not supported by the
     // client, an INTERNAL error status will occur on the client side."
     guard compression.supported else {
-      return .failure(.unsupportedMessageEncoding)
+      return .failure(.unsupportedMessageEncoding(compression.rawValue))
     }
 
     let reader = LengthPrefixedMessageReader(
@@ -585,7 +609,7 @@ extension GRPCClientStateMachine.State {
       logger: logger
     )
 
-    return .success(.reading(responseArity, reader))
+    return .success(.reading(arity, reader))
   }
 
   /// Parses the response trailers ("Trailers" in the specification) from the server into
@@ -594,16 +618,57 @@ extension GRPCClientStateMachine.State {
   /// See: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#responses
   ///
   /// - Parameter trailers: Trailers to parse.
-  private func parseTrailers(_ trailers: HTTPHeaders) -> GRPCStatus {
-    // Extract the "Status"
-    let code = trailers[GRPCHeaderName.statusCode].first
-      .flatMap(Int.init)
-      .flatMap(GRPCStatus.Code.init) ?? .unknown
-
-    // Extract and unmarshall the "Status-Message"
-    let message = trailers[GRPCHeaderName.statusMessage].first
-      .map(GRPCStatusMessageMarshaller.unmarshall)
-
+  private func parseTrailers(_ trailers: HPACKHeaders) -> GRPCStatus {
+    // Extract the "Status" and "Status-Message"
+    let code = self.readStatusCode(from: trailers) ?? .unknown
+    let message = self.readStatusMessage(from: trailers)
     return .init(code: code, message: message)
+  }
+
+  private func readStatusCode(from trailers: HPACKHeaders) -> GRPCStatus.Code? {
+    return trailers[GRPCHeaderName.statusCode].first
+      .flatMap(Int.init)
+      .flatMap(GRPCStatus.Code.init)
+  }
+
+  private func readStatusMessage(from trailers: HPACKHeaders) -> String? {
+    return trailers[GRPCHeaderName.statusMessage].first
+      .map(GRPCStatusMessageMarshaller.unmarshall)
+  }
+
+  /// Parses a "Trailers-Only" response from the server into a `GRPCStatus`.
+  ///
+  /// See: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#responses
+  ///
+  /// - Parameter trailers: Trailers to parse.
+  private func parseTrailersOnly(
+    _ trailers: HPACKHeaders
+  ) -> Result<GRPCStatus, ReceiveEndOfResponseStreamError> {
+    // We need to check whether we have a valid HTTP status in the headers, if we don't then we also
+    // need to check whether we have a gRPC status as it should take preference over a synthesising
+    // one from the ":status".
+    //
+    // See: https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md
+    let statusHeader = trailers[":status"].first
+    guard let status = statusHeader.flatMap(Int.init).map({ HTTPResponseStatus(statusCode: $0) })
+      else {
+        return .failure(.invalidHTTPStatus(nil))
+    }
+
+    guard status == .ok else {
+      if let code = self.readStatusCode(from: trailers) {
+        let message = self.readStatusMessage(from: trailers)
+        return .failure(.invalidHTTPStatusWithGRPCStatus(.init(code: code, message: message)))
+      } else {
+        return .failure(.invalidHTTPStatus(status))
+      }
+    }
+
+    guard trailers["content-type"].first.flatMap(ContentType.init) != nil else {
+      return .failure(.invalidContentType)
+    }
+
+    // We've verified the status and content type are okay: parse the trailers.
+    return .success(self.parseTrailers(trailers))
   }
 }

--- a/Tests/GRPCTests/GRPCClientStateMachineTests.swift
+++ b/Tests/GRPCTests/GRPCClientStateMachineTests.swift
@@ -18,6 +18,7 @@ import Foundation
 import EchoModel
 import Logging
 import NIOHTTP1
+import NIOHPACK
 import NIO
 import SwiftProtobuf
 import XCTest
@@ -59,11 +60,15 @@ class GRPCClientStateMachineTests: GRPCTestCase {
     writer.write(messageData, into: &buffer)
   }
 
-  /// Returns a minimally valid `HTTPResponseHead`.
-  func makeResponseHead() -> HTTPResponseHead {
-    var headers = HTTPHeaders()
-    headers.add(name: "content-type", value: "application/grpc")
-    return .init(version: .init(major: 2, minor: 0), status: .ok, headers: headers)
+  /// Returns a minimally valid `HPACKHeaders` for a response.
+  func makeResponseHeaders(
+    status: String? = "200",
+    contentType: String? = "application/grpc+proto"
+  ) -> HPACKHeaders {
+    var headers: HPACKHeaders = [:]
+    status.map { headers.add(name: ":status", value: $0) }
+    contentType.map { headers.add(name: "content-type", value: $0) }
+    return headers
   }
 }
 
@@ -72,7 +77,8 @@ class GRPCClientStateMachineTests: GRPCTestCase {
 extension GRPCClientStateMachineTests {
   func doTestSendRequestHeadersFromInvalidState(_ state: StateMachine.State) {
     var stateMachine = self.makeStateMachine(state)
-    stateMachine.sendRequestHead(
+    stateMachine.sendRequestHeaders(
+      scheme: "http",
       host: "host",
       path: "/echo/Get",
       options: .init(),
@@ -84,7 +90,8 @@ extension GRPCClientStateMachineTests {
 
   func testSendRequestHeadersFromIdle() {
     var stateMachine = self.makeStateMachine(.clientIdleServerIdle(pendingWriteState: .one(), readArity: .one))
-    stateMachine.sendRequestHead(
+    stateMachine.sendRequestHeaders(
+      scheme: "http",
       host: "host",
       path: "/echo/Get",
       options: .init(),
@@ -228,14 +235,14 @@ extension GRPCClientStateMachineTests {
     expected: ReceiveResponseHeadError
   ) {
     var stateMachine = self.makeStateMachine(state)
-    stateMachine.receiveResponseHead(self.makeResponseHead()).assertFailure {
+    stateMachine.receiveResponseHeaders(self.makeResponseHeaders()).assertFailure {
       XCTAssertEqual($0, expected)
     }
   }
 
   func doTestReceiveResponseHeadersFromValidState(_ state: StateMachine.State) {
     var stateMachine = self.makeStateMachine(state)
-    stateMachine.receiveResponseHead(self.makeResponseHead()).assertSuccess()
+    stateMachine.receiveResponseHeaders(self.makeResponseHeaders()).assertSuccess()
   }
 
   func testReceiveResponseHeadersFromIdle() {
@@ -354,17 +361,27 @@ extension GRPCClientStateMachineTests {
     expected: ReceiveEndOfResponseStreamError
   ) {
     var stateMachine = self.makeStateMachine(state)
-    stateMachine.receiveEndOfResponseStream(HTTPHeaders()).assertFailure {
-      XCTAssertEqual($0, expected)
-    }
+    stateMachine.receiveEndOfResponseStream(.init()).assertFailure()
   }
 
   func doTestReceiveEndOfResponseStreamFromValidState(_ state: StateMachine.State) {
     var stateMachine = self.makeStateMachine(state)
 
-    var trailers = HTTPHeaders()
-    trailers.add(name: GRPCHeaderName.statusCode, value: "\(GRPCStatus.Code.ok.rawValue)")
-    trailers.add(name: GRPCHeaderName.statusMessage, value: "ok")
+    var trailers: HPACKHeaders = [
+      GRPCHeaderName.statusCode: "0",
+      GRPCHeaderName.statusMessage: "ok"
+    ]
+
+    // When the server is idle it's a "Trailers-Only" response, we need the :status and
+    // content-type to make a valid set of trailers.
+    switch state {
+    case .clientActiveServerIdle,
+         .clientClosedServerIdle:
+      trailers.add(name: ":status", value: "200")
+      trailers.add(name: "content-type", value: "application/grpc+proto")
+    default:
+      break
+    }
 
     stateMachine.receiveEndOfResponseStream(trailers).assertSuccess { status in
       XCTAssertEqual(status.code, .ok)
@@ -414,8 +431,8 @@ extension GRPCClientStateMachineTests {
 // MARK: - Basic RPC flow.
 
 extension GRPCClientStateMachineTests {
-  func makeTrailers(status: GRPCStatus.Code, message: String? = nil) -> HTTPHeaders {
-    var headers = HTTPHeaders()
+  func makeTrailers(status: GRPCStatus.Code, message: String? = nil) -> HPACKHeaders {
+    var headers = HPACKHeaders()
     headers.add(name: GRPCHeaderName.statusCode, value: "\(status.rawValue)")
     if let message = message {
       headers.add(name: GRPCHeaderName.statusMessage, value: message)
@@ -427,10 +444,16 @@ extension GRPCClientStateMachineTests {
     var stateMachine = self.makeStateMachine(.clientIdleServerIdle(pendingWriteState: .one(), readArity: .one))
 
     // Initiate the RPC
-    stateMachine.sendRequestHead(host: "foo", path: "/echo/Get", options: .init(), requestID: "bar").assertSuccess()
+    stateMachine.sendRequestHeaders(
+      scheme: "https",
+      host: "foo",
+      path: "/echo/Get",
+      options: .init(),
+      requestID: "bar"
+    ).assertSuccess()
 
     // Receive acknowledgement.
-    stateMachine.receiveResponseHead(self.makeResponseHead()).assertSuccess()
+    stateMachine.receiveResponseHeaders(self.makeResponseHeaders()).assertSuccess()
 
     // Send a request.
     stateMachine.sendRequest(.with { $0.text = "Hello!" }, allocator: self.allocator).assertSuccess()
@@ -450,10 +473,16 @@ extension GRPCClientStateMachineTests {
     var stateMachine = self.makeStateMachine(.clientIdleServerIdle(pendingWriteState: .many(), readArity: .one))
 
     // Initiate the RPC
-    stateMachine.sendRequestHead(host: "foo", path: "/echo/Get", options: .init(), requestID: "bar").assertSuccess()
+    stateMachine.sendRequestHeaders(
+      scheme: "https",
+      host: "foo",
+      path: "/echo/Get",
+      options: .init(),
+      requestID: "bar"
+    ).assertSuccess()
 
     // Receive acknowledgement.
-    stateMachine.receiveResponseHead(self.makeResponseHead()).assertSuccess()
+    stateMachine.receiveResponseHeaders(self.makeResponseHeaders()).assertSuccess()
 
     // Send some requests.
     stateMachine.sendRequest(.with { $0.text = "1" }, allocator: self.allocator).assertSuccess()
@@ -475,10 +504,16 @@ extension GRPCClientStateMachineTests {
     var stateMachine = self.makeStateMachine(.clientIdleServerIdle(pendingWriteState: .one(), readArity: .many))
 
     // Initiate the RPC
-    stateMachine.sendRequestHead(host: "foo", path: "/echo/Get", options: .init(), requestID: "bar").assertSuccess()
+    stateMachine.sendRequestHeaders(
+      scheme: "https",
+      host: "foo",
+      path: "/echo/Get",
+      options: .init(),
+      requestID: "bar"
+    ).assertSuccess()
 
     // Receive acknowledgement.
-    stateMachine.receiveResponseHead(self.makeResponseHead()).assertSuccess()
+    stateMachine.receiveResponseHeaders(self.makeResponseHeaders()).assertSuccess()
 
     // Send a request.
     stateMachine.sendRequest(.with { $0.text = "1" }, allocator: self.allocator).assertSuccess()
@@ -503,10 +538,16 @@ extension GRPCClientStateMachineTests {
     var stateMachine = self.makeStateMachine(.clientIdleServerIdle(pendingWriteState: .many(), readArity: .many))
 
     // Initiate the RPC
-    stateMachine.sendRequestHead(host: "foo", path: "/echo/Get", options: .init(), requestID: "bar").assertSuccess()
+    stateMachine.sendRequestHeaders(
+      scheme: "https",
+      host: "foo",
+      path: "/echo/Get",
+      options: .init(),
+      requestID: "bar"
+    ).assertSuccess()
 
     // Receive acknowledgement.
-    stateMachine.receiveResponseHead(self.makeResponseHead()).assertSuccess()
+    stateMachine.receiveResponseHeaders(self.makeResponseHeaders()).assertSuccess()
 
     // Interleave requests and responses:
     stateMachine.sendRequest(.with { $0.text = "1" }, allocator: self.allocator).assertSuccess()
@@ -606,60 +647,44 @@ extension GRPCClientStateMachineTests {
 extension GRPCClientStateMachineTests {
   func testSendRequestHeaders() throws {
     var stateMachine = self.makeStateMachine(.clientIdleServerIdle(pendingWriteState: .one(), readArity: .one))
-    stateMachine.sendRequestHead(
+    stateMachine.sendRequestHeaders(
+      scheme: "http",
       host: "localhost",
       path: "/echo/Get",
       options: CallOptions(timeout: .hours(rounding: 1), requestIDHeader: "x-grpc-id"),
       requestID: "request-id"
-    ).assertSuccess { requestHead in
-      XCTAssertEqual(requestHead.method, .POST)
-      XCTAssertEqual(requestHead.uri, "/echo/Get")
-      XCTAssertEqual(requestHead.headers["content-type"], ["application/grpc"])
-      XCTAssertEqual(requestHead.headers["host"], ["localhost"])
-      XCTAssertEqual(requestHead.headers["te"], ["trailers"])
-      XCTAssertEqual(requestHead.headers["grpc-timeout"], ["1H"])
-      XCTAssertEqual(requestHead.headers["x-grpc-id"], ["request-id"])
-      XCTAssertTrue(requestHead.headers["user-agent"].first?.starts(with: "grpc-swift") ?? false)
+    ).assertSuccess { headers in
+      XCTAssertEqual(headers[":method"], ["POST"])
+      XCTAssertEqual(headers[":path"], ["/echo/Get"])
+      XCTAssertEqual(headers[":authority"], ["localhost"])
+      XCTAssertEqual(headers[":scheme"], ["http"])
+      XCTAssertEqual(headers["content-type"], ["application/grpc+proto"])
+      XCTAssertEqual(headers["te"], ["trailers"])
+      XCTAssertEqual(headers["grpc-timeout"], ["1H"])
+      XCTAssertEqual(headers["x-grpc-id"], ["request-id"])
+      XCTAssertTrue(headers["user-agent"].first?.starts(with: "grpc-swift") ?? false)
     }
   }
 
   func testReceiveResponseHeadersWithOkStatus() throws {
     var stateMachine = self.makeStateMachine(.clientActiveServerIdle(writeState: .one(), readArity: .one))
-
-    var headers = HTTPHeaders()
-    headers.add(name: "content-type", value: "application/grpc")
-    let responseHead = HTTPResponseHead(
-      version: .init(major: 2, minor: 0),
-      status: .ok,
-      headers: headers
-    )
-
-    stateMachine.receiveResponseHead(responseHead).assertSuccess()
+    stateMachine.receiveResponseHeaders(self.makeResponseHeaders()).assertSuccess()
   }
 
   func testReceiveResponseHeadersWithNotOkStatus() throws {
     var stateMachine = self.makeStateMachine(.clientActiveServerIdle(writeState: .one(), readArity: .one))
 
-    let responseHead = HTTPResponseHead(
-      version: .init(major: 2, minor: 0),
-      status: .imATeapot,
-      headers: HTTPHeaders()
-    )
-
-    stateMachine.receiveResponseHead(responseHead).assertFailure {
-      XCTAssertEqual($0, .invalidHTTPStatus(.imATeapot))
+    let headers = self.makeResponseHeaders(status: "\(HTTPResponseStatus.paymentRequired.code)")
+    stateMachine.receiveResponseHeaders(headers).assertFailure {
+      XCTAssertEqual($0, .invalidHTTPStatus(.paymentRequired))
     }
   }
 
   func testReceiveResponseHeadersWithoutContentType() throws {
     var stateMachine = self.makeStateMachine(.clientActiveServerIdle(writeState: .one(), readArity: .one))
 
-    let responseHead = HTTPResponseHead(
-      version: .init(major: 2, minor: 0),
-      status: .ok
-    )
-
-    stateMachine.receiveResponseHead(responseHead).assertFailure {
+    let headers = self.makeResponseHeaders(contentType: nil)
+    stateMachine.receiveResponseHeaders(headers).assertFailure {
       XCTAssertEqual($0, .invalidContentType)
     }
   }
@@ -667,15 +692,8 @@ extension GRPCClientStateMachineTests {
   func testReceiveResponseHeadersWithInvalidContentType() throws {
     var stateMachine = self.makeStateMachine(.clientActiveServerIdle(writeState: .one(), readArity: .one))
 
-    var headers = HTTPHeaders()
-    headers.add(name: "content-type", value: "video/mpeg")
-    let responseHead = HTTPResponseHead(
-      version: .init(major: 2, minor: 0),
-      status: .ok,
-      headers: headers
-    )
-
-    stateMachine.receiveResponseHead(responseHead).assertFailure {
+    let headers = self.makeResponseHeaders(contentType: "video/mpeg")
+    stateMachine.receiveResponseHeaders(headers).assertFailure {
       XCTAssertEqual($0, .invalidContentType)
     }
   }
@@ -683,18 +701,11 @@ extension GRPCClientStateMachineTests {
   func testReceiveResponseHeadersWithSupportedCompressionMechanism() throws {
     var stateMachine = self.makeStateMachine(.clientActiveServerIdle(writeState: .one(), readArity: .one))
 
-    var headers = HTTPHeaders()
-    headers.add(name: "content-type", value: "application/grpc")
+    var headers = self.makeResponseHeaders()
     // Identity should always be supported.
     headers.add(name: "grpc-encoding", value: "identity")
 
-    let responseHead = HTTPResponseHead(
-      version: .init(major: 2, minor: 0),
-      status: .ok,
-      headers: headers
-    )
-
-    stateMachine.receiveResponseHead(responseHead).assertSuccess()
+    stateMachine.receiveResponseHeaders(headers).assertSuccess()
 
     switch stateMachine.state {
     case let .clientActiveServerActive(_, .reading(_, reader)):
@@ -707,44 +718,29 @@ extension GRPCClientStateMachineTests {
   func testReceiveResponseHeadersWithUnsupportedCompressionMechanism() throws {
     var stateMachine = self.makeStateMachine(.clientActiveServerIdle(writeState: .one(), readArity: .one))
 
-    var headers = HTTPHeaders()
-    headers.add(name: "content-type", value: "application/grpc")
+    var headers = self.makeResponseHeaders()
     headers.add(name: "grpc-encoding", value: "snappy")
 
-    let responseHead = HTTPResponseHead(
-      version: .init(major: 2, minor: 0),
-      status: .ok,
-      headers: headers
-    )
-
-    stateMachine.receiveResponseHead(responseHead).assertFailure {
-      XCTAssertEqual($0, .unsupportedMessageEncoding)
+    stateMachine.receiveResponseHeaders(headers).assertFailure {
+      XCTAssertEqual($0, .unsupportedMessageEncoding("snappy"))
     }
   }
 
   func testReceiveResponseHeadersWithUnknownCompressionMechanism() throws {
     var stateMachine = self.makeStateMachine(.clientActiveServerIdle(writeState: .one(), readArity: .one))
 
-    var headers = HTTPHeaders()
-    headers.add(name: "content-type", value: "application/grpc")
+    var headers = self.makeResponseHeaders()
     headers.add(name: "grpc-encoding", value: "not-a-known-compression-(probably)")
 
-    let responseHead = HTTPResponseHead(
-      version: .init(major: 2, minor: 0),
-      status: .ok,
-      headers: headers
-    )
-
-    stateMachine.receiveResponseHead(responseHead).assertFailure {
-      XCTAssertEqual($0, .unsupportedMessageEncoding)
+    stateMachine.receiveResponseHeaders(headers).assertFailure {
+      XCTAssertEqual($0, .unsupportedMessageEncoding("unknown"))
     }
   }
 
   func testReceiveEndOfResponseStreamWithStatus() throws {
     var stateMachine = self.makeStateMachine(.clientClosedServerActive(readState: .one()))
 
-    var trailers = HTTPHeaders()
-    trailers.add(name: "grpc-status", value: "0")
+    let trailers: HPACKHeaders = ["grpc-status": "0"]
     stateMachine.receiveEndOfResponseStream(trailers).assertSuccess { status in
       XCTAssertEqual(status.code, GRPCStatus.Code(rawValue: 0))
       XCTAssertEqual(status.message, nil)
@@ -754,8 +750,7 @@ extension GRPCClientStateMachineTests {
   func testReceiveEndOfResponseStreamWithUnknownStatus() throws {
     var stateMachine = self.makeStateMachine(.clientClosedServerActive(readState: .one()))
 
-    var trailers = HTTPHeaders()
-    trailers.add(name: "grpc-status", value: "999")
+    let trailers: HPACKHeaders = ["grpc-status": "999"]
     stateMachine.receiveEndOfResponseStream(trailers).assertSuccess { status in
       XCTAssertEqual(status.code, .unknown)
     }
@@ -764,8 +759,7 @@ extension GRPCClientStateMachineTests {
   func testReceiveEndOfResponseStreamWithNonIntStatus() throws {
     var stateMachine = self.makeStateMachine(.clientClosedServerActive(readState: .one()))
 
-    var trailers = HTTPHeaders()
-    trailers.add(name: "grpc-status", value: "not-a-real-status-code")
+    let trailers: HPACKHeaders = ["grpc-status": "not-a-real-status-code"]
     stateMachine.receiveEndOfResponseStream(trailers).assertSuccess { status in
       XCTAssertEqual(status.code, .unknown)
     }
@@ -774,9 +768,10 @@ extension GRPCClientStateMachineTests {
   func testReceiveEndOfResponseStreamWithStatusAndMessage() throws {
     var stateMachine = self.makeStateMachine(.clientClosedServerActive(readState: .one()))
 
-    var trailers = HTTPHeaders()
-    trailers.add(name: "grpc-status", value: "5")
-    trailers.add(name: "grpc-message", value: "foo bar 🚀")
+    let trailers: HPACKHeaders = [
+      "grpc-status": "5",
+      "grpc-message": "foo bar 🚀"
+    ]
     stateMachine.receiveEndOfResponseStream(trailers).assertSuccess { status in
       XCTAssertEqual(status.code, GRPCStatus.Code(rawValue: 5))
       XCTAssertEqual(status.message, "foo bar 🚀")

--- a/Tests/GRPCTests/GRPCClientStateMachineTests.swift
+++ b/Tests/GRPCTests/GRPCClientStateMachineTests.swift
@@ -77,26 +77,28 @@ class GRPCClientStateMachineTests: GRPCTestCase {
 extension GRPCClientStateMachineTests {
   func doTestSendRequestHeadersFromInvalidState(_ state: StateMachine.State) {
     var stateMachine = self.makeStateMachine(state)
-    stateMachine.sendRequestHeaders(
+    stateMachine.sendRequestHeaders(requestHead: .init(
+      method: "POST",
       scheme: "http",
-      host: "host",
       path: "/echo/Get",
-      options: .init(),
-      requestID: "bar"
-    ).assertFailure {
+      host: "host",
+      timeout: .infinite,
+      customMetadata: [:]
+    )).assertFailure {
       XCTAssertEqual($0, .invalidState)
     }
   }
 
   func testSendRequestHeadersFromIdle() {
     var stateMachine = self.makeStateMachine(.clientIdleServerIdle(pendingWriteState: .one(), readArity: .one))
-    stateMachine.sendRequestHeaders(
+    stateMachine.sendRequestHeaders(requestHead: .init(
+      method: "POST",
       scheme: "http",
-      host: "host",
       path: "/echo/Get",
-      options: .init(),
-      requestID: "bar"
-    ).assertSuccess()
+      host: "host",
+      timeout: .infinite,
+      customMetadata: [:]
+    )).assertSuccess()
   }
 
   func testSendRequestHeadersFromClientActiveServerIdle() {
@@ -444,13 +446,14 @@ extension GRPCClientStateMachineTests {
     var stateMachine = self.makeStateMachine(.clientIdleServerIdle(pendingWriteState: .one(), readArity: .one))
 
     // Initiate the RPC
-    stateMachine.sendRequestHeaders(
+    stateMachine.sendRequestHeaders(requestHead: .init(
+      method: "POST",
       scheme: "https",
-      host: "foo",
       path: "/echo/Get",
-      options: .init(),
-      requestID: "bar"
-    ).assertSuccess()
+      host: "foo",
+      timeout: .infinite,
+      customMetadata: [:]
+    )).assertSuccess()
 
     // Receive acknowledgement.
     stateMachine.receiveResponseHeaders(self.makeResponseHeaders()).assertSuccess()
@@ -473,13 +476,14 @@ extension GRPCClientStateMachineTests {
     var stateMachine = self.makeStateMachine(.clientIdleServerIdle(pendingWriteState: .many(), readArity: .one))
 
     // Initiate the RPC
-    stateMachine.sendRequestHeaders(
+    stateMachine.sendRequestHeaders(requestHead: .init(
+      method: "POST",
       scheme: "https",
-      host: "foo",
       path: "/echo/Get",
-      options: .init(),
-      requestID: "bar"
-    ).assertSuccess()
+      host: "foo",
+      timeout: .infinite,
+      customMetadata: [:]
+    )).assertSuccess()
 
     // Receive acknowledgement.
     stateMachine.receiveResponseHeaders(self.makeResponseHeaders()).assertSuccess()
@@ -504,13 +508,14 @@ extension GRPCClientStateMachineTests {
     var stateMachine = self.makeStateMachine(.clientIdleServerIdle(pendingWriteState: .one(), readArity: .many))
 
     // Initiate the RPC
-    stateMachine.sendRequestHeaders(
+    stateMachine.sendRequestHeaders(requestHead: .init(
+      method: "POST",
       scheme: "https",
-      host: "foo",
       path: "/echo/Get",
-      options: .init(),
-      requestID: "bar"
-    ).assertSuccess()
+      host: "foo",
+      timeout: .infinite,
+      customMetadata: [:]
+    )).assertSuccess()
 
     // Receive acknowledgement.
     stateMachine.receiveResponseHeaders(self.makeResponseHeaders()).assertSuccess()
@@ -538,13 +543,14 @@ extension GRPCClientStateMachineTests {
     var stateMachine = self.makeStateMachine(.clientIdleServerIdle(pendingWriteState: .many(), readArity: .many))
 
     // Initiate the RPC
-    stateMachine.sendRequestHeaders(
+    stateMachine.sendRequestHeaders(requestHead: .init(
+      method: "POST",
       scheme: "https",
-      host: "foo",
       path: "/echo/Get",
-      options: .init(),
-      requestID: "bar"
-    ).assertSuccess()
+      host: "foo",
+      timeout: .infinite,
+      customMetadata: [:]
+    )).assertSuccess()
 
     // Receive acknowledgement.
     stateMachine.receiveResponseHeaders(self.makeResponseHeaders()).assertSuccess()
@@ -647,13 +653,14 @@ extension GRPCClientStateMachineTests {
 extension GRPCClientStateMachineTests {
   func testSendRequestHeaders() throws {
     var stateMachine = self.makeStateMachine(.clientIdleServerIdle(pendingWriteState: .one(), readArity: .one))
-    stateMachine.sendRequestHeaders(
+    stateMachine.sendRequestHeaders(requestHead: .init(
+      method: "POST",
       scheme: "http",
-      host: "localhost",
       path: "/echo/Get",
-      options: CallOptions(timeout: .hours(rounding: 1), requestIDHeader: "x-grpc-id"),
-      requestID: "request-id"
-    ).assertSuccess { headers in
+      host: "localhost",
+      timeout: .hours(rounding: 1),
+      customMetadata: ["x-grpc-id": "request-id"]
+    )).assertSuccess { headers in
       XCTAssertEqual(headers[":method"], ["POST"])
       XCTAssertEqual(headers[":path"], ["/echo/Get"])
       XCTAssertEqual(headers[":authority"], ["localhost"])


### PR DESCRIPTION
Motivation:

8db70dd8 (#580) introduced a client state machine which enables us to
reduce the number of channel handlers the client has and confine much of
the stream state tracking to a single place. However, none of our
channel handlers were designed to use it!

Modifications:

Create a client channel handler using the aforementioned state machine
and update the state machine to talk in HTTP/2 concepts to avoid having
to use an additional handler to translate between HTTP/1 and HTTP/2
concepts.

Result:

Functionally, nothing, as the channel handler is not yet used.