### PR TITLE
Update dependencies

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "ff01888051cd7efceb1bf8319c1dd3986c4bf6fc",
-          "version": "2.10.1"
+          "revision": "e208ab9555ffb5fefb58cb5cb17df0f9fe9ee47e",
+          "version": "2.11.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
         "state": {
           "branch": null,
-          "revision": "867259332c45d5405efed844f7b3997ebfa94167",
-          "version": "1.7.2"
+          "revision": "c1bfb7ce3f201e41ff60ef38fa63e67e0eb66a24",
+          "version": "1.9.0"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "ccf96bbe65ecc7c1558ab0dba7ffabdea5c1d31f",
-          "version": "2.4.4"
+          "revision": "b015dcbe871d9c4d36bb343b0d37293521e3df07",
+          "version": "2.4.5"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
         "state": {
           "branch": null,
-          "revision": "80b11dc13261e0e52f75ea3a0b2e04f24e925019",
-          "version": "1.2.1"
+          "revision": "c7f06384dc5ce7e8506de5ed9b59e35b4d88c64b",
+          "version": "1.3.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -26,16 +26,16 @@ let package = Package(
   dependencies: [
     // GRPC dependencies:
     // Main SwiftNIO package
-    .package(url: "https://github.com/apple/swift-nio.git", from: "2.7.1"),
+    .package(url: "https://github.com/apple/swift-nio.git", from: "2.11.0"),
     // HTTP2 via SwiftNIO
-    .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.6.0"),
+    .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.8.0"),
     // TLS via SwiftNIO
     .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.4.1"),
     // Support for Network.framework where possible.
-    .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.1.0"),
+    .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.3.0"),
 
     // Official SwiftProtobuf library, for [de]serializing data to send on the wire.
-    .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.5.0"),
+    .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.7.0"),
 
     // Logging API.
     .package(url: "https://github.com/apple/swift-log", from: "1.0.0"),


### PR DESCRIPTION
Motivation:

Recent NIO releases deprecated a bunch of things which cause many build
time warnings.

Modifications:

Update dependencies.

Result:

Fewer warnings.