### PR TITLE
Cache CI dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,8 +77,8 @@ stages:
 cache:
   apt: true
   directories:
-    - .build
     - $HOME/bin_cache
+    - $HOME/zip_cache
 
 addons:
   apt:


### PR DESCRIPTION
Motivation:

The CI quite often fails because we get rate limited when downloading
protobuf from GitHub. Let's try sticking it in the Travis cache; it
still has to be downloaded from there but hopefully we won't get rate
limited.

Modifications:

- Cache protobuf
- Remove .build cache (the cache is currently *huge* and fetching this probably
  slows things down)

Result:

- Maybe fewer CI failures?