### PR TITLE
Add a server builder

### DIFF
--- a/Sources/Examples/HelloWorld/Server/main.swift
+++ b/Sources/Examples/HelloWorld/Server/main.swift
@@ -30,15 +30,11 @@ defer {
   try! group.syncShutdownGracefully()
 }
 
-// Create some configuration for the server:
-let configuration = Server.Configuration(
-  target: .hostAndPort("localhost", 0),
-  eventLoopGroup: group,
-  serviceProviders: [GreeterProvider()]
-)
-
 // Start the server and print its address once it has started.
-let server = Server.start(configuration: configuration)
+let server = Server.insecure(group: group)
+  .withServiceProviders([GreeterProvider()])
+  .bind(host: "localhost", port: 0)
+
 server.map {
   $0.channel.localAddress
 }.whenSuccess { address in

--- a/Sources/Examples/RouteGuide/Server/main.swift
+++ b/Sources/Examples/RouteGuide/Server/main.swift
@@ -51,15 +51,11 @@ func main(args: [String]) throws {
   // Create a provider using the features we read.
   let provider = RouteGuideProvider(features: features)
 
-  // Tie these together in some configuration:
-  let configuration = Server.Configuration(
-    target: .hostAndPort("localhost", 0),
-    eventLoopGroup: group,
-    serviceProviders: [provider]
-  )
-
   // Start the server and print its address once it has started.
-  let server = Server.start(configuration: configuration)
+  let server = Server.insecure(group: group)
+    .withServiceProviders([provider])
+    .bind(host: "localhost", port: 0)
+
   server.map {
     $0.channel.localAddress
   }.whenSuccess { address in

--- a/Sources/GRPC/ServerBuilder.swift
+++ b/Sources/GRPC/ServerBuilder.swift
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2020, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import NIO
+import NIOSSL
+
+extension Server {
+  public class Builder {
+    private let group: EventLoopGroup
+    private var maybeTLS: Server.Configuration.TLS? { return nil }
+    private var providers: [CallHandlerProvider] = []
+    private var errorDelegate: ServerErrorDelegate?
+    private var messageEncoding: ServerMessageEncoding = .disabled
+
+    fileprivate init(group: EventLoopGroup) {
+      self.group = group
+    }
+
+    public class Secure: Builder {
+      private var tls: Server.Configuration.TLS
+      override var maybeTLS: Server.Configuration.TLS? {
+        return self.tls
+      }
+
+      fileprivate init(group: EventLoopGroup, certificateChain: [NIOSSLCertificate], privateKey: NIOSSLPrivateKey) {
+        self.tls = .init(
+          certificateChain: certificateChain.map { .certificate($0) },
+          privateKey: .privateKey(privateKey)
+        )
+        super.init(group: group)
+      }
+    }
+
+    public func bind(host: String, port: Int) -> EventLoopFuture<Server> {
+      let configuration = Server.Configuration(
+        target: .hostAndPort(host, port),
+        eventLoopGroup: self.group,
+        serviceProviders: self.providers,
+        errorDelegate: self.errorDelegate,
+        tls: self.maybeTLS,
+        messageEncoding: self.messageEncoding
+      )
+      return Server.start(configuration: configuration)
+    }
+  }
+}
+
+extension Server.Builder {
+  /// Sets the server error delegate.
+  @discardableResult
+  public func withErrorDelegate(_ delegate: ServerErrorDelegate?) -> Self {
+    self.errorDelegate = delegate
+    return self
+  }
+}
+
+extension Server.Builder {
+  /// Sets the service providers that this server should offer. Note that calling this multiple
+  /// times will override any previously set providers.
+  public func withServiceProviders(_ providers: [CallHandlerProvider]) -> Self {
+    self.providers = providers
+    return self
+  }
+}
+
+extension Server.Builder {
+  /// Sets the message compression configuration. Compression is disabled if this is not configured
+  /// and any RPCs using compression will not be accepted.
+  public func withMessageCompression(_ encoding: ServerMessageEncoding) -> Self {
+    self.messageEncoding = encoding
+    return self
+  }
+}
+
+extension Server.Builder.Secure {
+  /// Sets the trust roots to use to validate certificates. This only needs to be provided if you
+  /// intend to validate certificates. Defaults to the system provided trust store (`.default`) if
+  /// not set.
+  @discardableResult
+  public func withTLS(trustRoots: NIOSSLTrustRoots) -> Self {
+    self.tls.trustRoots = trustRoots
+    return self
+  }
+
+  /// Sets whether certificates should be verified. Defaults to `.fullVerification` if not set.
+  @discardableResult
+  public func withTLS(certificateVerification: CertificateVerification) -> Self {
+    self.tls.certificateVerification = certificateVerification
+    return self
+  }
+}
+
+extension Server {
+  /// Returns an insecure `Server` builder which is *not configured with TLS*.
+  public static func insecure(group: EventLoopGroup) -> Builder {
+    return Builder(group: group)
+  }
+
+  /// Returns a `Server` builder configured with TLS.
+  public static func secure(
+    group: EventLoopGroup,
+    certificateChain: [NIOSSLCertificate],
+    privateKey: NIOSSLPrivateKey
+  ) -> Builder.Secure {
+    return Builder.Secure(
+      group: group,
+      certificateChain: certificateChain,
+      privateKey: privateKey
+    )
+  }
+}

--- a/Sources/GRPCPerformanceTests/Benchmarks/ServerProvidingBenchmark.swift
+++ b/Sources/GRPCPerformanceTests/Benchmarks/ServerProvidingBenchmark.swift
@@ -30,12 +30,10 @@ class ServerProvidingBenchmark: Benchmark {
 
   func setUp() throws {
     self.group = MultiThreadedEventLoopGroup(numberOfThreads: self.threadCount)
-    let configuration = Server.Configuration(
-      target: .hostAndPort("127.0.0.1", 0),
-      eventLoopGroup: self.group,
-      serviceProviders: self.providers
-    )
-    self.server = try Server.start(configuration: configuration).wait()
+    self.server = try Server.insecure(group: self.group)
+      .withServiceProviders(self.providers)
+      .bind(host: "127.0.0.1", port: 0)
+      .wait()
   }
 
   func tearDown() throws {

--- a/Tests/GRPCTests/ClientConnectionBackoffTests.swift
+++ b/Tests/GRPCTests/ClientConnectionBackoffTests.swift
@@ -116,12 +116,9 @@ class ClientConnectionBackoffTests: GRPCTestCase {
   }
 
   func makeServer() -> EventLoopFuture<Server> {
-    let configuration = Server.Configuration(
-      target: .hostAndPort("localhost", self.port),
-      eventLoopGroup: self.serverGroup,
-      serviceProviders: [EchoProvider()])
-
-    return Server.start(configuration: configuration)
+    return Server.insecure(group: self.serverGroup)
+      .withServiceProviders([EchoProvider()])
+      .bind(host: "localhost", port: self.port)
   }
 
   func connectionBuilder() -> ClientConnection.Builder {

--- a/Tests/GRPCTests/ClientTLSFailureTests.swift
+++ b/Tests/GRPCTests/ClientTLSFailureTests.swift
@@ -72,14 +72,13 @@ class ClientTLSFailureTests: GRPCTestCase {
   override func setUp() {
     self.serverEventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 
-    let configuration = Server.Configuration(
-      target: .hostAndPort("localhost", 0),
-      eventLoopGroup: self.serverEventLoopGroup,
-      serviceProviders: [EchoProvider()],
-      errorDelegate: nil,
-      tls: self.defaultServerTLSConfiguration)
-
-    self.server = try! Server.start(configuration: configuration).wait()
+    self.server = try! Server.secure(
+      group: self.serverEventLoopGroup,
+      certificateChain: [SampleCertificate.server.certificate],
+      privateKey: SamplePrivateKey.server
+    ).withServiceProviders([EchoProvider()])
+      .bind(host: "localhost", port: 0)
+      .wait()
 
     self.port = self.server.channel.localAddress?.port
 

--- a/Tests/GRPCTests/CompressionTests.swift
+++ b/Tests/GRPCTests/CompressionTests.swift
@@ -39,14 +39,11 @@ class MessageCompressionTests: GRPCTestCase {
   }
 
   func setupServer(encoding: ServerMessageEncoding) throws {
-    let configuration = Server.Configuration(
-      target: .hostAndPort("localhost", 0),
-      eventLoopGroup: self.group,
-      serviceProviders: [EchoProvider()],
-      messageEncoding: encoding
-    )
-
-    self.server = try Server.start(configuration: configuration).wait()
+    self.server = try Server.insecure(group: self.group)
+      .withServiceProviders([EchoProvider()])
+      .withMessageCompression(encoding)
+      .bind(host: "localhost", port: 0)
+      .wait()
   }
 
   func setupClient(encoding: ClientMessageEncoding) {

--- a/Tests/GRPCTests/GRPCCustomPayloadTests.swift
+++ b/Tests/GRPCTests/GRPCCustomPayloadTests.swift
@@ -28,13 +28,10 @@ class GRPCCustomPayloadTests: GRPCTestCase {
     super.setUp()
     self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 
-    let serverConfig: Server.Configuration = .init(
-      target: .hostAndPort("localhost", 0),
-      eventLoopGroup: self.group,
-      serviceProviders: [CustomPayloadProvider()]
-    )
-
-    self.server = try! Server.start(configuration: serverConfig).wait()
+    self.server = try! Server.insecure(group: self.group)
+      .withServiceProviders([CustomPayloadProvider()])
+      .bind(host: "localhost", port: 0)
+      .wait()
 
     let channel = ClientConnection.insecure(group: self.group)
       .connect(host: "localhost", port: server.channel.localAddress!.port!)

--- a/Tests/GRPCTests/HeaderNormalizationTests.swift
+++ b/Tests/GRPCTests/HeaderNormalizationTests.swift
@@ -93,13 +93,10 @@ class HeaderNormalizationTests: GRPCTestCase {
 
     self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 
-    let serverConfig = Server.Configuration(
-      target: .hostAndPort("localhost", 0),
-      eventLoopGroup: self.group,
-      serviceProviders: [EchoMetadataValidator()]
-    )
-
-    self.server = try! Server.start(configuration: serverConfig).wait()
+    self.server = try! Server.insecure(group: self.group)
+      .withServiceProviders([EchoMetadataValidator()])
+      .bind(host: "localhost", port: 0)
+      .wait()
 
     self.channel = ClientConnection.insecure(group: self.group)
       .connect(host: "localhost", port: self.server.channel.localAddress!.port!)


### PR DESCRIPTION
Motivation:

Configuring a server with err... `Configuration` can be a bit unwieldy
and makes it easy for users to not use TLS. It's also a slight SemVer burden
since we'd want to add a new `init` each time we add a member.

Modifications:

- Add a `Server.Builder`
- Replace existing use of `Server.Configuration` with the builder
- Update docs

Result:

- Server starting API is nicer
- You have to type `insecure` to not use TLS