### PR TITLE
Percent encoding benchmark

### DIFF
--- a/Sources/GRPCPerformanceTests/Benchmarks/PercentEncoding.swift
+++ b/Sources/GRPCPerformanceTests/Benchmarks/PercentEncoding.swift
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import NIO
+import GRPC
+import Foundation
+
+class PercentEncoding: Benchmark {
+  // The message is used in the interop-tests.
+  let message = "\t\ntest with whitespace\r\nand Unicode BMP ☺ and non-BMP 😈\t\n"
+  let allocator = ByteBufferAllocator()
+
+  let iterations: Int
+
+  init(iterations: Int) {
+    self.iterations = iterations
+  }
+
+  func setUp() throws {
+  }
+
+  func tearDown() throws {
+  }
+
+  func run() throws {
+    var totalLength: Int = 0
+
+    for _ in 0..<self.iterations {
+      var buffer = self.allocator.buffer(capacity: 0)
+
+      let marshalled = GRPCStatusMessageMarshaller.marshall(self.message)!
+      let length = buffer.writeString(marshalled)
+      let unmarshalled = GRPCStatusMessageMarshaller.unmarshall(buffer.readString(length: length)!)
+
+      totalLength += unmarshalled.count
+    }
+  }
+}

--- a/Sources/GRPCPerformanceTests/main.swift
+++ b/Sources/GRPCPerformanceTests/main.swift
@@ -61,6 +61,12 @@ func runBenchmarks(spec: TestSpec) {
     benchmark: EmbeddedClientThroughput(requests: 10_000, text: smallRequest),
     spec: spec
   )
+
+  measureAndPrint(
+    description: "percent_encode_decode_10k_status_messages",
+    benchmark: PercentEncoding(iterations: 10_000),
+    spec: spec
+  )
 }
 
 struct TestSpec {


### PR DESCRIPTION
Motivation:

To measure performance, we need benchmarks. Here's one for percent
encoding and decoding of status messages.

Modifications:

Add a benchmark for encoding and decoding status messages.

Result:

We have a benchmark for encode and decoding status messages.