### PR TITLE
Allow the connectivity state delegate queue to be specified

### DIFF
--- a/Sources/GRPC/ClientConnection.swift
+++ b/Sources/GRPC/ClientConnection.swift
@@ -234,6 +234,10 @@ extension ClientConnection {
     /// A delegate which is called when the connectivity state is changed.
     public var connectivityStateDelegate: ConnectivityStateDelegate?
 
+    /// The `DispatchQueue` on which to call the connectivity state delegate. If a delegate is
+    /// provided but the queue is `nil` then one will be created by gRPC.
+    public var connectivityStateDelegateQueue: DispatchQueue?
+
     /// TLS configuration for this connection. `nil` if TLS is not desired.
     public var tls: TLS?
 
@@ -264,6 +268,8 @@ extension ClientConnection {
     /// - Parameter errorDelegate: The error delegate, defaulting to a delegate which will log only
     ///     on debug builds.
     /// - Parameter connectivityStateDelegate: A connectivity state delegate, defaulting to `nil`.
+    /// - Parameter connectivityStateDelegateQueue: A `DispatchQueue` on which to call the
+    ///     `connectivityStateDelegate`.
     /// - Parameter tlsConfiguration: TLS configuration, defaulting to `nil`.
     /// - Parameter connectionBackoff: The connection backoff configuration to use.
     /// - Parameter messageEncoding: Message compression configuration, defaults to no compression.
@@ -273,6 +279,7 @@ extension ClientConnection {
       eventLoopGroup: EventLoopGroup,
       errorDelegate: ClientErrorDelegate? = LoggingClientErrorDelegate(),
       connectivityStateDelegate: ConnectivityStateDelegate? = nil,
+      connectivityStateDelegateQueue: DispatchQueue? = nil,
       tls: Configuration.TLS? = nil,
       connectionBackoff: ConnectionBackoff? = ConnectionBackoff(),
       connectionIdleTimeout: TimeAmount = .minutes(5),
@@ -282,6 +289,7 @@ extension ClientConnection {
       self.eventLoopGroup = eventLoopGroup
       self.errorDelegate = errorDelegate
       self.connectivityStateDelegate = connectivityStateDelegate
+      self.connectivityStateDelegateQueue = connectivityStateDelegateQueue
       self.tls = tls
       self.connectionBackoff = connectionBackoff
       self.connectionIdleTimeout = connectionIdleTimeout

--- a/Sources/GRPC/ConnectionManager.swift
+++ b/Sources/GRPC/ConnectionManager.swift
@@ -212,7 +212,10 @@ internal class ConnectionManager {
     let eventLoop = configuration.eventLoopGroup.next()
     self.eventLoop = eventLoop
     self.state = .idle(IdleState(configuration: configuration))
-    self.monitor = ConnectivityStateMonitor(delegate: configuration.connectivityStateDelegate)
+    self.monitor = ConnectivityStateMonitor(
+      delegate: configuration.connectivityStateDelegate,
+      queue: configuration.connectivityStateDelegateQueue
+    )
 
     self.channelProvider = channelProvider
 

--- a/Sources/GRPC/ConnectivityState.swift
+++ b/Sources/GRPC/ConnectivityState.swift
@@ -66,9 +66,10 @@ public class ConnectivityStateMonitor {
   /// Creates a new connectivity state monitor.
   ///
   /// - Parameter delegate: A delegate to call when the connectivity state changes.
-  init(delegate: ConnectivityStateDelegate?) {
+  /// - Parameter queue: The `DispatchQueue` on which the delegate will be called.
+  init(delegate: ConnectivityStateDelegate?, queue: DispatchQueue?) {
     self._delegate = delegate
-    self.delegateCallbackQueue = DispatchQueue(label: "io.grpc.connectivity")
+    self.delegateCallbackQueue = queue ?? DispatchQueue(label: "io.grpc.connectivity")
   }
 
   /// The current state of connectivity.

--- a/Tests/GRPCTests/ConnectivityStateMonitorTests.swift
+++ b/Tests/GRPCTests/ConnectivityStateMonitorTests.swift
@@ -33,7 +33,7 @@ class ConnectivityStateMonitorTests: GRPCTestCase {
       ])
     }
 
-    let monitor = ConnectivityStateMonitor(delegate: recorder)
+    let monitor = ConnectivityStateMonitor(delegate: recorder, queue: nil)
     monitor.delegate = recorder
 
     monitor.updateState(to: .connecting, logger: self.logger)


### PR DESCRIPTION
Motivation:

We create a queue on which the connectivity state delegate is called; we
should let users specify the queue to use.

Modifications:

- Allow the queue to be set in configuration / in the builder

Result:

Users can choose the DispatchQueue their connectivity state delegate is
executed on.