### PR TITLE
Tolerate receiving pings when `permitWithoutCalls` is disabled

### DIFF
--- a/Tests/GRPCTests/XCTestManifests.swift
+++ b/Tests/GRPCTests/XCTestManifests.swift
@@ -496,6 +496,8 @@ extension GRPCPingHandlerTests {
         ("testIntervalWithoutCallsInFlightButPermitted", testIntervalWithoutCallsInFlightButPermitted),
         ("testPingStrikesOnClientShouldHaveNoEffect", testPingStrikesOnClientShouldHaveNoEffect),
         ("testPingStrikesOnServer", testPingStrikesOnServer),
+        ("testPingWithoutDataResultsInPongForClient", testPingWithoutDataResultsInPongForClient),
+        ("testPingWithoutDataResultsInPongForServer", testPingWithoutDataResultsInPongForServer),
     ]
 }
 


### PR DESCRIPTION
Motivation:

The recently introduced keepalive handlers have some a configuration option
`permitWithoutCalls` to control whether pings may be sent when there are
no active RPCs. This was mistakenly applied to receiving pings as well.
For clients, the default is to have this option set to `false`, any
pings received when no streams were active would result in the client
closing the connection to the server.

Since gRPC implementations may send pings which are not used for
keepalive (libgrpc sends pings to estimate BDP, for example), any such
ping would result in the client closing the connection.

Modifications:

- Have the GRPCKeepaliveHandlers always respond to pings (unless the
  ping is considered to be a strike)
- Minor refactoring: change the private `now` property to be a function
- Minor refactoring: document `isPingStrike`
- Add tests

Result:

We tolerate receiving pings so long as they aren't a strike.