### PR TITLE
support Swift 5.1 on Linux

### DIFF
--- a/Tests/SwiftGRPCNIOTests/NIOServerWebTests.swift
+++ b/Tests/SwiftGRPCNIOTests/NIOServerWebTests.swift
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import NIO
 @testable import SwiftGRPCNIO
 import XCTest


### PR DESCRIPTION
Motivation:

On Linux in Swift 5.1, `URLSession` moved to the `FoundationNetworking` module.

Modification:

Import `FoundationNetworking` if that's a thing.

Result:

Test suite compatible with 5.1 on Linux.