### PR TITLE
Suppress #file/#filePath warnings on recent compilers

### DIFF
--- a/Tests/GRPCTests/EventLoopFuture+Assertions.swift
+++ b/Tests/GRPCTests/EventLoopFuture+Assertions.swift
@@ -24,7 +24,7 @@ extension EventLoopFuture where Value: Equatable {
   /// - Parameters:
   ///   - expected: The expected value.
   ///   - expectation: A test expectation to fulfill once the future has completed.
-  func assertEqual(_ expected: Value, fulfill expectation: XCTestExpectation, file: StaticString = #file, line: UInt = #line) {
+  func assertEqual(_ expected: Value, fulfill expectation: XCTestExpectation, file: StaticString = magicFile(), line: UInt = #line) {
     self.whenComplete { result in
       defer {
         expectation.fulfill()
@@ -50,7 +50,7 @@ extension EventLoopFuture {
   /// - Parameters:
   ///   - expectation: A test expectation to fulfill once the future has completed.
   ///   - handler: A block to run additional verification on the error. Defaults to no-op.
-  func assertError(fulfill expectation: XCTestExpectation, file: StaticString = #file, line: UInt = #line, handler: @escaping (Error) -> Void = { _ in }) {
+  func assertError(fulfill expectation: XCTestExpectation, file: StaticString = magicFile(), line: UInt = #line, handler: @escaping (Error) -> Void = { _ in }) {
     self.whenComplete { result in
       defer {
         expectation.fulfill()

--- a/Tests/GRPCTests/FunctionalTests.swift
+++ b/Tests/GRPCTests/FunctionalTests.swift
@@ -137,21 +137,21 @@ class FunctionalTestsInsecureTransport: EchoTestCaseBase {
     XCTAssertNoThrow(try doTestClientStreaming(messages: lotsOfStrings))
   }
 
-  func doTestServerStreaming(messages: [String], file: StaticString = #file, line: UInt = #line) throws {
+  private func doTestServerStreaming(messages: [String], line: UInt = #line) throws {
     let responseExpectation = self.makeResponseExpectation(expectedFulfillmentCount: messages.count)
     let statusExpectation = self.makeStatusExpectation()
 
     var iterator = messages.enumerated().makeIterator()
     let call = client.expand(Echo_EchoRequest(text: messages.joined(separator: " "))) { response in
       if let (index, message) = iterator.next() {
-        XCTAssertEqual(Echo_EchoResponse(text: "Swift echo expand (\(index)): \(message)"), response, file: file, line: line)
+        XCTAssertEqual(Echo_EchoResponse(text: "Swift echo expand (\(index)): \(message)"), response, line: line)
         responseExpectation.fulfill()
       } else {
-        XCTFail("Too many responses received", file: file, line: line)
+        XCTFail("Too many responses received", line: line)
       }
     }
 
-    call.status.map { $0.code }.assertEqual(.ok, fulfill: statusExpectation, file: file, line: line)
+    call.status.map { $0.code }.assertEqual(.ok, fulfill: statusExpectation, line: line)
     self.wait(for: [responseExpectation, statusExpectation], timeout: self.defaultTestTimeout)
   }
 
@@ -165,7 +165,7 @@ class FunctionalTestsInsecureTransport: EchoTestCaseBase {
     XCTAssertNoThrow(try doTestServerStreaming(messages: lotsOfStrings))
   }
 
-  private func doTestBidirectionalStreaming(messages: [String], waitForEachResponse: Bool = false, file: StaticString = #file, line: UInt = #line) throws {
+  private func doTestBidirectionalStreaming(messages: [String], waitForEachResponse: Bool = false, line: UInt = #line) throws {
     let responseExpectation = self.makeResponseExpectation(expectedFulfillmentCount: messages.count)
     let statusExpectation = self.makeStatusExpectation()
 
@@ -174,19 +174,19 @@ class FunctionalTestsInsecureTransport: EchoTestCaseBase {
     var iterator = messages.enumerated().makeIterator()
     let call = client.update { response in
       if let (index, message) = iterator.next() {
-        XCTAssertEqual(Echo_EchoResponse(text: "Swift echo update (\(index)): \(message)"), response, file: file, line: line)
+        XCTAssertEqual(Echo_EchoResponse(text: "Swift echo update (\(index)): \(message)"), response, line: line)
         responseExpectation.fulfill()
         responseReceived?.signal()
       } else {
-        XCTFail("Too many responses received", file: file, line: line)
+        XCTFail("Too many responses received", line: line)
       }
     }
 
-    call.status.map { $0.code }.assertEqual(.ok, fulfill: statusExpectation, file: file, line: line)
+    call.status.map { $0.code }.assertEqual(.ok, fulfill: statusExpectation, line: line)
 
     messages.forEach { part in
       call.sendMessage(Echo_EchoRequest(text: part), promise: nil)
-      XCTAssertNotEqual(responseReceived?.wait(timeout: .now() + .seconds(1)), .some(.timedOut), file: file, line: line)
+      XCTAssertNotEqual(responseReceived?.wait(timeout: .now() + .seconds(1)), .some(.timedOut), line: line)
     }
     call.sendEnd(promise: nil)
 

--- a/Tests/GRPCTests/GRPCInteroperabilityTests.swift
+++ b/Tests/GRPCTests/GRPCInteroperabilityTests.swift
@@ -66,7 +66,7 @@ class GRPCInsecureInteroperabilityTests: GRPCTestCase {
     super.tearDown()
   }
 
-  func doRunTest(_ testCase: InteroperabilityTestCase, file: StaticString = #file, line: UInt = #line) {
+  private func doRunTest(_ testCase: InteroperabilityTestCase, line: UInt = #line) {
     // Does the server support the test?
     let implementedFeatures = TestServiceProvider.implementedFeatures
     let missingFeatures = testCase.requiredServerFeatures.subtracting(implementedFeatures)
@@ -82,7 +82,7 @@ class GRPCInsecureInteroperabilityTests: GRPCTestCase {
     )
     test.configure(builder: builder)
     self.clientConnection = builder.connect(host: "localhost", port: self.serverPort)
-    XCTAssertNoThrow(try test.run(using: self.clientConnection), file: file, line: line)
+    XCTAssertNoThrow(try test.run(using: self.clientConnection), line: line)
   }
 
   func testEmptyUnary() {

--- a/Tests/GRPCTests/GRPCTypeSizeTests.swift
+++ b/Tests/GRPCTests/GRPCTypeSizeTests.swift
@@ -29,8 +29,8 @@ import XCTest
 class GRPCTypeSizeTests: GRPCTestCase {
   let existentialContainerBufferSize = 24
 
-  func checkSize<T>(of: T.Type, file: StaticString = #file, line: UInt = #line) {
-    XCTAssertLessThanOrEqual(MemoryLayout<T>.size, self.existentialContainerBufferSize, file: file, line: line)
+  private func checkSize<T>(of: T.Type, line: UInt = #line) {
+    XCTAssertLessThanOrEqual(MemoryLayout<T>.size, self.existentialContainerBufferSize, line: line)
   }
 
   // `GRPCStatus` isn't wrapped in `NIOAny` but is passed around through functions taking a type

--- a/Tests/GRPCTests/HeaderNormalizationTests.swift
+++ b/Tests/GRPCTests/HeaderNormalizationTests.swift
@@ -24,13 +24,12 @@ import XCTest
 class EchoMetadataValidator: Echo_EchoProvider {
   private func assertCustomMetadataIsLowercased(
     _ headers: HTTPHeaders,
-    file: StaticString = #file,
     line: UInt = #line
   ) {
     // Header lookup is case-insensitive so we need to pull out the values we know the client sent
     // as custom-metadata and then compare a new set of headers.
     let customMetadata = HTTPHeaders(headers.filter { name, value in value == "client" })
-    XCTAssertEqual(customMetadata, ["client": "client"], file: file, line: line)
+    XCTAssertEqual(customMetadata, ["client": "client"], line: line)
   }
 
   func get(

--- a/Tests/GRPCTests/LengthPrefixedMessageReaderTests.swift
+++ b/Tests/GRPCTests/LengthPrefixedMessageReaderTests.swift
@@ -42,18 +42,18 @@ class LengthPrefixedMessageReaderTests: GRPCTestCase {
     ] + twoByteMessage
   }
 
-  func assertMessagesEqual(expected expectedBytes: [UInt8], actual buffer: ByteBuffer?, file: StaticString = #file, line: UInt = #line) {
+  private func assertMessagesEqual(expected expectedBytes: [UInt8], actual buffer: ByteBuffer?, line: UInt = #line) {
     guard let buffer = buffer else {
-      XCTFail("buffer is nil", file: file, line: line)
+      XCTFail("buffer is nil", line: line)
       return
     }
 
     guard let bytes = buffer.getBytes(at: buffer.readerIndex, length: expectedBytes.count) else {
-      XCTFail("Expected \(expectedBytes.count) bytes, but only \(buffer.readableBytes) bytes are readable", file: file, line: line)
+      XCTFail("Expected \(expectedBytes.count) bytes, but only \(buffer.readableBytes) bytes are readable", line: line)
       return
     }
 
-    XCTAssertEqual(expectedBytes, bytes, file: file, line: line)
+    XCTAssertEqual(expectedBytes, bytes, line: line)
   }
 
   func testNextMessageReturnsNilWhenNoBytesAppended() throws {

--- a/Tests/GRPCTests/MagicFile.swift
+++ b/Tests/GRPCTests/MagicFile.swift
@@ -1,0 +1,15 @@
+// SE-0274 renames #file to #filePath so that #file may refer to the name of a file instead of
+// its path. From Swift 5.3+ XCTAssert* accepts #filePath and warns when a #file is passed to it.
+// These functions are used to work around that.
+//
+// https://github.com/apple/swift-evolution/blob/master/proposals/0274-magic-file.md
+
+#if swift(>=5.3)
+func magicFile(file: StaticString = #filePath) -> StaticString {
+    return file
+}
+#else
+func magicFile(file: StaticString = #file) -> StaticString {
+    return file
+}
+#endif

--- a/Tests/GRPCTests/MagicFile.swift
+++ b/Tests/GRPCTests/MagicFile.swift
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // SE-0274 renames #file to #filePath so that #file may refer to the name of a file instead of
 // its path. From Swift 5.3+ XCTAssert* accepts #filePath and warns when a #file is passed to it.
 // These functions are used to work around that.

--- a/Tests/GRPCTests/SampleCertificate+Assertions.swift
+++ b/Tests/GRPCTests/SampleCertificate+Assertions.swift
@@ -18,7 +18,7 @@ import XCTest
 import GRPCSampleData
 
 extension SampleCertificate {
-  func assertNotExpired(file: StaticString = #file, line: UInt = #line) {
+  func assertNotExpired(file: StaticString = magicFile(), line: UInt = #line) {
     XCTAssertFalse(self.isExpired, "Certificate expired at \(self.notAfter)", file: file, line: line)
   }
 }

--- a/Tests/GRPCTests/ServerWebTests.swift
+++ b/Tests/GRPCTests/ServerWebTests.swift
@@ -63,7 +63,7 @@ class ServerWebTests: EchoTestCaseBase {
       handler(data, error)
       sem.signal()
     }.resume()
-    _ = sem.wait()
+    sem.wait()
   }
 }
 


### PR DESCRIPTION
Motivation:

Newer compilers warn when a `#file` is passed where a `#filePath` is
expected, such as in `XCTAssert*`.

Modifications:

- Remove use of `#file` for helpers which are private to a file
- Add a `magicFile()` which does the right thing based on Swift version

Result:

No warnings on recent compilers