### PR TITLE
Require generated client protocols to accept `CallOptions`

### DIFF
--- a/Sources/Examples/Echo/Model/echo.grpc.swift
+++ b/Sources/Examples/Echo/Model/echo.grpc.swift
@@ -28,14 +28,56 @@ import SwiftProtobuf
 
 
 /// Usage: instantiate Echo_EchoClient, then call methods of this protocol to make API calls.
-public protocol Echo_EchoClientProtocol {
-  func get(_ request: Echo_EchoRequest, callOptions: CallOptions?) -> UnaryCall<Echo_EchoRequest, Echo_EchoResponse>
-  func expand(_ request: Echo_EchoRequest, callOptions: CallOptions?, handler: @escaping (Echo_EchoResponse) -> Void) -> ServerStreamingCall<Echo_EchoRequest, Echo_EchoResponse>
-  func collect(callOptions: CallOptions?) -> ClientStreamingCall<Echo_EchoRequest, Echo_EchoResponse>
-  func update(callOptions: CallOptions?, handler: @escaping (Echo_EchoResponse) -> Void) -> BidirectionalStreamingCall<Echo_EchoRequest, Echo_EchoResponse>
+public protocol Echo_EchoClientProtocol: GRPCClient {
+  func get(
+    _ request: Echo_EchoRequest,
+    callOptions: CallOptions
+  ) -> UnaryCall<Echo_EchoRequest, Echo_EchoResponse>
+
+  func expand(
+    _ request: Echo_EchoRequest,
+    callOptions: CallOptions,
+    handler: @escaping (Echo_EchoResponse) -> Void
+  ) -> ServerStreamingCall<Echo_EchoRequest, Echo_EchoResponse>
+
+  func collect(
+    callOptions: CallOptions
+  ) -> ClientStreamingCall<Echo_EchoRequest, Echo_EchoResponse>
+
+  func update(
+    callOptions: CallOptions,
+    handler: @escaping (Echo_EchoResponse) -> Void
+  ) -> BidirectionalStreamingCall<Echo_EchoRequest, Echo_EchoResponse>
+
 }
 
-public final class Echo_EchoClient: GRPCClient, Echo_EchoClientProtocol {
+extension Echo_EchoClientProtocol {
+  public func get(
+    _ request: Echo_EchoRequest
+  ) -> UnaryCall<Echo_EchoRequest, Echo_EchoResponse> {
+    return self.get(request, callOptions: self.defaultCallOptions)
+  }
+
+  public func expand(
+    _ request: Echo_EchoRequest,
+    handler: @escaping (Echo_EchoResponse) -> Void
+  ) -> ServerStreamingCall<Echo_EchoRequest, Echo_EchoResponse> {
+    return self.expand(request, callOptions: self.defaultCallOptions, handler: handler)
+  }
+
+  public func collect() -> ClientStreamingCall<Echo_EchoRequest, Echo_EchoResponse> {
+    return self.collect(callOptions: self.defaultCallOptions)
+  }
+
+  public func update(
+    handler: @escaping (Echo_EchoResponse) -> Void
+  ) -> BidirectionalStreamingCall<Echo_EchoRequest, Echo_EchoResponse> {
+    return self.update(callOptions: self.defaultCallOptions, handler: handler)
+  }
+
+}
+
+public final class Echo_EchoClient: Echo_EchoClientProtocol {
   public let channel: GRPCChannel
   public var defaultCallOptions: CallOptions
 
@@ -53,16 +95,16 @@ public final class Echo_EchoClient: GRPCClient, Echo_EchoClientProtocol {
   ///
   /// - Parameters:
   ///   - request: Request to send to Get.
-  ///   - callOptions: Call options; `self.defaultCallOptions` is used if `nil`.
+  ///   - callOptions: Call options.
   /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
   public func get(
     _ request: Echo_EchoRequest,
-    callOptions: CallOptions? = nil
+    callOptions: CallOptions
   ) -> UnaryCall<Echo_EchoRequest, Echo_EchoResponse> {
     return self.makeUnaryCall(
       path: "/echo.Echo/Get",
       request: request,
-      callOptions: callOptions ?? self.defaultCallOptions
+      callOptions: callOptions
     )
   }
 
@@ -70,18 +112,18 @@ public final class Echo_EchoClient: GRPCClient, Echo_EchoClientProtocol {
   ///
   /// - Parameters:
   ///   - request: Request to send to Expand.
-  ///   - callOptions: Call options; `self.defaultCallOptions` is used if `nil`.
+  ///   - callOptions: Call options.
   ///   - handler: A closure called when each response is received from the server.
   /// - Returns: A `ServerStreamingCall` with futures for the metadata and status.
   public func expand(
     _ request: Echo_EchoRequest,
-    callOptions: CallOptions? = nil,
+    callOptions: CallOptions,
     handler: @escaping (Echo_EchoResponse) -> Void
   ) -> ServerStreamingCall<Echo_EchoRequest, Echo_EchoResponse> {
     return self.makeServerStreamingCall(
       path: "/echo.Echo/Expand",
       request: request,
-      callOptions: callOptions ?? self.defaultCallOptions,
+      callOptions: callOptions,
       handler: handler
     )
   }
@@ -92,14 +134,14 @@ public final class Echo_EchoClient: GRPCClient, Echo_EchoClientProtocol {
   /// to the server. The caller should send an `.end` after the final message has been sent.
   ///
   /// - Parameters:
-  ///   - callOptions: Call options; `self.defaultCallOptions` is used if `nil`.
+  ///   - callOptions: Call options.
   /// - Returns: A `ClientStreamingCall` with futures for the metadata, status and response.
   public func collect(
-    callOptions: CallOptions? = nil
+    callOptions: CallOptions
   ) -> ClientStreamingCall<Echo_EchoRequest, Echo_EchoResponse> {
     return self.makeClientStreamingCall(
       path: "/echo.Echo/Collect",
-      callOptions: callOptions ?? self.defaultCallOptions
+      callOptions: callOptions
     )
   }
 
@@ -109,16 +151,16 @@ public final class Echo_EchoClient: GRPCClient, Echo_EchoClientProtocol {
   /// to the server. The caller should send an `.end` after the final message has been sent.
   ///
   /// - Parameters:
-  ///   - callOptions: Call options; `self.defaultCallOptions` is used if `nil`.
+  ///   - callOptions: Call options.
   ///   - handler: A closure called when each response is received from the server.
   /// - Returns: A `ClientStreamingCall` with futures for the metadata and status.
   public func update(
-    callOptions: CallOptions? = nil,
+    callOptions: CallOptions,
     handler: @escaping (Echo_EchoResponse) -> Void
   ) -> BidirectionalStreamingCall<Echo_EchoRequest, Echo_EchoResponse> {
     return self.makeBidirectionalStreamingCall(
       path: "/echo.Echo/Update",
-      callOptions: callOptions ?? self.defaultCallOptions,
+      callOptions: callOptions,
       handler: handler
     )
   }

--- a/Sources/Examples/HelloWorld/Model/helloworld.grpc.swift
+++ b/Sources/Examples/HelloWorld/Model/helloworld.grpc.swift
@@ -28,11 +28,24 @@ import SwiftProtobuf
 
 
 /// Usage: instantiate Helloworld_GreeterClient, then call methods of this protocol to make API calls.
-public protocol Helloworld_GreeterClientProtocol {
-  func sayHello(_ request: Helloworld_HelloRequest, callOptions: CallOptions?) -> UnaryCall<Helloworld_HelloRequest, Helloworld_HelloReply>
+public protocol Helloworld_GreeterClientProtocol: GRPCClient {
+  func sayHello(
+    _ request: Helloworld_HelloRequest,
+    callOptions: CallOptions
+  ) -> UnaryCall<Helloworld_HelloRequest, Helloworld_HelloReply>
+
 }
 
-public final class Helloworld_GreeterClient: GRPCClient, Helloworld_GreeterClientProtocol {
+extension Helloworld_GreeterClientProtocol {
+  public func sayHello(
+    _ request: Helloworld_HelloRequest
+  ) -> UnaryCall<Helloworld_HelloRequest, Helloworld_HelloReply> {
+    return self.sayHello(request, callOptions: self.defaultCallOptions)
+  }
+
+}
+
+public final class Helloworld_GreeterClient: Helloworld_GreeterClientProtocol {
   public let channel: GRPCChannel
   public var defaultCallOptions: CallOptions
 
@@ -50,16 +63,16 @@ public final class Helloworld_GreeterClient: GRPCClient, Helloworld_GreeterClien
   ///
   /// - Parameters:
   ///   - request: Request to send to SayHello.
-  ///   - callOptions: Call options; `self.defaultCallOptions` is used if `nil`.
+  ///   - callOptions: Call options.
   /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
   public func sayHello(
     _ request: Helloworld_HelloRequest,
-    callOptions: CallOptions? = nil
+    callOptions: CallOptions
   ) -> UnaryCall<Helloworld_HelloRequest, Helloworld_HelloReply> {
     return self.makeUnaryCall(
       path: "/helloworld.Greeter/SayHello",
       request: request,
-      callOptions: callOptions ?? self.defaultCallOptions
+      callOptions: callOptions
     )
   }
 }

--- a/Sources/Examples/RouteGuide/Model/route_guide.grpc.swift
+++ b/Sources/Examples/RouteGuide/Model/route_guide.grpc.swift
@@ -28,14 +28,56 @@ import SwiftProtobuf
 
 
 /// Usage: instantiate Routeguide_RouteGuideClient, then call methods of this protocol to make API calls.
-public protocol Routeguide_RouteGuideClientProtocol {
-  func getFeature(_ request: Routeguide_Point, callOptions: CallOptions?) -> UnaryCall<Routeguide_Point, Routeguide_Feature>
-  func listFeatures(_ request: Routeguide_Rectangle, callOptions: CallOptions?, handler: @escaping (Routeguide_Feature) -> Void) -> ServerStreamingCall<Routeguide_Rectangle, Routeguide_Feature>
-  func recordRoute(callOptions: CallOptions?) -> ClientStreamingCall<Routeguide_Point, Routeguide_RouteSummary>
-  func routeChat(callOptions: CallOptions?, handler: @escaping (Routeguide_RouteNote) -> Void) -> BidirectionalStreamingCall<Routeguide_RouteNote, Routeguide_RouteNote>
+public protocol Routeguide_RouteGuideClientProtocol: GRPCClient {
+  func getFeature(
+    _ request: Routeguide_Point,
+    callOptions: CallOptions
+  ) -> UnaryCall<Routeguide_Point, Routeguide_Feature>
+
+  func listFeatures(
+    _ request: Routeguide_Rectangle,
+    callOptions: CallOptions,
+    handler: @escaping (Routeguide_Feature) -> Void
+  ) -> ServerStreamingCall<Routeguide_Rectangle, Routeguide_Feature>
+
+  func recordRoute(
+    callOptions: CallOptions
+  ) -> ClientStreamingCall<Routeguide_Point, Routeguide_RouteSummary>
+
+  func routeChat(
+    callOptions: CallOptions,
+    handler: @escaping (Routeguide_RouteNote) -> Void
+  ) -> BidirectionalStreamingCall<Routeguide_RouteNote, Routeguide_RouteNote>
+
 }
 
-public final class Routeguide_RouteGuideClient: GRPCClient, Routeguide_RouteGuideClientProtocol {
+extension Routeguide_RouteGuideClientProtocol {
+  public func getFeature(
+    _ request: Routeguide_Point
+  ) -> UnaryCall<Routeguide_Point, Routeguide_Feature> {
+    return self.getFeature(request, callOptions: self.defaultCallOptions)
+  }
+
+  public func listFeatures(
+    _ request: Routeguide_Rectangle,
+    handler: @escaping (Routeguide_Feature) -> Void
+  ) -> ServerStreamingCall<Routeguide_Rectangle, Routeguide_Feature> {
+    return self.listFeatures(request, callOptions: self.defaultCallOptions, handler: handler)
+  }
+
+  public func recordRoute() -> ClientStreamingCall<Routeguide_Point, Routeguide_RouteSummary> {
+    return self.recordRoute(callOptions: self.defaultCallOptions)
+  }
+
+  public func routeChat(
+    handler: @escaping (Routeguide_RouteNote) -> Void
+  ) -> BidirectionalStreamingCall<Routeguide_RouteNote, Routeguide_RouteNote> {
+    return self.routeChat(callOptions: self.defaultCallOptions, handler: handler)
+  }
+
+}
+
+public final class Routeguide_RouteGuideClient: Routeguide_RouteGuideClientProtocol {
   public let channel: GRPCChannel
   public var defaultCallOptions: CallOptions
 
@@ -58,16 +100,16 @@ public final class Routeguide_RouteGuideClient: GRPCClient, Routeguide_RouteGuid
   ///
   /// - Parameters:
   ///   - request: Request to send to GetFeature.
-  ///   - callOptions: Call options; `self.defaultCallOptions` is used if `nil`.
+  ///   - callOptions: Call options.
   /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
   public func getFeature(
     _ request: Routeguide_Point,
-    callOptions: CallOptions? = nil
+    callOptions: CallOptions
   ) -> UnaryCall<Routeguide_Point, Routeguide_Feature> {
     return self.makeUnaryCall(
       path: "/routeguide.RouteGuide/GetFeature",
       request: request,
-      callOptions: callOptions ?? self.defaultCallOptions
+      callOptions: callOptions
     )
   }
 
@@ -80,18 +122,18 @@ public final class Routeguide_RouteGuideClient: GRPCClient, Routeguide_RouteGuid
   ///
   /// - Parameters:
   ///   - request: Request to send to ListFeatures.
-  ///   - callOptions: Call options; `self.defaultCallOptions` is used if `nil`.
+  ///   - callOptions: Call options.
   ///   - handler: A closure called when each response is received from the server.
   /// - Returns: A `ServerStreamingCall` with futures for the metadata and status.
   public func listFeatures(
     _ request: Routeguide_Rectangle,
-    callOptions: CallOptions? = nil,
+    callOptions: CallOptions,
     handler: @escaping (Routeguide_Feature) -> Void
   ) -> ServerStreamingCall<Routeguide_Rectangle, Routeguide_Feature> {
     return self.makeServerStreamingCall(
       path: "/routeguide.RouteGuide/ListFeatures",
       request: request,
-      callOptions: callOptions ?? self.defaultCallOptions,
+      callOptions: callOptions,
       handler: handler
     )
   }
@@ -105,14 +147,14 @@ public final class Routeguide_RouteGuideClient: GRPCClient, Routeguide_RouteGuid
   /// to the server. The caller should send an `.end` after the final message has been sent.
   ///
   /// - Parameters:
-  ///   - callOptions: Call options; `self.defaultCallOptions` is used if `nil`.
+  ///   - callOptions: Call options.
   /// - Returns: A `ClientStreamingCall` with futures for the metadata, status and response.
   public func recordRoute(
-    callOptions: CallOptions? = nil
+    callOptions: CallOptions
   ) -> ClientStreamingCall<Routeguide_Point, Routeguide_RouteSummary> {
     return self.makeClientStreamingCall(
       path: "/routeguide.RouteGuide/RecordRoute",
-      callOptions: callOptions ?? self.defaultCallOptions
+      callOptions: callOptions
     )
   }
 
@@ -125,16 +167,16 @@ public final class Routeguide_RouteGuideClient: GRPCClient, Routeguide_RouteGuid
   /// to the server. The caller should send an `.end` after the final message has been sent.
   ///
   /// - Parameters:
-  ///   - callOptions: Call options; `self.defaultCallOptions` is used if `nil`.
+  ///   - callOptions: Call options.
   ///   - handler: A closure called when each response is received from the server.
   /// - Returns: A `ClientStreamingCall` with futures for the metadata and status.
   public func routeChat(
-    callOptions: CallOptions? = nil,
+    callOptions: CallOptions,
     handler: @escaping (Routeguide_RouteNote) -> Void
   ) -> BidirectionalStreamingCall<Routeguide_RouteNote, Routeguide_RouteNote> {
     return self.makeBidirectionalStreamingCall(
       path: "/routeguide.RouteGuide/RouteChat",
-      callOptions: callOptions ?? self.defaultCallOptions,
+      callOptions: callOptions,
       handler: handler
     )
   }

--- a/dev/codegen-tests/01-echo/golden/echo.grpc.swift
+++ b/dev/codegen-tests/01-echo/golden/echo.grpc.swift
@@ -28,14 +28,56 @@ import SwiftProtobuf
 
 
 /// Usage: instantiate Echo_EchoClient, then call methods of this protocol to make API calls.
-internal protocol Echo_EchoClientProtocol {
-  func get(_ request: Echo_EchoRequest, callOptions: CallOptions?) -> UnaryCall<Echo_EchoRequest, Echo_EchoResponse>
-  func expand(_ request: Echo_EchoRequest, callOptions: CallOptions?, handler: @escaping (Echo_EchoResponse) -> Void) -> ServerStreamingCall<Echo_EchoRequest, Echo_EchoResponse>
-  func collect(callOptions: CallOptions?) -> ClientStreamingCall<Echo_EchoRequest, Echo_EchoResponse>
-  func update(callOptions: CallOptions?, handler: @escaping (Echo_EchoResponse) -> Void) -> BidirectionalStreamingCall<Echo_EchoRequest, Echo_EchoResponse>
+internal protocol Echo_EchoClientProtocol: GRPCClient {
+  func get(
+    _ request: Echo_EchoRequest,
+    callOptions: CallOptions
+  ) -> UnaryCall<Echo_EchoRequest, Echo_EchoResponse>
+
+  func expand(
+    _ request: Echo_EchoRequest,
+    callOptions: CallOptions,
+    handler: @escaping (Echo_EchoResponse) -> Void
+  ) -> ServerStreamingCall<Echo_EchoRequest, Echo_EchoResponse>
+
+  func collect(
+    callOptions: CallOptions
+  ) -> ClientStreamingCall<Echo_EchoRequest, Echo_EchoResponse>
+
+  func update(
+    callOptions: CallOptions,
+    handler: @escaping (Echo_EchoResponse) -> Void
+  ) -> BidirectionalStreamingCall<Echo_EchoRequest, Echo_EchoResponse>
+
 }
 
-internal final class Echo_EchoClient: GRPCClient, Echo_EchoClientProtocol {
+extension Echo_EchoClientProtocol {
+  internal func get(
+    _ request: Echo_EchoRequest
+  ) -> UnaryCall<Echo_EchoRequest, Echo_EchoResponse> {
+    return self.get(request, callOptions: self.defaultCallOptions)
+  }
+
+  internal func expand(
+    _ request: Echo_EchoRequest,
+    handler: @escaping (Echo_EchoResponse) -> Void
+  ) -> ServerStreamingCall<Echo_EchoRequest, Echo_EchoResponse> {
+    return self.expand(request, callOptions: self.defaultCallOptions, handler: handler)
+  }
+
+  internal func collect() -> ClientStreamingCall<Echo_EchoRequest, Echo_EchoResponse> {
+    return self.collect(callOptions: self.defaultCallOptions)
+  }
+
+  internal func update(
+    handler: @escaping (Echo_EchoResponse) -> Void
+  ) -> BidirectionalStreamingCall<Echo_EchoRequest, Echo_EchoResponse> {
+    return self.update(callOptions: self.defaultCallOptions, handler: handler)
+  }
+
+}
+
+internal final class Echo_EchoClient: Echo_EchoClientProtocol {
   internal let channel: GRPCChannel
   internal var defaultCallOptions: CallOptions
 
@@ -53,16 +95,16 @@ internal final class Echo_EchoClient: GRPCClient, Echo_EchoClientProtocol {
   ///
   /// - Parameters:
   ///   - request: Request to send to Get.
-  ///   - callOptions: Call options; `self.defaultCallOptions` is used if `nil`.
+  ///   - callOptions: Call options.
   /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
   internal func get(
     _ request: Echo_EchoRequest,
-    callOptions: CallOptions? = nil
+    callOptions: CallOptions
   ) -> UnaryCall<Echo_EchoRequest, Echo_EchoResponse> {
     return self.makeUnaryCall(
       path: "/echo.Echo/Get",
       request: request,
-      callOptions: callOptions ?? self.defaultCallOptions
+      callOptions: callOptions
     )
   }
 
@@ -70,18 +112,18 @@ internal final class Echo_EchoClient: GRPCClient, Echo_EchoClientProtocol {
   ///
   /// - Parameters:
   ///   - request: Request to send to Expand.
-  ///   - callOptions: Call options; `self.defaultCallOptions` is used if `nil`.
+  ///   - callOptions: Call options.
   ///   - handler: A closure called when each response is received from the server.
   /// - Returns: A `ServerStreamingCall` with futures for the metadata and status.
   internal func expand(
     _ request: Echo_EchoRequest,
-    callOptions: CallOptions? = nil,
+    callOptions: CallOptions,
     handler: @escaping (Echo_EchoResponse) -> Void
   ) -> ServerStreamingCall<Echo_EchoRequest, Echo_EchoResponse> {
     return self.makeServerStreamingCall(
       path: "/echo.Echo/Expand",
       request: request,
-      callOptions: callOptions ?? self.defaultCallOptions,
+      callOptions: callOptions,
       handler: handler
     )
   }
@@ -92,14 +134,14 @@ internal final class Echo_EchoClient: GRPCClient, Echo_EchoClientProtocol {
   /// to the server. The caller should send an `.end` after the final message has been sent.
   ///
   /// - Parameters:
-  ///   - callOptions: Call options; `self.defaultCallOptions` is used if `nil`.
+  ///   - callOptions: Call options.
   /// - Returns: A `ClientStreamingCall` with futures for the metadata, status and response.
   internal func collect(
-    callOptions: CallOptions? = nil
+    callOptions: CallOptions
   ) -> ClientStreamingCall<Echo_EchoRequest, Echo_EchoResponse> {
     return self.makeClientStreamingCall(
       path: "/echo.Echo/Collect",
-      callOptions: callOptions ?? self.defaultCallOptions
+      callOptions: callOptions
     )
   }
 
@@ -109,16 +151,16 @@ internal final class Echo_EchoClient: GRPCClient, Echo_EchoClientProtocol {
   /// to the server. The caller should send an `.end` after the final message has been sent.
   ///
   /// - Parameters:
-  ///   - callOptions: Call options; `self.defaultCallOptions` is used if `nil`.
+  ///   - callOptions: Call options.
   ///   - handler: A closure called when each response is received from the server.
   /// - Returns: A `ClientStreamingCall` with futures for the metadata and status.
   internal func update(
-    callOptions: CallOptions? = nil,
+    callOptions: CallOptions,
     handler: @escaping (Echo_EchoResponse) -> Void
   ) -> BidirectionalStreamingCall<Echo_EchoRequest, Echo_EchoResponse> {
     return self.makeBidirectionalStreamingCall(
       path: "/echo.Echo/Update",
-      callOptions: callOptions ?? self.defaultCallOptions,
+      callOptions: callOptions,
       handler: handler
     )
   }

--- a/dev/codegen-tests/02-multifile/golden/a.grpc.swift
+++ b/dev/codegen-tests/02-multifile/golden/a.grpc.swift
@@ -28,11 +28,24 @@ import SwiftProtobuf
 
 
 /// Usage: instantiate A_ServiceAClient, then call methods of this protocol to make API calls.
-internal protocol A_ServiceAClientProtocol {
-  func callServiceA(_ request: A_MessageA, callOptions: CallOptions?) -> UnaryCall<A_MessageA, SwiftProtobuf.Google_Protobuf_Empty>
+internal protocol A_ServiceAClientProtocol: GRPCClient {
+  func callServiceA(
+    _ request: A_MessageA,
+    callOptions: CallOptions
+  ) -> UnaryCall<A_MessageA, SwiftProtobuf.Google_Protobuf_Empty>
+
 }
 
-internal final class A_ServiceAClient: GRPCClient, A_ServiceAClientProtocol {
+extension A_ServiceAClientProtocol {
+  internal func callServiceA(
+    _ request: A_MessageA
+  ) -> UnaryCall<A_MessageA, SwiftProtobuf.Google_Protobuf_Empty> {
+    return self.callServiceA(request, callOptions: self.defaultCallOptions)
+  }
+
+}
+
+internal final class A_ServiceAClient: A_ServiceAClientProtocol {
   internal let channel: GRPCChannel
   internal var defaultCallOptions: CallOptions
 
@@ -50,16 +63,16 @@ internal final class A_ServiceAClient: GRPCClient, A_ServiceAClientProtocol {
   ///
   /// - Parameters:
   ///   - request: Request to send to CallServiceA.
-  ///   - callOptions: Call options; `self.defaultCallOptions` is used if `nil`.
+  ///   - callOptions: Call options.
   /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
   internal func callServiceA(
     _ request: A_MessageA,
-    callOptions: CallOptions? = nil
+    callOptions: CallOptions
   ) -> UnaryCall<A_MessageA, SwiftProtobuf.Google_Protobuf_Empty> {
     return self.makeUnaryCall(
       path: "/a.ServiceA/CallServiceA",
       request: request,
-      callOptions: callOptions ?? self.defaultCallOptions
+      callOptions: callOptions
     )
   }
 }

--- a/dev/codegen-tests/02-multifile/golden/b.grpc.swift
+++ b/dev/codegen-tests/02-multifile/golden/b.grpc.swift
@@ -28,11 +28,24 @@ import SwiftProtobuf
 
 
 /// Usage: instantiate B_ServiceBClient, then call methods of this protocol to make API calls.
-internal protocol B_ServiceBClientProtocol {
-  func callServiceB(_ request: B_MessageB, callOptions: CallOptions?) -> UnaryCall<B_MessageB, SwiftProtobuf.Google_Protobuf_Empty>
+internal protocol B_ServiceBClientProtocol: GRPCClient {
+  func callServiceB(
+    _ request: B_MessageB,
+    callOptions: CallOptions
+  ) -> UnaryCall<B_MessageB, SwiftProtobuf.Google_Protobuf_Empty>
+
 }
 
-internal final class B_ServiceBClient: GRPCClient, B_ServiceBClientProtocol {
+extension B_ServiceBClientProtocol {
+  internal func callServiceB(
+    _ request: B_MessageB
+  ) -> UnaryCall<B_MessageB, SwiftProtobuf.Google_Protobuf_Empty> {
+    return self.callServiceB(request, callOptions: self.defaultCallOptions)
+  }
+
+}
+
+internal final class B_ServiceBClient: B_ServiceBClientProtocol {
   internal let channel: GRPCChannel
   internal var defaultCallOptions: CallOptions
 
@@ -50,16 +63,16 @@ internal final class B_ServiceBClient: GRPCClient, B_ServiceBClientProtocol {
   ///
   /// - Parameters:
   ///   - request: Request to send to CallServiceB.
-  ///   - callOptions: Call options; `self.defaultCallOptions` is used if `nil`.
+  ///   - callOptions: Call options.
   /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
   internal func callServiceB(
     _ request: B_MessageB,
-    callOptions: CallOptions? = nil
+    callOptions: CallOptions
   ) -> UnaryCall<B_MessageB, SwiftProtobuf.Google_Protobuf_Empty> {
     return self.makeUnaryCall(
       path: "/b.ServiceB/CallServiceB",
       request: request,
-      callOptions: callOptions ?? self.defaultCallOptions
+      callOptions: callOptions
     )
   }
 }

--- a/dev/codegen-tests/03-multifile-with-module-map/golden/a.grpc.swift
+++ b/dev/codegen-tests/03-multifile-with-module-map/golden/a.grpc.swift
@@ -29,11 +29,24 @@ import ModuleB
 
 
 /// Usage: instantiate A_ServiceAClient, then call methods of this protocol to make API calls.
-internal protocol A_ServiceAClientProtocol {
-  func callServiceA(_ request: A_MessageA, callOptions: CallOptions?) -> UnaryCall<A_MessageA, SwiftProtobuf.Google_Protobuf_Empty>
+internal protocol A_ServiceAClientProtocol: GRPCClient {
+  func callServiceA(
+    _ request: A_MessageA,
+    callOptions: CallOptions
+  ) -> UnaryCall<A_MessageA, SwiftProtobuf.Google_Protobuf_Empty>
+
 }
 
-internal final class A_ServiceAClient: GRPCClient, A_ServiceAClientProtocol {
+extension A_ServiceAClientProtocol {
+  internal func callServiceA(
+    _ request: A_MessageA
+  ) -> UnaryCall<A_MessageA, SwiftProtobuf.Google_Protobuf_Empty> {
+    return self.callServiceA(request, callOptions: self.defaultCallOptions)
+  }
+
+}
+
+internal final class A_ServiceAClient: A_ServiceAClientProtocol {
   internal let channel: GRPCChannel
   internal var defaultCallOptions: CallOptions
 
@@ -51,16 +64,16 @@ internal final class A_ServiceAClient: GRPCClient, A_ServiceAClientProtocol {
   ///
   /// - Parameters:
   ///   - request: Request to send to CallServiceA.
-  ///   - callOptions: Call options; `self.defaultCallOptions` is used if `nil`.
+  ///   - callOptions: Call options.
   /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
   internal func callServiceA(
     _ request: A_MessageA,
-    callOptions: CallOptions? = nil
+    callOptions: CallOptions
   ) -> UnaryCall<A_MessageA, SwiftProtobuf.Google_Protobuf_Empty> {
     return self.makeUnaryCall(
       path: "/a.ServiceA/CallServiceA",
       request: request,
-      callOptions: callOptions ?? self.defaultCallOptions
+      callOptions: callOptions
     )
   }
 }

--- a/dev/codegen-tests/03-multifile-with-module-map/golden/b.grpc.swift
+++ b/dev/codegen-tests/03-multifile-with-module-map/golden/b.grpc.swift
@@ -28,11 +28,24 @@ import SwiftProtobuf
 
 
 /// Usage: instantiate B_ServiceBClient, then call methods of this protocol to make API calls.
-internal protocol B_ServiceBClientProtocol {
-  func callServiceB(_ request: B_MessageB, callOptions: CallOptions?) -> UnaryCall<B_MessageB, SwiftProtobuf.Google_Protobuf_Empty>
+internal protocol B_ServiceBClientProtocol: GRPCClient {
+  func callServiceB(
+    _ request: B_MessageB,
+    callOptions: CallOptions
+  ) -> UnaryCall<B_MessageB, SwiftProtobuf.Google_Protobuf_Empty>
+
 }
 
-internal final class B_ServiceBClient: GRPCClient, B_ServiceBClientProtocol {
+extension B_ServiceBClientProtocol {
+  internal func callServiceB(
+    _ request: B_MessageB
+  ) -> UnaryCall<B_MessageB, SwiftProtobuf.Google_Protobuf_Empty> {
+    return self.callServiceB(request, callOptions: self.defaultCallOptions)
+  }
+
+}
+
+internal final class B_ServiceBClient: B_ServiceBClientProtocol {
   internal let channel: GRPCChannel
   internal var defaultCallOptions: CallOptions
 
@@ -50,16 +63,16 @@ internal final class B_ServiceBClient: GRPCClient, B_ServiceBClientProtocol {
   ///
   /// - Parameters:
   ///   - request: Request to send to CallServiceB.
-  ///   - callOptions: Call options; `self.defaultCallOptions` is used if `nil`.
+  ///   - callOptions: Call options.
   /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
   internal func callServiceB(
     _ request: B_MessageB,
-    callOptions: CallOptions? = nil
+    callOptions: CallOptions
   ) -> UnaryCall<B_MessageB, SwiftProtobuf.Google_Protobuf_Empty> {
     return self.makeUnaryCall(
       path: "/b.ServiceB/CallServiceB",
       request: request,
-      callOptions: callOptions ?? self.defaultCallOptions
+      callOptions: callOptions
     )
   }
 }

--- a/dev/codegen-tests/05-service-only/golden/test.grpc.swift
+++ b/dev/codegen-tests/05-service-only/golden/test.grpc.swift
@@ -28,11 +28,24 @@ import SwiftProtobuf
 
 
 /// Usage: instantiate Codegentest_FooClient, then call methods of this protocol to make API calls.
-internal protocol Codegentest_FooClientProtocol {
-  func bar(_ request: SwiftProtobuf.Google_Protobuf_Empty, callOptions: CallOptions?) -> UnaryCall<SwiftProtobuf.Google_Protobuf_Empty, SwiftProtobuf.Google_Protobuf_Empty>
+internal protocol Codegentest_FooClientProtocol: GRPCClient {
+  func bar(
+    _ request: SwiftProtobuf.Google_Protobuf_Empty,
+    callOptions: CallOptions
+  ) -> UnaryCall<SwiftProtobuf.Google_Protobuf_Empty, SwiftProtobuf.Google_Protobuf_Empty>
+
 }
 
-internal final class Codegentest_FooClient: GRPCClient, Codegentest_FooClientProtocol {
+extension Codegentest_FooClientProtocol {
+  internal func bar(
+    _ request: SwiftProtobuf.Google_Protobuf_Empty
+  ) -> UnaryCall<SwiftProtobuf.Google_Protobuf_Empty, SwiftProtobuf.Google_Protobuf_Empty> {
+    return self.bar(request, callOptions: self.defaultCallOptions)
+  }
+
+}
+
+internal final class Codegentest_FooClient: Codegentest_FooClientProtocol {
   internal let channel: GRPCChannel
   internal var defaultCallOptions: CallOptions
 
@@ -50,16 +63,16 @@ internal final class Codegentest_FooClient: GRPCClient, Codegentest_FooClientPro
   ///
   /// - Parameters:
   ///   - request: Request to send to Bar.
-  ///   - callOptions: Call options; `self.defaultCallOptions` is used if `nil`.
+  ///   - callOptions: Call options.
   /// - Returns: A `UnaryCall` with futures for the metadata, status and response.
   internal func bar(
     _ request: SwiftProtobuf.Google_Protobuf_Empty,
-    callOptions: CallOptions? = nil
+    callOptions: CallOptions
   ) -> UnaryCall<SwiftProtobuf.Google_Protobuf_Empty, SwiftProtobuf.Google_Protobuf_Empty> {
     return self.makeUnaryCall(
       path: "/codegentest.Foo/Bar",
       request: request,
-      callOptions: callOptions ?? self.defaultCallOptions
+      callOptions: callOptions
     )
   }
 }


### PR DESCRIPTION
Motivation:

The generated protocol for clients allows the caller to optionally pass
in some `CallOptions`. The generated client conforming to this protocol
defaults this argument to `nil` and falls back to default options set on
that client in that case.

It is therefore possible to call, for example,
`theClient.someUnaryRPC(someRequest)` but not
`theProtocol.someUnaryRPC(someRequest)`.

Without explicitly passing the call options, the protocol offers little
value when coding to the protocol rather than to a concrete
implementation.

Modifications:

- Generated client protocols now extend `GRPCClient` (previously the
  generated client implementations conformed to `GRPCClient` and the
  protocol)
- Generated client protocol requires `CallOptions`
- Generated client protocols now have a generated extension for each RPC
  which does not require call options whose implementation forwards the
  default call options courtesy of `GRPCClient`.

Result:

- It is possible to reasonably implement code against the generated
  protocol rather than a concrete implementation
- We lose the ability to call an RPC with `callOptions: nil`
