### PR TITLE
Workaround for SR-11564

### DIFF
--- a/Sources/GRPC/ClientResponseChannelHandler.swift
+++ b/Sources/GRPC/ClientResponseChannelHandler.swift
@@ -301,6 +301,12 @@ final class GRPCClientUnaryResponseChannelHandler<ResponseMessage: Message>: Cli
       self.responsePromise.fail(status)
     }
   }
+
+  // Workaround for SR-11564 (observed in Xcode 11.2 Beta).
+  // See: https://bugs.swift.org/browse/SR-11564
+  override internal func scheduleTimeout(eventLoop: EventLoop) {
+    super.scheduleTimeout(eventLoop: eventLoop)
+  }
 }
 
 /// A channel handler for client calls which receive a stream of responses.
@@ -339,6 +345,12 @@ final class GRPCClientStreamingResponseChannelHandler<ResponseMessage: Message>:
   /// - Parameter response: The response received from the service.
   override func onResponse(_ response: _Box<ResponseMessage>) {
     self.responseHandler(response.value)
+  }
+
+  // Workaround for SR-11564 (observed in Xcode 11.2 Beta).
+  // See: https://bugs.swift.org/browse/SR-11564
+  override internal func scheduleTimeout(eventLoop: EventLoop) {
+    super.scheduleTimeout(eventLoop: eventLoop)
   }
 }
 

--- a/Sources/GRPC/ClientResponseChannelHandler.swift
+++ b/Sources/GRPC/ClientResponseChannelHandler.swift
@@ -304,6 +304,8 @@ final class GRPCClientUnaryResponseChannelHandler<ResponseMessage: Message>: Cli
 
   // Workaround for SR-11564 (observed in Xcode 11.2 Beta).
   // See: https://bugs.swift.org/browse/SR-11564
+  //
+  // TODO: Remove this once SR-11564 is resolved.
   override internal func scheduleTimeout(eventLoop: EventLoop) {
     super.scheduleTimeout(eventLoop: eventLoop)
   }
@@ -349,6 +351,8 @@ final class GRPCClientStreamingResponseChannelHandler<ResponseMessage: Message>:
 
   // Workaround for SR-11564 (observed in Xcode 11.2 Beta).
   // See: https://bugs.swift.org/browse/SR-11564
+  //
+  // TODO: Remove this once SR-11564 is resolved.
   override internal func scheduleTimeout(eventLoop: EventLoop) {
     super.scheduleTimeout(eventLoop: eventLoop)
   }


### PR DESCRIPTION
Motivation:

gRPC Swift crashes when running any RPC on iOS when built with Xcode
11.2 beta (see issue: #605).

Modifications:

- Add methods `override`ing the `scheduleTimeout` method on the different
  client response channel handler subclasses. The overriden methods just
  explicitly call the method in the `super` class.

Result:

No crash on iOS when compiled with Xcode 11.2 beta.