### PR TITLE
workaround SR-12939

### DIFF
--- a/Sources/CGRPCZlib/empty.c
+++ b/Sources/CGRPCZlib/empty.c
@@ -13,3 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// Xcode's Archive builds with Xcode's Package support struggle with empty .c files
+// (https://bugs.swift.org/browse/SR-12939).
+void CGRPCZlib_i_do_nothing_just_working_around_a_darwin_toolchain_bug(void) {}


### PR DESCRIPTION
Motivation:

Xcode's Archive builds hit https://bugs.swift.org/browse/SR-12939 when encountering completely empty `.o` files.

Modification:

Add a useless symbol.

Result:

Fewer build failures.