### PR TITLE
Replace 'ConnectionTarget' enum with a struct

### DIFF
--- a/Sources/GRPC/Server.swift
+++ b/Sources/GRPC/Server.swift
@@ -262,7 +262,7 @@ fileprivate extension Channel {
 
 fileprivate extension ServerBootstrapProtocol {
   func bind(to target: BindTarget) -> EventLoopFuture<Channel> {
-    switch target {
+    switch target.wrapped {
     case .hostAndPort(let host, let port):
       return self.bind(host: host, port: port)
 


### PR DESCRIPTION
Motivation:

Public enums are bad for API evolution.

Modifications:

Turn the 'ConnectionTarget' enum into a struct.

Result:

API is less prone to broken in a major way.