### PR TITLE
Correctly set the authority to the host rather than scheme

### DIFF
--- a/Sources/GRPC/ClientCalls/BidirectionalStreamingCall.swift
+++ b/Sources/GRPC/ClientCalls/BidirectionalStreamingCall.swift
@@ -58,7 +58,7 @@ public final class BidirectionalStreamingCall<RequestMessage: Message, ResponseM
     let requestHead = GRPCRequestHead(
       scheme: connection.configuration.httpProtocol.scheme,
       path: path,
-      host: connection.configuration.httpProtocol.scheme,
+      host: connection.configuration.target.host,
       requestID: requestID,
       options: callOptions
     )

--- a/Sources/GRPC/ClientCalls/ClientStreamingCall.swift
+++ b/Sources/GRPC/ClientCalls/ClientStreamingCall.swift
@@ -62,7 +62,7 @@ public final class ClientStreamingCall<RequestMessage: Message, ResponseMessage:
     let requestHead = GRPCRequestHead(
       scheme: connection.configuration.httpProtocol.scheme,
       path: path,
-      host: connection.configuration.httpProtocol.scheme,
+      host: connection.configuration.target.host,
       requestID: requestID,
       options: callOptions
     )

--- a/Sources/GRPC/ClientCalls/ServerStreamingCall.swift
+++ b/Sources/GRPC/ClientCalls/ServerStreamingCall.swift
@@ -50,7 +50,7 @@ public final class ServerStreamingCall<RequestMessage: Message, ResponseMessage:
     let requestHead = GRPCRequestHead(
       scheme: connection.configuration.httpProtocol.scheme,
       path: path,
-      host: connection.configuration.httpProtocol.scheme,
+      host: connection.configuration.target.host,
       requestID: requestID,
       options: callOptions
     )

--- a/Sources/GRPC/ClientCalls/UnaryCall.swift
+++ b/Sources/GRPC/ClientCalls/UnaryCall.swift
@@ -59,7 +59,7 @@ public final class UnaryCall<RequestMessage: Message, ResponseMessage: Message>
     let requestHead = GRPCRequestHead(
       scheme: connection.configuration.httpProtocol.scheme,
       path: path,
-      host: connection.configuration.httpProtocol.scheme,
+      host: connection.configuration.target.host,
       requestID: requestID,
       options: callOptions
     )


### PR DESCRIPTION
Per the HTTP2 spec, the `:authority` header should include the authority portion of the URI.

https://http2.github.io/http2-spec/#HttpRequest
https://tools.ietf.org/html/rfc3986#section-3.2

Certain proxies that read the host from the authority field fail to forward the RPC to the correct service. This change sets the authority field to the target host.