### PR TITLE
Update build_podspecs script and re-run

### DIFF
--- a/CGRPCZlib.podspec
+++ b/CGRPCZlib.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
     s.name = 'CGRPCZlib'
     s.module_name = 'CGRPCZlib'
-    s.version = '1.0.0-alpha.11'
+    s.version = '1.0.0-alpha.12'
     s.license = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.summary = 'Compression library that provides in-memory compression and decompression functions'
     s.homepage = 'https://www.grpc.io'
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
 
     s.swift_version = '5.0'
     s.ios.deployment_target = '10.0'
-    s.osx.deployment_target = '10.10'
+    s.osx.deployment_target = '10.12'
     s.tvos.deployment_target = '10.0'
     s.source_files = 'Sources/CGRPCZlib/**/*.{swift,c,h}'
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ necessary targets:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/grpc/grpc-swift.git", from: "1.0.0-alpha.11")
+  .package(url: "https://github.com/grpc/grpc-swift.git", from: "1.0.0-alpha.12")
 ]
 ```
 
@@ -85,7 +85,7 @@ Alternatively, gRPC Swift can be manually integrated into a project:
 gRPC Swift is currently available [from CocoaPods](https://cocoapods.org/pods/gRPC-Swift).
 To integrate, add the following line to your `Podfile`:
 ```ruby
-    pod 'gRPC-Swift', '1.0.0-alpha.11'
+    pod 'gRPC-Swift', '1.0.0-alpha.12'
 ```
 
 Then, run `pod install` from command line and use your project's generated

--- a/gRPC-Swift.podspec
+++ b/gRPC-Swift.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
     s.name = 'gRPC-Swift'
     s.module_name = 'GRPC'
-    s.version = '1.0.0-alpha.11'
+    s.version = '1.0.0-alpha.12'
     s.license = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.summary = 'Swift gRPC code generator plugin and runtime library'
     s.homepage = 'https://www.grpc.io'
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
 
     s.swift_version = '5.0'
     s.ios.deployment_target = '10.0'
-    s.osx.deployment_target = '10.10'
+    s.osx.deployment_target = '10.12'
     s.tvos.deployment_target = '10.0'
     s.source_files = 'Sources/GRPC/**/*.{swift,c,h}'
 

--- a/scripts/build_podspecs.py
+++ b/scripts/build_podspecs.py
@@ -89,7 +89,7 @@ class Pod:
         podspec += "    s.swift_version = '5.0'\n"
 
         podspec += "    s.ios.deployment_target = '10.0'\n"
-        podspec += "    s.osx.deployment_target = '10.10'\n"
+        podspec += "    s.osx.deployment_target = '10.12'\n"
         podspec += "    s.tvos.deployment_target = '10.0'\n"
 
         podspec += "    s.source_files = 'Sources/%s/**/*.{swift,c,h}'\n" % (self.module_name)
@@ -122,16 +122,16 @@ class PodManager:
 
     def build_pods(self):
         cgrpczlib_pod = Pod(
-            'CGRPCZlib', 
-            'CGRPCZlib', 
+            'CGRPCZlib',
+            'CGRPCZlib',
             self.version,
             'Compression library that provides in-memory compression and decompression functions'
         )
 
         grpc_pod = Pod(
-            'gRPC-Swift', 
-            'GRPC', 
-            self.version, 
+            'gRPC-Swift',
+            'GRPC',
+            self.version,
             'Swift gRPC code generator plugin and runtime library',
             get_grpc_deps()
         )


### PR DESCRIPTION
Motivation:

- NIO{SSL,HTTP2,TS} only support macOS 10.12+, our script for building
  podspecs set the macOS deployment target to 10.10. This is
  problematic!

Modifications:

- Change macOS deployment target version in build_podspecs
- Run build_podspecs for 1.0.0-alpha.12

Result:

Fewer pod problems...