### PR TITLE
Added .git ending for `swift-log`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,7 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.8.0"),
 
     // Logging API.
-    .package(url: "https://github.com/apple/swift-log", from: "1.0.0"),
+    .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
   ],
   targets: [
     // The main GRPC module.


### PR DESCRIPTION
### Motivation

- Xcode doesn't seem smart enough to checkout `swift-log` if it is missing `.git`.
- all other dependencies have a `.git` at the end.

### Changes

- in Package.swift: `swift-log` -> `swift-log.git`