### PR TITLE
Discard excess read bytes in LengthPrefixedMessageReader.

### DIFF
--- a/Tests/GRPCTests/XCTestManifests.swift
+++ b/Tests/GRPCTests/XCTestManifests.swift
@@ -499,6 +499,7 @@ extension LengthPrefixedMessageReaderTests {
     // to regenerate.
     static let __allTests__LengthPrefixedMessageReaderTests = [
         ("testAppendReadsAllBytes", testAppendReadsAllBytes),
+        ("testExcessiveBytesAreDiscarded", testExcessiveBytesAreDiscarded),
         ("testNextMessageDeliveredAcrossMultipleByteBuffers", testNextMessageDeliveredAcrossMultipleByteBuffers),
         ("testNextMessageDoesNotThrowWhenCompressionFlagIsExpectedButNotSet", testNextMessageDoesNotThrowWhenCompressionFlagIsExpectedButNotSet),
         ("testNextMessageReturnsMessageForZeroLengthMessage", testNextMessageReturnsMessageForZeroLengthMessage),


### PR DESCRIPTION
It is possible, in some use-cases, for LengthPrefixedMessageReader to
build up a buffer with loads of "free" space at the front that is not
usable, but that cannot be freed due to incoming messages arriving
sufficiently quickly.

We should, from time to time, try to discard those messages by
compacting the buffer. It's hard to have a good heuristic here, so this
patch represents a first-pass: if there's more than 1kB of usable space
in the buffer that we could free up with compaction, and if that space
is larger than the usable bytes in the buffer, we should try to obtain
it.

This effectively doubles the size of the buffer "for free", which is
what a resizing would do anyway. It also makes a subsequent resizing
cheaper, as we no longer need to copy the leading bytes to preserve the
reader index.

I'm not really sure what the best way to test this is, given that most of the relevant data points are private. I suppose I can add some diagnostic internal properties. Does that sound good to you @glbrntt?

Resolves #779.