### PR TITLE
Update CI to run Swift 5.2 development snapshot

### DIFF
--- a/.travis-install.sh
+++ b/.travis-install.sh
@@ -78,9 +78,12 @@ install_swift() {
   if [ "$TRAVIS_OS_NAME" != "osx" ]; then
     info "Installing Swift $SWIFT_VERSION"
 
-    SWIFT_URL=https://swift.org/builds/swift-${SWIFT_VERSION}-release/ubuntu1804/swift-${SWIFT_VERSION}-RELEASE/swift-${SWIFT_VERSION}-RELEASE-ubuntu18.04.tar.gz
+    if [ -z "${SWIFT_URL}" ]; then
+      SWIFT_URL=https://swift.org/builds/swift-${SWIFT_VERSION}-release/ubuntu1804/swift-${SWIFT_VERSION}-RELEASE/swift-${SWIFT_VERSION}-RELEASE-ubuntu18.04.tar.gz
+    fi
+
     info "Downloading Swift from $SWIFT_URL"
-    curl -fSsL $SWIFT_URL -o swift.tar.gz
+    curl -fSsL "$SWIFT_URL" -o swift.tar.gz
 
     info "Extracting Swift from swift.tar.gz"
     tar -xzf swift.tar.gz --strip-components=2 --directory=local

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,47 +15,58 @@
 #
 # Travis CI build file for gRPC Swift.
 
+language: minimal
 jobs:
   include:
     # Tests for each PR.
     - &tests
       stage: "Test"
-      name: "Ubuntu 18.04 (Swift 5.1)"
+      name: "Unit Tests: Ubuntu 18.04 (Swift 5.1)"
       os: linux
       dist: bionic
       script: ./.travis-script.sh
       env: RUN_INTEROP_TESTS=false SWIFT_VERSION=5.1.3
+    - &development
+      <<: *tests
+      name: "Unit Tests: Ubuntu 18.04 (Swift 5.2 Development Snapshot 2020-01-06)"
+      env: >-
+        RUN_INTEROP_TESTS=false
+        SWIFT_VERSION=5.2
+        SWIFT_URL=https://swift.org/builds/swift-5.2-branch/ubuntu1804/swift-5.2-DEVELOPMENT-SNAPSHOT-2020-01-06-a/swift-5.2-DEVELOPMENT-SNAPSHOT-2020-01-06-a-ubuntu18.04.tar.gz
     - <<: *tests
-      name: "Ubuntu 18.04 (Swift 5.0)"
+      name: "Unit Tests: Ubuntu 18.04 (Swift 5.0)"
       env: RUN_INTEROP_TESTS=false SWIFT_VERSION=5.0.3
     - <<: *tests
-      name: "Xcode 11.2 (Swift 5.1)"
+      name: "Unit Tests: Xcode 11.3 (Swift 5.1)"
       os: osx
-      osx_image: xcode11.2
+      osx_image: xcode11.3
     - <<: *tests
-      name: "Xcode 10.3 (Swift 5.0)"
+      name: "Unit Tests: Xcode 10.3 (Swift 5.0)"
       os: osx
       osx_image: xcode10.3
     # Interop Tests.
     - &interop_tests
       stage: "Interoperability Tests"
       # Linux
-      name: "Ubuntu 18.04 (Swift 5.1)"
+      name: "Interoperability Tests: Ubuntu 18.04 (Swift 5.1)"
       os: linux
       dist: bionic
       script: ./.travis-script.sh
       env: RUN_INTEROP_TESTS=true SWIFT_VERSION=5.1.3
     - <<: *interop_tests
-      name: "Ubuntu 18.04 (Swift 5.0)"
+      name: "Interoperability Tests: Ubuntu 18.04 (Swift 5.0)"
       env: RUN_INTEROP_TESTS=true SWIFT_VERSION=5.0.3
     - <<: *interop_tests
-      name: "Xcode 11.2 (Swift 5.1)"
+      name: "Interoperability Tests: Xcode 11.3 (Swift 5.1)"
       os: osx
-      osx_image: xcode11.2
+      osx_image: xcode11.3
     - <<: *interop_tests
-      name: "Xcode 10.3 (Swift 5.0)"
+      name: "Interoperability Tests: Xcode 10.3 (Swift 5.0)"
       os: osx
       osx_image: xcode10.3
+  allow_failures:
+    # Swift Development builds are allowed to fail since they're pre-release.
+    - <<: *development
 
 stages:
   # Always run this stage.
@@ -69,8 +80,6 @@ cache:
   directories:
     - .build
     - $HOME/bin_cache
-
-sudo: false
 
 addons:
   apt:


### PR DESCRIPTION
Motivation:

We should run our CI against development versions of Swift so that we
can catch any language regressions, bugs, etc. before release.

Modifications:

- Add Swift Development 5.2 to run unit tests for all PRs.
- Allow the job to be failable.
- Update Xcode for CI to 11.3

Result:

Pre-release Swift running as part of CI on Linux.