### PR TITLE
Update README with Swift 5.2 dependency instructions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ import PackageDescription
 import Foundation
 
 let package = Package(
-  name: "GRPC",
+  name: "grpc-swift",
   platforms: [
     // We can't use `.watchOS(.v6)` since it isn't available with `swift-tools-version:5.0`.
     .macOS(.v10_12), .iOS(.v10), .tvOS(.v10), .watchOS("6.0")

--- a/README.md
+++ b/README.md
@@ -45,6 +45,27 @@ dependencies: [
 ]
 ```
 
+The syntax for target dependencies changed in Swift 5.2 and requires the package
+of each dependency to be specified.
+
+For Swift 5.2 (`swift-tools-version:5.2`):
+
+```swift
+.target(
+  name: ...,
+  dependencies: [.product(name: "GRPC", package: "grpc-swift")]
+)
+```
+
+For Swift 5.0 (`swift-tools-version:5.0`) and 5.1 (`swift-tools-version:5.1`):
+
+```swift
+.target(
+  name: ...,
+  dependencies: ["GRPC"]
+)
+```
+
 ##### Xcode
 
 From Xcode 11 it is possible to [add Swift Package dependencies to Xcode


### PR DESCRIPTION
Motivation:

In Swift 5.2, the package description API changed such that targets must
specify the package from which each their dependcies come from.

Modifications:

- Rename our package in Package.swift from "GRPC" to "grpc-swift"
- Update the README with how to depend on GRPC

Result:

Better instructions on how to depend on gRPC Swift