### PR TITLE
NetworkPreference.best should be POSIX on older platforms

### DIFF
--- a/Sources/GRPC/PlatformSupport.swift
+++ b/Sources/GRPC/PlatformSupport.swift
@@ -78,11 +78,12 @@ extension NetworkPreference {
     switch self.wrapped {
     case .best:
       #if canImport(Network)
-      guard #available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *) else {
-        // This is gated by the availability of `.networkFramework` so should never happen.
-        fatalError(".networkFramework is being used on an unsupported platform")
+      if #available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *) {
+        return .networkFramework
+      } else {
+        // Older platforms must use the POSIX loop.
+        return .posix
       }
-      return .networkFramework
       #else
       return .posix
       #endif


### PR DESCRIPTION
Motivation:

While NetworkPreference.best was supposed to abstract away the choice of
exactly which event loop would be used, on older Darwin platforms it
would actually lead to runtime crashes as it would try to use an
implementation it didn't have.

Modifications:

Have .best's .implementation fall back to POSIX on older platforms.

Result:

Fewer crashes on older platforms.