### PR TITLE
Remove warning from a now-redundant try

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "9cb641037babeda5031b6ee6078d579c86fd67cb",
-          "version": "2.7.4"
+          "revision": "d381bc53edd9de88a75480a2b969bfc26d61ee76",
+          "version": "2.8.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
     // HTTP2 via SwiftNIO
     .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.12.1"),
     // TLS via SwiftNIO
-    .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.7.4"),
+    .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.8.0"),
     // Support for Network.framework where possible.
     .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.6.0"),
 

--- a/Sources/GRPC/Server.swift
+++ b/Sources/GRPC/Server.swift
@@ -253,7 +253,7 @@ fileprivate extension Channel {
   func configureTLS(configuration: Server.Configuration.TLS) -> EventLoopFuture<Void> {
     do {
       let context = try NIOSSLContext(configuration: configuration.configuration)
-      return self.pipeline.addHandler(try NIOSSLServerHandler(context: context))
+      return self.pipeline.addHandler(NIOSSLServerHandler(context: context))
     } catch {
       return self.pipeline.eventLoop.makeFailedFuture(error)
     }


### PR DESCRIPTION
Motivation:

NIOSSLServerHandler.init became non-throwing in 2.8.0; the compiler
warns us that our try is now redundant.

Modifications:

- Update minimum NIOSSL version and remove redundant try

Result:

No more warnings