### PR TITLE
Remove GRPCStreamType public enum

### DIFF
--- a/Sources/GRPC/CallHandlers/ServerStreamingCallHandler.swift
+++ b/Sources/GRPC/CallHandlers/ServerStreamingCallHandler.swift
@@ -67,7 +67,7 @@ public final class ServerStreamingCallHandler<
     guard let eventObserver = self.eventObserver,
       let callContext = self.callContext else {
         self.logger.error("processMessage(_:) called before the call started or after the call completed")
-        throw GRPCError.StreamCardinalityViolation(stream: .request).captureContext()
+        throw GRPCError.StreamCardinalityViolation.request.captureContext()
     }
 
     let resultFuture = eventObserver(message)
@@ -79,7 +79,7 @@ public final class ServerStreamingCallHandler<
 
   override internal func endOfStreamReceived() throws {
     if self.eventObserver != nil {
-      throw GRPCError.StreamCardinalityViolation(stream: .request).captureContext()
+      throw GRPCError.StreamCardinalityViolation.request.captureContext()
     }
   }
 

--- a/Sources/GRPC/CallHandlers/UnaryCallHandler.swift
+++ b/Sources/GRPC/CallHandlers/UnaryCallHandler.swift
@@ -64,7 +64,7 @@ public final class UnaryCallHandler<
     guard let eventObserver = self.eventObserver,
       let context = self.callContext else {
       self.logger.error("processMessage(_:) called before the call started or after the call completed")
-      throw GRPCError.StreamCardinalityViolation(stream: .request).captureContext()
+      throw GRPCError.StreamCardinalityViolation.request.captureContext()
     }
 
     let resultFuture = eventObserver(message)
@@ -76,7 +76,7 @@ public final class UnaryCallHandler<
 
   internal override func endOfStreamReceived() throws {
     if self.eventObserver != nil {
-      throw GRPCError.StreamCardinalityViolation(stream: .request).captureContext()
+      throw GRPCError.StreamCardinalityViolation.request.captureContext()
     }
   }
 

--- a/Sources/GRPC/GRPCError.swift
+++ b/Sources/GRPC/GRPCError.swift
@@ -163,19 +163,16 @@ public enum GRPCError {
   /// Too many, or too few, messages were sent over the given stream.
   public struct StreamCardinalityViolation: GRPCErrorProtocol {
     /// The stream on which there was a cardinality violation.
-    public var stream: GRPCStreamType
+    public let description: String
 
-    public init(stream: GRPCStreamType) {
-      self.stream = stream
-    }
+    /// A request stream cardinality violation.
+    public static let request = StreamCardinalityViolation("Request stream cardinality violation")
 
-    public var description: String {
-      switch self.stream {
-      case .request:
-        return "Request stream cardinality violation"
-      case .response:
-        return "Response stream cardinality violation"
-      }
+    /// A response stream cardinality violation.
+    public static let response = StreamCardinalityViolation("Response stream cardinality violation")
+
+    private init(_ description: String) {
+      self.description = description
     }
 
     public func makeGRPCStatus() -> GRPCStatus {
@@ -295,13 +292,6 @@ extension GRPCErrorProtocol {
   ) -> GRPCError.WithContext {
     return GRPCError.WithContext(self, file: file, line: line, function: function)
   }
-}
-
-/// The type of stream. Messages are sent from the client to the server on the request stream, and
-/// from the server to the client on the response stream.
-public enum GRPCStreamType {
-  case request
-  case response
 }
 
 extension GRPCStatus.Code {

--- a/Sources/GRPC/_GRPCClientChannelHandler.swift
+++ b/Sources/GRPC/_GRPCClientChannelHandler.swift
@@ -396,7 +396,7 @@ extension _GRPCClientChannelHandler: ChannelInboundHandler {
     let result = self.stateMachine.receiveResponseBuffer(&buffer).mapError { error -> GRPCError.WithContext in
       switch error {
       case .cardinalityViolation:
-        return GRPCError.StreamCardinalityViolation(stream: .response).captureContext()
+        return GRPCError.StreamCardinalityViolation.response.captureContext()
       case .deserializationFailed, .leftOverBytes:
         return GRPCError.DeserializationFailure().captureContext()
       case .decompressionLimitExceeded(let compressedSize):


### PR DESCRIPTION
Motivation:

GRPCStreamType is only user to inform the 'StreamCardinalityViolation'
error of the stream type.

Modifications:

- Remove `GRPCStreamType`
- Provide static `let`s for request and response `StreamCardinalityViolation`s

Result:

- Removed a more-or-less pointless type