### PR TITLE
Update dependencies, rebuild .podspec files

### DIFF
--- a/CGRPCZlib.podspec
+++ b/CGRPCZlib.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
     s.name = 'CGRPCZlib'
     s.module_name = 'CGRPCZlib'
-    s.version = '1.0.0-alpha.13'
+    s.version = '1.0.0-alpha.14'
     s.license = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.summary = 'Compression library that provides in-memory compression and decompression functions'
     s.homepage = 'https://www.grpc.io'

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
         "state": {
           "branch": null,
-          "revision": "c8f952dbc37fe60def17eb15e2c90787ce6ee78a",
-          "version": "1.12.1"
+          "revision": "c5d10f4165128c3d0cc0e3c0f0a8ef55947a73a6",
+          "version": "1.12.2"
         }
       },
       {

--- a/gRPC-Swift.podspec
+++ b/gRPC-Swift.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
     s.name = 'gRPC-Swift'
     s.module_name = 'GRPC'
-    s.version = '1.0.0-alpha.13'
+    s.version = '1.0.0-alpha.14'
     s.license = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.summary = 'Swift gRPC code generator plugin and runtime library'
     s.homepage = 'https://www.grpc.io'
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
 
     s.dependency 'Logging', '>= 1.2.0', '< 2'
     s.dependency 'SwiftNIO', '>= 2.18.0', '< 3'
-    s.dependency 'SwiftNIOHTTP2', '>= 1.12.1', '< 2'
+    s.dependency 'SwiftNIOHTTP2', '>= 1.12.2', '< 2'
     s.dependency 'SwiftNIOSSL', '>= 2.7.4', '< 3'
     s.dependency 'SwiftNIOTransportServices', '>= 1.6.0', '< 2'
     s.dependency 'SwiftProtobuf', '>= 1.9.0', '< 2'


### PR DESCRIPTION
Motivation:

Our podspec building script relies on Package.resolved, and NIOHTTP2
shipped a podspec fix in 1.12.2; we need pull in that fix to release an
update podspec.

Modifications:

- Update Package.resolved
- Regenerate our .podspec files

Result:

The built podspec is has the right dependencies. Hopefully.