### PR TITLE
Fix up test using connectivity state delegate

### DIFF
--- a/Tests/GRPCTests/ConnectionManagerTests.swift
+++ b/Tests/GRPCTests/ConnectionManagerTests.swift
@@ -619,7 +619,7 @@ extension ConnectionManagerTests {
   }
 }
 
-private struct Change: Hashable, CustomStringConvertible {
+internal struct Change: Hashable, CustomStringConvertible {
   var from: ConnectivityState
   var to: ConnectivityState
 
@@ -628,7 +628,7 @@ private struct Change: Hashable, CustomStringConvertible {
   }
 }
 
-private class RecordingConnectivityDelegate: ConnectivityStateDelegate {
+internal class RecordingConnectivityDelegate: ConnectivityStateDelegate {
   private let serialQueue = DispatchQueue(label: "io.grpc.testing")
   private let semaphore = DispatchSemaphore(value: 0)
 


### PR DESCRIPTION
Motivation:

We recently switched to calling connectivity state delegates from
DispatchQueue; some tests weren't updated in light of this change.

Modifications:

- Replace usage of `ConnectivityStateCollectionDelegate` with
  `RecordingConnectivityDelegate`

Result:

Less flaky tests