### PR TITLE
Add default user-agent to header if customMetadata doesn't have one

### DIFF
--- a/Sources/GRPC/GRPCClientStateMachine.swift
+++ b/Sources/GRPC/GRPCClientStateMachine.swift
@@ -519,7 +519,6 @@ extension GRPCClientStateMachine.State {
       ":scheme": scheme,
       "content-type": "application/grpc",
       "te": "trailers",  // Used to detect incompatible proxies, part of the gRPC specification.
-      "user-agent": "grpc-swift-nio",  //  TODO: Add a more specific user-agent.
     ]
 
     switch compression {
@@ -548,6 +547,11 @@ extension GRPCClientStateMachine.State {
     headers.add(contentsOf: customMetadata.map { (name, value, indexing) in
       return (name.lowercased(), value, indexing)
     })
+
+    // Add default user-agent value, if `customMetadata` didn't contain user-agent
+    if headers["user-agent"].isEmpty {
+      headers.add(name: "user-agent", value: "grpc-swift-nio")  // TODO: Add a more specific user-agent.
+    }
 
     return headers
   }

--- a/Tests/GRPCTests/GRPCClientStateMachineTests.swift
+++ b/Tests/GRPCTests/GRPCClientStateMachineTests.swift
@@ -716,6 +716,25 @@ extension GRPCClientStateMachineTests {
     }
   }
 
+  func testSendRequestHeadersWithCustomUserAgent() throws {
+    let customMetadata: HPACKHeaders = [
+      "user-agent": "test-user-agent"
+    ]
+
+    var stateMachine = self.makeStateMachine(.clientIdleServerIdle(pendingWriteState: .one(), readArity: .one))
+    stateMachine.sendRequestHeaders(requestHead: .init(
+      method: "POST",
+      scheme: "http",
+      path: "/echo/Get",
+      host: "localhost",
+      deadline: .distantFuture,
+      customMetadata: customMetadata,
+      encoding: .enabled(.init(forRequests: nil, acceptableForResponses: [], decompressionLimit: .ratio(10)))
+    )).assertSuccess { headers in
+      XCTAssertEqual(headers["user-agent"], ["test-user-agent"])
+    }
+  }
+
   func testSendRequestHeadersWithNoCompressionInEitherDirection() throws {
     var stateMachine = self.makeStateMachine(.clientIdleServerIdle(pendingWriteState: .one(), readArity: .one))
     stateMachine.sendRequestHeaders(requestHead: .init(

--- a/Tests/GRPCTests/XCTestManifests.swift
+++ b/Tests/GRPCTests/XCTestManifests.swift
@@ -348,6 +348,7 @@ extension GRPCClientStateMachineTests {
         ("testSendRequestHeadersFromClosed", testSendRequestHeadersFromClosed),
         ("testSendRequestHeadersFromIdle", testSendRequestHeadersFromIdle),
         ("testSendRequestHeadersNormalizesCustomMetadata", testSendRequestHeadersNormalizesCustomMetadata),
+        ("testSendRequestHeadersWithCustomUserAgent", testSendRequestHeadersWithCustomUserAgent),
         ("testSendRequestHeadersWithNoCompressionForRequests", testSendRequestHeadersWithNoCompressionForRequests),
         ("testSendRequestHeadersWithNoCompressionForResponses", testSendRequestHeadersWithNoCompressionForResponses),
         ("testSendRequestHeadersWithNoCompressionInEitherDirection", testSendRequestHeadersWithNoCompressionInEitherDirection),


### PR DESCRIPTION
This pull request adds a userAgent option to CallOptions struct. It makes clients possible to request with customized user-agent to the gRPC servers which require the particular format of user-agent. 

Currently it partially supports customize user-agent by setting `customMetadata` with "user-agent" key but it always produces string starts with "grpc-swift-nio, ". 

In a project I belong to have a log parser that requires a particular user-agent and couldn't accept string having that prefix. I think other gRPC clients can be set custom user-agent so that it's also useful for grpc-swift.