### PR TITLE
Avoid a double-idle in the idle handler.

### DIFF
--- a/Tests/GRPCTests/XCTestManifests.swift
+++ b/Tests/GRPCTests/XCTestManifests.swift
@@ -154,6 +154,7 @@ extension ConnectionManagerTests {
         ("testConnectOnSecondAttempt", testConnectOnSecondAttempt),
         ("testDoomedOptimisticChannelFromConnecting", testDoomedOptimisticChannelFromConnecting),
         ("testDoomedOptimisticChannelFromIdle", testDoomedOptimisticChannelFromIdle),
+        ("testDoubleIdle", testDoubleIdle),
         ("testGoAwayWhenReady", testGoAwayWhenReady),
         ("testIdleShutdown", testIdleShutdown),
         ("testIdleTimeoutWhenThereAreActiveStreams", testIdleTimeoutWhenThereAreActiveStreams),


### PR DESCRIPTION
Motivation:

The idle connectivity state can be achieved in two ways:
1. We have no active streams and receive a GOAWAY frame, and
2. We have no active streams and the idle timeout elapses.

The only valid state we can be in to transition to idle is ready (i.e. we have
an active channel and have received the first SETTINGS frame). We don't
currently protect against going idle twice: that is, receiving a GOAWAY
and subequently having the timeout fire. This leads to an invalid state
transition (idle to idle).

Modifications:

- Check our 'readiness' state in the idle handler before calling
  'idle()' on the connection manager
- Add a test.
- Alseo cancel the timeout when the handler is removed.

Result:

We avoid invalid state transitions when double-idling.