### PR TITLE
Add SSWG badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/grpc/grpc-swift.svg?branch=nio)](https://travis-ci.org/grpc/grpc-swift)
+[![sswg:sandbox|94x20](https://img.shields.io/badge/sswg-sandbox-lightgrey.svg)](https://github.com/swift-server/sswg/blob/master/process/incubation.md#sandbox-level)
 
 # gRPC Swift
 


### PR DESCRIPTION
Motivation:

gRPC Swift now has now been approved as an SSWG sandbox project; let's
add the badge to our README to let people know.

Modifications:

Add SSWG badge to README

Result:

More badges on our README, more SSWG awareness