### PR TITLE
Add supported platforms to Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,10 @@ import Foundation
 
 let package = Package(
   name: "GRPC",
+  platforms: [
+    // We can't use `.watchOS(.v6)` since it isn't available with `swift-tools-version:5.0`.
+    .macOS(.v10_12), .iOS(.v10), .tvOS(.v10), .watchOS("6.0")
+  ],
   products: [
     .library(name: "GRPC", targets: ["GRPC"]),
     .executable(name: "protoc-gen-grpc-swift", targets: ["protoc-gen-grpc-swift"]),


### PR DESCRIPTION
Motivation:

We should be clearer about which Darwin platforms we support.

Modifications:

Add the supported platforms to Package.swift

Result:

Clearer platform support model.