### PR TITLE
Remove fix-project-settings.rb references from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ project: ${XCODEPROJ}
 
 ${XCODEPROJ}:
 	${SWIFT_PACKAGE} generate-xcodeproj --output $@
-	@-ruby fix-project-settings.rb GRPC.xcodeproj || \
+	@-ruby scripts/fix-project-settings.rb GRPC.xcodeproj || \
 		echo "Consider running 'sudo gem install xcodeproj' to automatically set correct indentation settings for the generated project."
 
 # Generates LinuxMain.swift, only on macOS.

--- a/scripts/fix-project-settings.rb
+++ b/scripts/fix-project-settings.rb
@@ -1,0 +1,26 @@
+require 'xcodeproj'
+project_path = ARGV[0]
+project = Xcodeproj::Project.open(project_path)
+
+# Fix indentation settings.
+project.main_group.uses_tabs = '0'
+project.main_group.tab_width = '2'
+project.main_group.indent_width = '2'
+
+# Set the `CURRENT_PROJECT_VERSION` variable for each config to ensure
+# that the generated frameworks pass App Store validation (#291).
+project.build_configurations.each do |config|
+  config.build_settings["CURRENT_PROJECT_VERSION"] = "1.0"
+end
+
+# Set each target's iOS deployment target to 10.0
+project.targets.each do |target|
+  target.build_configurations.each do |config|
+    config.build_settings["IPHONEOS_DEPLOYMENT_TARGET"] = "10.0"
+    if config.build_settings["PRODUCT_BUNDLE_IDENTIFIER"] then
+      config.build_settings["PRODUCT_BUNDLE_IDENTIFIER"] = "io.grpc." + config.build_settings["PRODUCT_BUNDLE_IDENTIFIER"]
+    end
+  end
+end
+
+project.save


### PR DESCRIPTION
Motivation:

The Makefile referenced a file which no longer exists.

Modifications:

Remove references to that file.

Result:

More happy project generation.