### PR TITLE
Fix license header check

### DIFF
--- a/Sources/GRPC/_EmbeddedThroughput.swift
+++ b/Sources/GRPC/_EmbeddedThroughput.swift
@@ -1,18 +1,18 @@
 /*
-* Copyright 2020, gRPC Authors All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2020, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import NIO
 import Logging
 import SwiftProtobuf


### PR DESCRIPTION
Motivation:

The license header script silently stopped working when we let it find
all issues before exiting.

Modifications:

- Fix script
- Fix bad indentation in header

Result:

Licnese checking works again.