### PR TITLE
Fix bug with BoringSSLError.invalidSNIName exception

### DIFF
--- a/Sources/GRPC/ClientConnection.swift
+++ b/Sources/GRPC/ClientConnection.swift
@@ -361,7 +361,7 @@ extension ClientConnection {
     logger: Logger
   ) -> ClientBootstrapProtocol {
     // Provide a server hostname if we're using TLS. Prefer the override.
-    let serverHostname: String? = configuration.tls.map {
+    var serverHostname: String? = configuration.tls.map {
       if let hostnameOverride = $0.hostnameOverride {
         logger.debug("using hostname override for TLS", metadata: ["server-hostname": "\(hostnameOverride)"])
         return hostnameOverride
@@ -370,6 +370,11 @@ extension ClientConnection {
         logger.debug("using host from connection target for TLS", metadata: ["server-hostname": "\(host)"])
         return host
       }
+    }
+    
+    if let hostname = serverHostname, hostname.isIPAddress {
+      logger.debug("IP address cannot be used for TLS SNI extension. No host used", metadata: ["server-hostname": "nil"])
+      serverHostname = nil
     }
 
     let bootstrap = PlatformSupport.makeClientBootstrap(group: eventLoop)
@@ -540,7 +545,7 @@ fileprivate extension Channel {
     do {
       let sslClientHandler = try NIOSSLClientHandler(
         context: try NIOSSLContext(configuration: configuration),
-        serverHostname: serverHostname.flatMap { $0.isIPAddress ? nil : $0 }
+        serverHostname: serverHostname
       )
 
       return self.pipeline.addHandlers(sslClientHandler, TLSVerificationHandler())
@@ -578,14 +583,14 @@ extension HTTP2ToHTTP1ClientCodec.HTTPProtocol {
 }
 
 fileprivate extension String {
-    var isIPAddress: Bool {
-        // We need some scratch space to let inet_pton write into.
-        var ipv4Addr = in_addr()
-        var ipv6Addr = in6_addr()
-
-        return self.withCString { ptr in
-            return inet_pton(AF_INET, ptr, &ipv4Addr) == 1 ||
-                   inet_pton(AF_INET6, ptr, &ipv6Addr) == 1
-        }
+  var isIPAddress: Bool {
+    // We need some scratch space to let inet_pton write into.
+    var ipv4Addr = in_addr()
+    var ipv6Addr = in6_addr()
+    
+    return self.withCString { ptr in
+      return inet_pton(AF_INET, ptr, &ipv4Addr) == 1 ||
+        inet_pton(AF_INET6, ptr, &ipv6Addr) == 1
     }
+  }
 }

--- a/Sources/GRPC/ClientConnection.swift
+++ b/Sources/GRPC/ClientConnection.swift
@@ -540,7 +540,7 @@ fileprivate extension Channel {
     do {
       let sslClientHandler = try NIOSSLClientHandler(
         context: try NIOSSLContext(configuration: configuration),
-        serverHostname: serverHostname
+        serverHostname: serverHostname.flatMap { $0.isIPAddress ? nil : $0 }
       )
 
       return self.pipeline.addHandlers(sslClientHandler, TLSVerificationHandler())
@@ -575,4 +575,17 @@ extension HTTP2ToHTTP1ClientCodec.HTTPProtocol {
       return "https"
     }
   }
+}
+
+fileprivate extension String {
+    var isIPAddress: Bool {
+        // We need some scratch space to let inet_pton write into.
+        var ipv4Addr = in_addr()
+        var ipv6Addr = in6_addr()
+
+        return self.withCString { ptr in
+            return inet_pton(AF_INET, ptr, &ipv4Addr) == 1 ||
+                   inet_pton(AF_INET6, ptr, &ipv6Addr) == 1
+        }
+    }
 }

--- a/Sources/GRPC/ClientConnection.swift
+++ b/Sources/GRPC/ClientConnection.swift
@@ -373,7 +373,7 @@ extension ClientConnection {
     }
     
     if let hostname = serverHostname, hostname.isIPAddress {
-      logger.debug("IP address cannot be used for TLS SNI extension. No host used", metadata: ["server-hostname": "nil"])
+      logger.debug("IP address cannot be used for TLS SNI extension. No host used", metadata: ["server-hostname": "\(hostname)"])
       serverHostname = nil
     }
 


### PR DESCRIPTION
When IP address is given as a host to ClientConnection BoringSSLError.invalidSNIName exception is thrown from [NIOSSLClientHandler](https://github.com/apple/swift-nio-ssl/blob/4f9d64ddd04cd1fe97d74dad7b5a77b882d8bf5d/Sources/NIOSSL/NIOSSLClientHandler.swift#L42)

This pull request fixes this by passing `nil` to `NIOSSLClientHandler` if `serverHostname` is an IP address