### PR TITLE
Fix incorrect documentation for certificate verification on the server builder

### DIFF
--- a/Sources/GRPC/ServerBuilder.swift
+++ b/Sources/GRPC/ServerBuilder.swift
@@ -111,7 +111,7 @@ extension Server.Builder.Secure {
     return self
   }
 
-  /// Sets whether certificates should be verified. Defaults to `.fullVerification` if not set.
+  /// Sets whether certificates should be verified. Defaults to `.none` if not set.
   @discardableResult
   public func withTLS(certificateVerification: CertificateVerification) -> Self {
     self.tls.certificateVerification = certificateVerification

--- a/Sources/GRPC/TLSConfiguration.swift
+++ b/Sources/GRPC/TLSConfiguration.swift
@@ -160,7 +160,7 @@ extension Server.Configuration {
       }
     }
 
-    /// TLS Configuration with suitable defaults for clients.
+    /// TLS Configuration with suitable defaults for servers.
     ///
     /// This is a wrapper around `NIOSSL.TLSConfiguration` to restrict input to values which comply
     /// with the gRPC protocol.


### PR DESCRIPTION
Motivation:

The server build incorrectly claimed that without manually calling
`withTLS(certificateVerification:)` that `.fullVerification` would be
used. The default is actually `.none`.

Modifications:

Change the documented default to `.none`.

Result:

Documentation is no longer incorrect.