### PR TITLE
Don't log at info level

### DIFF
--- a/Sources/GRPC/ClientCalls/BidirectionalStreamingCall.swift
+++ b/Sources/GRPC/ClientCalls/BidirectionalStreamingCall.swift
@@ -43,7 +43,7 @@ public final class BidirectionalStreamingCall<RequestMessage: Message, ResponseM
     let requestID = callOptions.requestIDProvider.requestID()
 
     let logger = Logger(subsystem: .clientChannelCall, metadata: [MetadataKey.requestID: "\(requestID)"])
-    logger.info("starting rpc", metadata: ["path": "\(path)"])
+    logger.debug("starting rpc", metadata: ["path": "\(path)"])
 
     let responseHandler = GRPCClientStreamingResponseChannelHandler(
       initialMetadataPromise: connection.channel.eventLoop.makePromise(),

--- a/Sources/GRPC/ClientCalls/ClientStreamingCall.swift
+++ b/Sources/GRPC/ClientCalls/ClientStreamingCall.swift
@@ -43,7 +43,7 @@ public final class ClientStreamingCall<RequestMessage: Message, ResponseMessage:
   ) {
     let requestID = callOptions.requestIDProvider.requestID()
     let logger = Logger(subsystem: .clientChannelCall, metadata: [MetadataKey.requestID: "\(requestID)"])
-    logger.info("starting rpc", metadata: ["path": "\(path)"])
+    logger.debug("starting rpc", metadata: ["path": "\(path)"])
 
     self.messageQueue = connection.eventLoop.makeSucceededFuture(())
     let responsePromise = connection.eventLoop.makePromise(of: ResponseMessage.self)

--- a/Sources/GRPC/ClientCalls/ServerStreamingCall.swift
+++ b/Sources/GRPC/ClientCalls/ServerStreamingCall.swift
@@ -35,7 +35,7 @@ public final class ServerStreamingCall<RequestMessage: Message, ResponseMessage:
   ) {
     let requestID = callOptions.requestIDProvider.requestID()
     let logger = Logger(subsystem: .clientChannelCall, metadata: [MetadataKey.requestID: "\(requestID)"])
-    logger.info("starting rpc", metadata: ["path": "\(path)"])
+    logger.debug("starting rpc", metadata: ["path": "\(path)"])
 
     let responseHandler = GRPCClientStreamingResponseChannelHandler(
       initialMetadataPromise: connection.channel.eventLoop.makePromise(),

--- a/Sources/GRPC/ClientCalls/UnaryCall.swift
+++ b/Sources/GRPC/ClientCalls/UnaryCall.swift
@@ -41,7 +41,7 @@ public final class UnaryCall<RequestMessage: Message, ResponseMessage: Message>
   ) {
     let requestID = callOptions.requestIDProvider.requestID()
     let logger = Logger(subsystem: .clientChannelCall, metadata: [MetadataKey.requestID: "\(requestID)"])
-    logger.info("starting rpc", metadata: ["path": "\(path)"])
+    logger.debug("starting rpc", metadata: ["path": "\(path)"])
 
     let responsePromise = connection.channel.eventLoop.makePromise(of: ResponseMessage.self)
     self.response = responsePromise.futureResult

--- a/Sources/GRPC/ClientConnection.swift
+++ b/Sources/GRPC/ClientConnection.swift
@@ -184,7 +184,7 @@ public class ClientConnection {
       // We're already shutdown or in the process of shutting down.
       return channel.flatMap { $0.closeFuture }
     } else {
-      self.logger.info("shutting down channel")
+      self.logger.debug("shutting down channel")
       self.connectivity.initiateUserShutdown()
       return channel.flatMap { $0.close() }
     }

--- a/Sources/GRPC/ConnectivityState.swift
+++ b/Sources/GRPC/ConnectivityState.swift
@@ -110,7 +110,7 @@ public class ConnectivityStateMonitor {
 
     let oldValue = self._state
     if oldValue != newValue {
-      self.logger.info("connectivity state change: \(oldValue) to \(newValue)")
+      self.logger.debug("connectivity state change: \(oldValue) to \(newValue)")
       self._state = newValue
       self._delegate?.connectivityStateDidChange(from: oldValue, to: newValue)
     }

--- a/Sources/GRPC/GRPCClientResponseChannelHandler.swift
+++ b/Sources/GRPC/GRPCClientResponseChannelHandler.swift
@@ -81,7 +81,7 @@ internal class GRPCClientResponseChannelHandler<ResponseMessage: Message>: Chann
 
     if let stopwatch = self.stopwatch {
       let millis = stopwatch.elapsedMillis()
-      self.logger.info("rpc call finished", metadata: [
+      self.logger.debug("rpc call finished", metadata: [
         "duration_ms": "\(millis)",
         "status_code": "\(status.code.rawValue)"
       ])

--- a/Sources/GRPC/HTTP1ToRawGRPCServerCodec.swift
+++ b/Sources/GRPC/HTTP1ToRawGRPCServerCodec.swift
@@ -156,7 +156,7 @@ extension HTTP1ToRawGRPCServerCodec: ChannelInboundHandler {
     }
 
     self.stopwatch = .start()
-    self.accessLog.info("rpc call started", metadata: [
+    self.accessLog.debug("rpc call started", metadata: [
       "path": "\(requestHead.uri)",
       "method": "\(requestHead.method)",
       "version": "\(requestHead.version)"
@@ -327,7 +327,7 @@ extension HTTP1ToRawGRPCServerCodec: ChannelOutboundHandler {
         self.stopwatch = nil
         let millis = stopwatch.elapsedMillis()
 
-        self.accessLog.info("rpc call finished", metadata: [
+        self.accessLog.debug("rpc call finished", metadata: [
           "duration_ms": "\(millis)",
           "status_code": "\(status.code.rawValue)"
         ])

--- a/Sources/GRPC/PlatformSupport.swift
+++ b/Sources/GRPC/PlatformSupport.swift
@@ -60,10 +60,10 @@ extension NetworkPreference {
         // This is gated by the availability of `.networkFramework` so should never happen.
         fatalError(".networkFramework is being used on an unsupported platform")
       }
-      PlatformSupport.logger.info("'best' NetworkImplementation is .networkFramework")
+      PlatformSupport.logger.debug("'best' NetworkImplementation is .networkFramework")
       return .networkFramework
       #else
-      PlatformSupport.logger.info("'best' NetworkImplementation is .posix")
+      PlatformSupport.logger.debug("'best' NetworkImplementation is .posix")
       return .posix
       #endif
 
@@ -134,7 +134,7 @@ public enum PlatformSupport {
     loopCount: Int,
     networkPreference: NetworkPreference = .best
   ) -> EventLoopGroup {
-    logger.info("making EventLoopGroup for \(networkPreference) network preference")
+    logger.debug("making EventLoopGroup for \(networkPreference) network preference")
     switch networkPreference.implementation {
     #if canImport(Network)
     case .networkFramework:

--- a/Sources/GRPC/TLSVerificationHandler.swift
+++ b/Sources/GRPC/TLSVerificationHandler.swift
@@ -85,7 +85,7 @@ public class TLSVerificationHandler: ChannelInboundHandler, RemovableChannelHand
         return
     }
 
-    self.logger.info("TLS handshake completed, negotiated protocol: \(String(describing: negotiatedProtocol))")
+    self.logger.debug("TLS handshake completed, negotiated protocol: \(String(describing: negotiatedProtocol))")
     if let proto = negotiatedProtocol, GRPCApplicationProtocolIdentifier(rawValue: proto) != nil {
       self.logger.debug("negotiated application protocol is valid")
       self.verificationPromise.succeed(())


### PR DESCRIPTION
Motivation:

Since gRPC is really at the I/O level most users shouldn't ever have to
worry about log messages, yet we still log a few things as info.

Modifications:

Don't log anything above debug level.

Result:

No logging at info level.