### PR TITLE
Updated Dependencies to use latest

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "a27a07719ca785bcaca019a5b9fe1814b981b4a2",
-          "version": "2.15.0"
+          "revision": "120acb15c39aa3217e9888e515de160378fbcc1e",
+          "version": "2.18.0"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "ae213938e151964aa691f0e902462fbe06baeeb6",
-          "version": "2.7.1"
+          "revision": "9cb641037babeda5031b6ee6078d579c86fd67cb",
+          "version": "2.7.4"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
         "state": {
           "branch": null,
-          "revision": "c7f06384dc5ce7e8506de5ed9b59e35b4d88c64b",
-          "version": "1.3.0"
+          "revision": "2ac8fde712c1b1a147ecb7065824a40d2c09d0cb",
+          "version": "1.6.0"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/apple/swift-protobuf.git",
         "state": {
           "branch": null,
-          "revision": "7790acf0a81d08429cb20375bf42a8c7d279c5fe",
-          "version": "1.8.0"
+          "revision": "7f36441e3372665b1b414f8ac93b5905cc42a405",
+          "version": "1.9.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -27,19 +27,19 @@ let package = Package(
   dependencies: [
     // GRPC dependencies:
     // Main SwiftNIO package
-    .package(url: "https://github.com/apple/swift-nio.git", from: "2.14.0"),
+    .package(url: "https://github.com/apple/swift-nio.git", from: "2.18.0"),
     // HTTP2 via SwiftNIO
     .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.12.1"),
     // TLS via SwiftNIO
-    .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.6.2"),
+    .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.7.4"),
     // Support for Network.framework where possible.
-    .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.3.0"),
+    .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.6.0"),
 
     // Official SwiftProtobuf library, for [de]serializing data to send on the wire.
-    .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.8.0"),
+    .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.9.0"),
 
     // Logging API.
-    .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
+    .package(url: "https://github.com/apple/swift-log.git", from: "1.2.0"),
   ],
   targets: [
     // The main GRPC module.

--- a/gRPC-Swift.podspec
+++ b/gRPC-Swift.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
     s.name = 'gRPC-Swift'
     s.module_name = 'GRPC'
-    s.version = '1.0.0-alpha.12'
+    s.version = '1.0.0-alpha.13'
     s.license = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.summary = 'Swift gRPC code generator plugin and runtime library'
     s.homepage = 'https://www.grpc.io'
@@ -17,11 +17,11 @@ Pod::Spec.new do |s|
     s.source_files = 'Sources/GRPC/**/*.{swift,c,h}'
 
     s.dependency 'Logging', '1.2.0'
-    s.dependency 'SwiftNIO', '2.15.0'
-    s.dependency 'SwiftNIOHTTP2', '1.11.0'
-    s.dependency 'SwiftNIOSSL', '2.7.1'
-    s.dependency 'SwiftNIOTransportServices', '1.3.0'
-    s.dependency 'SwiftProtobuf', '1.8.0'
+    s.dependency 'SwiftNIO', '2.18.0'
+    s.dependency 'SwiftNIOHTTP2', '1.12.1'
+    s.dependency 'SwiftNIOSSL', '2.7.4'
+    s.dependency 'SwiftNIOTransportServices', '1.6.0'
+    s.dependency 'SwiftProtobuf', '1.9.0'
     s.dependency 'CGRPCZlib', s.version.to_s
 
 end


### PR DESCRIPTION
This also adds the workaround in https://github.com/grpc/grpc-swift/issues/822 