### PR TITLE
Reduce logging verbosity

### DIFF
--- a/Sources/GRPC/CallHandlers/BidirectionalStreamingCallHandler.swift
+++ b/Sources/GRPC/CallHandlers/BidirectionalStreamingCallHandler.swift
@@ -32,7 +32,7 @@ public class BidirectionalStreamingCallHandler<RequestMessage: Message, Response
 
   private var observerState: ClientStreamingHandlerObserverState<EventObserverFactory, EventObserver> {
     willSet(newState) {
-      self.logger.info("observerState changed from \(self.observerState) to \(newState)")
+      self.logger.debug("observerState changed from \(self.observerState) to \(newState)")
     }
   }
   private var callContext: Context?

--- a/Sources/GRPC/CallHandlers/ClientStreamingCallHandler.swift
+++ b/Sources/GRPC/CallHandlers/ClientStreamingCallHandler.swift
@@ -40,7 +40,7 @@ public class ClientStreamingCallHandler<RequestMessage: Message, ResponseMessage
 
   private var observerState: ClientStreamingHandlerObserverState<EventObserverFactory, EventObserver> {
     willSet(newState) {
-      self.logger.info("observerState changed from \(self.observerState) to \(newState)")
+      self.logger.debug("observerState changed from \(self.observerState) to \(newState)")
     }
   }
   private var callContext: UnaryResponseCallContext<ResponseMessage>?

--- a/Sources/GRPC/ClientCalls/BaseClientCall.swift
+++ b/Sources/GRPC/ClientCalls/BaseClientCall.swift
@@ -113,7 +113,7 @@ public class BaseClientCall<Request: Message, Response: Message>: ClientCall {
     self.subchannel.whenComplete {
       switch $0 {
       case .success(let channel):
-        self.logger.debug("firing .cancelled event")
+        self.logger.trace("firing .cancelled event")
         channel.pipeline.triggerUserOutboundEvent(GRPCClientUserEvent.cancelled, promise: promise)
       case .failure(let error):
         promise?.fail(error)
@@ -123,7 +123,7 @@ public class BaseClientCall<Request: Message, Response: Message>: ClientCall {
 
   public func cancel() -> EventLoopFuture<Void> {
     return self.subchannel.flatMap { channel in
-      self.logger.debug("firing .cancelled event")
+      self.logger.trace("firing .cancelled event")
       return channel.pipeline.triggerUserOutboundEvent(GRPCClientUserEvent.cancelled)
     }
   }

--- a/Sources/GRPC/ClientCalls/BidirectionalStreamingCall.swift
+++ b/Sources/GRPC/ClientCalls/BidirectionalStreamingCall.swift
@@ -43,7 +43,7 @@ public final class BidirectionalStreamingCall<RequestMessage: Message, ResponseM
     let requestID = callOptions.requestIDProvider.requestID()
 
     let logger = Logger(subsystem: .clientChannelCall, metadata: [MetadataKey.requestID: "\(requestID)"])
-    logger.info("making bidirectional streaming call to '\(path)', request type: \(RequestMessage.self), response type: \(ResponseMessage.self)")
+    logger.info("starting rpc", metadata: ["path": "\(path)"])
 
     let responseHandler = GRPCClientStreamingResponseChannelHandler(
       initialMetadataPromise: connection.channel.eventLoop.makePromise(),

--- a/Sources/GRPC/ClientCalls/ClientStreamingCall.swift
+++ b/Sources/GRPC/ClientCalls/ClientStreamingCall.swift
@@ -43,7 +43,7 @@ public final class ClientStreamingCall<RequestMessage: Message, ResponseMessage:
   ) {
     let requestID = callOptions.requestIDProvider.requestID()
     let logger = Logger(subsystem: .clientChannelCall, metadata: [MetadataKey.requestID: "\(requestID)"])
-    logger.info("making client streaming call to '\(path)', request type: \(RequestMessage.self), response type: \(ResponseMessage.self)")
+    logger.info("starting rpc", metadata: ["path": "\(path)"])
 
     self.messageQueue = connection.eventLoop.makeSucceededFuture(())
     let responsePromise = connection.eventLoop.makePromise(of: ResponseMessage.self)

--- a/Sources/GRPC/ClientCalls/ServerStreamingCall.swift
+++ b/Sources/GRPC/ClientCalls/ServerStreamingCall.swift
@@ -35,7 +35,7 @@ public final class ServerStreamingCall<RequestMessage: Message, ResponseMessage:
   ) {
     let requestID = callOptions.requestIDProvider.requestID()
     let logger = Logger(subsystem: .clientChannelCall, metadata: [MetadataKey.requestID: "\(requestID)"])
-    logger.info("making server streaming call to '\(path)', request type: \(RequestMessage.self), response type: \(ResponseMessage.self)")
+    logger.info("starting rpc", metadata: ["path": "\(path)"])
 
     let responseHandler = GRPCClientStreamingResponseChannelHandler(
       initialMetadataPromise: connection.channel.eventLoop.makePromise(),

--- a/Sources/GRPC/ClientCalls/UnaryCall.swift
+++ b/Sources/GRPC/ClientCalls/UnaryCall.swift
@@ -41,7 +41,7 @@ public final class UnaryCall<RequestMessage: Message, ResponseMessage: Message>
   ) {
     let requestID = callOptions.requestIDProvider.requestID()
     let logger = Logger(subsystem: .clientChannelCall, metadata: [MetadataKey.requestID: "\(requestID)"])
-    logger.info("making unary call to '\(path)', request type: \(RequestMessage.self), response type: \(ResponseMessage.self)")
+    logger.info("starting rpc", metadata: ["path": "\(path)"])
 
     let responsePromise = connection.channel.eventLoop.makePromise(of: ResponseMessage.self)
     self.response = responsePromise.futureResult

--- a/Sources/GRPC/ClientConnection.swift
+++ b/Sources/GRPC/ClientConnection.swift
@@ -66,7 +66,7 @@ import Logging
 /// delegated error handler which uses the error delegate associated with this connection
 /// (see `DelegatingErrorHandler`).
 ///
-/// See `BaseClientCall` for a description of the pipelines assoicated with each HTTP/2 stream.
+/// See `BaseClientCall` for a description of the pipelines associated with each HTTP/2 stream.
 public class ClientConnection {
   internal let logger: Logger
   /// The UUID of this connection, used for logging.
@@ -213,7 +213,7 @@ extension ClientConnection {
     channel.flatMap { $0.closeFuture }.whenComplete { result in
       switch result {
       case .success:
-        self.logger.info("client connection shutdown successfully")
+        self.logger.debug("client connection shutdown successfully")
       case .failure(let error):
         self.logger.warning(
           "client connection shutdown failed",
@@ -275,7 +275,7 @@ extension ClientConnection {
       return configuration.eventLoopGroup.next().makeFailedFuture(GRPCStatus.processingError)
     }
 
-    logger.info("attempting to connect to \(configuration.target)")
+    logger.debug("attempting to connect to \(configuration.target)")
     connectivity.state = .connecting
     let timeoutAndBackoff = backoffIterator?.next()
 
@@ -298,7 +298,7 @@ extension ClientConnection {
     // If we don't have backoff then we can't retry, just return the `channel` no matter what
     // state we are in.
     guard let backoff = timeoutAndBackoff?.backoff else {
-      logger.info("backoff exhausted, no more connection attempts will be made")
+      logger.debug("backoff exhausted, no more connection attempts will be made")
       return channel
     }
 
@@ -327,7 +327,7 @@ extension ClientConnection {
     backoffIterator: ConnectionBackoffIterator?,
     logger: Logger
   ) -> EventLoopFuture<Channel> {
-    logger.info("scheduling connection attempt in \(timeout) seconds")
+    logger.debug("scheduling connection attempt in \(timeout) seconds")
     // The `futureResult` of the scheduled task is of type
     // `EventLoopFuture<EventLoopFuture<Channel>>`, so we need to `flatMap` it to
     // remove a level of indirection.
@@ -387,10 +387,10 @@ extension ClientConnection {
       }
 
     if let timeout = timeout {
-      logger.info("setting connect timeout to \(timeout) seconds")
+      logger.debug("setting connect timeout to \(timeout) seconds")
       return bootstrap.connectTimeout(.seconds(timeInterval: timeout))
     } else {
-      logger.info("no connect timeout provided")
+      logger.debug("no connect timeout provided")
       return bootstrap
     }
   }

--- a/Sources/GRPC/ConnectivityState.swift
+++ b/Sources/GRPC/ConnectivityState.swift
@@ -87,7 +87,7 @@ public class ConnectivityStateMonitor {
   /// Updates `_state` to `newValue`.
   ///
   /// If the user has initiated shutdown then state updates are _ignored_. This may happen if the
-  /// connection is being estabilshed as the user initiates shutdown.
+  /// connection is being established as the user initiates shutdown.
   ///
   /// - Important: This is **not** thread safe.
   private func setNewState(to newValue: ConnectivityState) {

--- a/Sources/GRPC/GRPCClientChannelHandler.swift
+++ b/Sources/GRPC/GRPCClientChannelHandler.swift
@@ -220,13 +220,13 @@ public final class GRPCClientChannelHandler<Request: Message, Response: Message>
     self.logger = logger
     switch callType {
     case .unary:
-      self.stateMachine = .init(requestArity: .one, responseArity: .one, logger: logger)
+      self.stateMachine = .init(requestArity: .one, responseArity: .one)
     case .clientStreaming:
-      self.stateMachine = .init(requestArity: .many, responseArity: .one, logger: logger)
+      self.stateMachine = .init(requestArity: .many, responseArity: .one)
     case .serverStreaming:
-      self.stateMachine = .init(requestArity: .one, responseArity: .many, logger: logger)
+      self.stateMachine = .init(requestArity: .one, responseArity: .many)
     case .bidirectionalStreaming:
-      self.stateMachine = .init(requestArity: .many, responseArity: .many, logger: logger)
+      self.stateMachine = .init(requestArity: .many, responseArity: .many)
     }
   }
 }

--- a/Sources/GRPC/HTTP1ToRawGRPCServerCodec.swift
+++ b/Sources/GRPC/HTTP1ToRawGRPCServerCodec.swift
@@ -45,17 +45,13 @@ public enum RawGRPCServerResponsePart {
 /// The translation from HTTP2 to HTTP1 is done by `HTTP2ToHTTP1ServerCodec`.
 public final class HTTP1ToRawGRPCServerCodec {
   public init(logger: Logger) {
-    self.logger = logger.addingMetadata(key: MetadataKey.channelHandler, value: "HTTP1ToRawGRPCServerCodec")
+    self.logger = logger
 
     var accessLog = Logger(subsystem: .serverAccess)
     accessLog[metadataKey: MetadataKey.requestID] = logger[metadataKey: MetadataKey.requestID]
     self.accessLog = accessLog
 
-    self.messageReader = LengthPrefixedMessageReader(
-      mode: .server,
-      compressionMechanism: .none,
-      logger: logger
-    )
+    self.messageReader = LengthPrefixedMessageReader(mode: .server, compressionMechanism: .none)
   }
 
   // 1-byte for compression flag, 4-bytes for message length.
@@ -86,13 +82,13 @@ public final class HTTP1ToRawGRPCServerCodec {
   var inboundState = InboundState.expectingHeaders {
     willSet {
       guard newValue != self.inboundState else { return }
-      self.logger.info("inbound state changed from \(self.inboundState) to \(newValue)")
+      self.logger.debug("inbound state changed from \(self.inboundState) to \(newValue)")
     }
   }
   var outboundState = OutboundState.expectingHeaders {
     willSet {
       guard newValue != self.outboundState else { return }
-      self.logger.info("outbound state changed from \(self.outboundState) to \(newValue)")
+      self.logger.debug("outbound state changed from \(self.outboundState) to \(newValue)")
     }
   }
 

--- a/Sources/GRPC/PlatformSupport.swift
+++ b/Sources/GRPC/PlatformSupport.swift
@@ -159,7 +159,7 @@ public enum PlatformSupport {
   ///
   /// - Parameter group: The `EventLoopGroup` to use.
   public static func makeClientBootstrap(group: EventLoopGroup) -> ClientBootstrapProtocol {
-    logger.info("making client bootstrap with event loop group of type \(type(of: group))")
+    logger.debug("making client bootstrap with event loop group of type \(type(of: group))")
     #if canImport(Network)
     if #available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *) {
       if let tsGroup = group as? NIOTSEventLoopGroup {
@@ -183,7 +183,7 @@ public enum PlatformSupport {
   ///
   /// - Parameter group: The `EventLoopGroup` to use.
   public static func makeServerBootstrap(group: EventLoopGroup) -> ServerBootstrapProtocol {
-    logger.info("making server bootstrap with event loop group of type \(type(of: group))")
+    logger.debug("making server bootstrap with event loop group of type \(type(of: group))")
     #if canImport(Network)
     if #available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *) {
       if let tsGroup = group as? NIOTSEventLoopGroup {

--- a/Sources/GRPC/SettingsObservingHandler.swift
+++ b/Sources/GRPC/SettingsObservingHandler.swift
@@ -36,7 +36,7 @@ class InitialSettingsObservingHandler: ChannelInboundHandler, RemovableChannelHa
     let frame = self.unwrapInboundIn(data)
 
     if frame.streamID == .rootStream, case .settings(.settings) = frame.payload {
-      self.logger.info("observed initial settings frame on the root stream")
+      self.logger.debug("observed initial settings frame on the root stream")
       self.connectivityStateMonitor.state = .ready
 
       // We're no longer needed at this point, remove ourselves from the pipeline.

--- a/Sources/GRPC/TLSVerificationHandler.swift
+++ b/Sources/GRPC/TLSVerificationHandler.swift
@@ -45,7 +45,7 @@ public class TLSVerificationHandler: ChannelInboundHandler, RemovableChannelHand
 
   /// A future which is fulfilled when the state of the TLS handshake is known. If the handshake
   /// was successful and the negotiated application protocol is valid then the future is succeeded.
-  /// If an error occured or the application protocol is not valid then the future will have been
+  /// If an error occurred or the application protocol is not valid then the future will have been
   /// failed.
   ///
   /// - Important: The promise associated with this future is created in `handlerAdded(context:)`,

--- a/Tests/GRPCTests/GRPCClientStateMachineTests.swift
+++ b/Tests/GRPCTests/GRPCClientStateMachineTests.swift
@@ -31,10 +31,7 @@ class GRPCClientStateMachineTests: GRPCTestCase {
   var allocator = ByteBufferAllocator()
 
   func makeStateMachine(_ state: StateMachine.State) -> StateMachine {
-    return StateMachine(
-      state: state,
-      logger: Logger(label: "io.grpc.testing")
-    )
+    return StateMachine(state: state)
   }
 
   /// Writes a message into a new `ByteBuffer` (with length-prefixing).
@@ -934,8 +931,7 @@ extension ReadState {
   static func one() -> ReadState {
     let reader = LengthPrefixedMessageReader(
       mode: .client,
-      compressionMechanism: .none,
-      logger: Logger(label: "io.grpc.reader")
+      compressionMechanism: .none
     )
     return .reading(.one, reader)
   }
@@ -943,8 +939,7 @@ extension ReadState {
   static func many() -> ReadState {
     let reader = LengthPrefixedMessageReader(
       mode: .client,
-      compressionMechanism: .none,
-      logger: Logger(label: "io.grpc.reader")
+      compressionMechanism: .none
     )
     return .reading(.many, reader)
   }

--- a/Tests/GRPCTests/LengthPrefixedMessageReaderTests.swift
+++ b/Tests/GRPCTests/LengthPrefixedMessageReaderTests.swift
@@ -24,11 +24,7 @@ class LengthPrefixedMessageReaderTests: GRPCTestCase {
 
   override func setUp() {
     super.setUp()
-    self.reader = LengthPrefixedMessageReader(
-      mode: .client,
-      compressionMechanism: .none,
-      logger: Logger(label: "io.grpc.testing")
-    )
+    self.reader = LengthPrefixedMessageReader(mode: .client, compressionMechanism: .none)
   }
 
   var allocator = ByteBufferAllocator()


### PR DESCRIPTION
Motivation:

The gRPC client and server log a lot. Too much at info level anyway.

Modifications:

- remove unnecessary logs
- lower the priorty of most log messages

Result:

At info level the client and server will only log (in the happy case):
- start and end of rpcs (access logs)
- connectivity state changes (client only)