### PR TITLE
Replace Compression option enum with a struct

### DIFF
--- a/Sources/GRPC/ClientCalls/BidirectionalStreamingCall.swift
+++ b/Sources/GRPC/ClientCalls/BidirectionalStreamingCall.swift
@@ -98,7 +98,7 @@ public final class BidirectionalStreamingCall<
     compression: Compression = .deferToCallDefault,
     promise: EventLoopPromise<Void>?
   ) {
-    let compressed = compression.isEnabled(enabledOnCall: self.options.messageEncoding.enabledForRequests)
+    let compressed = compression.isEnabled(callDefault: self.options.messageEncoding.enabledForRequests)
     let messageContext = _MessageContext(message, compressed: compressed)
     self.transport.sendRequest(.message(messageContext), promise: promise)
   }
@@ -119,7 +119,7 @@ public final class BidirectionalStreamingCall<
     compression: Compression = .deferToCallDefault,
     promise: EventLoopPromise<Void>?
   ) where S: Sequence, S.Element == RequestPayload {
-    let compressed = compression.isEnabled(enabledOnCall: self.options.messageEncoding.enabledForRequests)
+    let compressed = compression.isEnabled(callDefault: self.options.messageEncoding.enabledForRequests)
     self.transport.sendRequests(messages.map {
       .message(_MessageContext($0, compressed: compressed))
     }, promise: promise)

--- a/Sources/GRPC/ClientCalls/ClientStreamingCall.swift
+++ b/Sources/GRPC/ClientCalls/ClientStreamingCall.swift
@@ -101,7 +101,7 @@ public final class ClientStreamingCall<
     compression: Compression = .deferToCallDefault,
     promise: EventLoopPromise<Void>?
   ) {
-    let compressed = compression.isEnabled(enabledOnCall: self.options.messageEncoding.enabledForRequests)
+    let compressed = compression.isEnabled(callDefault: self.options.messageEncoding.enabledForRequests)
     let messageContext = _MessageContext(message, compressed: compressed)
     self.transport.sendRequest(.message(messageContext), promise: promise)
   }
@@ -122,7 +122,7 @@ public final class ClientStreamingCall<
     compression: Compression = .deferToCallDefault,
     promise: EventLoopPromise<Void>?
   ) where S: Sequence, S.Element == RequestPayload {
-    let compressed = compression.isEnabled(enabledOnCall: self.options.messageEncoding.enabledForRequests)
+    let compressed = compression.isEnabled(callDefault: self.options.messageEncoding.enabledForRequests)
     self.transport.sendRequests(messages.map {
       .message(_MessageContext($0, compressed: compressed))
     }, promise: promise)

--- a/Sources/GRPC/Compression/MessageEncoding.swift
+++ b/Sources/GRPC/Compression/MessageEncoding.swift
@@ -15,28 +15,39 @@
  */
 
 /// Whether compression should be enabled for the message.
-public enum Compression {
+public struct Compression: Hashable {
+  private enum Wrapped: Hashable {
+    case enabled
+    case disabled
+    case deferToCallDefault
+  }
+
+  private var wrapped: Wrapped
+  private init(_ wrapped: Wrapped) {
+    self.wrapped = wrapped
+  }
+
   /// Enable compression. Note that this will be ignored if compression has not been enabled or is
   /// not supported on the call.
-  case enabled
+  public static let enabled = Compression(.enabled)
 
   /// Disable compression.
-  case disabled
+  public static let disabled = Compression(.disabled)
 
   /// Defer to the call (the `CallOptions` for the client, and the context for the server) to
   /// determine whether compression should be used for the message.
-  case deferToCallDefault
+  public static let deferToCallDefault = Compression(.deferToCallDefault)
 }
 
 extension Compression {
-  func isEnabled(enabledOnCall: Bool) -> Bool {
-    switch self {
+  internal func isEnabled(callDefault: Bool) -> Bool {
+    switch self.wrapped {
     case .enabled:
-      return enabledOnCall
+      return callDefault
     case .disabled:
       return false
     case .deferToCallDefault:
-      return enabledOnCall
+      return callDefault
     }
   }
 }

--- a/Sources/GRPC/ServerCallContexts/StreamingResponseCallContext.swift
+++ b/Sources/GRPC/ServerCallContexts/StreamingResponseCallContext.swift
@@ -78,7 +78,7 @@ open class StreamingResponseCallContextImpl<ResponsePayload: GRPCPayload>: Strea
 
   open override func sendResponse(_ message: ResponsePayload, compression: Compression = .deferToCallDefault) -> EventLoopFuture<Void> {
     let promise: EventLoopPromise<Void> = eventLoop.makePromise()
-    let messageContext = _MessageContext(message, compressed: compression.isEnabled(enabledOnCall: self.compressionEnabled))
+    let messageContext = _MessageContext(message, compressed: compression.isEnabled(callDefault: self.compressionEnabled))
     self.channel.writeAndFlush(NIOAny(WrappedResponse.message(messageContext)), promise: promise)
     return promise.futureResult
   }


### PR DESCRIPTION
Motivation:

Public `enum`s are bad for API evolution.

Modifications:

- Replace the 'Compression' `enum` with a `struct` backed by an `enum`.
- Rename a related internal function label

Result:

More evolvable API.