### PR TITLE
Remove 'nio' tag from Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,7 +1,7 @@
 ---
 name: 🐛 Bug Report
 about: If something isn't working as expected 🤔
-labels: bug, nio
+labels: bug
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,7 +1,7 @@
 ---
 name: 🚀 Feature Request
 about: Suggest an idea to improve gRPC Swift
-labels: enhancement, nio
+labels: enhancement
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/QUESTION.md
+++ b/.github/ISSUE_TEMPLATE/QUESTION.md
@@ -1,7 +1,7 @@
 ---
 name: ❓ Support Question
 about: Not sure how something works? Ask us here. (But please check the README and issues first 🙃.)
-labels: question, nio
+labels: question
 ---
 
 <!--


### PR DESCRIPTION
Motivation:

We no longer need to call ourselves out as being the NIO based
implementation. From now on 'nio' is implicit and we'll tag 'cgrpc'
related issues explicitly.

Modifications:

Remove the 'nio' tag from issue templates

Result:

Issues aren't tagged with 'nio'.