### PR TITLE
Make HTTP/2 flow control window size configurable for clients and servers

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
         "state": {
           "branch": null,
-          "revision": "82eb3fa0974b838358ee46bc6c5381e5ae5de6b9",
-          "version": "1.11.0"
+          "revision": "c8f952dbc37fe60def17eb15e2c90787ce6ee78a",
+          "version": "1.12.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
     // Main SwiftNIO package
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.14.0"),
     // HTTP2 via SwiftNIO
-    .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.8.0"),
+    .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.12.1"),
     // TLS via SwiftNIO
     .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.6.2"),
     // Support for Network.framework where possible.

--- a/Sources/GRPC/ClientConnection.swift
+++ b/Sources/GRPC/ClientConnection.swift
@@ -240,6 +240,9 @@ extension ClientConnection {
     /// The connection backoff configuration. If no connection retrying is required then this should
     /// be `nil`.
     public var connectionBackoff: ConnectionBackoff?
+    
+    ///The HTTP/2 flow control target window size.
+    public var httpTargetWindowSize: Int
 
     /// The HTTP protocol used for this connection.
     public var httpProtocol: HTTP2ToHTTP1ClientCodec.HTTPProtocol {
@@ -258,13 +261,15 @@ extension ClientConnection {
     /// - Parameter tlsConfiguration: TLS configuration, defaulting to `nil`.
     /// - Parameter connectionBackoff: The connection backoff configuration to use.
     /// - Parameter messageEncoding: Message compression configuration, defaults to no compression.
+    /// - Parameter targetWindowSize: The HTTP/2 flow control target window size.
     public init(
       target: ConnectionTarget,
       eventLoopGroup: EventLoopGroup,
       errorDelegate: ClientErrorDelegate? = LoggingClientErrorDelegate(),
       connectivityStateDelegate: ConnectivityStateDelegate? = nil,
       tls: Configuration.TLS? = nil,
-      connectionBackoff: ConnectionBackoff? = ConnectionBackoff()
+      connectionBackoff: ConnectionBackoff? = ConnectionBackoff(),
+      httpTargetWindowSize: Int = 65535
     ) {
       self.target = target
       self.eventLoopGroup = eventLoopGroup
@@ -272,6 +277,7 @@ extension ClientConnection {
       self.connectivityStateDelegate = connectivityStateDelegate
       self.tls = tls
       self.connectionBackoff = connectionBackoff
+      self.httpTargetWindowSize = httpTargetWindowSize
     }
   }
 }
@@ -324,6 +330,7 @@ extension Channel {
   }
 
   func configureGRPCClient(
+    httpTargetWindowSize: Int,
     tlsConfiguration: TLSConfiguration?,
     tlsServerHostname: String?,
     connectionManager: ConnectionManager,
@@ -335,7 +342,7 @@ extension Channel {
     }
 
     return (tlsConfigured ?? self.eventLoop.makeSucceededFuture(())).flatMap {
-      self.configureHTTP2Pipeline(mode: .client)
+      self.configureHTTP2Pipeline(mode: .client, targetWindowSize: httpTargetWindowSize)
     }.flatMap { _ in
       return self.pipeline.handler(type: NIOHTTP2Handler.self).flatMap { http2Handler in
         self.pipeline.addHandler(

--- a/Sources/GRPC/ClientConnection.swift
+++ b/Sources/GRPC/ClientConnection.swift
@@ -241,7 +241,7 @@ extension ClientConnection {
     /// be `nil`.
     public var connectionBackoff: ConnectionBackoff?
     
-    ///The HTTP/2 flow control target window size.
+    /// The HTTP/2 flow control target window size.
     public var httpTargetWindowSize: Int
 
     /// The HTTP protocol used for this connection.

--- a/Sources/GRPC/ConnectionManager.swift
+++ b/Sources/GRPC/ConnectionManager.swift
@@ -555,6 +555,7 @@ extension ConnectionManager {
       .channelOption(ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
       .channelInitializer { channel in
         channel.configureGRPCClient(
+          httpTargetWindowSize: configuration.httpTargetWindowSize,
           tlsConfiguration: configuration.tls?.configuration,
           tlsServerHostname: serverHostname,
           connectionManager: self,

--- a/Sources/GRPC/GRPCChannel/GRPCChannelBuilder.swift
+++ b/Sources/GRPC/GRPCChannel/GRPCChannelBuilder.swift
@@ -36,6 +36,7 @@ extension ClientConnection {
     private var connectionBackoffIsEnabled = true
     private var errorDelegate: ClientErrorDelegate?
     private var connectivityStateDelegate: ConnectivityStateDelegate?
+    private var httpTargetWindowSize: Int = 65535
 
     fileprivate init(group: EventLoopGroup) {
       self.group = group
@@ -48,7 +49,8 @@ extension ClientConnection {
         errorDelegate: self.errorDelegate,
         connectivityStateDelegate: self.connectivityStateDelegate,
         tls: self.maybeTLS,
-        connectionBackoff: self.connectionBackoffIsEnabled ? self.connectionBackoff : nil
+        connectionBackoff: self.connectionBackoffIsEnabled ? self.connectionBackoff : nil,
+        httpTargetWindowSize: self.httpTargetWindowSize
       )
       return ClientConnection(configuration: configuration)
     }
@@ -191,6 +193,15 @@ extension ClientConnection.Builder.Secure {
   @discardableResult
   public func withTLS(trustRoots: NIOSSLTrustRoots) -> Self {
     self.tls.trustRoots = trustRoots
+    return self
+  }
+}
+
+extension ClientConnection.Builder {
+  /// Sets the HTTP/2 flow control target window size. Defaults to 65,535 if not explicitly set.
+  @discardableResult
+  public func withHTTPTargetWindowSize(_ httpTargetWindowSize: Int) -> Self {
+    self.httpTargetWindowSize = httpTargetWindowSize
     return self
   }
 }

--- a/Sources/GRPC/Server.swift
+++ b/Sources/GRPC/Server.swift
@@ -99,7 +99,10 @@ public final class Server {
       .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
       // Set the handlers that are applied to the accepted Channels
       .childChannelInitializer { channel in
-        let protocolSwitcher = HTTPProtocolSwitcher(errorDelegate: configuration.errorDelegate) { channel -> EventLoopFuture<Void> in
+        let protocolSwitcher = HTTPProtocolSwitcher(
+          errorDelegate: configuration.errorDelegate,
+          httpTargetWindowSize: configuration.httpTargetWindowSize
+        ) { channel -> EventLoopFuture<Void> in
           let logger = Logger(subsystem: .serverChannelCall, metadata: [MetadataKey.requestID: "\(UUID())"])
           let handler = GRPCServerRequestRoutingHandler(
             servicesByName: configuration.serviceProvidersByName,
@@ -173,7 +176,7 @@ extension Server {
   public struct Configuration {
     /// The target to bind to.
     public var target: BindTarget
-
+    
     /// The event loop group to run the connection on.
     public var eventLoopGroup: EventLoopGroup
 
@@ -196,6 +199,9 @@ extension Server {
     /// streaming and bidirectional streaming RPCs) by passing setting `compression` to `.disabled`
     /// in `sendResponse(_:compression)`.
     public var messageEncoding: ServerMessageEncoding
+    
+    /// The HTTP/2 flow control target window size.
+    public var httpTargetWindowSize: Int
 
     /// Create a `Configuration` with some pre-defined defaults.
     ///
@@ -212,7 +218,8 @@ extension Server {
       serviceProviders: [CallHandlerProvider],
       errorDelegate: ServerErrorDelegate? = LoggingServerErrorDelegate.shared,
       tls: TLS? = nil,
-      messageEncoding: ServerMessageEncoding = .disabled
+      messageEncoding: ServerMessageEncoding = .disabled,
+      httpTargetWindowSize: Int = 65535
     ) {
       self.target = target
       self.eventLoopGroup = eventLoopGroup
@@ -220,6 +227,7 @@ extension Server {
       self.errorDelegate = errorDelegate
       self.tls = tls
       self.messageEncoding = messageEncoding
+      self.httpTargetWindowSize = httpTargetWindowSize
     }
   }
 }

--- a/Sources/GRPC/Server.swift
+++ b/Sources/GRPC/Server.swift
@@ -176,7 +176,6 @@ extension Server {
   public struct Configuration {
     /// The target to bind to.
     public var target: BindTarget
-    
     /// The event loop group to run the connection on.
     public var eventLoopGroup: EventLoopGroup
 

--- a/Sources/GRPC/ServerBuilder.swift
+++ b/Sources/GRPC/ServerBuilder.swift
@@ -23,6 +23,7 @@ extension Server {
     private var providers: [CallHandlerProvider] = []
     private var errorDelegate: ServerErrorDelegate?
     private var messageEncoding: ServerMessageEncoding = .disabled
+    private var httpTargetWindowSize: Int = 65535
 
     fileprivate init(group: EventLoopGroup) {
       self.group = group
@@ -50,7 +51,8 @@ extension Server {
         serviceProviders: self.providers,
         errorDelegate: self.errorDelegate,
         tls: self.maybeTLS,
-        messageEncoding: self.messageEncoding
+        messageEncoding: self.messageEncoding,
+        httpTargetWindowSize: self.httpTargetWindowSize
       )
       return Server.start(configuration: configuration)
     }
@@ -98,6 +100,15 @@ extension Server.Builder.Secure {
   @discardableResult
   public func withTLS(certificateVerification: CertificateVerification) -> Self {
     self.tls.certificateVerification = certificateVerification
+    return self
+  }
+}
+
+extension Server.Builder {
+  /// Sets the HTTP/2 flow control target window size.
+  @discardableResult
+  public func withHttpTargetWindowSize(_ httpTargetWindowSize: Int) -> Self {
+    self.httpTargetWindowSize = httpTargetWindowSize
     return self
   }
 }

--- a/Sources/GRPC/ServerBuilder.swift
+++ b/Sources/GRPC/ServerBuilder.swift
@@ -105,9 +105,9 @@ extension Server.Builder.Secure {
 }
 
 extension Server.Builder {
-  /// Sets the HTTP/2 flow control target window size.
+  /// Sets the HTTP/2 flow control target window size. Defaults to 65,535 if not explicitly set.
   @discardableResult
-  public func withHttpTargetWindowSize(_ httpTargetWindowSize: Int) -> Self {
+  public func withHTTPTargetWindowSize(_ httpTargetWindowSize: Int) -> Self {
     self.httpTargetWindowSize = httpTargetWindowSize
     return self
   }


### PR DESCRIPTION
Make HTTP/2 flow control target window size configurable in a client or server HTTP2 connection. 
Motivation:

Higher streaming thruput between server and client is available by the either specifying a HTTP/2 flow control window size higher than the initial value of 2^16-1. The target value needs to be passed either using `SETTINGS_INITIAL_WINDOW_SIZE` in the connection preface, or via a `WINDOW_UPDATE`. As implemented here, the `HTTP2FlowControlWindow` passes the value configured in a `windowUpdate`.

Modifications:

For the client:
Added property `targetWindowSize` to `ClientConnection.Configuration`.
In the existing `ClientConnection.Configuration.init`, sets the new `targetWindowSize` property to the initial flow-control window size (65535).
Duplicated `ClientConnection.Configuration.init` and added a `targetWindowSize` arg.
Added property and setter for `targetWindowSize` to `ClientConnection.Builder`.
During client bootstrap, pass `configuration.targetWindowSize` to the channel initializer.
Duplicated channel initializer `configureGRPCClient` and added a `targetWindowSize` arg.
Duplicated all tests that directly invoke the original `ClientConnection.Configuration.init` to explicitly pass `targetWindowSize`to the new initializer.

For the server:
Added property `httpTargetWindowSize` to `Server.Configuration`.
In `Server.Configuration.init`, added httpTargetWindowSize arg with default value 2^16-1.
Added property and setter for `httpTargetWindowSize` to `Server.Builder`.
During server bootstrap in `Server.start`, pass `configuration.httpTargetWindowSize` to the `HTTPProtocolSwitcher`.
Configure http/2 flow control target window size on the http2 pipeline in `HTTPProxySwitcher`.
Result:

One can build a `ClientConnection` or `Server`with a target window size value that is configured via a WINDOW_UPDATE after the connection is established.