### PR TITLE
Stop sending requests in call init

### DIFF
--- a/Sources/GRPC/ClientCalls/BidirectionalStreamingCall.swift
+++ b/Sources/GRPC/ClientCalls/BidirectionalStreamingCall.swift
@@ -26,7 +26,7 @@ public final class BidirectionalStreamingCall<
   RequestPayload: GRPCPayload,
   ResponsePayload: GRPCPayload
 >: StreamingRequestClientCall {
-  private let transport: ChannelTransport<RequestPayload, ResponsePayload>
+  internal let transport: ChannelTransport<RequestPayload, ResponsePayload>
 
   /// The options used to make the RPC.
   public let options: CallOptions
@@ -134,40 +134,33 @@ public final class BidirectionalStreamingCall<
   }
 
   internal init(
-    path: String,
-    scheme: String,
-    authority: String,
-    callOptions: CallOptions,
-    eventLoop: EventLoop,
+    transport: ChannelTransport<RequestPayload, ResponsePayload>,
+    options: CallOptions
+  ) {
+    self.transport = transport
+    self.options = options
+  }
+}
+
+extension BidirectionalStreamingCall {
+  internal static func makeOnHTTP2Stream(
     multiplexer: EventLoopFuture<HTTP2StreamMultiplexer>,
+    callOptions: CallOptions,
     errorDelegate: ClientErrorDelegate?,
     logger: Logger,
-    handler: @escaping (ResponsePayload) -> Void
-  ) {
-    let requestID = callOptions.requestIDProvider.requestID()
-    var logger = logger
-    logger[metadataKey: MetadataKey.requestID] = "\(requestID)"
-    logger.debug("starting rpc", metadata: ["path": "\(path)"])
-
-    self.transport = ChannelTransport(
+    responseHandler: @escaping (ResponsePayload) -> Void
+  ) -> BidirectionalStreamingCall<RequestPayload, ResponsePayload> {
+    let eventLoop = multiplexer.eventLoop
+    let transport = ChannelTransport<RequestPayload, ResponsePayload>(
       multiplexer: multiplexer,
-      responseContainer: .init(eventLoop: eventLoop, streamingResponseHandler: handler),
+      responseContainer: .init(eventLoop: eventLoop, streamingResponseHandler: responseHandler),
       callType: .bidirectionalStreaming,
       timeLimit: callOptions.timeLimit,
       errorDelegate: errorDelegate,
       logger: logger
     )
 
-    self.options = callOptions
-
-    let requestHead = _GRPCRequestHead(
-      scheme: scheme,
-      path: path,
-      host: authority,
-      requestID: requestID,
-      options: callOptions
-    )
-
-    self.transport.sendRequest(.head(requestHead), promise: nil)
+    return BidirectionalStreamingCall(transport: transport, options: callOptions)
   }
 }
+

--- a/Sources/GRPC/ClientCalls/BidirectionalStreamingCall.swift
+++ b/Sources/GRPC/ClientCalls/BidirectionalStreamingCall.swift
@@ -26,7 +26,7 @@ public final class BidirectionalStreamingCall<
   RequestPayload: GRPCPayload,
   ResponsePayload: GRPCPayload
 >: StreamingRequestClientCall {
-  internal let transport: ChannelTransport<RequestPayload, ResponsePayload>
+  private let transport: ChannelTransport<RequestPayload, ResponsePayload>
 
   /// The options used to make the RPC.
   public let options: CallOptions
@@ -139,6 +139,10 @@ public final class BidirectionalStreamingCall<
   ) {
     self.transport = transport
     self.options = options
+  }
+
+  internal func sendHead(_ head: _GRPCRequestHead) {
+    self.transport.sendRequest(.head(head), promise: nil)
   }
 }
 

--- a/Sources/GRPC/ClientCalls/ClientStreamingCall.swift
+++ b/Sources/GRPC/ClientCalls/ClientStreamingCall.swift
@@ -26,7 +26,7 @@ public final class ClientStreamingCall<
   RequestPayload: GRPCPayload,
   ResponsePayload: GRPCPayload
 > : StreamingRequestClientCall, UnaryResponseClientCall {
-  internal let transport: ChannelTransport<RequestPayload, ResponsePayload>
+  private let transport: ChannelTransport<RequestPayload, ResponsePayload>
 
   /// The options used to make the RPC.
   public let options: CallOptions
@@ -144,6 +144,10 @@ public final class ClientStreamingCall<
     self.response = response
     self.transport = transport
     self.options = options
+  }
+
+  internal func sendHead(_ head: _GRPCRequestHead) {
+    self.transport.sendRequest(.head(head), promise: nil)
   }
 }
 

--- a/Sources/GRPC/ClientCalls/ClientStreamingCall.swift
+++ b/Sources/GRPC/ClientCalls/ClientStreamingCall.swift
@@ -26,7 +26,7 @@ public final class ClientStreamingCall<
   RequestPayload: GRPCPayload,
   ResponsePayload: GRPCPayload
 > : StreamingRequestClientCall, UnaryResponseClientCall {
-  private let transport: ChannelTransport<RequestPayload, ResponsePayload>
+  internal let transport: ChannelTransport<RequestPayload, ResponsePayload>
 
   /// The options used to make the RPC.
   public let options: CallOptions
@@ -137,22 +137,26 @@ public final class ClientStreamingCall<
   }
 
   internal init(
-    path: String,
-    scheme: String,
-    authority: String,
-    callOptions: CallOptions,
-    eventLoop: EventLoop,
+    response: EventLoopFuture<ResponsePayload>,
+    transport: ChannelTransport<RequestPayload, ResponsePayload>,
+    options: CallOptions
+  ) {
+    self.response = response
+    self.transport = transport
+    self.options = options
+  }
+}
+
+extension ClientStreamingCall {
+  internal static func makeOnHTTP2Stream(
     multiplexer: EventLoopFuture<HTTP2StreamMultiplexer>,
+    callOptions: CallOptions,
     errorDelegate: ClientErrorDelegate?,
     logger: Logger
-  ) {
-    let requestID = callOptions.requestIDProvider.requestID()
-    var logger = logger
-    logger[metadataKey: MetadataKey.requestID] = "\(requestID)"
-    logger.debug("starting rpc", metadata: ["path": "\(path)"])
-
+  ) -> ClientStreamingCall<RequestPayload, ResponsePayload> {
+    let eventLoop = multiplexer.eventLoop
     let responsePromise: EventLoopPromise<ResponsePayload> = eventLoop.makePromise()
-    self.transport = ChannelTransport(
+    let transport = ChannelTransport<RequestPayload, ResponsePayload>(
       multiplexer: multiplexer,
       responseContainer: .init(eventLoop: eventLoop, unaryResponsePromise: responsePromise),
       callType: .clientStreaming,
@@ -160,17 +164,6 @@ public final class ClientStreamingCall<
       errorDelegate: errorDelegate,
       logger: logger
     )
-    self.options = callOptions
-    self.response = responsePromise.futureResult
-
-    let requestHead = _GRPCRequestHead(
-      scheme: scheme,
-      path: path,
-      host: authority,
-      requestID: requestID,
-      options: callOptions
-    )
-
-    self.transport.sendRequest(.head(requestHead), promise: nil)
+    return ClientStreamingCall(response: responsePromise.futureResult, transport: transport, options: callOptions)
   }
 }

--- a/Sources/GRPC/ClientCalls/ServerStreamingCall.swift
+++ b/Sources/GRPC/ClientCalls/ServerStreamingCall.swift
@@ -24,7 +24,7 @@ public final class ServerStreamingCall<
   RequestPayload: GRPCPayload,
   ResponsePayload: GRPCPayload
 >: ClientCall {
-  private let transport: ChannelTransport<RequestPayload, ResponsePayload>
+  internal let transport: ChannelTransport<RequestPayload, ResponsePayload>
 
   /// The options used to make the RPC.
   public let options: CallOptions
@@ -78,47 +78,34 @@ public final class ServerStreamingCall<
       }
     }
   }
-  
-  init(
-    path: String,
-    scheme: String,
-    authority: String,
-    callOptions: CallOptions,
-    eventLoop: EventLoop,
+
+  internal init(
+    transport: ChannelTransport<RequestPayload, ResponsePayload>,
+    options: CallOptions
+  ) {
+    self.transport = transport
+    self.options = options
+  }
+}
+
+extension ServerStreamingCall {
+  internal static func makeOnHTTP2Stream(
     multiplexer: EventLoopFuture<HTTP2StreamMultiplexer>,
+    callOptions: CallOptions,
     errorDelegate: ClientErrorDelegate?,
     logger: Logger,
-    request: RequestPayload,
-    handler: @escaping (ResponsePayload) -> Void
-  ) {
-    let requestID = callOptions.requestIDProvider.requestID()
-    var logger = logger
-    logger[metadataKey: MetadataKey.requestID] = "\(requestID)"
-    logger[metadataKey: "path"] = "\(path)"
-
-    self.transport = ChannelTransport(
+    responseHandler: @escaping (ResponsePayload) -> Void
+  ) -> ServerStreamingCall<RequestPayload, ResponsePayload> {
+    let eventLoop = multiplexer.eventLoop
+    let transport = ChannelTransport<RequestPayload, ResponsePayload>(
       multiplexer: multiplexer,
-      responseContainer: .init(eventLoop: eventLoop, streamingResponseHandler: handler),
+      responseContainer: .init(eventLoop: eventLoop, streamingResponseHandler: responseHandler),
       callType: .serverStreaming,
       timeLimit: callOptions.timeLimit,
       errorDelegate: errorDelegate,
       logger: logger
     )
 
-    self.options = callOptions
-
-    let requestHead = _GRPCRequestHead(
-      scheme: scheme,
-      path: path,
-      host: authority,
-      requestID: requestID,
-      options: callOptions
-    )
-
-    self.transport.sendUnary(
-      requestHead,
-      request: request,
-      compressed: callOptions.messageEncoding.enabledForRequests
-    )
+    return ServerStreamingCall(transport: transport, options: callOptions)
   }
 }

--- a/Sources/GRPC/ClientCalls/ServerStreamingCall.swift
+++ b/Sources/GRPC/ClientCalls/ServerStreamingCall.swift
@@ -24,7 +24,7 @@ public final class ServerStreamingCall<
   RequestPayload: GRPCPayload,
   ResponsePayload: GRPCPayload
 >: ClientCall {
-  internal let transport: ChannelTransport<RequestPayload, ResponsePayload>
+  private let transport: ChannelTransport<RequestPayload, ResponsePayload>
 
   /// The options used to make the RPC.
   public let options: CallOptions
@@ -85,6 +85,10 @@ public final class ServerStreamingCall<
   ) {
     self.transport = transport
     self.options = options
+  }
+
+  internal func send(_ head: _GRPCRequestHead, request: RequestPayload) {
+    self.transport.sendUnary(head, request: request, compressed: self.options.messageEncoding.enabledForRequests)
   }
 }
 

--- a/Sources/GRPC/ClientCalls/UnaryCall.swift
+++ b/Sources/GRPC/ClientCalls/UnaryCall.swift
@@ -26,7 +26,7 @@ public final class UnaryCall<
   RequestPayload: GRPCPayload,
   ResponsePayload: GRPCPayload
 >: UnaryResponseClientCall {
-  internal let transport: ChannelTransport<RequestPayload, ResponsePayload>
+  private let transport: ChannelTransport<RequestPayload, ResponsePayload>
 
   /// The options used to make the RPC.
   public let options: CallOptions
@@ -92,6 +92,10 @@ public final class UnaryCall<
     self.response = response
     self.transport = transport
     self.options = options
+  }
+
+  internal func send(_ head: _GRPCRequestHead, request: RequestPayload) {
+    self.transport.sendUnary(head, request: request, compressed: self.options.messageEncoding.enabledForRequests)
   }
 }
 

--- a/Sources/GRPC/ClientCalls/UnaryCall.swift
+++ b/Sources/GRPC/ClientCalls/UnaryCall.swift
@@ -26,7 +26,7 @@ public final class UnaryCall<
   RequestPayload: GRPCPayload,
   ResponsePayload: GRPCPayload
 >: UnaryResponseClientCall {
-  private let transport: ChannelTransport<RequestPayload, ResponsePayload>
+  internal let transport: ChannelTransport<RequestPayload, ResponsePayload>
 
   /// The options used to make the RPC.
   public let options: CallOptions
@@ -85,23 +85,26 @@ public final class UnaryCall<
   }
 
   internal init(
-    path: String,
-    scheme: String,
-    authority: String,
-    callOptions: CallOptions,
-    eventLoop: EventLoop,
-    multiplexer: EventLoopFuture<HTTP2StreamMultiplexer>,
-    errorDelegate: ClientErrorDelegate?,
-    logger: Logger,
-    request: RequestPayload
+    response: EventLoopFuture<ResponsePayload>,
+    transport: ChannelTransport<RequestPayload, ResponsePayload>,
+    options: CallOptions
   ) {
-    let requestID = callOptions.requestIDProvider.requestID()
-    var logger = logger
-    logger[metadataKey: MetadataKey.requestID] = "\(requestID)"
-    logger[metadataKey: "path"] = "\(path)"
+    self.response = response
+    self.transport = transport
+    self.options = options
+  }
+}
 
+extension UnaryCall {
+  internal static func makeOnHTTP2Stream(
+    multiplexer: EventLoopFuture<HTTP2StreamMultiplexer>,
+    callOptions: CallOptions,
+    errorDelegate: ClientErrorDelegate?,
+    logger: Logger
+  ) -> UnaryCall<RequestPayload, ResponsePayload> {
+    let eventLoop = multiplexer.eventLoop
     let responsePromise: EventLoopPromise<ResponsePayload> = eventLoop.makePromise()
-    self.transport = ChannelTransport(
+    let transport = ChannelTransport<RequestPayload, ResponsePayload>(
       multiplexer: multiplexer,
       responseContainer: .init(eventLoop: eventLoop, unaryResponsePromise: responsePromise),
       callType: .unary,
@@ -109,22 +112,6 @@ public final class UnaryCall<
       errorDelegate: errorDelegate,
       logger: logger
     )
-
-    self.options = callOptions
-    self.response = responsePromise.futureResult
-
-    let requestHead = _GRPCRequestHead(
-      scheme: scheme,
-      path: path,
-      host: authority,
-      requestID: requestID,
-      options: callOptions
-    )
-
-    self.transport.sendUnary(
-      requestHead,
-      request: request,
-      compressed: callOptions.messageEncoding.enabledForRequests
-    )
+    return UnaryCall(response: responsePromise.futureResult, transport: transport, options: callOptions)
   }
 }

--- a/Sources/GRPC/ClientConnection.swift
+++ b/Sources/GRPC/ClientConnection.swift
@@ -151,8 +151,7 @@ extension ClientConnection: GRPCChannel {
       logger: logger
     )
 
-    let head = self.makeRequestHead(path: path, options: callOptions, requestID: requestID)
-    call.transport.sendUnary(head, request: request, compressed: callOptions.messageEncoding.enabledForRequests)
+    call.send(self.makeRequestHead(path: path, options: callOptions, requestID: requestID), request: request)
 
     return call
   }
@@ -172,8 +171,7 @@ extension ClientConnection: GRPCChannel {
       logger: logger
     )
 
-    let head = self.makeRequestHead(path: path, options: callOptions, requestID: requestID)
-    call.transport.sendRequest(.head(head), promise: nil)
+    call.sendHead(self.makeRequestHead(path: path, options: callOptions, requestID: requestID))
 
     return call
   }
@@ -196,8 +194,7 @@ extension ClientConnection: GRPCChannel {
       responseHandler: handler
     )
 
-    let head = self.makeRequestHead(path: path, options: callOptions, requestID: requestID)
-    call.transport.sendUnary(head, request: request, compressed: callOptions.messageEncoding.enabledForRequests)
+    call.send(self.makeRequestHead(path: path, options: callOptions, requestID: requestID), request: request)
 
     return call
   }
@@ -219,8 +216,7 @@ extension ClientConnection: GRPCChannel {
       responseHandler: handler
     )
 
-    let head = self.makeRequestHead(path: path, options: callOptions, requestID: requestID)
-    call.transport.sendRequest(.head(head), promise: nil)
+    call.sendHead(self.makeRequestHead(path: path, options: callOptions, requestID: requestID))
 
     return call
   }
@@ -280,7 +276,7 @@ extension ClientConnection {
     ///
     /// If a connection becomes idle, starting a new RPC will automatically create a new connection.
     public var connectionIdleTimeout: TimeAmount
-    
+
     /// The HTTP/2 flow control target window size.
     public var httpTargetWindowSize: Int
 
@@ -426,7 +422,7 @@ extension String {
     // We need some scratch space to let inet_pton write into.
     var ipv4Addr = in_addr()
     var ipv6Addr = in6_addr()
-    
+
     return self.withCString { ptr in
       return inet_pton(AF_INET, ptr, &ipv4Addr) == 1 ||
         inet_pton(AF_INET6, ptr, &ipv6Addr) == 1

--- a/Sources/GRPC/GRPCChannel/EmbeddedGRPCChannel.swift
+++ b/Sources/GRPC/GRPCChannel/EmbeddedGRPCChannel.swift
@@ -73,8 +73,7 @@ class EmbeddedGRPCChannel: GRPCChannel {
       logger: self.logger
     )
 
-    let head = self.makeRequestHead(path: path, options: callOptions)
-    call.transport.sendUnary(head, request: request, compressed: callOptions.messageEncoding.enabledForRequests)
+    call.send(self.makeRequestHead(path: path, options: callOptions), request: request)
 
     return call
   }
@@ -90,8 +89,7 @@ class EmbeddedGRPCChannel: GRPCChannel {
       logger: self.logger
     )
 
-    let head = self.makeRequestHead(path: path, options: callOptions)
-    call.transport.sendRequest(.head(head), promise: nil)
+    call.sendHead(self.makeRequestHead(path: path, options: callOptions))
 
     return call
   }
@@ -110,8 +108,7 @@ class EmbeddedGRPCChannel: GRPCChannel {
       responseHandler: handler
     )
 
-    let head = self.makeRequestHead(path: path, options: callOptions)
-    call.transport.sendUnary(head, request: request, compressed: callOptions.messageEncoding.enabledForRequests)
+    call.send(self.makeRequestHead(path: path, options: callOptions), request: request)
 
     return call
   }
@@ -129,8 +126,7 @@ class EmbeddedGRPCChannel: GRPCChannel {
       responseHandler: handler
     )
 
-    let head = self.makeRequestHead(path: path, options: callOptions)
-    call.transport.sendRequest(.head(head), promise: nil)
+    call.sendHead(self.makeRequestHead(path: path, options: callOptions))
 
     return call
   }

--- a/Sources/GRPC/GRPCChannel/EmbeddedGRPCChannel.swift
+++ b/Sources/GRPC/GRPCChannel/EmbeddedGRPCChannel.swift
@@ -51,75 +51,87 @@ class EmbeddedGRPCChannel: GRPCChannel {
     self.errorDelegate = errorDelegate
   }
 
-  func makeUnaryCall<Request: GRPCPayload, Response: GRPCPayload>(
+  private func makeRequestHead(path: String, options: CallOptions) -> _GRPCRequestHead {
+    return _GRPCRequestHead(
+      scheme: self.scheme,
+      path: path,
+      host: self.authority,
+      requestID: options.requestIDProvider.requestID(),
+      options: options
+    )
+  }
+
+  internal func makeUnaryCall<Request: GRPCPayload, Response: GRPCPayload>(
     path: String,
     request: Request,
     callOptions: CallOptions
-  ) -> UnaryCall<Request, Response> where Request : GRPCPayload, Response : GRPCPayload {
-    return UnaryCall(
-      path: path,
-      scheme: self.scheme,
-      authority: self.authority,
-      callOptions: callOptions,
-      eventLoop: self.eventLoop,
+  ) -> UnaryCall<Request, Response> {
+    let call = UnaryCall<Request, Response>.makeOnHTTP2Stream(
       multiplexer: self.multiplexer,
-      errorDelegate: self.errorDelegate,
-      logger: self.logger,
-      request: request
-    )
-  }
-
-  func makeClientStreamingCall<Request: GRPCPayload, Response: GRPCPayload>(
-    path: String,
-    callOptions: CallOptions
-  ) -> ClientStreamingCall<Request, Response> {
-    return ClientStreamingCall(
-      path: path,
-      scheme: self.scheme,
-      authority: self.authority,
       callOptions: callOptions,
-      eventLoop: self.eventLoop,
-      multiplexer: self.multiplexer,
       errorDelegate: self.errorDelegate,
       logger: self.logger
     )
+
+    let head = self.makeRequestHead(path: path, options: callOptions)
+    call.transport.sendUnary(head, request: request, compressed: callOptions.messageEncoding.enabledForRequests)
+
+    return call
   }
 
-  func makeServerStreamingCall<Request: GRPCPayload, Response: GRPCPayload>(
+  internal func makeClientStreamingCall<Request: GRPCPayload, Response: GRPCPayload>(
+    path: String,
+    callOptions: CallOptions
+  ) -> ClientStreamingCall<Request, Response> {
+    let call = ClientStreamingCall<Request, Response>.makeOnHTTP2Stream(
+      multiplexer: self.multiplexer,
+      callOptions: callOptions,
+      errorDelegate: self.errorDelegate,
+      logger: self.logger
+    )
+
+    let head = self.makeRequestHead(path: path, options: callOptions)
+    call.transport.sendRequest(.head(head), promise: nil)
+
+    return call
+  }
+
+  internal func makeServerStreamingCall<Request: GRPCPayload, Response: GRPCPayload>(
     path: String,
     request: Request,
     callOptions: CallOptions,
     handler: @escaping (Response) -> Void
   ) -> ServerStreamingCall<Request, Response> {
-    return ServerStreamingCall(
-      path: path,
-      scheme: self.scheme,
-      authority: self.authority,
-      callOptions: callOptions,
-      eventLoop: self.eventLoop,
+    let call = ServerStreamingCall<Request, Response>.makeOnHTTP2Stream(
       multiplexer: self.multiplexer,
+      callOptions: callOptions,
       errorDelegate: self.errorDelegate,
       logger: self.logger,
-      request: request,
-      handler: handler
+      responseHandler: handler
     )
+
+    let head = self.makeRequestHead(path: path, options: callOptions)
+    call.transport.sendUnary(head, request: request, compressed: callOptions.messageEncoding.enabledForRequests)
+
+    return call
   }
 
-  func makeBidirectionalStreamingCall<Request: GRPCPayload, Response: GRPCPayload>(
+  internal func makeBidirectionalStreamingCall<Request: GRPCPayload, Response: GRPCPayload>(
     path: String,
     callOptions: CallOptions,
     handler: @escaping (Response) -> Void
   ) -> BidirectionalStreamingCall<Request, Response> {
-    return BidirectionalStreamingCall(
-      path: path,
-      scheme: self.scheme,
-      authority: self.authority,
-      callOptions: callOptions,
-      eventLoop: self.eventLoop,
+    let call = BidirectionalStreamingCall<Request, Response>.makeOnHTTP2Stream(
       multiplexer: self.multiplexer,
+      callOptions: callOptions,
       errorDelegate: self.errorDelegate,
       logger: self.logger,
-      handler: handler
+      responseHandler: handler
     )
+
+    let head = self.makeRequestHead(path: path, options: callOptions)
+    call.transport.sendRequest(.head(head), promise: nil)
+
+    return call
   }
 }


### PR DESCRIPTION
Motivation:

Previously @lukasa noted that we did some networking in the call init's
which isn't ideal. I forgot that calls are made though an internal
class, so it is indeed possible to move the networking calls.

Modifications:

- Move networking calls to just after the call object is created
- Shuffling code about, no real functional changes

Result:

- No networking in the *Call inits
- Cleaner inits
- Nothing functional