### PR TITLE
Build protoc plugins in release mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ DerivedData/
 .build
 build
 /protoc-gen-swift
-/protoc-gen-swiftgrpc
+/protoc-gen-grpc-swift
 third_party/**
 /Echo
 /EchoNIO

--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,17 @@
 SWIFT:=swift
 # Where products will be built; this is the SPM default.
 SWIFT_BUILD_PATH:=./.build
-SWIFT_BUILD_CONFIGURATION:=debug
-SWIFT_FLAGS:=--build-path=${SWIFT_BUILD_PATH} --configuration=${SWIFT_BUILD_CONFIGURATION}
+SWIFT_BUILD_CONFIGURATION=debug
+SWIFT_FLAGS=--build-path=${SWIFT_BUILD_PATH} --configuration=${SWIFT_BUILD_CONFIGURATION}
+# Force release configuration (for plugins)
+SWIFT_FLAGS_RELEASE=$(patsubst --configuration=%,--configuration=release,$(SWIFT_FLAGS))
 
 # protoc plugins.
-PROTOC_GEN_SWIFT=${SWIFT_BUILD_PATH}/${SWIFT_BUILD_CONFIGURATION}/protoc-gen-swift
-PROTOC_GEN_GRPC_SWIFT=${SWIFT_BUILD_PATH}/${SWIFT_BUILD_CONFIGURATION}/protoc-gen-grpc-swift
+PROTOC_GEN_SWIFT=${SWIFT_BUILD_PATH}/release/protoc-gen-swift
+PROTOC_GEN_GRPC_SWIFT=${SWIFT_BUILD_PATH}/release/protoc-gen-grpc-swift
 
 SWIFT_BUILD:=${SWIFT} build ${SWIFT_FLAGS}
+SWIFT_BUILD_RELEASE:=${SWIFT} build ${SWIFT_FLAGS_RELEASE}
 SWIFT_TEST:=${SWIFT} test ${SWIFT_FLAGS}
 SWIFT_PACKAGE:=${SWIFT} package ${SWIFT_FLAGS}
 
@@ -23,12 +26,13 @@ all:
 
 .PHONY:
 plugins: ${PROTOC_GEN_SWIFT} ${PROTOC_GEN_GRPC_SWIFT}
+	cp $^ .
 
 ${PROTOC_GEN_SWIFT}:
-	${SWIFT_BUILD} --product protoc-gen-swift
+	${SWIFT_BUILD_RELEASE} --product protoc-gen-swift
 
 ${PROTOC_GEN_GRPC_SWIFT}:
-	${SWIFT_BUILD} --product protoc-gen-grpc-swift
+	${SWIFT_BUILD_RELEASE} --product protoc-gen-grpc-swift
 
 interop-test-runner:
 	${SWIFT_BUILD} --product GRPCInteroperabilityTests


### PR DESCRIPTION
Motivation:

It's easy for users to build the protoc plugins in debug mode (the
default for the Makefile) without realising. They then have to dig
through the build output to find the right binaries. This should be
easier for users.

Modifications:

- Build the plugins in release mode when invoked via `make plugins`
- Copy the plugins to the current directory after building them

Result:

Easier to find the protoc plugins.