### PR TITLE
Remove required platforms from SPM

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,7 +3,7 @@
     "pins": [
       {
         "package": "swift-log",
-        "repositoryURL": "https://github.com/apple/swift-log",
+        "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
           "revision": "74d7b91ceebc85daf387ebb206003f78813f71aa",
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "16ab4d657e1ad4e77bd5f8b94af8538561643053",
-          "version": "2.14.0"
+          "revision": "a27a07719ca785bcaca019a5b9fe1814b981b4a2",
+          "version": "2.15.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
         "state": {
           "branch": null,
-          "revision": "c1bfb7ce3f201e41ff60ef38fa63e67e0eb66a24",
-          "version": "1.9.0"
+          "revision": "82eb3fa0974b838358ee46bc6c5381e5ae5de6b9",
+          "version": "1.11.0"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "af46d9b58fafbb76f9b01177568d435a1b024f99",
-          "version": "2.6.2"
+          "revision": "584c0d06c46233d3e1759695e5eff495b12edcd2",
+          "version": "2.7.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -19,10 +19,6 @@ import Foundation
 
 let package = Package(
   name: "grpc-swift",
-  platforms: [
-    // We can't use `.watchOS(.v6)` since it isn't available with `swift-tools-version:5.0`.
-    .macOS(.v10_12), .iOS(.v10), .tvOS(.v10), .watchOS("6.0")
-  ],
   products: [
     .library(name: "GRPC", targets: ["GRPC"]),
     .executable(name: "protoc-gen-grpc-swift", targets: ["protoc-gen-grpc-swift"]),

--- a/Sources/GRPC/GRPCError.swift
+++ b/Sources/GRPC/GRPCError.swift
@@ -291,7 +291,7 @@ extension GRPCErrorProtocol {
   internal func captureContext(
       file: StaticString = #file,
       line: Int = #line,
-      function: StaticString = #file
+      function: StaticString = #function
   ) -> GRPCError.WithContext {
     return GRPCError.WithContext(self, file: file, line: line, function: function)
   }


### PR DESCRIPTION
Motivation:

We recently specified which platforms we supported in Package.swift
based on what SwiftNIO supported. These minimum versions recently
decreased making the platform requirement specification in Package.swift
unnecessary.

Modifications:

- Remove platforms from Package.swift
- Fix #file passed to function argument

Result:

- Dependents of gRPC Swift don't require their Package.swift to declare
  their supported platforms