### PR TITLE
Set iOS deployment target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,7 @@ import Foundation
 
 let package = Package(
   name: "grpc-swift",
+  platforms: [.iOS("13.5")],
   products: [
     .library(name: "GRPC", targets: ["GRPC"]),
     .library(name: "CGRPCZlib", targets: ["CGRPCZlib"]),


### PR DESCRIPTION
I am not sure if this is the right fix, so let me detail the situation:

1. I have created a swift project based on SPM (i.e. defined in a Package.swift file).
2. I made this project depend on grpc-swift (again, in the Package.swift).
3. When I open this SPM project in Xcode, it seems to "just work".
4. If I run `swift package generate-xcodeproj` and build that for iOS, I get the following error when building "GRPC":

```
Compiling for iOS 8.0, but module 'SwiftProtobuf' has a minimum deployment target of iOS 13.5
```

I have tried, from my project, to set the deployment target using an xcconfig, but without success (see [here](https://stackoverflow.com/questions/62849280/xcconfig-has-no-effect-when-running-swift-package-generate-xcodeproj)). Finally, I made it work with this change (i.e. setting the iOS deployment target directly in grpc-swift's Package.swift).

I am not really sure if this is the right thing to do, but it seems to me that if SwiftProtobuf requires iOS 13.5, then it makes sense to enforce that in grpc-swift, too. What I don't understand is that SwiftProtobuf does not specify this in [its Package.swift](https://github.com/apple/swift-protobuf/blob/master/Package.swift), so I don't know where that requirement comes from.

What do you think?