### PR TITLE
Use metadata in log messages

### DIFF
--- a/Sources/GRPC/ClientConnection.swift
+++ b/Sources/GRPC/ClientConnection.swift
@@ -275,7 +275,7 @@ extension ClientConnection {
       return configuration.eventLoopGroup.next().makeFailedFuture(GRPCStatus.processingError)
     }
 
-    logger.debug("attempting to connect to \(configuration.target) on \(eventLoop)")
+    logger.debug("attempting to connect", metadata: ["target": "\(configuration.target)", "eventLoop": "\(eventLoop)"])
     connectivity.state = .connecting
     let timeoutAndBackoff = backoffIterator?.next()
 
@@ -327,7 +327,7 @@ extension ClientConnection {
     backoffIterator: ConnectionBackoffIterator?,
     logger: Logger
   ) -> EventLoopFuture<Channel> {
-    logger.debug("scheduling connection attempt in \(timeout) seconds")
+    logger.debug("scheduling connection attempt", metadata: ["delay_seconds": "\(timeout)"])
     // The `futureResult` of the scheduled task is of type
     // `EventLoopFuture<EventLoopFuture<Channel>>`, so we need to `flatMap` it to
     // remove a level of indirection.
@@ -392,7 +392,7 @@ extension ClientConnection {
       }
 
     if let timeout = timeout {
-      logger.debug("setting connect timeout to \(timeout) seconds")
+      logger.debug("setting connect timeout", metadata: ["timeout_seconds" : "\(timeout)"])
       return bootstrap.connectTimeout(.seconds(timeInterval: timeout))
     } else {
       logger.debug("no connect timeout provided")

--- a/Sources/GRPC/ClientConnection.swift
+++ b/Sources/GRPC/ClientConnection.swift
@@ -275,7 +275,7 @@ extension ClientConnection {
       return configuration.eventLoopGroup.next().makeFailedFuture(GRPCStatus.processingError)
     }
 
-    logger.debug("attempting to connect", metadata: ["target": "\(configuration.target)", "eventLoop": "\(eventLoop)"])
+    logger.debug("attempting to connect", metadata: ["target": "\(configuration.target)", "event_loop": "\(eventLoop)"])
     connectivity.state = .connecting
     let timeoutAndBackoff = backoffIterator?.next()
 

--- a/Sources/GRPC/ConnectivityState.swift
+++ b/Sources/GRPC/ConnectivityState.swift
@@ -104,13 +104,13 @@ public class ConnectivityStateMonitor {
   /// - Important: This is **not** thread safe.
   private func setNewState(to newValue: ConnectivityState) {
     if self._userInitiatedShutdown {
-      self.logger.debug("user has initiated shutdown: ignoring new state: \(newValue)")
+      self.logger.debug("user has initiated shutdown: ignoring new state", metadata: ["new_state": "\(newValue)"])
       return
     }
 
     let oldValue = self._state
     if oldValue != newValue {
-      self.logger.debug("connectivity state change: \(oldValue) to \(newValue)")
+      self.logger.debug("connectivity state change", metadata: ["old_state": "\(oldValue)", "new_state": "\(newValue)"])
       self._state = newValue
       self._delegate?.connectivityStateDidChange(from: oldValue, to: newValue)
     }

--- a/Sources/GRPC/HTTPProtocolSwitcher.swift
+++ b/Sources/GRPC/HTTPProtocolSwitcher.swift
@@ -36,7 +36,7 @@ internal class HTTPProtocolSwitcher {
 
   private var state: State = .notConfigured {
     willSet {
-      self.logger.debug("state changed from '\(self.state)' to '\(newValue)'")
+      self.logger.debug("state changed", metadata: ["old_state": "\(self.state)", "new_state": "\(newValue)"])
     }
   }
   private var bufferedData: [NIOAny] = []
@@ -74,7 +74,7 @@ extension HTTPProtocolSwitcher: ChannelInboundHandler, RemovableChannelHandler {
     case .notConfigured:
       self.logger.debug("determining http protocol version")
       self.state = .configuring
-      self.logger.debug("buffering data \(data)")
+      self.logger.debug("buffering data", metadata: ["data": "\(data)"])
       self.bufferedData.append(data)
 
       // Detect the HTTP protocol version for the incoming request, or error out if it
@@ -141,7 +141,7 @@ extension HTTPProtocolSwitcher: ChannelInboundHandler, RemovableChannelHandler {
       }
 
     case .configuring:
-      self.logger.debug("buffering data \(data)")
+      self.logger.debug("buffering data", metadata: ["data": "\(data)"])
       self.bufferedData.append(data)
 
     case .configured:

--- a/Sources/GRPC/SettingsObservingHandler.swift
+++ b/Sources/GRPC/SettingsObservingHandler.swift
@@ -40,7 +40,9 @@ class InitialSettingsObservingHandler: ChannelInboundHandler, RemovableChannelHa
       self.connectivityStateMonitor.state = .ready
 
       let remoteAddressDescription = context.channel.remoteAddress.map { "\($0)" } ?? "n/a"
-      self.logger.info("gRPC connection to \(remoteAddressDescription) on \(context.eventLoop) ready")
+      self.logger.info("gRPC connection ready", metadata: [
+        "remoteAddress": "\(remoteAddressDescription)",
+        "eventLoop": "\(context.eventLoop)"])
 
       // We're no longer needed at this point, remove ourselves from the pipeline.
       self.logger.debug("removing 'InitialSettingsObservingHandler' from the channel")

--- a/Sources/GRPC/SettingsObservingHandler.swift
+++ b/Sources/GRPC/SettingsObservingHandler.swift
@@ -41,7 +41,7 @@ class InitialSettingsObservingHandler: ChannelInboundHandler, RemovableChannelHa
 
       let remoteAddressDescription = context.channel.remoteAddress.map { "\($0)" } ?? "n/a"
       self.logger.info("gRPC connection ready", metadata: [
-        "remoteAddress": "\(remoteAddressDescription)",
+        "remote_address": "\(remoteAddressDescription)",
         "eventLoop": "\(context.eventLoop)"])
 
       // We're no longer needed at this point, remove ourselves from the pipeline.

--- a/Sources/GRPC/SettingsObservingHandler.swift
+++ b/Sources/GRPC/SettingsObservingHandler.swift
@@ -42,7 +42,7 @@ class InitialSettingsObservingHandler: ChannelInboundHandler, RemovableChannelHa
       let remoteAddressDescription = context.channel.remoteAddress.map { "\($0)" } ?? "n/a"
       self.logger.info("gRPC connection ready", metadata: [
         "remote_address": "\(remoteAddressDescription)",
-        "eventLoop": "\(context.eventLoop)"])
+        "event_loop": "\(context.eventLoop)"])
 
       // We're no longer needed at this point, remove ourselves from the pipeline.
       self.logger.debug("removing 'InitialSettingsObservingHandler' from the channel")


### PR DESCRIPTION
Motivation:

I was analyzing some logs produced by grpc-swift but some of the messages lack structure, making it more difficult than it should be to run queries on the logs.

SwiftLog supports structured logging and its API allow us to log a message and some metadata associated to it.
Keeping the message string constant and logging the variable pieces of information as metadata, the logs produced by grpc-swift are going to be more easily analysed and processed.

Modifications:

This commit changes the logging calls where we had a variable message to have a constant message. The variable pieces of information are stored as metadata.

Result:

grpc-swift will produce log messages that can be analyzed and processed more easily.