### PR TITLE
Add a 'preflight check' stage to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,20 +18,32 @@
 language: minimal
 jobs:
   include:
+    # Sanity checks for PRs.
+    - &sanity
+      stage: "Preflight Checks"
+      name: "Sanity (license headers and formatting)"
+      os: linux
+      dist: bionic
+      install: ./.travis-install.sh -f  # install swiftformat
+      script: ./.travis-script.sh -s  # just sanity
+      env: SWIFT_VERSION=5.2
     # Tests for each PR.
     - &tests
       stage: "Test"
       name: "Unit Tests: Ubuntu 18.04 (Swift 5.2)"
       os: linux
       dist: bionic
-      script: ./.travis-script.sh
-      env: RUN_INTEROP_TESTS=false SWIFT_VERSION=5.2
+      install: ./.travis-install.sh -p  # install protoc
+      script: ./.travis-script.sh -t  # with tsan
+      env: SWIFT_VERSION=5.2
     - <<: *tests
       name: "Unit Tests: Ubuntu 18.04 (Swift 5.1)"
-      env: RUN_INTEROP_TESTS=false SWIFT_VERSION=5.1.5 NO_TSAN=true
+      script: ./.travis-script.sh
+      env: SWIFT_VERSION=5.1.5
     - <<: *tests
       name: "Unit Tests: Ubuntu 18.04 (Swift 5.0)"
-      env: RUN_INTEROP_TESTS=false SWIFT_VERSION=5.0.3 NO_TSAN=true
+      script: ./.travis-script.sh
+      env: SWIFT_VERSION=5.0.3
     - <<: *tests
       name: "Unit Tests: Xcode 11.5"
       os: osx
@@ -47,14 +59,15 @@ jobs:
       name: "Interoperability Tests: Ubuntu 18.04 (Swift 5.2)"
       os: linux
       dist: bionic
-      script: ./.travis-script.sh
-      env: RUN_INTEROP_TESTS=true SWIFT_VERSION=5.2
+      install: ./.travis-install.sh -p -i # install protoc and interop server
+      script: ./.travis-script.sh -i  # interop tests
+      env: SWIFT_VERSION=5.2
     - <<: *interop_tests
       name: "Interoperability Tests: Ubuntu 18.04 (Swift 5.1)"
-      env: RUN_INTEROP_TESTS=true SWIFT_VERSION=5.1.5
+      env: SWIFT_VERSION=5.1.5
     - <<: *interop_tests
       name: "Interoperability Tests: Ubuntu 18.04 (Swift 5.0)"
-      env: RUN_INTEROP_TESTS=true SWIFT_VERSION=5.0.3
+      env: SWIFT_VERSION=5.0.3
     - <<: *interop_tests
       name: "Interoperability Tests: Xcode 11.5"
       os: osx
@@ -68,6 +81,7 @@ jobs:
     - <<: *development
 
 stages:
+  - name: "Preflight Checks"
   # Always run this stage.
   - name: "Test"
   # Only run when pushing (or merging) to main
@@ -91,7 +105,3 @@ addons:
       - g++
       - zlib1g-dev
       - python3
-
-before_install: ./scripts/license-check.sh
-install: ./.travis-install.sh
-script: ./.travis-script.sh

--- a/scripts/license-check.sh
+++ b/scripts/license-check.sh
@@ -140,11 +140,4 @@ check_copyright_headers() {
 
 errors=0
 check_copyright_headers
-
-if [[ "$errors" == 0 ]]; then
-  echo "License headers: OK"
-else
-  echo "License headers: found $errors issue(s)."
-fi
-
 exit $errors

--- a/scripts/sanity.sh
+++ b/scripts/sanity.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Copyright 2020, gRPC Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+function run_logged() {
+  local message=$1
+  local command=$2
+
+  log=$(mktemp)
+
+  printf '==> %s ... ' "$message"
+
+  if $command > "$log" 2>&1; then
+    printf "\033[0;32mOK\033[0m\n"
+  else
+    printf "\033[0;31mFAILED\033[0m\n"
+    echo "=== Captured output:"
+    cat "$log"
+    echo "==="
+  fi
+}
+
+function check_license_headers() {
+  run_logged "Checking license headers" "$HERE/license-check.sh"
+}
+
+function check_formatting() {
+  hash swiftformat 2> /dev/null || { printf "\033[0;31mERROR\033[0m swiftformat must be installed (see: https://github.com/nicklockwood/SwiftFormat)\n"; exit 1; }
+  run_logged "Checking formatting" "swiftformat --lint $HERE/.."
+}
+
+check_license_headers
+
+# We won't run this just yet.
+# check_formatting


### PR DESCRIPTION
Motivation:

Often contributors miss out license checks, have formatting issues or
haven't generated linux tests. Let's bring these checks up front and
make sure they're done before we run any tests.

Modifications:

- Add a "Preflight Checks" stage to CI
- Add a sanity script which currently just checks license headers; we
  can add other checks later.

Result:

- We have a way to check non-code related things before checking
  functional changes