### PR TITLE
Make gRPC error types extensible

### DIFF
--- a/Sources/GRPC/CallHandlers/ServerStreamingCallHandler.swift
+++ b/Sources/GRPC/CallHandlers/ServerStreamingCallHandler.swift
@@ -57,7 +57,7 @@ public final class ServerStreamingCallHandler<
     guard let eventObserver = self.eventObserver,
       let callContext = self.callContext else {
         self.logger.error("processMessage(_:) called before the call started or after the call completed")
-        throw GRPCError.server(.tooManyRequests)
+        throw GRPCError.StreamCardinalityViolation(stream: .request).captureContext()
     }
 
     let resultFuture = eventObserver(message)
@@ -69,7 +69,7 @@ public final class ServerStreamingCallHandler<
 
   override internal func endOfStreamReceived() throws {
     if self.eventObserver != nil {
-      throw GRPCError.server(.noRequestsButOneExpected)
+      throw GRPCError.StreamCardinalityViolation(stream: .request).captureContext()
     }
   }
 

--- a/Sources/GRPC/CallHandlers/UnaryCallHandler.swift
+++ b/Sources/GRPC/CallHandlers/UnaryCallHandler.swift
@@ -57,7 +57,7 @@ public final class UnaryCallHandler<
     guard let eventObserver = self.eventObserver,
       let context = self.callContext else {
       self.logger.error("processMessage(_:) called before the call started or after the call completed")
-      throw GRPCError.server(.tooManyRequests)
+      throw GRPCError.StreamCardinalityViolation(stream: .request).captureContext()
     }
 
     let resultFuture = eventObserver(message)
@@ -69,7 +69,7 @@ public final class UnaryCallHandler<
 
   internal override func endOfStreamReceived() throws {
     if self.eventObserver != nil {
-      throw GRPCError.server(.noRequestsButOneExpected)
+      throw GRPCError.StreamCardinalityViolation(stream: .request).captureContext()
     }
   }
 

--- a/Sources/GRPC/ClientErrorDelegate.swift
+++ b/Sources/GRPC/ClientErrorDelegate.swift
@@ -33,6 +33,14 @@ public protocol ClientErrorDelegate: class {
   func didCatchError(_ error: Error, logger: Logger, file: StaticString, line: Int)
 }
 
+extension ClientErrorDelegate {
+  /// Calls `didCatchError(_:logger:file:line:)` with appropriate context placeholders when no
+  /// context is available.
+  internal func didCatchErrorWithoutContext(_ error: Error, logger: Logger) {
+    self.didCatchError(error, logger: logger, file: "<unknown>", line: 0)
+  }
+}
+
 /// A `ClientErrorDelegate` which logs errors.
 public class LoggingClientErrorDelegate: ClientErrorDelegate {
   public init() { }

--- a/Sources/GRPC/DelegatingErrorHandler.swift
+++ b/Sources/GRPC/DelegatingErrorHandler.swift
@@ -42,8 +42,11 @@ class DelegatingErrorHandler: ChannelInboundHandler {
     }
 
     if let delegate = self.delegate {
-      let grpcError = (error as? GRPCError) ?? .unknown(error, origin: .client)
-      delegate.didCatchError(grpcError.wrappedError, logger: self.logger, file: grpcError.file, line: grpcError.line)
+      if let context = error as? GRPCError.WithContext {
+        delegate.didCatchError(context.error, logger: self.logger, file: context.file, line: context.line)
+      } else {
+        delegate.didCatchErrorWithoutContext(error, logger: self.logger)
+      }
     }
     context.close(promise: nil)
   }

--- a/Sources/GRPC/GRPCServerCodec.swift
+++ b/Sources/GRPC/GRPCServerCodec.swift
@@ -54,7 +54,7 @@ extension GRPCServerCodec: ChannelInboundHandler {
       do {
         context.fireChannelRead(self.wrapInboundOut(.message(try RequestMessage(serializedData: messageAsData))))
       } catch {
-        context.fireErrorCaught(GRPCError.server(.requestProtoDeserializationFailure))
+        context.fireErrorCaught(GRPCError.DeserializationFailure().captureContext())
       }
 
     case .end:
@@ -78,7 +78,7 @@ extension GRPCServerCodec: ChannelOutboundHandler {
         let messageData = try message.serializedData()
         context.write(self.wrapOutboundOut(.message(messageData)), promise: promise)
       } catch {
-        let error = GRPCError.server(.responseProtoSerializationFailure)
+        let error = GRPCError.SerializationFailure().captureContext()
         promise?.fail(error)
         context.fireErrorCaught(error)
       }

--- a/Sources/GRPC/HTTPProtocolSwitcher.swift
+++ b/Sources/GRPC/HTTPProtocolSwitcher.swift
@@ -163,7 +163,15 @@ extension HTTPProtocolSwitcher: ChannelInboundHandler, RemovableChannelHandler {
   func errorCaught(context: ChannelHandlerContext, error: Error) {
     switch self.state {
     case .notConfigured, .configuring:
-      errorDelegate?.observeLibraryError(error)
+      let baseError: Error
+
+      if let errorWithContext = error as? GRPCError.WithContext {
+        baseError = errorWithContext.error
+      } else {
+        baseError = error
+      }
+
+      errorDelegate?.observeLibraryError(baseError)
       context.close(mode: .all, promise: nil)
 
     case .configured:

--- a/Sources/GRPC/TLSVerificationHandler.swift
+++ b/Sources/GRPC/TLSVerificationHandler.swift
@@ -88,7 +88,7 @@ internal class TLSVerificationHandler: ChannelInboundHandler, RemovableChannelHa
     } else {
       self.logger.debug("TLS handshake completed, no protocol negotiated")
     }
-    
+
     self.verificationPromise.succeed(())
   }
 }

--- a/Tests/GRPCTests/ClientTLSFailureTests.swift
+++ b/Tests/GRPCTests/ClientTLSFailureTests.swift
@@ -13,8 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Foundation
-import GRPC
+@testable import GRPC
 import GRPCSampleData
 import EchoImplementation
 import Logging
@@ -99,7 +98,6 @@ class ClientTLSFailureTests: GRPCTestCase {
     self.server = nil
     self.serverEventLoopGroup = nil
   }
-
 
   func testClientConnectionFailsWhenServerIsUnknown() throws {
     let shutdownExpectation = self.expectation(description: "client shutdown")

--- a/Tests/GRPCTests/GRPCChannelHandlerResponseCapturingTestCase.swift
+++ b/Tests/GRPCTests/GRPCChannelHandlerResponseCapturingTestCase.swift
@@ -34,18 +34,6 @@ class CollectingChannelHandler<OutboundIn>: ChannelOutboundHandler {
 class CollectingServerErrorDelegate: ServerErrorDelegate {
   var errors: [Error] = []
 
-  var asGRPCErrors: [GRPCError]? {
-    return self.errors as? [GRPCError]
-  }
-
-  var asGRPCServerErrors: [GRPCServerError]? {
-    return (self.asGRPCErrors?.map { $0.wrappedError }) as? [GRPCServerError]
-  }
-
-  var asGRPCCommonErrors: [GRPCCommonError]? {
-    return (self.asGRPCErrors?.map { $0.wrappedError }) as? [GRPCCommonError]
-  }
-
   func observeLibraryError(_ error: Error) {
     self.errors.append(error)
   }

--- a/Tests/GRPCTests/GRPCChannelHandlerTests.swift
+++ b/Tests/GRPCTests/GRPCChannelHandlerTests.swift
@@ -27,8 +27,8 @@ class GRPCChannelHandlerTests: GRPCChannelHandlerResponseCapturingTestCase {
       try channel.writeInbound(_RawGRPCServerRequestPart.head(requestHead))
     }
 
-    let expectedError = GRPCServerError.unimplementedMethod("unimplementedMethodName")
-    XCTAssertEqual([expectedError], errorCollector.asGRPCServerErrors)
+    let expectedError = GRPCError.RPCNotImplemented(rpc: "unimplementedMethodName")
+    XCTAssertEqual(expectedError, errorCollector.errors.first as? GRPCError.RPCNotImplemented)
 
     responses[0].assertStatus { status in
       XCTAssertEqual(status, expectedError.asGRPCStatus())
@@ -64,8 +64,8 @@ class GRPCChannelHandlerTests: GRPCChannelHandlerResponseCapturingTestCase {
       try channel.writeInbound(_RawGRPCServerRequestPart.message(buffer))
     }
 
-    let expectedError = GRPCServerError.requestProtoDeserializationFailure
-    XCTAssertEqual([expectedError], errorCollector.asGRPCServerErrors)
+    let expectedError = GRPCError.DeserializationFailure()
+    XCTAssertEqual(expectedError, errorCollector.errors.first as? GRPCError.DeserializationFailure)
 
     responses[0].assertHeaders()
     responses[1].assertStatus { status in

--- a/Tests/GRPCTests/GRPCClientStateMachineTests.swift
+++ b/Tests/GRPCTests/GRPCClientStateMachineTests.swift
@@ -678,9 +678,10 @@ extension GRPCClientStateMachineTests {
   func testReceiveResponseHeadersWithNotOkStatus() throws {
     var stateMachine = self.makeStateMachine(.clientActiveServerIdle(writeState: .one(), readArity: .one))
 
-    let headers = self.makeResponseHeaders(status: "\(HTTPResponseStatus.paymentRequired.code)")
+    let code = "\(HTTPResponseStatus.paymentRequired.code)"
+    let headers = self.makeResponseHeaders(status: code)
     stateMachine.receiveResponseHeaders(headers).assertFailure {
-      XCTAssertEqual($0, .invalidHTTPStatus(.paymentRequired))
+      XCTAssertEqual($0, .invalidHTTPStatus(code))
     }
   }
 
@@ -689,7 +690,7 @@ extension GRPCClientStateMachineTests {
 
     let headers = self.makeResponseHeaders(contentType: nil)
     stateMachine.receiveResponseHeaders(headers).assertFailure {
-      XCTAssertEqual($0, .invalidContentType)
+      XCTAssertEqual($0, .invalidContentType(nil))
     }
   }
 
@@ -698,7 +699,7 @@ extension GRPCClientStateMachineTests {
 
     let headers = self.makeResponseHeaders(contentType: "video/mpeg")
     stateMachine.receiveResponseHeaders(headers).assertFailure {
-      XCTAssertEqual($0, .invalidContentType)
+      XCTAssertEqual($0, .invalidContentType("video/mpeg"))
     }
   }
 
@@ -929,18 +930,12 @@ extension Result {
 
 extension ReadState {
   static func one() -> ReadState {
-    let reader = LengthPrefixedMessageReader(
-      mode: .client,
-      compressionMechanism: .none
-    )
+    let reader = LengthPrefixedMessageReader(compressionMechanism: .none)
     return .reading(.one, reader)
   }
 
   static func many() -> ReadState {
-    let reader = LengthPrefixedMessageReader(
-      mode: .client,
-      compressionMechanism: .none
-    )
+    let reader = LengthPrefixedMessageReader(compressionMechanism: .none)
     return .reading(.many, reader)
   }
 

--- a/Tests/GRPCTests/LengthPrefixedMessageReaderTests.swift
+++ b/Tests/GRPCTests/LengthPrefixedMessageReaderTests.swift
@@ -23,7 +23,7 @@ class LengthPrefixedMessageReaderTests: GRPCTestCase {
 
   override func setUp() {
     super.setUp()
-    self.reader = LengthPrefixedMessageReader(mode: .client, compressionMechanism: .none)
+    self.reader = LengthPrefixedMessageReader(compressionMechanism: .none)
   }
 
   var allocator = ByteBufferAllocator()
@@ -215,7 +215,8 @@ class LengthPrefixedMessageReaderTests: GRPCTestCase {
     reader.append(buffer: &buffer)
 
     XCTAssertThrowsError(try reader.nextMessage()) { error in
-      XCTAssertEqual(.unsupportedCompressionMechanism("unknown"), (error as? GRPCError)?.wrappedError as? GRPCCommonError)
+      let errorWithContext = error as? GRPCError.WithContext
+      XCTAssertTrue(errorWithContext?.error is GRPCError.CompressionUnsupported)
     }
   }
 
@@ -228,7 +229,8 @@ class LengthPrefixedMessageReaderTests: GRPCTestCase {
     reader.append(buffer: &buffer)
 
     XCTAssertThrowsError(try reader.nextMessage()) { error in
-      XCTAssertEqual(.unexpectedCompression, (error as? GRPCError)?.wrappedError as? GRPCCommonError)
+      let errorWithContext = error as? GRPCError.WithContext
+      XCTAssertTrue(errorWithContext?.error is GRPCError.CompressionUnsupported)
     }
   }
 

--- a/Tests/GRPCTests/ServerWebTests.swift
+++ b/Tests/GRPCTests/ServerWebTests.swift
@@ -90,7 +90,10 @@ extension ServerWebTests {
 
   func testUnaryWithoutRequestMessage() {
     let expectedData = gRPCWebTrailers(
-      status: 12, message: "request cardinality violation; method requires exactly one request but client sent none")
+      status: 13,
+      message: "Request stream cardinality violation"
+    )
+
     let expectedResponse = expectedData.base64EncodedString()
 
     let completionHandlerExpectation = expectation(description: "completion handler called")


### PR DESCRIPTION
Motivation:

Adding new cases to an enum is a SemVer major change. To allow for
flexibility moving forward we should make our error types extensible so
that we can add cases without having to tag a major release.

Modifications:

- `GRPCError` is now a `struct` backed by the private `GRPCBaseError` `enum`
- `GRPCError` has static members and functions which map to the cases in
  `GRPCBaseError`.
- Updated usages of `GRPCError`

Result:

Our public facing error type, `GRPCError` can now have new 'cases' added
without requiring a SemVer major change.