### PR TITLE
Update CI to point to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,9 +71,9 @@ jobs:
 stages:
   # Always run this stage.
   - name: "Test"
-  # Only run when pushing (or merging) to nio.
+  # Only run when pushing (or merging) to master
   - name: "Interoperability Tests"
-    if: type = push AND branch = nio
+    if: type = push AND branch = master
 
 cache:
   apt: true


### PR DESCRIPTION
Motivation:

The CI only runs the interop tests when pushed to the `nio` branch;
since `master` is the new `nio` we need to update Travis accordingly.

Modifications:

Update the target branch for running interop tests in CI

Result:

Interop tests run when merged to master.