### PR TITLE
Add toggle for time-sensitive tests.

### DIFF
--- a/Tests/GRPCTests/FunctionalTests.swift
+++ b/Tests/GRPCTests/FunctionalTests.swift
@@ -57,6 +57,8 @@ class FunctionalTestsInsecureTransport: EchoTestCaseBase {
   }
 
   func testUnaryLotsOfRequests() throws {
+    guard self.runTimeSensitiveTests else { return }
+
     // Sending that many requests at once can sometimes trip things up, it seems.
     let clockStart = clock()
     let numberOfRequests = 2_000
@@ -130,6 +132,7 @@ class FunctionalTestsInsecureTransport: EchoTestCaseBase {
   }
 
   func testClientStreamingLotsOfMessages() throws {
+    guard self.runTimeSensitiveTests else { return }
     self.defaultTestTimeout = 15.0
     XCTAssertNoThrow(try doTestClientStreaming(messages: lotsOfStrings))
   }
@@ -157,6 +160,7 @@ class FunctionalTestsInsecureTransport: EchoTestCaseBase {
   }
 
   func testServerStreamingLotsOfMessages() {
+    guard self.runTimeSensitiveTests else { return }
     self.defaultTestTimeout = 15.0
     XCTAssertNoThrow(try doTestServerStreaming(messages: lotsOfStrings))
   }
@@ -198,11 +202,13 @@ class FunctionalTestsInsecureTransport: EchoTestCaseBase {
   }
 
   func testBidirectionalStreamingLotsOfMessagesBatched() throws {
+    guard self.runTimeSensitiveTests else { return }
     self.defaultTestTimeout = 15.0
     XCTAssertNoThrow(try doTestBidirectionalStreaming(messages: lotsOfStrings))
   }
 
   func testBidirectionalStreamingLotsOfMessagesPingPong() throws {
+    guard self.runTimeSensitiveTests else { return }
     self.defaultTestTimeout = 15.0
     XCTAssertNoThrow(try doTestBidirectionalStreaming(messages: lotsOfStrings, waitForEachResponse: true))
   }

--- a/Tests/GRPCTests/FunctionalTests.swift
+++ b/Tests/GRPCTests/FunctionalTests.swift
@@ -57,7 +57,7 @@ class FunctionalTestsInsecureTransport: EchoTestCaseBase {
   }
 
   func testUnaryLotsOfRequests() throws {
-    guard self.runTimeSensitiveTests else { return }
+    guard self.runTimeSensitiveTests() else { return }
 
     // Sending that many requests at once can sometimes trip things up, it seems.
     let clockStart = clock()
@@ -132,7 +132,7 @@ class FunctionalTestsInsecureTransport: EchoTestCaseBase {
   }
 
   func testClientStreamingLotsOfMessages() throws {
-    guard self.runTimeSensitiveTests else { return }
+    guard self.runTimeSensitiveTests() else { return }
     self.defaultTestTimeout = 15.0
     XCTAssertNoThrow(try doTestClientStreaming(messages: lotsOfStrings))
   }
@@ -160,7 +160,7 @@ class FunctionalTestsInsecureTransport: EchoTestCaseBase {
   }
 
   func testServerStreamingLotsOfMessages() {
-    guard self.runTimeSensitiveTests else { return }
+    guard self.runTimeSensitiveTests() else { return }
     self.defaultTestTimeout = 15.0
     XCTAssertNoThrow(try doTestServerStreaming(messages: lotsOfStrings))
   }
@@ -202,13 +202,13 @@ class FunctionalTestsInsecureTransport: EchoTestCaseBase {
   }
 
   func testBidirectionalStreamingLotsOfMessagesBatched() throws {
-    guard self.runTimeSensitiveTests else { return }
+    guard self.runTimeSensitiveTests() else { return }
     self.defaultTestTimeout = 15.0
     XCTAssertNoThrow(try doTestBidirectionalStreaming(messages: lotsOfStrings))
   }
 
   func testBidirectionalStreamingLotsOfMessagesPingPong() throws {
-    guard self.runTimeSensitiveTests else { return }
+    guard self.runTimeSensitiveTests() else { return }
     self.defaultTestTimeout = 15.0
     XCTAssertNoThrow(try doTestBidirectionalStreaming(messages: lotsOfStrings, waitForEachResponse: true))
   }

--- a/Tests/GRPCTests/GRPCTestCase.swift
+++ b/Tests/GRPCTests/GRPCTestCase.swift
@@ -24,7 +24,26 @@ class GRPCTestCase: XCTestCase {
   // locally; conditionally enable it based on the environment.
   //
   // https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
-  private static var isLoggingEnabled = ProcessInfo.processInfo.environment["CI"] != "true"
+  private static let isLoggingEnabled = !Bool(
+      fromTruthLike: ProcessInfo.processInfo.environment["CI"],
+      defaultingTo: false
+  )
+
+  private static let runTimeSensitiveTests = Bool(
+      fromTruthLike: ProcessInfo.processInfo.environment["ENABLE_TIMING_TESTS"],
+      defaultingTo: true
+  )
+
+  private static func bool(from value: String?, defaultingTo defaultValue: Bool) -> Bool {
+    switch value?.lowercased() {
+    case "0", "false", "no":
+      return false
+    case "1", "true", "yes":
+      return true
+    default:
+      return defaultValue
+    }
+  }
 
   // `LoggingSystem.bootstrap` must be called once per process. This is the suggested approach to
   // workaround this for XCTestCase.
@@ -46,6 +65,14 @@ class GRPCTestCase: XCTestCase {
     super.setUp()
     XCTAssertTrue(GRPCTestCase.isLoggingConfigured)
   }
+
+  var runTimeSensitiveTests: Bool {
+    let shouldRun = GRPCTestCase.runTimeSensitiveTests
+    if !shouldRun {
+      print("Skipping '\(self.name)' as ENABLE_TIMING_TESTS=false")
+    }
+    return shouldRun
+  }
 }
 
 /// A `LogHandler` which does nothing with log messages.
@@ -65,4 +92,17 @@ struct BlackHole: LogHandler {
 
   var metadata: Logger.Metadata = [:]
   var logLevel: Logger.Level = .critical
+}
+
+fileprivate extension Bool {
+  init(fromTruthLike value: String?, defaultingTo defaultValue: Bool) {
+    switch value?.lowercased() {
+    case "0", "false", "no":
+      self = false
+    case "1", "true", "yes":
+      self = true
+    default:
+      self = defaultValue
+    }
+  }
 }

--- a/Tests/GRPCTests/GRPCTestCase.swift
+++ b/Tests/GRPCTests/GRPCTestCase.swift
@@ -35,17 +35,6 @@ class GRPCTestCase: XCTestCase {
       defaultingTo: true
   )
 
-  private static func bool(from value: String?, defaultingTo defaultValue: Bool) -> Bool {
-    switch value?.lowercased() {
-    case "0", "false", "no":
-      return false
-    case "1", "true", "yes":
-      return true
-    default:
-      return defaultValue
-    }
-  }
-
   // `LoggingSystem.bootstrap` must be called once per process. This is the suggested approach to
   // workaround this for XCTestCase.
   //

--- a/Tests/GRPCTests/GRPCTestCase.swift
+++ b/Tests/GRPCTests/GRPCTestCase.swift
@@ -24,10 +24,11 @@ class GRPCTestCase: XCTestCase {
   // locally; conditionally enable it based on the environment.
   //
   // https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
-  private static let isLoggingEnabled = !Bool(
+  private static let isCI = Bool(
       fromTruthLike: ProcessInfo.processInfo.environment["CI"],
       defaultingTo: false
   )
+  private static let isLoggingEnabled = !isCI
 
   private static let runTimeSensitiveTests = Bool(
       fromTruthLike: ProcessInfo.processInfo.environment["ENABLE_TIMING_TESTS"],
@@ -66,7 +67,7 @@ class GRPCTestCase: XCTestCase {
     XCTAssertTrue(GRPCTestCase.isLoggingConfigured)
   }
 
-  var runTimeSensitiveTests: Bool {
+  func runTimeSensitiveTests() -> Bool {
     let shouldRun = GRPCTestCase.runTimeSensitiveTests
     if !shouldRun {
       print("Skipping '\(self.name)' as ENABLE_TIMING_TESTS=false")

--- a/Tests/GRPCTests/ServerWebTests.swift
+++ b/Tests/GRPCTests/ServerWebTests.swift
@@ -109,6 +109,7 @@ extension ServerWebTests {
   }
 
   func testUnaryLotsOfRequests() {
+    guard self.runTimeSensitiveTests else { return }
     // Sending that many requests at once can sometimes trip things up, it seems.
     let clockStart = clock()
     let numberOfRequests = 2_000

--- a/Tests/GRPCTests/ServerWebTests.swift
+++ b/Tests/GRPCTests/ServerWebTests.swift
@@ -109,7 +109,7 @@ extension ServerWebTests {
   }
 
   func testUnaryLotsOfRequests() {
-    guard self.runTimeSensitiveTests else { return }
+    guard self.runTimeSensitiveTests() else { return }
     // Sending that many requests at once can sometimes trip things up, it seems.
     let clockStart = clock()
     let numberOfRequests = 2_000


### PR DESCRIPTION
Motivation:

Sometimes, like when running under TSan, it's useful to disable long
running tests, or those which are sensitive to time.

Modifications:

Add an option to disable time sensitive tests via an envrionment
variable.

Result:

Certain tests are skipped if `ENABLE_TIMING_TESTS` is set to false.