### PR TITLE
Update to SwiftNIO HTTP/2 1.13.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
         "state": {
           "branch": null,
-          "revision": "c5d10f4165128c3d0cc0e3c0f0a8ef55947a73a6",
-          "version": "1.12.2"
+          "revision": "e9627350bdb85bde7e0dc69a29799e40961ced72",
+          "version": "1.13.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
     // Main SwiftNIO package
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.19.0"),
     // HTTP2 via SwiftNIO
-    .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.12.1"),
+    .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.13.0"),
     // TLS via SwiftNIO
     .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.8.0"),
     // Support for Network.framework where possible.

--- a/Sources/GRPC/ClientCalls/ClientCallTransport.swift
+++ b/Sources/GRPC/ClientCalls/ClientCallTransport.swift
@@ -168,13 +168,11 @@ internal class ChannelTransport<Request, Response> {
       multiplexer.whenComplete { result in
         switch result {
         case .success(let mux):
-          mux.createStreamChannel(promise: streamPromise) { stream, streamID in
-            var logger = logger
-            logger[metadataKey: MetadataKey.streamID] = "\(streamID)"
+          mux.createStreamChannel(promise: streamPromise) { stream in
             logger.trace("created http/2 stream")
 
             return stream.pipeline.addHandlers([
-              _GRPCClientChannelHandler(streamID: streamID, callType: callType, logger: logger),
+              _GRPCClientChannelHandler(callType: callType, logger: logger),
               GRPCClientCodecHandler(serializer: serializer, deserializer: deserializer),
               GRPCClientCallHandler(call: call)
             ])

--- a/Sources/GRPC/ClientConnection.swift
+++ b/Sources/GRPC/ClientConnection.swift
@@ -509,7 +509,7 @@ extension ClientConnection {
     public var httpTargetWindowSize: Int
 
     /// The HTTP protocol used for this connection.
-    public var httpProtocol: HTTP2ToHTTP1ClientCodec.HTTPProtocol {
+    public var httpProtocol: HTTP2FramePayloadToHTTP1ClientCodec.HTTPProtocol {
       return self.tls == nil ? .http : .https
     }
 
@@ -642,7 +642,7 @@ extension Channel {
     }
 
     let configuration: EventLoopFuture<Void> = (tlsConfigured ?? self.eventLoop.makeSucceededFuture(())).flatMap {
-      self.configureHTTP2Pipeline(mode: .client, targetWindowSize: httpTargetWindowSize)
+      self.configureHTTP2Pipeline(mode: .client, targetWindowSize: httpTargetWindowSize, inboundStreamInitializer: nil)
     }.flatMap { _ in
       return self.pipeline.handler(type: NIOHTTP2Handler.self).flatMap { http2Handler in
         self.pipeline.addHandlers([
@@ -677,7 +677,7 @@ extension Channel {
     errorDelegate: ClientErrorDelegate?,
     logger: Logger
   ) -> EventLoopFuture<Void> {
-    return self.configureHTTP2Pipeline(mode: .client).flatMap { _ in
+    return self.configureHTTP2Pipeline(mode: .client, inboundStreamInitializer: nil).flatMap { _ in
       self.pipeline.addHandler(DelegatingErrorHandler(logger: logger, delegate: errorDelegate))
     }
   }

--- a/Sources/GRPC/_EmbeddedThroughput.swift
+++ b/Sources/GRPC/_EmbeddedThroughput.swift
@@ -28,7 +28,7 @@ extension EmbeddedChannel {
     responseType: Response.Type = Response.self
   ) -> EventLoopFuture<Void> {
     return self.pipeline.addHandlers([
-      _GRPCClientChannelHandler(streamID: 1, callType: callType, logger: logger),
+      _GRPCClientChannelHandler(callType: callType, logger: logger),
       GRPCClientCodecHandler(
         serializer: ProtobufSerializer<Request>(),
         deserializer: ProtobufDeserializer<Response>()


### PR DESCRIPTION
Motivation:

The multiplexer from SwiftNIO HTTP/2 required that the first write on
each stream matched the order in which the streams were created.
Violating this led to a connection error; all in-flight and subsequent
RPCs on that connection would fail. Some of our users noticed this
(#912). SwiftNIO HTTP/2 recently reworked the API around how streams
are created: HTTP/2 stream channels are no longer created with a stream
ID and now deliver the frame payload to the channel pipeline rather than
the entire HTTP/2 frame. This allows for a stream ID to be assigned to a
stream when it attempts to flush its first write, rather than when the
stream is created.

Modifications:

- Increase the minimum HTTP/2 version to 1.13.0
- Move away from deprecated APIs: this required changing the inbound-in
  and outbound-out types for `_GRPCClientChannelHandler` as well as a
  few smaller changes elsewhere.

Result:

- RPCs can be created concurrently without fear of violating any stream
  ID ordering rules
- Resolves #912