### PR TITLE
Add a server-idle handler

### DIFF
--- a/Sources/GRPC/ClientConnection.swift
+++ b/Sources/GRPC/ClientConnection.swift
@@ -339,7 +339,7 @@ extension Channel {
     }.flatMap { _ in
       return self.pipeline.handler(type: NIOHTTP2Handler.self).flatMap { http2Handler in
         self.pipeline.addHandler(
-          ClientConnectivityHandler(connectionManager: connectionManager),
+          GRPCIdleHandler(mode: .client(connectionManager)),
           position: .after(http2Handler)
         )
       }.flatMap {

--- a/Tests/GRPCTests/ConnectionManagerTests.swift
+++ b/Tests/GRPCTests/ConnectionManagerTests.swift
@@ -116,7 +116,7 @@ extension ConnectionManagerTests {
 
     // Setup the real channel and activate it.
     let channel = EmbeddedChannel(
-      handler: ClientConnectivityHandler(connectionManager: manager),
+      handler: GRPCIdleHandler(mode: .client(manager)),
       loop: self.loop
     )
     channelPromise.succeed(channel)
@@ -150,7 +150,7 @@ extension ConnectionManagerTests {
 
     // Setup the channel.
     let channel = EmbeddedChannel(
-      handler: ClientConnectivityHandler(connectionManager: manager),
+      handler: GRPCIdleHandler(mode: .client(manager)),
       loop: self.loop
     )
     channelPromise.succeed(channel)
@@ -193,7 +193,7 @@ extension ConnectionManagerTests {
 
     // Setup the channel.
     let channel = EmbeddedChannel(
-      handler: ClientConnectivityHandler(connectionManager: manager),
+      handler: GRPCIdleHandler(mode: .client(manager)),
       loop: self.loop
     )
     channelPromise.succeed(channel)
@@ -249,7 +249,7 @@ extension ConnectionManagerTests {
 
     // Setup the channel.
     let channel = EmbeddedChannel(
-      handler: ClientConnectivityHandler(connectionManager: manager),
+      handler: GRPCIdleHandler(mode: .client(manager)),
       loop: self.loop
     )
     channelPromise.succeed(channel)
@@ -305,7 +305,7 @@ extension ConnectionManagerTests {
 
     // Setup the actual channel and complete the promise.
     let channel = EmbeddedChannel(
-      handler: ClientConnectivityHandler(connectionManager: manager),
+      handler: GRPCIdleHandler(mode: .client(manager)),
       loop: self.loop
     )
     channelPromise.succeed(channel)
@@ -401,7 +401,7 @@ extension ConnectionManagerTests {
 
     // Prepare the channel
     let channel = EmbeddedChannel(
-      handler: ClientConnectivityHandler(connectionManager: manager),
+      handler: GRPCIdleHandler(mode: .client(manager)),
       loop: self.loop
     )
     channelPromise.succeed(channel)
@@ -461,7 +461,7 @@ extension ConnectionManagerTests {
 
     // Prepare the channel
     let firstChannel = EmbeddedChannel(
-      handler: ClientConnectivityHandler(connectionManager: manager),
+      handler: GRPCIdleHandler(mode: .client(manager)),
       loop: self.loop
     )
     channelPromise.succeed(firstChannel)
@@ -521,7 +521,7 @@ extension ConnectionManagerTests {
 
     // Prepare the first channel
     let firstChannel = EmbeddedChannel(
-      handler: ClientConnectivityHandler(connectionManager: manager),
+      handler: GRPCIdleHandler(mode: .client(manager)),
       loop: self.loop
     )
     firstChannelPromise.succeed(firstChannel)
@@ -548,7 +548,7 @@ extension ConnectionManagerTests {
 
     // Prepare the second channel
     let secondChannel = EmbeddedChannel(
-      handler: ClientConnectivityHandler(connectionManager: manager),
+      handler: GRPCIdleHandler(mode: .client(manager)),
       loop: self.loop
     )
     secondChannelPromise.succeed(secondChannel)
@@ -582,7 +582,7 @@ extension ConnectionManagerTests {
 
     // Setup the channel.
     let channel = EmbeddedChannel(
-      handler: ClientConnectivityHandler(connectionManager: manager),
+      handler: GRPCIdleHandler(mode: .client(manager)),
       loop: self.loop
     )
     channelPromise.succeed(channel)


### PR DESCRIPTION
Motivation:

Connections should be dropped to save resources if there are not RPCs
for an idle timeout. This was added for clients in #798; this adds
similart functionality to the server.

Modifications:

- Add a `GRPCServerIdleHandler` to drop connections after 5 minutes of
  no RPCs

Note: timeout configuration will be added for client and server in a
followup PR.

Result:

- Server's will drop connections if the client isn't doing anything.
- Resolves #706