### PR TITLE
Capture logs in tests

### DIFF
--- a/Tests/GRPCTests/AnyServiceClientTests.swift
+++ b/Tests/GRPCTests/AnyServiceClientTests.swift
@@ -20,7 +20,10 @@ import XCTest
 
 class AnyServiceClientTests: EchoTestCaseBase {
   var anyServiceClient: AnyServiceClient {
-    return AnyServiceClient(channel: self.client.channel)
+    return AnyServiceClient(
+      channel: self.client.channel,
+      defaultCallOptions: self.callOptionsWithLogger
+    )
   }
 
   func testUnary() throws {

--- a/Tests/GRPCTests/BasicEchoTestCase.swift
+++ b/Tests/GRPCTests/BasicEchoTestCase.swift
@@ -100,15 +100,15 @@ class EchoTestCaseBase: GRPCTestCase {
     return try self.serverBuilder()
       .withErrorDelegate(makeErrorDelegate())
       .withServiceProviders([makeEchoProvider()])
+      .withLogger(self.serverLogger)
       .bind(host: "localhost", port: 0)
       .wait()
   }
 
   func makeClientConnection(port: Int) throws -> ClientConnection {
-    return self.connectionBuilder().connect(
-      host: "localhost",
-      port: port
-    )
+    return self.connectionBuilder()
+      .withBackgroundActivityLogger(self.clientLogger)
+      .connect(host: "localhost", port: port)
   }
 
   func makeEchoProvider() -> Echo_EchoProvider { return EchoProvider() }
@@ -116,7 +116,10 @@ class EchoTestCaseBase: GRPCTestCase {
   func makeErrorDelegate() -> ServerErrorDelegate? { return nil }
 
   func makeEchoClient(port: Int) throws -> Echo_EchoClient {
-    return Echo_EchoClient(channel: try self.makeClientConnection(port: port))
+    return Echo_EchoClient(
+      channel: try self.makeClientConnection(port: port),
+      defaultCallOptions: self.callOptionsWithLogger
+    )
   }
 
   override func setUp() {

--- a/Tests/GRPCTests/CallStartBehaviorTests.swift
+++ b/Tests/GRPCTests/CallStartBehaviorTests.swift
@@ -29,12 +29,13 @@ class CallStartBehaviorTests: GRPCTestCase {
     // and the RPC wouldn't complete until we call shutdown (because we're not setting a timeout).
     let channel = ClientConnection.insecure(group: group)
       .withCallStartBehavior(.fastFailure)
+      .withBackgroundActivityLogger(self.clientLogger)
       .connect(host: "http://unreachable.invalid", port: 0)
     defer {
       XCTAssertNoThrow(try channel.close().wait())
     }
 
-    let echo = Echo_EchoClient(channel: channel)
+    let echo = Echo_EchoClient(channel: channel, defaultCallOptions: self.callOptionsWithLogger)
     let get = echo.get(.with { $0.text = "Is anyone out there?" })
 
     XCTAssertThrowsError(try get.response.wait())

--- a/Tests/GRPCTests/CapturingLogHandler.swift
+++ b/Tests/GRPCTests/CapturingLogHandler.swift
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2020, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import struct Foundation.Date
+import Logging
+import NIOConcurrencyHelpers
+
+/// A `LogHandler` factory which captures all logs emitted by the handlers it makes.
+internal class CapturingLogHandlerFactory {
+  private var lock = Lock()
+  private var _logs: [CapturedLog] = []
+
+  /// Returns all captured logs and empties the store of captured logs.
+  func clearCapturedLogs() -> [CapturedLog] {
+    return self.lock.withLock {
+      let logs = self._logs
+      self._logs.removeAll()
+      return logs
+    }
+  }
+
+  /// Make a `LogHandler` whose logs will be recorded by this factory.
+  func make(_ label: String) -> LogHandler {
+    return CapturingLogHandler(label: label) { log in
+      self.lock.withLockVoid {
+        self._logs.append(log)
+      }
+    }
+  }
+}
+
+/// A captured log.
+internal struct CapturedLog {
+  var label: String
+  var level: Logger.Level
+  var message: Logger.Message
+  var metadata: Logger.Metadata
+  var file: String
+  var function: String
+  var line: UInt
+  var date: Date
+}
+
+/// A log handler which captures all logs it records.
+internal struct CapturingLogHandler: LogHandler {
+  private let capture: (CapturedLog) -> Void
+
+  internal let label: String
+  internal var metadata: Logger.Metadata = [:]
+  internal var logLevel: Logger.Level = .trace
+
+  fileprivate init(label: String, capture: @escaping (CapturedLog) -> ()) {
+    self.label = label
+    self.capture = capture
+  }
+
+  internal func log(
+    level: Logger.Level,
+    message: Logger.Message,
+    metadata: Logger.Metadata?,
+    file: String,
+    function: String,
+    line: UInt
+  ) {
+    let merged: Logger.Metadata
+
+    if let metadata = metadata {
+      merged = self.metadata.merging(metadata, uniquingKeysWith: { old, new in return new })
+    } else {
+      merged = self.metadata
+    }
+
+    let log = CapturedLog(
+      label: self.label,
+      level: level,
+      message: message,
+      metadata: merged,
+      file: file,
+      function: function,
+      line: line,
+      date: Date()
+    )
+
+    self.capture(log)
+  }
+
+  internal subscript(metadataKey metadataKey: String) -> Logger.Metadata.Value? {
+    get {
+      return self.metadata[metadataKey]
+    }
+    set {
+      self.metadata[metadataKey] = newValue
+    }
+  }
+}

--- a/Tests/GRPCTests/ConnectionManagerTests.swift
+++ b/Tests/GRPCTests/ConnectionManagerTests.swift
@@ -27,7 +27,8 @@ class ConnectionManagerTests: GRPCTestCase {
       target: .unixDomainSocket("/ignored"),
       eventLoopGroup: self.loop,
       connectivityStateDelegate: self.recorder,
-      connectionBackoff: nil
+      connectionBackoff: nil,
+      backgroundActivityLogger: self.clientLogger
     )
   }
 

--- a/Tests/GRPCTests/EchoTestClientTests.swift
+++ b/Tests/GRPCTests/EchoTestClientTests.swift
@@ -74,12 +74,14 @@ class EchoTestClientTests: GRPCTestCase {
 
     let server = try Server.insecure(group: group)
       .withServiceProviders([EchoProvider()])
+      .withLogger(self.serverLogger)
       .bind(host: "127.0.0.1", port: 0)
       .wait()
 
     self.server = server
 
     let channel = ClientConnection.insecure(group: group)
+      .withBackgroundActivityLogger(self.clientLogger)
       .connect(host: "127.0.0.1", port: server.channel.localAddress!.port!)
 
     self.channel = channel
@@ -102,7 +104,7 @@ class EchoTestClientTests: GRPCTestCase {
   }
 
   func testGetWithTestClient() {
-    let client = Echo_EchoTestClient()
+    let client = Echo_EchoTestClient(defaultCallOptions: self.callOptionsWithLogger)
     let model = EchoModel(client: client)
 
     let completed = self.expectation(description: "'Get' completed")
@@ -126,7 +128,7 @@ class EchoTestClientTests: GRPCTestCase {
 
   func testGetWithRealClientAndServer() throws {
     let channel = try self.setUpServerAndChannel()
-    let client = Echo_EchoClient(channel: channel)
+    let client = Echo_EchoClient(channel: channel, defaultCallOptions: self.callOptionsWithLogger)
     let model = EchoModel(client: client)
 
     let completed = self.expectation(description: "'Get' completed")
@@ -146,7 +148,7 @@ class EchoTestClientTests: GRPCTestCase {
   }
 
   func testUpdateWithTestClient() {
-    let client = Echo_EchoTestClient()
+    let client = Echo_EchoTestClient(defaultCallOptions: self.callOptionsWithLogger)
     let model = EchoModel(client: client)
 
     let completed = self.expectation(description: "'Update' completed")
@@ -175,7 +177,7 @@ class EchoTestClientTests: GRPCTestCase {
 
   func testUpdateWithRealClientAndServer() throws {
     let channel = try self.setUpServerAndChannel()
-    let client = Echo_EchoClient(channel: channel)
+    let client = Echo_EchoClient(channel: channel, defaultCallOptions: self.callOptionsWithLogger)
     let model = EchoModel(client: client)
 
     let completed = self.expectation(description: "'Update' completed")

--- a/Tests/GRPCTests/FakeChannelTests.swift
+++ b/Tests/GRPCTests/FakeChannelTests.swift
@@ -25,7 +25,8 @@ class FakeChannelTests: GRPCTestCase {
   var channel: FakeChannel!
 
   override func setUp() {
-    self.channel = FakeChannel()
+    super.setUp()
+    self.channel = FakeChannel(logger: self.clientLogger)
   }
 
   private func makeUnaryResponse(

--- a/Tests/GRPCTests/GRPCIdleTests.swift
+++ b/Tests/GRPCTests/GRPCIdleTests.swift
@@ -42,6 +42,7 @@ class GRPCIdleTests: GRPCTestCase {
     let server = try Server.insecure(group: group)
       .withServiceProviders([EchoProvider()])
       .withConnectionIdleTimeout(serverIdle)
+      .withLogger(self.serverLogger)
       .bind(host: "localhost", port: 0)
       .wait()
     defer {
@@ -62,6 +63,7 @@ class GRPCIdleTests: GRPCTestCase {
     let connection = ClientConnection.insecure(group: group)
       .withConnectivityStateDelegate(stateRecorder)
       .withConnectionIdleTimeout(clientIdle)
+      .withBackgroundActivityLogger(self.clientLogger)
       .connect(host: "localhost", port: server.channel.localAddress!.port!)
     defer {
       XCTAssertNoThrow(try connection.close().wait())

--- a/Tests/GRPCTests/GRPCInteroperabilityTests.swift
+++ b/Tests/GRPCTests/GRPCInteroperabilityTests.swift
@@ -38,7 +38,8 @@ class GRPCInsecureInteroperabilityTests: GRPCTestCase {
       host: "localhost",
       port: 0,
       eventLoopGroup: self.serverEventLoopGroup!,
-      useTLS: self.useTLS
+      useTLS: self.useTLS,
+      logger: self.serverLogger
     ).wait()
 
     guard let serverPort = self.server.channel.localAddress?.port else {
@@ -80,7 +81,7 @@ class GRPCInsecureInteroperabilityTests: GRPCTestCase {
     let builder = makeInteroperabilityTestClientBuilder(
       group: self.clientEventLoopGroup,
       useTLS: self.useTLS
-    )
+    ).withBackgroundActivityLogger(self.clientLogger)
     test.configure(builder: builder)
     self.clientConnection = builder.connect(host: "localhost", port: self.serverPort)
     XCTAssertNoThrow(try test.run(using: self.clientConnection), line: line)

--- a/Tests/GRPCTests/GRPCServerRequestRoutingHandlerTests.swift
+++ b/Tests/GRPCTests/GRPCServerRequestRoutingHandlerTests.swift
@@ -41,6 +41,7 @@ class GRPCServerRequestRoutingHandlerTests: GRPCTestCase {
 
   override func tearDown() {
     XCTAssertNoThrow(try self.channel.finish())
+    super.tearDown()
   }
 
   func testInvalidGRPCContentTypeReturnsUnsupportedMediaType() throws {

--- a/Tests/GRPCTests/HTTP1ToGRPCServerCodecTests.swift
+++ b/Tests/GRPCTests/HTTP1ToGRPCServerCodecTests.swift
@@ -32,8 +32,8 @@ class HTTP1ToGRPCServerCodecTests: GRPCTestCase {
   }
 
   override func tearDown() {
-    super.tearDown()
     XCTAssertNoThrow(try self.channel.finish())
+    super.tearDown()
   }
 
   func makeRequestHead() -> HTTPRequestHead {

--- a/Tests/GRPCTests/HeaderNormalizationTests.swift
+++ b/Tests/GRPCTests/HeaderNormalizationTests.swift
@@ -106,6 +106,7 @@ class HeaderNormalizationTests: GRPCTestCase {
     XCTAssertNoThrow(try self.channel.close().wait())
     XCTAssertNoThrow(try self.server.close().wait())
     XCTAssertNoThrow(try self.group.syncShutdownGracefully())
+    super.tearDown()
   }
 
   private func assertCustomMetadataIsLowercased(

--- a/Tests/GRPCTests/PlatformSupportTests.swift
+++ b/Tests/GRPCTests/PlatformSupportTests.swift
@@ -24,6 +24,7 @@ class PlatformSupportTests: GRPCTestCase {
 
   override func tearDown() {
     XCTAssertNoThrow(try self.group?.syncShutdownGracefully())
+    super.tearDown()
   }
 
   func testMakeEventLoopGroupReturnsMultiThreadedGroupForPosix() {

--- a/Tests/GRPCTests/ServerTLSErrorTests.swift
+++ b/Tests/GRPCTests/ServerTLSErrorTests.swift
@@ -66,6 +66,7 @@ class ServerTLSErrorTests: GRPCTestCase {
   }
 
   override func setUp() {
+    super.setUp()
     self.serverEventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     self.clientEventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
   }
@@ -76,6 +77,7 @@ class ServerTLSErrorTests: GRPCTestCase {
 
     XCTAssertNoThrow(try self.serverEventLoopGroup.syncShutdownGracefully())
     self.serverEventLoopGroup = nil
+    super.tearDown()
   }
 
   func testErrorIsLoggedWhenSSLContextErrors() throws {

--- a/Tests/GRPCTests/TestClientExample.swift
+++ b/Tests/GRPCTests/TestClientExample.swift
@@ -24,7 +24,7 @@ class FakeResponseStreamExampleTests: GRPCTestCase {
 
   override func setUp() {
     super.setUp()
-    self.client = Echo_EchoTestClient()
+    self.client = Echo_EchoTestClient(defaultCallOptions: self.callOptionsWithLogger)
   }
 
   func testUnary() {


### PR DESCRIPTION
Motivation:

In #902 we changed behaviour such that gRPC will not log unless you
explicitly pass in a logger. When  tests fail it's useful to have the
logs to triage them, especially when they fail under CI, for example.

Modifications:

- Add a capturing log handler factory to the test module which captures
  all logs emitted by handlers it makes
- Wire up loggers in tests
- Hook up `GRPCTestCase` to print the captured logs only if a test fails
  (or an environment variable was set)
- Add a bunch of missing `super.setUp` and `super.tearDown` calls

Result:

- If a test fails we get all `.trace` level logs emitted during that
  test