### PR TITLE
Fix typo in the "grpc-exp" ALPN name

### DIFF
--- a/Sources/GRPC/TLSVerificationHandler.swift
+++ b/Sources/GRPC/TLSVerificationHandler.swift
@@ -23,7 +23,7 @@ import Logging
 internal enum GRPCApplicationProtocolIdentifier: String, CaseIterable {
   // This is not in the IANA ALPN protocol ID registry, but may be used by servers to indicate that
   // they serve only gRPC traffic. It is part of the gRPC core implementation.
-  case gRPC = "grpc-ext"
+  case gRPC = "grpc-exp"
   case h2 = "h2"
 }
 

--- a/Tests/GRPCTests/ClientTLSFailureTests.swift
+++ b/Tests/GRPCTests/ClientTLSFailureTests.swift
@@ -107,7 +107,7 @@ class ClientTLSFailureTests: GRPCTestCase {
     // We use the underlying configuration because `applicationProtocols` is not user-configurable
     // via `Configuration.TLS`.
     var tlsConfiguration = self.defaultClientTLSConfiguration.configuration
-    tlsConfiguration.applicationProtocols = ["not-h2", "not-grpc-ext"]
+    tlsConfiguration.applicationProtocols = ["not-h2", "not-grpc-exp"]
 
     let tls = ClientConnection.Configuration.TLS(
       configuration: tlsConfiguration,


### PR DESCRIPTION
Motivation:

gRPC has an experimental ALPN name "grpc-exp". Unfortunately, we spelled
it as "grpc-ext".

Fortunately if "grpc-exp" is specifid, then so too must "h2", so we
would always still manage to negotiate a protocol.

Modifications:

Fix typo.

Result:

We can now negotiate "grpc-exp" via ALPN.