### PR TITLE
Don't specify a custom module name when generating Podspecs

### DIFF
--- a/scripts/build_podspecs.py
+++ b/scripts/build_podspecs.py
@@ -51,7 +51,7 @@ class Dependency:
 
     def as_podspec(self):
         indent='    '
-        
+
         if self.use_verbatim_version:
             return indent + "s.dependency '%s', %s\n" % (self.name, self.version)
 
@@ -79,11 +79,9 @@ class Pod:
         print('-----------------------------------------------------------')
 
         indent='    '
-        
+
         podspec = "Pod::Spec.new do |s|\n\n"
         podspec += indent + "s.name = '%s'\n" % self.name
-        if not self.is_plugins_pod:
-            podspec += indent + "s.module_name = '%s'\n" % self.module_name
         podspec += indent + "s.version = '%s'\n" % self.version
         podspec += indent + "s.license = { :type => 'Apache 2.0', :file => 'LICENSE' }\n"
         podspec += indent + "s.summary = '%s'\n" % self.description
@@ -94,7 +92,7 @@ class Pod:
         podspec += indent + "s.ios.deployment_target = '10.0'\n"
         podspec += indent + "s.osx.deployment_target = '10.12'\n"
         podspec += indent + "s.tvos.deployment_target = '10.0'\n"
-        
+
         if self.is_plugins_pod:
             podspec += indent + "s.source = { :http => \"https://github.com/grpc/grpc-swift/releases/download/#{s.version}/protoc-grpc-swift-plugins-#{s.version}.zip\"}\n\n"
             podspec += indent + "s.preserve_paths = '*'\n"
@@ -143,7 +141,7 @@ class PodManager:
             'Swift gRPC code generator plugin and runtime library',
             get_grpc_deps()
         )
-        
+
         grpc_plugins_pod = Pod(
             'gRPC-Swift-Plugins',
             '',


### PR DESCRIPTION
Motivation:

The "gRPC-Core" cocoapod specifies its module name as "grpc"; this is
unfortunate because we also specify our module name as "GRPC". This is
problematic if both are used in the same dependency graph. In CocoaPods
`module_name` is "name to use for the framework / clang module which
will be generated". We therefore end up with two "GRPC" frameworks.

If the module name is not specified it will default to the spec name
instead.

Modifications:

- Don't generate a custom module name when generating Podspecs
- Delete trailing whitespace

Result:

- Resolves #905
- Generated frameworks match Podspec names (i.e. "gRPC-Swift" gets
  converted to "gRPC_Swift")