### PR TITLE
Replace usage of ClientConnection.init with builders

### DIFF
--- a/Sources/Examples/HelloWorld/Client/main.swift
+++ b/Sources/Examples/HelloWorld/Client/main.swift
@@ -65,18 +65,12 @@ func main(args: [String]) {
       try! group.syncShutdownGracefully()
     }
 
-    // Provide some basic configuration for the connection, in this case we connect to an endpoint on
-    // localhost at the given port.
-    let configuration = ClientConnection.Configuration(
-      target: .hostAndPort("localhost", port),
-      eventLoopGroup: group
-    )
-
-    // Create a connection using the configuration.
-    let connection = ClientConnection(configuration: configuration)
+    // Configure the channel, we're not using TLS so the connection is `insecure`.
+    let channel = ClientConnection.insecure(group: group)
+      .connect(host: "localhost", port: port)
 
     // Provide the connection to the generated client.
-    let greeter = Helloworld_GreeterClient(channel: connection)
+    let greeter = Helloworld_GreeterClient(channel: channel)
 
     // Do the greeting.
     greet(name: name, client: greeter)

--- a/Sources/Examples/RouteGuide/Client/main.swift
+++ b/Sources/Examples/RouteGuide/Client/main.swift
@@ -28,13 +28,10 @@ LoggingSystem.bootstrap {
 
 /// Makes a `RouteGuide` client for a service hosted on "localhost" and listening on the given port.
 func makeClient(port: Int, group: EventLoopGroup) -> Routeguide_RouteGuideClient {
-  let config = ClientConnection.Configuration(
-    target: .hostAndPort("localhost", port),
-    eventLoopGroup: group
-  )
+  let channel = ClientConnection.insecure(group: group)
+    .connect(host: "localhost", port: port)
 
-  let connection = ClientConnection(configuration: config)
-  return Routeguide_RouteGuideClient(channel: connection)
+  return Routeguide_RouteGuideClient(channel: channel)
 }
 
 /// Unary call example. Calls `getFeature` and prints the response.

--- a/Sources/GRPC/ClientConnection.swift
+++ b/Sources/GRPC/ClientConnection.swift
@@ -100,7 +100,9 @@ public class ClientConnection {
     return self.channel.eventLoop
   }
 
-  /// Creates a new connection from the given configuration.
+  /// Creates a new connection from the given configuration. Prefer using
+  /// `ClientConnection.secure(group:)` to build a connection secured with TLS or
+  /// `ClientConnection.insecure(group:)` to build a plaintext connection.
   ///
   /// - Important: Users should prefer using `ClientConnection.secure(group:)` to build a connection
   ///   with TLS, or `ClientConnection.insecure(group:)` to build a connection without TLS.
@@ -489,7 +491,9 @@ extension ClientConnection {
       return self.tls == nil ? .http : .https
     }
 
-    /// Create a `Configuration` with some pre-defined defaults.
+    /// Create a `Configuration` with some pre-defined defaults. Prefer using
+    /// `ClientConnection.secure(group:)` to build a connection secured with TLS or
+    /// `ClientConnection.insecure(group:)` to build a plaintext connection.
     ///
     /// - Parameter target: The target to connect to.
     /// - Parameter eventLoopGroup: The event loop group to run the connection on.

--- a/Sources/GRPCInteroperabilityTestsImplementation/InteroperabilityTestCase.swift
+++ b/Sources/GRPCInteroperabilityTestsImplementation/InteroperabilityTestCase.swift
@@ -34,12 +34,11 @@ public protocol InteroperabilityTest {
   /// per-test basis.
   ///
   /// - Parameter defaults: The default configuration for the test run.
-  func configure(defaults: ClientConnection.Configuration) -> ClientConnection.Configuration
+  func configure(builder: ClientConnection.Builder)
 }
 
 extension InteroperabilityTest {
-  func configure(defaults: ClientConnection.Configuration) -> ClientConnection.Configuration {
-    return defaults
+  func configure(builder: ClientConnection.Builder) {
   }
 }
 

--- a/Sources/GRPCPerformanceTests/Benchmarks/ServerProvidingBenchmark.swift
+++ b/Sources/GRPCPerformanceTests/Benchmarks/ServerProvidingBenchmark.swift
@@ -31,7 +31,7 @@ class ServerProvidingBenchmark: Benchmark {
   func setUp() throws {
     self.group = MultiThreadedEventLoopGroup(numberOfThreads: self.threadCount)
     let configuration = Server.Configuration(
-      target: .hostAndPort("", 0),
+      target: .hostAndPort("127.0.0.1", 0),
       eventLoopGroup: self.group,
       serviceProviders: self.providers
     )

--- a/Sources/GRPCPerformanceTests/Benchmarks/UnaryThroughput.swift
+++ b/Sources/GRPCPerformanceTests/Benchmarks/UnaryThroughput.swift
@@ -39,14 +39,10 @@ class Unary: ServerProvidingBenchmark {
   override func setUp() throws {
     try super.setUp()
     self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    let channel = ClientConnection.insecure(group: self.group)
+      .connect(host: "127.0.0.1", port: self.server.channel.localAddress!.port!)
 
-    let configuration = ClientConnection.Configuration(
-      target: .socketAddress(self.server.channel.localAddress!),
-      eventLoopGroup: self.group
-    )
-
-    let connection = ClientConnection(configuration: configuration)
-    self.client = .init(channel: connection)
+    self.client = .init(channel: channel)
   }
 
   override func run() throws {

--- a/Tests/GRPCTests/GRPCCustomPayloadTests.swift
+++ b/Tests/GRPCTests/GRPCCustomPayloadTests.swift
@@ -36,12 +36,10 @@ class GRPCCustomPayloadTests: GRPCTestCase {
 
     self.server = try! Server.start(configuration: serverConfig).wait()
 
-    let clientConfig: ClientConnection.Configuration = .init(
-      target: .hostAndPort("localhost", server.channel.localAddress!.port!),
-      eventLoopGroup: self.group
-    )
+    let channel = ClientConnection.insecure(group: self.group)
+      .connect(host: "localhost", port: server.channel.localAddress!.port!)
 
-    self.client = AnyServiceClient(channel: ClientConnection(configuration: clientConfig))
+    self.client = AnyServiceClient(channel: channel)
   }
 
   override func tearDown() {

--- a/Tests/GRPCTests/HeaderNormalizationTests.swift
+++ b/Tests/GRPCTests/HeaderNormalizationTests.swift
@@ -101,12 +101,8 @@ class HeaderNormalizationTests: GRPCTestCase {
 
     self.server = try! Server.start(configuration: serverConfig).wait()
 
-    let clientConfig = ClientConnection.Configuration(
-      target: .hostAndPort("localhost", self.server.channel.localAddress!.port!),
-      eventLoopGroup: self.group
-    )
-
-    self.channel = ClientConnection(configuration: clientConfig)
+    self.channel = ClientConnection.insecure(group: self.group)
+      .connect(host: "localhost", port: self.server.channel.localAddress!.port!)
     self.client = Echo_EchoClient(channel: self.channel)
   }
 

--- a/docs/basic-tutorial.md
+++ b/docs/basic-tutorial.md
@@ -471,8 +471,9 @@ service. You can see our complete example client code in
 To call service methods, we first need to create a *stub*. All generated Swift
 stubs are *non-blocking/asynchronous*.
 
-First we need to create a gRPC connection for our stub, specifying the server
-address and port we want to connect to:
+First we need to create a gRPC channel for our stub, we're not using TLS so we
+use the `insecure` builder and specify the server address and port we want to
+connect to:
 
 ```swift
 let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
@@ -480,13 +481,10 @@ defer {
   try? group.syncShutdownGracefully()
 }
 
-let configuration = ClientConnection.Configuration(
-  target: .hostAndPort("localhost", port),
-  eventLoopGroup: group
-)
+let channel = ClientConnection.insecure(group: group)
+  .connect(host: "localhost", port: port)
 
-let connection = ClientConnection(configuration: config)
-let client = Routeguide_RouteGuideServiceClient(connection: connection)
+let client = Routeguide_RouteGuideClient(channel: channel)
 ```
 
 #### Calling service methods


### PR DESCRIPTION
Motivation:

We recently introduced a builder for client connections; this API is
the preferred way to configure connections. We should use it wherever
possible.

Modifications:

Replaces usages of manual configuration using
`ClientConnection.Configuration` with usage of
`ClientConnection.Builder` instead.

Result:

- No functional changes
- Idiomatic API is more widely used.