### PR TITLE
Switch a `numericCast` to the required type

### DIFF
--- a/Sources/GRPC/HTTP1ToGRPCServerCodec.swift
+++ b/Sources/GRPC/HTTP1ToGRPCServerCodec.swift
@@ -403,7 +403,7 @@ extension HTTP1ToGRPCServerCodec: ChannelOutboundHandler {
         let encodedData = accumulatedData.base64EncodedString()
 
         // Reuse our first buffer.
-        responseTextBuffer.clear(minimumCapacity: numericCast(encodedData.utf8.count))
+        responseTextBuffer.clear(minimumCapacity: UInt32(encodedData.utf8.count))
         responseTextBuffer.writeString(encodedData)
 
         // After collecting all response for gRPC Web connections, send one final aggregated


### PR DESCRIPTION
Motivation:

The server codec uses `numericCast` to turn an `Int` into `_Capacity` in
order to call `ByteBuffer.clear(minimumCapacity:)` which accidentally
requires an underscore-internal type for capacity. The as yet unreleased
fix in NIO deprecates that function and adds an identical signature
using `Int` instead of `_Capacity`.

Using `numericCast` in this instance will result in a compiler error
since the type is ambiguous.

Modifications:

- Replace the `numericCast` with `UInt32`, the alias of `_Capacity`.

Result:

- When the NIO fix is released, gRPC will still be able to compile.