### PR TITLE
Provide errors to failed client promises rather than a status

### DIFF
--- a/Sources/GRPC/ClientCalls/ResponsePartContainer.swift
+++ b/Sources/GRPC/ClientCalls/ResponsePartContainer.swift
@@ -37,16 +37,16 @@ internal struct ResponsePartContainer<Response: GRPCPayload> {
 
   /// Fail all promises - except for the status promise - with the given error status. Succeed the
   /// status promise.
-  mutating func fail(with status: GRPCStatus) {
-    self.lazyInitialMetadataPromise.fail(status)
+  mutating func fail(with error: Error, status: GRPCStatus) {
+    self.lazyInitialMetadataPromise.fail(error)
 
     switch self.responseHandler {
     case .unary(let response):
-      response.fail(status)
+      response.fail(error)
     case .stream:
       ()
     }
-    self.lazyTrailingMetadataPromise.fail(status)
+    self.lazyTrailingMetadataPromise.fail(error)
     // We always succeed the status.
     self.lazyStatusPromise.succeed(status)
   }

--- a/Tests/GRPCTests/ClientCancellingTests.swift
+++ b/Tests/GRPCTests/ClientCancellingTests.swift
@@ -27,7 +27,7 @@ class ClientCancellingTests: EchoTestCaseBase {
     call.cancel(promise: nil)
 
     call.response.whenFailure { error in
-      XCTAssertEqual((error as? GRPCStatus)?.code, .cancelled)
+      XCTAssertTrue(error is GRPCError.RPCCancelledByClient)
       responseReceived.fulfill()
     }
 
@@ -47,7 +47,7 @@ class ClientCancellingTests: EchoTestCaseBase {
     call.cancel(promise: nil)
 
     call.response.whenFailure { error in
-      XCTAssertEqual((error as? GRPCStatus)?.code, .cancelled)
+      XCTAssertTrue(error is GRPCError.RPCCancelledByClient)
       responseReceived.fulfill()
     }
 

--- a/Tests/GRPCTests/XCTestManifests.swift
+++ b/Tests/GRPCTests/XCTestManifests.swift
@@ -22,6 +22,7 @@ extension ChannelTransportTests {
         ("testBufferedWritesAreFailedOnClose", testBufferedWritesAreFailedOnClose),
         ("testChannelBecomesInactive", testChannelBecomesInactive),
         ("testChannelError", testChannelError),
+        ("testErrorsAreNotAlwaysStatus", testErrorsAreNotAlwaysStatus),
         ("testInboundMethodsAfterShutdown", testInboundMethodsAfterShutdown),
         ("testOutboundMethodsAfterShutdown", testOutboundMethodsAfterShutdown),
         ("testTimeoutAfterActivating", testTimeoutAfterActivating),


### PR DESCRIPTION
Motivation:

If an RPC fails for some reason we will convert the error into an
appropriate `GRPCStatus`. This status is used to succeed the status
promise and fail any other promises (initial and trailing metadata, and
if applicable, the response promise). Without looking at logs it's
harder to determine the exact nature of the error.

Modifications:

- Fail the initial metadata, trailing metadata and response promise with
  the error that the status was derived from.

Result:

More helpful errors.