### PR TITLE
Update Swift 5.2 development snapshot.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,11 @@ jobs:
       env: RUN_INTEROP_TESTS=false SWIFT_VERSION=5.1.3
     - &development
       <<: *tests
-      name: "Unit Tests: Ubuntu 18.04 (Swift 5.2 Development Snapshot 2020-01-06)"
+      name: "Unit Tests: Ubuntu 18.04 (Swift 5.2 Development Snapshot 2020-01-14)"
       env: >-
         RUN_INTEROP_TESTS=false
         SWIFT_VERSION=5.2
-        SWIFT_URL=https://swift.org/builds/swift-5.2-branch/ubuntu1804/swift-5.2-DEVELOPMENT-SNAPSHOT-2020-01-06-a/swift-5.2-DEVELOPMENT-SNAPSHOT-2020-01-06-a-ubuntu18.04.tar.gz
+        SWIFT_URL=https://swift.org/builds/swift-5.2-branch/ubuntu1804/swift-5.2-DEVELOPMENT-SNAPSHOT-2020-01-14-a/swift-5.2-DEVELOPMENT-SNAPSHOT-2020-01-14-a-ubuntu18.04.tar.gz
     - <<: *tests
       name: "Unit Tests: Ubuntu 18.04 (Swift 5.0)"
       env: RUN_INTEROP_TESTS=false SWIFT_VERSION=5.0.3


### PR DESCRIPTION
Motivation:

We should keep our pre-release swift builds up-to-date.

Modifications:

Update development snapshot to latest.

Result:

Up-to-date CI.