### PR TITLE
Update minimum NIO version

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "e208ab9555ffb5fefb58cb5cb17df0f9fe9ee47e",
-          "version": "2.11.0"
+          "revision": "4409b57d4c0c40d41ac2b320fccf02e4d451e3db",
+          "version": "2.13.0"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "b015dcbe871d9c4d36bb343b0d37293521e3df07",
-          "version": "2.4.5"
+          "revision": "cf54f5c1db1c3740a6c7d662dc8569c150c3846c",
+          "version": "2.6.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -30,11 +30,11 @@ let package = Package(
   dependencies: [
     // GRPC dependencies:
     // Main SwiftNIO package
-    .package(url: "https://github.com/apple/swift-nio.git", from: "2.11.0"),
+    .package(url: "https://github.com/apple/swift-nio.git", from: "2.13.0"),
     // HTTP2 via SwiftNIO
     .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.8.0"),
     // TLS via SwiftNIO
-    .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.4.1"),
+    .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.6.0"),
     // Support for Network.framework where possible.
     .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.3.0"),
 

--- a/Tests/GRPCTests/ClientTLSFailureTests.swift
+++ b/Tests/GRPCTests/ClientTLSFailureTests.swift
@@ -143,11 +143,11 @@ class ClientTLSFailureTests: GRPCTestCase {
 
     self.wait(for: [shutdownExpectation, errorExpectation], timeout: self.defaultTestTimeout)
 
-    if let nioSSLError = errorRecorder.errors.first as? NIOSSLError,
-      case .unableToValidateCertificate = nioSSLError {
+    if let nioSSLError = errorRecorder.errors.first as? NIOSSLExtraError {
+      XCTAssertEqual(nioSSLError, .failedToValidateHostname)
       // Expected case.
     } else {
-      XCTFail("Expected NIOSSLError.unableToValidateCertificate")
+      XCTFail("Expected NIOSSLExtraError.failedToValidateHostname")
     }
   }
 }


### PR DESCRIPTION
Motivation:

NIO 2.13.0 fixed some bugs which would in some cases cause messages to
get 'stuck'. NIO SSL 2.6.0 includes some improvements to error messaging
around TLS handshake failure.

Modifications:

- Update NIO to 2.13.0 and NIO SSL to 2.6.0.
- Update a test which relied on a NIO SSL error which is no longer thrown in
  2.6.0

Result:

Fewer bugs, better errors.