### PR TITLE
Update docs and CI to reflect our 'main' branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,9 +70,9 @@ jobs:
 stages:
   # Always run this stage.
   - name: "Test"
-  # Only run when pushing (or merging) to master
+  # Only run when pushing (or merging) to main
   - name: "Interoperability Tests"
-    if: type = push AND branch = master
+    if: type = push AND branch = main
 
 cache:
   apt: true

--- a/Examples/Google/SpeechToText/Sources/SpeechService.swift
+++ b/Examples/Google/SpeechToText/Sources/SpeechService.swift
@@ -37,7 +37,7 @@ final class SpeechService {
     precondition(!Constants.apiKey.isEmpty, "Please refer to the README on how to configure your API Key properly.")
 
     // Make EventLoopGroup for the specific platform (NIOTSEventLoopGroup for iOS)
-    // see https://github.com/grpc/grpc-swift/blob/master/docs/apple-platforms.md for more details
+    // see https://github.com/grpc/grpc-swift/blob/main/docs/apple-platforms.md for more details
     let group = PlatformSupport.makeEventLoopGroup(loopCount: 1)
 
     // Create a connection secured with TLS to Google's speech service running on our `EventLoopGroup`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/grpc/grpc-swift.svg?branch=master)](https://travis-ci.org/grpc/grpc-swift)
+[![Build Status](https://travis-ci.org/grpc/grpc-swift.svg?branch=main)](https://travis-ci.org/grpc/grpc-swift)
 [![sswg:sandbox|94x20](https://img.shields.io/badge/sswg-sandbox-lightgrey.svg)](https://github.com/swift-server/sswg/blob/master/process/incubation.md#sandbox-level)
 [![Latest Version](https://img.shields.io/github/v/release/grpc/grpc-swift?include_prereleases&sort=semver)](https://img.shields.io/github/v/release/grpc/grpc-swift?include_prereleases&sort=semver)
 
@@ -24,7 +24,7 @@ opposed to the core library provided by the [gRPC project][grpc].
 
 Version | Implementation | Branch                 | `protoc` Plugin         | CocoaPod              | Support
 --------|----------------|------------------------|-------------------------|-----------------------|-----------------------------------------
-1.x     | SwiftNIO       | [`master`][branch-new] | `protoc-gen-grpc-swift` | [gRPC-Swift][pod-new] | Actively developed and supported
+1.x     | SwiftNIO       | [`main`][branch-new]   | `protoc-gen-grpc-swift` | [gRPC-Swift][pod-new] | Actively developed and supported
 0.x     | gRPC C library | [`cgrpc`][branch-old]  | `proroc-gen-swiftgrpc`  | [SwiftGRPC][pod-old]  | No longer developed; security fixes only
 
 The remainder of this README refers to the 1.x version of gRPC Swift.
@@ -178,7 +178,7 @@ Please get involved! See our [guidelines for contributing](CONTRIBUTING.md).
 [xcode-spm]: https://help.apple.com/xcode/mac/current/#/devb83d64851
 [pod-new]: https://cocoapods.org/pods/gRPC-Swift
 [pod-old]: https://cocoapods.org/pods/SwiftGRPC
-[branch-new]: https://github.com/grpc/grpc-swift/tree/master
+[branch-new]: https://github.com/grpc/grpc-swift/tree/main
 [branch-old]: https://github.com/grpc/grpc-swift/tree/cgrpc
-[examples-out-of-source]: https://github.com/grpc/grpc-swift/tree/master/Examples
-[examples-in-source]: https://github.com/grpc/grpc-swift/tree/master/Sources/Examples
+[examples-out-of-source]: https://github.com/grpc/grpc-swift/tree/main/Examples
+[examples-in-source]: https://github.com/grpc/grpc-swift/tree/main/Sources/Examples


### PR DESCRIPTION
Motivation:

We're changing our default branch from 'master' to 'main'; our CI and
some URLs also need updating.

Modifications:

- Update .travis.yml to run interop tests when pushed to 'main'
- Update README to refer to 'main'
- Update a couple or URLs which point to 'master'

Result:

Our links/CI aren't out-of-sync with out branch name.