### PR TITLE
grpc-swift: generate only requested files

### DIFF
--- a/Sources/protoc-gen-grpc-swift/main.swift
+++ b/Sources/protoc-gen-grpc-swift/main.swift
@@ -108,7 +108,8 @@ func main() throws {
 
   // process each .proto file in filename order in an attempt to stabilise the output (i.e. where
   // conformance to `GRPCPayload` is generated)
-  for fileDescriptor in descriptorSet.files.sorted(by: { $0.name < $1.name }) {
+  for name in request.fileToGenerate.sorted() {
+    let fileDescriptor = descriptorSet.lookupFileDescriptor(protoName: name)
     if fileDescriptor.services.count > 0 {
       let grpcFileName = uniqueOutputFileName(component: "grpc", fileDescriptor: fileDescriptor, fileNamingOption: options.fileNaming)
       let grpcGenerator = Generator(fileDescriptor, options: options, observedMessages: observedMessages)


### PR DESCRIPTION
When trying to generate a `.proto` file the plugin is generating classes for all the dependencies. But according to the [doc](https://github.com/apple/swift-protobuf/blob/1f064e1f6c23f2855dfac403e76c52826d40258a/Sources/SwiftProtobufPluginLibrary/plugin.pb.swift#L132) it should only generate the protos listed in `filesToGenerate` 

Steps to reproduce:

a.proto
```proto
syntax = "proto3";

package a;

import "b.proto";

message MessageA {
  string name = 1;
}
service ServiceA {
  rpc SendMessageA ( MessageA ) returns ( b.MessageB );
}
```

b.proto
```proto
syntax = "proto3";

package b;

import "google/protobuf/empty.proto";

message MessageB {
  string name = 1;
}

service ServiceB {
  rpc SendMessageB ( MessageB ) returns ( google.protobuf.Empty );
}
```
Run: `protoc -I ./ --plugin=protoc-gen-grpc-swift=./protoc-gen-grpc-swift --grpc-swift_out=./out a.proto`.
Expected result: `a.grpc.swift` is generated.
Actual result: `a.grpc.swift` and `b.grpc.swift` are generated.

This PR uses `request.fileToGenerate`