### PR TITLE
Adds the ability to use different payloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ project.xcworkspace
 xcuserdata
 DerivedData/
 .build
+.swiftpm
 build
 /protoc-gen-swift
 /protoc-gen-grpc-swift

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ plugins: ${PROTOC_GEN_SWIFT} ${PROTOC_GEN_GRPC_SWIFT}
 ${PROTOC_GEN_SWIFT}:
 	${SWIFT_BUILD_RELEASE} --product protoc-gen-swift
 
-${PROTOC_GEN_GRPC_SWIFT}:
+${PROTOC_GEN_GRPC_SWIFT}: Sources/protoc-gen-grpc-swift/*.swift
 	${SWIFT_BUILD_RELEASE} --product protoc-gen-grpc-swift
 
 interop-test-runner:

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,7 @@ plugins: ${PROTOC_GEN_SWIFT} ${PROTOC_GEN_GRPC_SWIFT}
 ${PROTOC_GEN_SWIFT}:
 	${SWIFT_BUILD_RELEASE} --product protoc-gen-swift
 
-${PROTOC_GEN_GRPC_SWIFT}:
-	${SWIFT_BUILD_RELEASE} --product protoc-gen-grpc-swift
+${PROTOC_GEN_GRPC_SWIFT}: Sources/protoc-gen-grpc-swift/*.swift
 
 interop-test-runner:
 	${SWIFT_BUILD} --product GRPCInteroperabilityTests

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,8 @@ plugins: ${PROTOC_GEN_SWIFT} ${PROTOC_GEN_GRPC_SWIFT}
 ${PROTOC_GEN_SWIFT}:
 	${SWIFT_BUILD_RELEASE} --product protoc-gen-swift
 
-${PROTOC_GEN_GRPC_SWIFT}: Sources/protoc-gen-grpc-swift/*.swift
+${PROTOC_GEN_GRPC_SWIFT}:
+	${SWIFT_BUILD_RELEASE} --product protoc-gen-grpc-swift
 
 interop-test-runner:
 	${SWIFT_BUILD} --product GRPCInteroperabilityTests

--- a/Sources/Examples/Echo/Model/echo.grpc.swift
+++ b/Sources/Examples/Echo/Model/echo.grpc.swift
@@ -149,3 +149,7 @@ extension Echo_EchoProvider {
   }
 }
 
+
+/// Provides conformance to `GRPCPayload` for the request and response messages
+extension Echo_EchoRequest: GRPCProtobufPayload {}
+extension Echo_EchoResponse: GRPCProtobufPayload {}

--- a/Sources/Examples/HelloWorld/Model/helloworld.grpc.swift
+++ b/Sources/Examples/HelloWorld/Model/helloworld.grpc.swift
@@ -84,3 +84,7 @@ extension Helloworld_GreeterProvider {
   }
 }
 
+
+/// Provides conformance to `GRPCPayload` for the request and response messages
+extension Helloworld_HelloRequest: GRPCProtobufPayload {}
+extension Helloworld_HelloReply: GRPCProtobufPayload {}

--- a/Sources/Examples/RouteGuide/Model/route_guide.grpc.swift
+++ b/Sources/Examples/RouteGuide/Model/route_guide.grpc.swift
@@ -149,3 +149,10 @@ extension Routeguide_RouteGuideProvider {
   }
 }
 
+
+/// Provides conformance to `GRPCPayload` for the request and response messages
+extension Routeguide_Point: GRPCProtobufPayload {}
+extension Routeguide_Feature: GRPCProtobufPayload {}
+extension Routeguide_Rectangle: GRPCProtobufPayload {}
+extension Routeguide_RouteSummary: GRPCProtobufPayload {}
+extension Routeguide_RouteNote: GRPCProtobufPayload {}

--- a/Sources/GRPC/CallHandlers/ServerStreamingCallHandler.swift
+++ b/Sources/GRPC/CallHandlers/ServerStreamingCallHandler.swift
@@ -24,20 +24,20 @@ import Logging
 /// - The observer block is implemented by the framework user and calls `context.sendResponse` as needed.
 /// - To close the call and send the status, complete the status future returned by the observer block.
 public final class ServerStreamingCallHandler<
-  RequestMessage: Message,
-  ResponseMessage: Message
->: _BaseCallHandler<RequestMessage, ResponseMessage> {
-  public typealias EventObserver = (RequestMessage) -> EventLoopFuture<GRPCStatus>
+  RequestPayload: GRPCPayload,
+  ResponsePayload: GRPCPayload
+>: _BaseCallHandler<RequestPayload, ResponsePayload> {
+  public typealias EventObserver = (RequestPayload) -> EventLoopFuture<GRPCStatus>
 
   private var eventObserver: EventObserver?
-  private var callContext: StreamingResponseCallContext<ResponseMessage>?
+  private var callContext: StreamingResponseCallContext<ResponsePayload>?
 
   public init(
     callHandlerContext: CallHandlerContext,
-    eventObserverFactory: (StreamingResponseCallContext<ResponseMessage>) -> EventObserver
+    eventObserverFactory: (StreamingResponseCallContext<ResponsePayload>) -> EventObserver
   ) {
     super.init(callHandlerContext: callHandlerContext)
-    let callContext = StreamingResponseCallContextImpl<ResponseMessage>(
+    let callContext = StreamingResponseCallContextImpl<ResponsePayload>(
       channel: self.callHandlerContext.channel,
       request: self.callHandlerContext.request,
       errorDelegate: self.callHandlerContext.errorDelegate,
@@ -53,7 +53,7 @@ public final class ServerStreamingCallHandler<
     }
   }
 
-  override internal func processMessage(_ message: RequestMessage) throws {
+  override internal func processMessage(_ message: RequestPayload) throws {
     guard let eventObserver = self.eventObserver,
       let callContext = self.callContext else {
         self.logger.error("processMessage(_:) called before the call started or after the call completed")

--- a/Sources/GRPC/CallHandlers/UnaryCallHandler.swift
+++ b/Sources/GRPC/CallHandlers/UnaryCallHandler.swift
@@ -25,19 +25,19 @@ import Logging
 /// - To return a response to the client, the framework user should complete that future
 ///   (similar to e.g. serving regular HTTP requests in frameworks such as Vapor).
 public final class UnaryCallHandler<
-  RequestMessage: Message,
-  ResponseMessage: Message
->: _BaseCallHandler<RequestMessage, ResponseMessage> {
-  public typealias EventObserver = (RequestMessage) -> EventLoopFuture<ResponseMessage>
+  RequestPayload: GRPCPayload,
+  ResponsePayload: GRPCPayload
+>: _BaseCallHandler<RequestPayload, ResponsePayload> {
+  public typealias EventObserver = (RequestPayload) -> EventLoopFuture<ResponsePayload>
   private var eventObserver: EventObserver?
-  private var callContext: UnaryResponseCallContext<ResponseMessage>?
+  private var callContext: UnaryResponseCallContext<ResponsePayload>?
 
   public init(
     callHandlerContext: CallHandlerContext,
-    eventObserverFactory: (UnaryResponseCallContext<ResponseMessage>) -> EventObserver
+    eventObserverFactory: (UnaryResponseCallContext<ResponsePayload>) -> EventObserver
   ) {
     super.init(callHandlerContext: callHandlerContext)
-    let callContext = UnaryResponseCallContextImpl<ResponseMessage>(
+    let callContext = UnaryResponseCallContextImpl<ResponsePayload>(
       channel: self.callHandlerContext.channel,
       request: self.callHandlerContext.request,
       errorDelegate: self.callHandlerContext.errorDelegate,
@@ -53,7 +53,7 @@ public final class UnaryCallHandler<
     }
   }
 
-  internal override func processMessage(_ message: RequestMessage) throws {
+  internal override func processMessage(_ message: RequestPayload) throws {
     guard let eventObserver = self.eventObserver,
       let context = self.callContext else {
       self.logger.error("processMessage(_:) called before the call started or after the call completed")

--- a/Sources/GRPC/CallHandlers/_BaseCallHandler.swift
+++ b/Sources/GRPC/CallHandlers/_BaseCallHandler.swift
@@ -23,15 +23,15 @@ import Logging
 ///
 /// Calls through to `processMessage` for individual messages it receives, which needs to be implemented by subclasses.
 /// - Important: This is **NOT** part of the public API.
-public class _BaseCallHandler<RequestMessage: Message, ResponseMessage: Message>: GRPCCallHandler {
+public class _BaseCallHandler<RequestPayload: GRPCPayload, ResponsePayload: GRPCPayload>: GRPCCallHandler {
   public func makeGRPCServerCodec() -> ChannelHandler {
-    return GRPCServerCodec<RequestMessage, ResponseMessage>()
+    return GRPCServerCodec<RequestPayload, ResponsePayload>()
   }
 
   /// Called whenever a message has been received.
   ///
   /// Overridden by subclasses.
-  internal func processMessage(_ message: RequestMessage) throws {
+  internal func processMessage(_ message: RequestPayload) throws {
     fatalError("needs to be overridden")
   }
 
@@ -71,7 +71,7 @@ public class _BaseCallHandler<RequestMessage: Message, ResponseMessage: Message>
 }
 
 extension _BaseCallHandler: ChannelInboundHandler {
-  public typealias InboundIn = _GRPCServerRequestPart<RequestMessage>
+  public typealias InboundIn = _GRPCServerRequestPart<RequestPayload>
 
   /// Passes errors to the user-provided `errorHandler`. After an error has been received an
   /// appropriate status is written. Errors which don't conform to `GRPCStatusTransformable`
@@ -120,8 +120,8 @@ extension _BaseCallHandler: ChannelInboundHandler {
 }
 
 extension _BaseCallHandler: ChannelOutboundHandler {
-  public typealias OutboundIn = _GRPCServerResponsePart<ResponseMessage>
-  public typealias OutboundOut = _GRPCServerResponsePart<ResponseMessage>
+  public typealias OutboundIn = _GRPCServerResponsePart<ResponsePayload>
+  public typealias OutboundOut = _GRPCServerResponsePart<ResponsePayload>
 
   public func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
     guard self.serverCanWrite else {

--- a/Sources/GRPC/ClientCalls/BaseClientCall.swift
+++ b/Sources/GRPC/ClientCalls/BaseClientCall.swift
@@ -48,9 +48,9 @@ import Logging
 ///
 /// This class also provides much of the framework user facing functionality via conformance to
 /// `ClientCall`.
-public class BaseClientCall<Request: Message, Response: Message>: ClientCall {
-  public typealias RequestMessage = Request
-  public typealias ResponseMessage = Response
+public class BaseClientCall<Request: GRPCPayload, Response: GRPCPayload>: ClientCall {
+  public typealias RequestPayload = Request
+  public typealias ResponsePayload = Response
 
   internal let logger: Logger
 

--- a/Sources/GRPC/ClientCalls/BidirectionalStreamingCall.swift
+++ b/Sources/GRPC/ClientCalls/BidirectionalStreamingCall.swift
@@ -27,8 +27,8 @@ import Logging
 /// - `initialMetadata`: the initial metadata returned from the server,
 /// - `status`: the status of the gRPC call after it has ended,
 /// - `trailingMetadata`: any metadata returned from the server alongside the `status`.
-public final class BidirectionalStreamingCall<RequestMessage: Message, ResponseMessage: Message>
-  : BaseClientCall<RequestMessage, ResponseMessage>,
+public final class BidirectionalStreamingCall<RequestPayload: GRPCPayload, ResponsePayload: GRPCPayload>
+  : BaseClientCall<RequestPayload, ResponsePayload>,
     StreamingRequestClientCall {
   private var messageQueue: EventLoopFuture<Void>
 
@@ -37,7 +37,7 @@ public final class BidirectionalStreamingCall<RequestMessage: Message, ResponseM
     path: String,
     callOptions: CallOptions,
     errorDelegate: ClientErrorDelegate?,
-    handler: @escaping (ResponseMessage) -> Void
+    handler: @escaping (ResponsePayload) -> Void
   ) {
     self.messageQueue = connection.channel.eventLoop.makeSucceededFuture(())
     let requestID = callOptions.requestIDProvider.requestID()
@@ -64,7 +64,7 @@ public final class BidirectionalStreamingCall<RequestMessage: Message, ResponseM
       options: callOptions
     )
 
-    let requestHandler = _StreamingRequestChannelHandler<RequestMessage>(requestHead: requestHead)
+    let requestHandler = _StreamingRequestChannelHandler<RequestPayload>(requestHead: requestHead)
 
     super.init(
       eventLoop: connection.eventLoop,

--- a/Sources/GRPC/ClientCalls/ClientStreamingCall.swift
+++ b/Sources/GRPC/ClientCalls/ClientStreamingCall.swift
@@ -28,11 +28,11 @@ import Logging
 /// - `response`: the response from the call,
 /// - `status`: the status of the gRPC call after it has ended,
 /// - `trailingMetadata`: any metadata returned from the server alongside the `status`.
-public final class ClientStreamingCall<RequestMessage: Message, ResponseMessage: Message>
-  : BaseClientCall<RequestMessage, ResponseMessage>,
+public final class ClientStreamingCall<RequestPayload: GRPCPayload, ResponsePayload: GRPCPayload>
+  : BaseClientCall<RequestPayload, ResponsePayload>,
     StreamingRequestClientCall,
     UnaryResponseClientCall {
-  public let response: EventLoopFuture<ResponseMessage>
+  public let response: EventLoopFuture<ResponsePayload>
   private var messageQueue: EventLoopFuture<Void>
 
   public init(
@@ -46,7 +46,7 @@ public final class ClientStreamingCall<RequestMessage: Message, ResponseMessage:
     logger.debug("starting rpc", metadata: ["path": "\(path)"])
 
     self.messageQueue = connection.eventLoop.makeSucceededFuture(())
-    let responsePromise = connection.eventLoop.makePromise(of: ResponseMessage.self)
+    let responsePromise = connection.eventLoop.makePromise(of: ResponsePayload.self)
     self.response = responsePromise.futureResult
 
     let responseHandler = GRPCClientUnaryResponseChannelHandler(
@@ -68,7 +68,7 @@ public final class ClientStreamingCall<RequestMessage: Message, ResponseMessage:
       options: callOptions
     )
 
-    let requestHandler = _StreamingRequestChannelHandler<RequestMessage>(requestHead: requestHead)
+    let requestHandler = _StreamingRequestChannelHandler<RequestPayload>(requestHead: requestHead)
 
     super.init(
       eventLoop: connection.eventLoop,

--- a/Sources/GRPC/ClientCalls/ServerStreamingCall.swift
+++ b/Sources/GRPC/ClientCalls/ServerStreamingCall.swift
@@ -24,14 +24,14 @@ import Logging
 /// - `initialMetadata`: the initial metadata returned from the server,
 /// - `status`: the status of the gRPC call after it has ended,
 /// - `trailingMetadata`: any metadata returned from the server alongside the `status`.
-public final class ServerStreamingCall<RequestMessage: Message, ResponseMessage: Message>: BaseClientCall<RequestMessage, ResponseMessage> {
+public final class ServerStreamingCall<RequestPayload: GRPCPayload, ResponsePayload: GRPCPayload>: BaseClientCall<RequestPayload, ResponsePayload> {
   public init(
     connection: ClientConnection,
     path: String,
-    request: RequestMessage,
+    request: RequestPayload,
     callOptions: CallOptions,
     errorDelegate: ClientErrorDelegate?,
-    handler: @escaping (ResponseMessage) -> Void
+    handler: @escaping (ResponsePayload) -> Void
   ) {
     let requestID = callOptions.requestIDProvider.requestID()
     let logger = Logger(subsystem: .clientChannelCall, metadata: [MetadataKey.requestID: "\(requestID)"])
@@ -56,7 +56,7 @@ public final class ServerStreamingCall<RequestMessage: Message, ResponseMessage:
       options: callOptions
     )
 
-    let requestHandler = _UnaryRequestChannelHandler<RequestMessage>(
+    let requestHandler = _UnaryRequestChannelHandler<RequestPayload>(
       requestHead: requestHead,
       request: .init(request)
     )

--- a/Sources/GRPC/ClientCalls/UnaryCall.swift
+++ b/Sources/GRPC/ClientCalls/UnaryCall.swift
@@ -27,15 +27,15 @@ import Logging
 /// - `response`: the response from the unary call,
 /// - `status`: the status of the gRPC call after it has ended,
 /// - `trailingMetadata`: any metadata returned from the server alongside the `status`.
-public final class UnaryCall<RequestMessage: Message, ResponseMessage: Message>
-  : BaseClientCall<RequestMessage, ResponseMessage>,
+public final class UnaryCall<RequestPayload: GRPCPayload, ResponsePayload: GRPCPayload>
+  : BaseClientCall<RequestPayload, ResponsePayload>,
     UnaryResponseClientCall {
-  public let response: EventLoopFuture<ResponseMessage>
+  public let response: EventLoopFuture<ResponsePayload>
 
   public init(
     connection: ClientConnection,
     path: String,
-    request: RequestMessage,
+    request: RequestPayload,
     callOptions: CallOptions,
     errorDelegate: ClientErrorDelegate?
   ) {
@@ -43,10 +43,10 @@ public final class UnaryCall<RequestMessage: Message, ResponseMessage: Message>
     let logger = Logger(subsystem: .clientChannelCall, metadata: [MetadataKey.requestID: "\(requestID)"])
     logger.debug("starting rpc", metadata: ["path": "\(path)"])
 
-    let responsePromise = connection.channel.eventLoop.makePromise(of: ResponseMessage.self)
+    let responsePromise = connection.channel.eventLoop.makePromise(of: ResponsePayload.self)
     self.response = responsePromise.futureResult
 
-    let responseHandler = GRPCClientUnaryResponseChannelHandler<ResponseMessage>(
+    let responseHandler = GRPCClientUnaryResponseChannelHandler<ResponsePayload>(
       initialMetadataPromise: connection.channel.eventLoop.makePromise(),
       trailingMetadataPromise: connection.channel.eventLoop.makePromise(),
       responsePromise: responsePromise,
@@ -65,7 +65,7 @@ public final class UnaryCall<RequestMessage: Message, ResponseMessage: Message>
       options: callOptions
     )
 
-    let requestHandler = _UnaryRequestChannelHandler<RequestMessage>(
+    let requestHandler = _UnaryRequestChannelHandler<RequestPayload>(
       requestHead: requestHead,
       request: .init(request)
     )

--- a/Sources/GRPC/Compression/Zlib.swift
+++ b/Sources/GRPC/Compression/Zlib.swift
@@ -49,15 +49,15 @@ enum Zlib {
     /// - Parameter input: The complete data to be compressed.
     /// - Parameter output: The `ByteBuffer` into which the compressed message should be written.
     /// - Returns: The number of bytes written into the `output` buffer.
-    func deflate(_ input: inout Data, into output: inout ByteBuffer) throws -> Int {
+    func deflate(_ input: inout ByteBuffer, into output: inout ByteBuffer) throws -> Int {
       // Note: This is only valid because we always use Z_FINISH to flush.
       //
       // From the documentation:
       //   Note that it is possible for the compressed size to be larger than the value returned
       //   by deflateBound() if flush options other than Z_FINISH or Z_NO_FLUSH are used.
-      let upperBound = CGRPCZlib_deflateBound(&self.stream.zstream, UInt(input.count))
+      let upperBound = CGRPCZlib_deflateBound(&self.stream.zstream, UInt(input.readableBytes))
 
-      return try input.withUnsafeMutableBytes { inputPointer in
+      return try input.withUnsafeMutableReadableBytes { inputPointer in
         try output.writeWithUnsafeMutableBytes(minimumWritableBytes: Int(upperBound)) { outputPointer in
           try self.stream.deflate(
             inputBuffer: CGRPCZlib_castVoidToBytefPointer(inputPointer.baseAddress!),

--- a/Sources/GRPC/GRPCClient.swift
+++ b/Sources/GRPC/GRPCClient.swift
@@ -26,7 +26,7 @@ public protocol GRPCClient {
 }
 
 extension GRPCClient {
-  public func makeUnaryCall<Request: Message, Response: Message>(
+  public func makeUnaryCall<Request: GRPCPayload, Response: GRPCPayload>(
     path: String,
     request: Request,
     callOptions: CallOptions? = nil,
@@ -40,7 +40,7 @@ extension GRPCClient {
       errorDelegate: self.connection.configuration.errorDelegate)
   }
 
-  public func makeServerStreamingCall<Request: Message, Response: Message>(
+  public func makeServerStreamingCall<Request: GRPCPayload, Response: GRPCPayload>(
     path: String,
     request: Request,
     callOptions: CallOptions? = nil,
@@ -56,7 +56,7 @@ extension GRPCClient {
       handler: handler)
   }
 
-  public func makeClientStreamingCall<Request: Message, Response: Message>(
+  public func makeClientStreamingCall<Request: GRPCPayload, Response: GRPCPayload>(
     path: String,
     callOptions: CallOptions? = nil,
     requestType: Request.Type = Request.self,
@@ -69,7 +69,7 @@ extension GRPCClient {
       errorDelegate: self.connection.configuration.errorDelegate)
   }
 
-  public func makeBidirectionalStreamingCall<Request: Message, Response: Message>(
+  public func makeBidirectionalStreamingCall<Request: GRPCPayload, Response: GRPCPayload>(
     path: String,
     callOptions: CallOptions? = nil,
     requestType: Request.Type = Request.self,

--- a/Sources/GRPC/GRPCClientStateMachine.swift
+++ b/Sources/GRPC/GRPCClientStateMachine.swift
@@ -66,7 +66,7 @@ enum SendEndOfRequestStreamError: Error {
 /// A state machine for a single gRPC call from the perspective of a client.
 ///
 /// See: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
-struct GRPCClientStateMachine<Request: Message, Response: Message> {
+struct GRPCClientStateMachine<Request: GRPCPayload, Response: GRPCPayload> {
   /// The combined state of the request (client) and response (server) streams for an RPC call.
   ///
   /// The following states are not possible:

--- a/Sources/GRPC/GRPCPayload.swift
+++ b/Sources/GRPC/GRPCPayload.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, gRPC Authors All rights reserved.
+ * Copyright 2020, gRPC Authors All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,11 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import SwiftProtobuf
+import NIO
 
-/// An event that can occur on a client-streaming RPC. Provided to the event observer registered for that call.
-public enum StreamEvent<Message: GRPCPayload> {
-  case message(Message)
-  case end
-  //! FIXME: Also support errors in this type, to propagate them to the event handler.
+/// Data passed through the library is required to conform to this GRPCPayload protocol
+public protocol GRPCPayload {
+  /// Passes a pointer to the underlying buffer which can be used to decode the data
+  init(serializedByteBuffer: inout NIO.ByteBuffer) throws
+
+  /// Passes a pointer to the buffer so the data can be encoded into it
+  func serialize(into buffer: inout NIO.ByteBuffer) throws
 }

--- a/Sources/GRPC/GRPCPayload.swift
+++ b/Sources/GRPC/GRPCPayload.swift
@@ -17,9 +17,17 @@ import NIO
 
 /// Data passed through the library is required to conform to this GRPCPayload protocol
 public protocol GRPCPayload {
-  /// Passes a pointer to the underlying buffer which can be used to decode the data
+  
+  /// Initializes a new payload object from a given `NIO.ByteBuffer`
+  ///
+  /// - Parameter serializedByteBuffer:
+  /// - Throws: Should throw an error if the data wasn't serialized properly
   init(serializedByteBuffer: inout NIO.ByteBuffer) throws
 
-  /// Passes a pointer to the buffer so the data can be encoded into it
+  /// serializes data into a `ByteBuffer`
+  ///
+  /// - Parameters:
+  ///   - buffer: The buffer to write the payload into.
+  /// - Note: Implementer should NOT clear `ByteBuffer`
   func serialize(into buffer: inout NIO.ByteBuffer) throws
 }

--- a/Sources/GRPC/GRPCPayload.swift
+++ b/Sources/GRPC/GRPCPayload.swift
@@ -20,14 +20,14 @@ public protocol GRPCPayload {
   
   /// Initializes a new payload object from a given `NIO.ByteBuffer`
   ///
-  /// - Parameter serializedByteBuffer:
+  /// - Parameter serializedByteBuffer: A buffer containing the serialised bytes of this payload.
   /// - Throws: Should throw an error if the data wasn't serialized properly
   init(serializedByteBuffer: inout NIO.ByteBuffer) throws
 
-  /// serializes data into a `ByteBuffer`
+  /// Serializes the payload into a `ByteBuffer`.
   ///
   /// - Parameters:
   ///   - buffer: The buffer to write the payload into.
-  /// - Note: Implementer should NOT clear `ByteBuffer`
+  /// - Note: Implementers must *NOT* clear or read bytes from `buffer`.
   func serialize(into buffer: inout NIO.ByteBuffer) throws
 }

--- a/Sources/GRPC/GRPCProtobufPayload.swift
+++ b/Sources/GRPC/GRPCProtobufPayload.swift
@@ -21,13 +21,10 @@ public protocol GRPCProtobufPayload: GRPCPayload, Message {}
 
 public extension GRPCProtobufPayload {
   
-  /// Initializer that confirms the type Message to GRPCPayload by accessing the data
-  /// in the buffer into a message
   init(serializedByteBuffer: inout NIO.ByteBuffer) throws {
     try self.init(serializedData: serializedByteBuffer.readData(length: serializedByteBuffer.readableBytes)!)
   }
 
-  /// Serializes the Message into ByteBuffer
   func serialize(into buffer: inout NIO.ByteBuffer) throws {
     let data = try self.serializedData()
     buffer.writeBytes(data)

--- a/Sources/GRPC/GRPCProtobufPayload.swift
+++ b/Sources/GRPC/GRPCProtobufPayload.swift
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import NIO
+import SwiftProtobuf
+
+/// GRPCProtobufPayload which allows Protobuf Messages to be passed into the library
+public protocol GRPCProtobufPayload: GRPCPayload, Message {}
+
+public extension GRPCProtobufPayload {
+  
+  /// Initializer that confirms the type Message to GRPCPayload by accessing the data
+  /// in the buffer into a message
+  init(serializedByteBuffer: inout NIO.ByteBuffer) throws {
+    try self.init(serializedData: serializedByteBuffer.readData(length: serializedByteBuffer.readableBytes)!)
+  }
+
+  /// Serializes the Message into ByteBuffer
+  func serialize(into buffer: inout NIO.ByteBuffer) throws {
+    let data = try self.serializedData()
+    buffer.writeBytes(data)
+  }
+}

--- a/Sources/GRPC/GRPCServerCodec.swift
+++ b/Sources/GRPC/GRPCServerCodec.swift
@@ -22,27 +22,31 @@ import NIOHTTP1
 /// Incoming gRPC package with a fixed message type.
 ///
 /// - Important: This is **NOT** part of the public API.
-public enum _GRPCServerRequestPart<RequestMessage: Message> {
+public enum _GRPCServerRequestPart<RequestPayload: GRPCPayload> {
   case head(HTTPRequestHead)
-  case message(RequestMessage)
+  case message(RequestPayload)
   case end
 }
 
 /// Outgoing gRPC package with a fixed message type.
 ///
 /// - Important: This is **NOT** part of the public API.
-public enum _GRPCServerResponsePart<ResponseMessage: Message> {
+public enum _GRPCServerResponsePart<ResponsePayload: GRPCPayload> {
   case headers(HTTPHeaders)
-  case message(ResponseMessage)
+  case message(ResponsePayload)
   case statusAndTrailers(GRPCStatus, HTTPHeaders)
 }
 
 /// A simple channel handler that translates raw gRPC packets into decoded protobuf messages, and vice versa.
-internal final class GRPCServerCodec<RequestMessage: Message, ResponseMessage: Message> {}
+internal final class GRPCServerCodec<RequestPayload: GRPCPayload, ResponsePayload: GRPCPayload> {
+  // 1-byte for compression flag, 4-bytes for message length.
+  private let protobufMetadataSize = 5
+  var messageWriter = LengthPrefixedMessageWriter(compression: .none)
+}
 
 extension GRPCServerCodec: ChannelInboundHandler {
   typealias InboundIn = _RawGRPCServerRequestPart
-  typealias InboundOut = _GRPCServerRequestPart<RequestMessage>
+  typealias InboundOut = _GRPCServerRequestPart<RequestPayload>
 
   func channelRead(context: ChannelHandlerContext, data: NIOAny) {
     switch self.unwrapInboundIn(data) {
@@ -50,9 +54,8 @@ extension GRPCServerCodec: ChannelInboundHandler {
       context.fireChannelRead(self.wrapInboundOut(.head(requestHead)))
 
     case .message(var message):
-      let messageAsData = message.readData(length: message.readableBytes)!
       do {
-        context.fireChannelRead(self.wrapInboundOut(.message(try RequestMessage(serializedData: messageAsData))))
+        context.fireChannelRead(self.wrapInboundOut(.message(try RequestPayload(serializedByteBuffer: &message))))
       } catch {
         context.fireErrorCaught(GRPCError.DeserializationFailure().captureContext())
       }
@@ -64,7 +67,7 @@ extension GRPCServerCodec: ChannelInboundHandler {
 }
 
 extension GRPCServerCodec: ChannelOutboundHandler {
-  typealias OutboundIn = _GRPCServerResponsePart<ResponseMessage>
+  typealias OutboundIn = _GRPCServerResponsePart<ResponsePayload>
   typealias OutboundOut = _RawGRPCServerResponsePart
 
   func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
@@ -75,8 +78,9 @@ extension GRPCServerCodec: ChannelOutboundHandler {
 
     case .message(let message):
       do {
-        let messageData = try message.serializedData()
-        context.write(self.wrapOutboundOut(.message(messageData)), promise: promise)
+        var responseBuffer = context.channel.allocator.buffer(capacity: protobufMetadataSize)
+        try messageWriter.write(message, into: &responseBuffer)
+        context.write(self.wrapOutboundOut(.message(responseBuffer)), promise: promise)
       } catch {
         let error = GRPCError.SerializationFailure().captureContext()
         promise?.fail(error)

--- a/Sources/GRPC/GRPCServerCodec.swift
+++ b/Sources/GRPC/GRPCServerCodec.swift
@@ -39,8 +39,6 @@ public enum _GRPCServerResponsePart<ResponsePayload: GRPCPayload> {
 
 /// A simple channel handler that translates raw gRPC packets into decoded protobuf messages, and vice versa.
 internal final class GRPCServerCodec<RequestPayload: GRPCPayload, ResponsePayload: GRPCPayload> {
-  // 1-byte for compression flag, 4-bytes for message length.
-  private let protobufMetadataSize = 5
   var messageWriter = LengthPrefixedMessageWriter(compression: .none)
 }
 
@@ -78,8 +76,8 @@ extension GRPCServerCodec: ChannelOutboundHandler {
 
     case .message(let message):
       do {
-        var responseBuffer = context.channel.allocator.buffer(capacity: protobufMetadataSize)
-        try messageWriter.write(message, into: &responseBuffer)
+        var responseBuffer = context.channel.allocator.buffer(capacity: 0)
+        try self.messageWriter.write(message, into: &responseBuffer)
         context.write(self.wrapOutboundOut(.message(responseBuffer)), promise: promise)
       } catch {
         let error = GRPCError.SerializationFailure().captureContext()

--- a/Sources/GRPC/HTTP1ToRawGRPCServerCodec.swift
+++ b/Sources/GRPC/HTTP1ToRawGRPCServerCodec.swift
@@ -264,7 +264,8 @@ extension HTTP1ToRawGRPCServerCodec: ChannelOutboundHandler {
         // it needs to be aggregated with all the responses plus the trailers, in order to have
         // the base64 response properly encoded in a single byte stream.
         
-        self.responseTextBuffer.writeBytes(messageBytes.readableBytesView)
+        var messageBytes = messageBytes
+        self.responseTextBuffer.writeBuffer(&messageBytes)
         
         // Since we stored the written data, mark the write promise as successful so that the
         // ServerStreaming provider continues sending the data.

--- a/Sources/GRPC/HTTP1ToRawGRPCServerCodec.swift
+++ b/Sources/GRPC/HTTP1ToRawGRPCServerCodec.swift
@@ -29,7 +29,7 @@ public enum _RawGRPCServerRequestPart {
 /// Outgoing gRPC package with an unknown message type (represented by `Data`).
 public enum _RawGRPCServerResponsePart {
   case headers(HTTPHeaders)
-  case message(Data)
+  case message(ByteBuffer)
   case statusAndTrailers(GRPCStatus, HTTPHeaders)
 }
 
@@ -53,14 +53,14 @@ public final class HTTP1ToRawGRPCServerCodec {
     self.messageReader = LengthPrefixedMessageReader()
   }
 
-  // 1-byte for compression flag, 4-bytes for message length.
-  private let protobufMetadataSize = 5
-
   private var contentType: ContentType?
 
   private let logger: Logger
   private let accessLog: Logger
   private var stopwatch: Stopwatch?
+  
+  // 1-byte for compression flag, 4-bytes for message length.
+  private let protobufMetadataSize = 5
 
   // The following buffers use force unwrapping explicitly. With optionals, developers
   // are encouraged to unwrap them using guard-else statements. These don't work cleanly
@@ -91,7 +91,6 @@ public final class HTTP1ToRawGRPCServerCodec {
     }
   }
 
-  var messageWriter = LengthPrefixedMessageWriter(compression: .none)
   var messageReader: LengthPrefixedMessageReader
 }
 
@@ -260,27 +259,29 @@ extension HTTP1ToRawGRPCServerCodec: ChannelOutboundHandler {
         self.logger.error("invalid state '\(self.outboundState)' while writing message", metadata: ["message": "\(messageBytes)"])
         return
       }
-
+      
       if contentType == .text {
         precondition(self.responseTextBuffer != nil)
 
         // Store the response into an independent buffer. We can't return the message directly as
         // it needs to be aggregated with all the responses plus the trailers, in order to have
         // the base64 response properly encoded in a single byte stream.
-        //
-        // We can try! here because the server does not support compression at the moment and this
-        // only throws when compression fails.
-        try! messageWriter.write(messageBytes, into: &self.responseTextBuffer)
-
+        
+        var messageBytes = messageBytes
+        // disregards the first 5 bytes since the rewritting them to the buffer doesnt require them
+        messageBytes.moveReaderIndex(forwardBy: protobufMetadataSize)
+        // Writes the compression bit as 'Zero' since the server cant compress data
+        self.responseTextBuffer.writeInteger(UInt8(0))
+        
+        // copying the old data to the responseTextBuffer
+        self.responseTextBuffer.writeInteger(UInt32(messageBytes.readableBytes))
+        self.responseTextBuffer.writeBytes(messageBytes.readableBytesView)
+        
         // Since we stored the written data, mark the write promise as successful so that the
         // ServerStreaming provider continues sending the data.
         promise?.succeed(())
       } else {
-        var responseBuffer = context.channel.allocator.buffer(capacity: LengthPrefixedMessageWriter.metadataLength)
-        // We can try! here because the server does not support compression at the moment and this
-        // only throws when compression fails.
-        try! messageWriter.write(messageBytes, into: &responseBuffer)
-        context.write(self.wrapOutboundOut(.body(.byteBuffer(responseBuffer))), promise: promise)
+        context.write(self.wrapOutboundOut(.body(.byteBuffer(messageBytes))), promise: promise)
       }
       self.outboundState = .expectingBodyOrStatus
 

--- a/Sources/GRPC/LengthPrefixedMessageWriter.swift
+++ b/Sources/GRPC/LengthPrefixedMessageWriter.swift
@@ -50,7 +50,7 @@ internal struct LengthPrefixedMessageWriter {
   /// - Precondition: `compression.supported` is `true`.
   /// - Note: See `LengthPrefixedMessageReader` for more details on the format.
   func write(_ payload: GRPCPayload, into buffer: inout ByteBuffer, disableCompression: Bool = false) throws {
-    buffer.reserveCapacity(MemoryLayout.size(ofValue: payload) + LengthPrefixedMessageWriter.metadataLength)
+    buffer.reserveCapacity(buffer.writerIndex + LengthPrefixedMessageWriter.metadataLength)
     
     if !disableCompression, let compressor = self.compressor {
       // Set the compression byte.

--- a/Sources/GRPC/LengthPrefixedMessageWriter.swift
+++ b/Sources/GRPC/LengthPrefixedMessageWriter.swift
@@ -44,7 +44,7 @@ internal struct LengthPrefixedMessageWriter {
   /// Writes the data into a `ByteBuffer` as a gRPC length-prefixed message.
   ///
   /// - Parameters:
-  ///   - payload: The serialized Protobuf message to write.
+  ///   - payload: The payload to serialize and write.
   ///   - buffer: The buffer to write the message into.
   /// - Returns: A `ByteBuffer` containing a gRPC length-prefixed message.
   /// - Precondition: `compression.supported` is `true`.
@@ -61,8 +61,6 @@ internal struct LengthPrefixedMessageWriter {
       let payloadSizeIndex = buffer.writerIndex
       buffer.moveWriterIndex(forwardBy: MemoryLayout<UInt32>.size)
 
-      // Build the message by serializing it into a Buffer first
-      // Since deflate can only take a ByteBuffer
       var messageBuf = ByteBufferAllocator().buffer(capacity: 0)
       try payload.serialize(into: &messageBuf)
       
@@ -92,10 +90,10 @@ internal struct LengthPrefixedMessageWriter {
       try payload.serialize(into: &buffer)
       
       // Calculates the Written bytes with respect to the prefixed ones
-      let writtenFrame = buffer.readableBytes - LengthPrefixedMessageWriter.metadataLength - startBufferIndex
+      let bytesWritten = buffer.readableBytes - LengthPrefixedMessageWriter.metadataLength - startBufferIndex
 
       // Write the message length.
-      buffer.writePayloadLength(UInt32(writtenFrame), at: payloadSizeIndex)
+      buffer.writePayloadLength(UInt32(bytesWritten), at: payloadSizeIndex)
     }
   }
 }

--- a/Sources/GRPC/ReadWriteStates.swift
+++ b/Sources/GRPC/ReadWriteStates.swift
@@ -54,7 +54,7 @@ enum WriteState {
   /// - Parameter allocator: An allocator to provide a `ByteBuffer` into which the message will be
   ///     written.
   mutating func write(
-    _ message: Message,
+    _ message: GRPCPayload,
     disableCompression: Bool,
     allocator: ByteBufferAllocator
   ) -> Result<ByteBuffer, MessageWriteError> {
@@ -63,16 +63,12 @@ enum WriteState {
       return .failure(.cardinalityViolation)
 
     case let .writing(writeArity, contentType, writer):
-      guard let data = try? message.serializedData() else {
-        self = .notWriting
-        return .failure(.serializationFailed)
-      }
-
       // Zero is fine: the writer will allocate the correct amount of space.
       var buffer = allocator.buffer(capacity: 0)
       do {
-        try writer.write(data, into: &buffer, disableCompression: disableCompression)
+        try writer.write(message, into: &buffer)
       } catch {
+        self = .notWriting
         return .failure(.serializationFailed)
       }
 
@@ -115,7 +111,7 @@ enum ReadState {
   /// a message has been produced then subsequent calls will result in an error.
   ///
   /// - Parameter buffer: The buffer to read from.
-  mutating func readMessages<MessageType: Message>(
+  mutating func readMessages<MessageType: GRPCPayload>(
     _ buffer: inout ByteBuffer,
     as: MessageType.Type = MessageType.self
   ) -> Result<[MessageType], MessageReadError> {
@@ -130,8 +126,7 @@ enum ReadState {
       do {
         while var serializedBytes = try? reader.nextMessage() {
           // Force unwrapping is okay here: we will always be able to read `readableBytes`.
-          let serializedData = serializedBytes.readData(length: serializedBytes.readableBytes)!
-          messages.append(try MessageType(serializedData: serializedData))
+          messages.append(try MessageType(serializedByteBuffer: &serializedBytes))
         }
       } catch {
         self = .notReading

--- a/Sources/GRPC/ReadWriteStates.swift
+++ b/Sources/GRPC/ReadWriteStates.swift
@@ -66,7 +66,7 @@ enum WriteState {
       // Zero is fine: the writer will allocate the correct amount of space.
       var buffer = allocator.buffer(capacity: 0)
       do {
-        try writer.write(message, into: &buffer)
+        try writer.write(message, into: &buffer, disableCompression: disableCompression)
       } catch {
         self = .notWriting
         return .failure(.serializationFailed)

--- a/Sources/GRPC/ServerCallContexts/UnaryResponseCallContext.swift
+++ b/Sources/GRPC/ServerCallContexts/UnaryResponseCallContext.swift
@@ -28,10 +28,10 @@ import Logging
 ///
 /// For unary calls, the response is not actually provided by fulfilling `responsePromise`, but instead by completing
 /// the future returned by `UnaryCallHandler.EventObserver`.
-open class UnaryResponseCallContext<ResponseMessage: Message>: ServerCallContextBase, StatusOnlyCallContext {
-  typealias WrappedResponse = _GRPCServerResponsePart<ResponseMessage>
+open class UnaryResponseCallContext<ResponsePayload: GRPCPayload>: ServerCallContextBase, StatusOnlyCallContext {
+  typealias WrappedResponse = _GRPCServerResponsePart<ResponsePayload>
 
-  public let responsePromise: EventLoopPromise<ResponseMessage>
+  public let responsePromise: EventLoopPromise<ResponsePayload>
   public var responseStatus: GRPCStatus = .ok
 
   public override init(eventLoop: EventLoop, request: HTTPRequestHead, logger: Logger) {
@@ -43,7 +43,7 @@ open class UnaryResponseCallContext<ResponseMessage: Message>: ServerCallContext
 /// Protocol variant of `UnaryResponseCallContext` that only exposes the `responseStatus` and `trailingMetadata`
 /// fields, but not `responsePromise`.
 ///
-/// Motivation: `UnaryCallHandler` already asks the call handler return an `EventLoopFuture<ResponseMessage>` which
+/// Motivation: `UnaryCallHandler` already asks the call handler return an `EventLoopFuture<ResponsePayload>` which
 /// is automatically cascaded into `UnaryResponseCallContext.responsePromise`, so that promise does not (and should not)
 /// be fulfilled by the user.
 ///
@@ -55,7 +55,7 @@ public protocol StatusOnlyCallContext: ServerCallContext {
 }
 
 /// Concrete implementation of `UnaryResponseCallContext` used by our generated code.
-open class UnaryResponseCallContextImpl<ResponseMessage: Message>: UnaryResponseCallContext<ResponseMessage> {
+open class UnaryResponseCallContextImpl<ResponsePayload: GRPCPayload>: UnaryResponseCallContext<ResponsePayload> {
   public let channel: Channel
 
   /// - Parameters:
@@ -93,4 +93,4 @@ open class UnaryResponseCallContextImpl<ResponseMessage: Message>: UnaryResponse
 /// Concrete implementation of `UnaryResponseCallContext` used for testing.
 ///
 /// Only provided to make it clear in tests that no "real" implementation is used.
-open class UnaryResponseCallContextTestStub<ResponseMessage: Message>: UnaryResponseCallContext<ResponseMessage> { }
+open class UnaryResponseCallContextTestStub<ResponsePayload: GRPCPayload>: UnaryResponseCallContext<ResponsePayload> { }

--- a/Sources/GRPC/_ClientRequestChannelHandler.swift
+++ b/Sources/GRPC/_ClientRequestChannelHandler.swift
@@ -21,9 +21,9 @@ import NIOHTTP1
 /// A base channel handler for client requests.
 ///
 /// - Important: This is **NOT** part of the public API.
-public class _ClientRequestChannelHandler<RequestMessage: Message>: ChannelInboundHandler {
+public class _ClientRequestChannelHandler<RequestPayload: GRPCPayload>: ChannelInboundHandler {
   public typealias InboundIn = Never
-  public typealias OutboundOut = _GRPCClientRequestPart<RequestMessage>
+  public typealias OutboundOut = _GRPCClientRequestPart<RequestPayload>
 
   /// The request head to send.
   internal let requestHead: _GRPCRequestHead
@@ -43,11 +43,11 @@ public class _ClientRequestChannelHandler<RequestMessage: Message>: ChannelInbou
 /// Sends the request head, message and end on `channelActive(context:)`.
 ///
 /// - Important: This is **NOT** part of the public API.
-public final class _UnaryRequestChannelHandler<RequestMessage: Message>: _ClientRequestChannelHandler<RequestMessage> {
+public final class _UnaryRequestChannelHandler<RequestPayload: GRPCPayload>: _ClientRequestChannelHandler<RequestPayload> {
   /// The request to send.
-  internal let request: _MessageContext<RequestMessage>
+  internal let request: _MessageContext<RequestPayload>
 
-  public init(requestHead: _GRPCRequestHead, request: _MessageContext<RequestMessage>) {
+  public init(requestHead: _GRPCRequestHead, request: _MessageContext<RequestPayload>) {
     self.request = request
     super.init(requestHead: requestHead)
   }
@@ -65,7 +65,7 @@ public final class _UnaryRequestChannelHandler<RequestMessage: Message>: _Client
 /// Sends the request head on `channelActive(context:)`.
 ///
 /// - Important: This is **NOT** part of the public API.
-public final class _StreamingRequestChannelHandler<RequestMessage: Message>: _ClientRequestChannelHandler<RequestMessage> {
+public final class _StreamingRequestChannelHandler<RequestPayload: GRPCPayload>: _ClientRequestChannelHandler<RequestPayload> {
   override public func channelActive(context: ChannelHandlerContext) {
     context.writeAndFlush(self.wrapOutboundOut(.head(self.requestHead)), promise: nil)
     context.fireChannelActive()

--- a/Sources/GRPC/_GRPCClientChannelHandler.swift
+++ b/Sources/GRPC/_GRPCClientChannelHandler.swift
@@ -24,7 +24,7 @@ import Logging
 ///
 /// - Important: This is **NOT** part of the public API. It is declared as
 ///   `public` because it is used within performance tests.
-public enum _GRPCClientRequestPart<Request: Message> {
+public enum _GRPCClientRequestPart<Request: GRPCPayload> {
   /// The 'head' of the request, that is, information about the initiation of the RPC.
   case head(_GRPCRequestHead)
 
@@ -174,7 +174,7 @@ public struct _GRPCRequestHead {
 /// A gRPC client response message part.
 ///
 /// - Important: This is **NOT** part of the public API.
-public enum _GRPCClientResponsePart<Response: Message> {
+public enum _GRPCClientResponsePart<Response: GRPCPayload> {
   /// Metadata received as the server acknowledges the RPC.
   case initialMetadata(HPACKHeaders)
 
@@ -231,7 +231,7 @@ public enum GRPCCallType {
 ///
 /// - Important: This is **NOT** part of the public API. It is declared as
 ///   `public` because it is used within performance tests.
-public final class _GRPCClientChannelHandler<Request: Message, Response: Message> {
+public final class _GRPCClientChannelHandler<Request: GRPCPayload, Response: GRPCPayload> {
   private let logger: Logger
   private let streamID: HTTP2StreamID
   private var stateMachine: GRPCClientStateMachine<Request, Response>

--- a/Sources/GRPC/_MessageContext.swift
+++ b/Sources/GRPC/_MessageContext.swift
@@ -18,7 +18,7 @@ import SwiftProtobuf
 /// Provides a context for Protobuf messages.
 ///
 /// - Important: This is **NOT** part of the public API.
-public final class _MessageContext<M: Message> {
+public final class _MessageContext<M: GRPCPayload> {
   let message: M
   let disableCompression: Bool
 

--- a/Sources/GRPCInteroperabilityTestModels/Generated/test.grpc.swift
+++ b/Sources/GRPCInteroperabilityTestModels/Generated/test.grpc.swift
@@ -361,21 +361,19 @@ extension Grpc_Testing_ReconnectServiceProvider {
   }
 }
 
-extension Grpc_Testing_SimpleRequest: GRPCProtobufPayload {}
 
-extension Grpc_Testing_SimpleResponse: GRPCProtobufPayload {}
-
-
+/// Provides conformance to `GRPCPayload` for the request and response messages
 extension Grpc_Testing_Empty: GRPCProtobufPayload {}
-
-extension Grpc_Testing_ReconnectParams: GRPCProtobufPayload {}
-
-extension Grpc_Testing_StreamingOutputCallResponse: GRPCProtobufPayload {}
-
+extension Grpc_Testing_SimpleRequest: GRPCProtobufPayload {}
+extension Grpc_Testing_SimpleResponse: GRPCProtobufPayload {}
 extension Grpc_Testing_StreamingOutputCallRequest: GRPCProtobufPayload {}
-
-extension Grpc_Testing_ReconnectInfo: GRPCProtobufPayload {}
-
+extension Grpc_Testing_StreamingOutputCallResponse: GRPCProtobufPayload {}
+extension Grpc_Testing_StreamingInputCallRequest: GRPCProtobufPayload {}
 extension Grpc_Testing_StreamingInputCallResponse: GRPCProtobufPayload {}
 
-extension Grpc_Testing_StreamingInputCallRequest: GRPCProtobufPayload {}
+/// Provides conformance to `GRPCPayload` for the request and response messages
+
+/// Provides conformance to `GRPCPayload` for the request and response messages
+extension Grpc_Testing_ReconnectParams: GRPCProtobufPayload {}
+extension Grpc_Testing_ReconnectInfo: GRPCProtobufPayload {}
+

--- a/Sources/GRPCInteroperabilityTestModels/Generated/test.grpc.swift
+++ b/Sources/GRPCInteroperabilityTestModels/Generated/test.grpc.swift
@@ -361,3 +361,21 @@ extension Grpc_Testing_ReconnectServiceProvider {
   }
 }
 
+extension Grpc_Testing_SimpleRequest: GRPCProtobufPayload {}
+
+extension Grpc_Testing_SimpleResponse: GRPCProtobufPayload {}
+
+
+extension Grpc_Testing_Empty: GRPCProtobufPayload {}
+
+extension Grpc_Testing_ReconnectParams: GRPCProtobufPayload {}
+
+extension Grpc_Testing_StreamingOutputCallResponse: GRPCProtobufPayload {}
+
+extension Grpc_Testing_StreamingOutputCallRequest: GRPCProtobufPayload {}
+
+extension Grpc_Testing_ReconnectInfo: GRPCProtobufPayload {}
+
+extension Grpc_Testing_StreamingInputCallResponse: GRPCProtobufPayload {}
+
+extension Grpc_Testing_StreamingInputCallRequest: GRPCProtobufPayload {}

--- a/Sources/protoc-gen-grpc-swift/Generator.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator.swift
@@ -117,5 +117,26 @@ class Generator {
         printServer()
       }
     }
+    println()
+    printProtoBufExtensions()
+  }
+    
+  internal func printProtoBufExtensions() {
+    var writtenValues = Set<String>()
+    for service in file.services {
+      self.service = service
+      println("/// Provides conformance to `GRPCPayload` for the request and response messages")
+      for method in service.methods {
+        self.method = method
+        printExtension(for: methodInputName, typesSeen: &writtenValues)
+        printExtension(for: methodOutputName, typesSeen: &writtenValues)
+      }
+    }
+  }
+
+  private func printExtension(for messageType: String, typesSeen: inout Set<String>) {
+    guard !typesSeen.contains(messageType) else { return }
+    println("extension \(messageType): GRPCProtobufPayload {}")
+    typesSeen.insert(messageType)
   }
 }

--- a/Sources/protoc-gen-grpc-swift/Generator.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator.swift
@@ -131,6 +131,7 @@ class Generator {
         printExtension(for: methodInputName, typesSeen: &writtenValues)
         printExtension(for: methodOutputName, typesSeen: &writtenValues)
       }
+      println()
     }
   }
 

--- a/Sources/protoc-gen-grpc-swift/Generator.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator.swift
@@ -123,9 +123,9 @@ class Generator {
     
   internal func printProtoBufExtensions() {
     var writtenValues = Set<String>()
+    println("/// Provides conformance to `GRPCPayload` for the request and response messages")
     for service in file.services {
       self.service = service
-      println("/// Provides conformance to `GRPCPayload` for the request and response messages")
       for method in service.methods {
         self.method = method
         printExtension(for: methodInputName, typesSeen: &writtenValues)

--- a/Tests/GRPCTests/RawGRPCServerResponsePart+Assertions.swift
+++ b/Tests/GRPCTests/RawGRPCServerResponsePart+Assertions.swift
@@ -16,6 +16,7 @@
 import Foundation
 import GRPC
 import NIOHTTP1
+import NIO
 import XCTest
 
 extension _RawGRPCServerResponsePart {
@@ -33,7 +34,7 @@ extension _RawGRPCServerResponsePart {
   /// Asserts that this value represents the message case.
   ///
   /// - Parameter validate: A block to further validate the message.
-  func assertMessage(validate: ((Data) -> Void)? = nil) {
+  func assertMessage(validate: ((NIO.ByteBuffer) -> Void)? = nil) {
     guard case .message(let message) = self else {
       XCTFail("Expected .message but got \(self)")
       return

--- a/Tests/GRPCTests/ZlibTests.swift
+++ b/Tests/GRPCTests/ZlibTests.swift
@@ -29,8 +29,9 @@ class ZlibTests: GRPCTestCase {
 
   @discardableResult
   func doCompressAndDecompress(of bytes: [UInt8], format: Zlib.CompressionFormat) throws -> Int  {
-    var data = Data(bytes)
-
+    var data = self.allocator.buffer(capacity: 0)
+    data.writeBytes(bytes)
+    
     // Compress it.
     let deflate = Zlib.Deflate(format: format)
     var compressed = self.allocator.buffer(capacity: 0)
@@ -96,7 +97,8 @@ class ZlibTests: GRPCTestCase {
       let inflate = Zlib.Inflate(format: format)
 
       for bytes in byteArrays {
-        var data = Data(bytes)
+        var data = self.allocator.buffer(capacity: 0)
+        data.writeBytes(bytes)
 
         // Compress it.
         var compressed = self.allocator.buffer(capacity: 0)


### PR DESCRIPTION
Good morning! 

The following PR will be moving the `Message Protocol` away from the code base and introduces the `Payload protocol` which will allow users, to decode messages according to the Type they want to send. it addresses the following issue: #708, @glbrntt let's see how we can make this better since I found the following issue:

- issues:
 - Adds an over head of the code gen since now you will have to add the
```swift
extension Helloworld_HelloReply: Payload {
    public init(serializedByteBuffer: inout ByteBuffer) throws {
        try self.init(serializedData: serializedByteBuffer.readData(length: serializedByteBuffer.readableBytes)!,
                  extensions: nil,
                  partial: false,
                  options: BinaryDecodingOptions())
    }
    
    public func serialize(into buffer: inout ByteBuffer) throws {
        let data = try serializedData()
        buffer.writeBytes(data)
    }
}
``` 
which is not needed all the time since the following object didn't require it to work
```swift
extension Routeguide_RouteNote: Payload {
    public init(serializedByteBuffer: inout ByteBuffer) throws {}
    public func serialize(into buffer: inout ByteBuffer) throws {}
}
```