### PR TITLE
Revert "Don't specify a custom module name when generating Podspecs (#916)"

### DIFF
--- a/scripts/build_podspecs.py
+++ b/scripts/build_podspecs.py
@@ -82,6 +82,8 @@ class Pod:
 
         podspec = "Pod::Spec.new do |s|\n\n"
         podspec += indent + "s.name = '%s'\n" % self.name
+        if not self.is_plugins_pod:
+            podspec += indent + "s.module_name = '%s'\n" % self.module_name
         podspec += indent + "s.version = '%s'\n" % self.version
         podspec += indent + "s.license = { :type => 'Apache 2.0', :file => 'LICENSE' }\n"
         podspec += indent + "s.summary = '%s'\n" % self.description


### PR DESCRIPTION
Motivation:

- #916 was really ill thought through and breaks Cocoapods support

Modifications:

- Revert commit fa00728faa93196b513fafa8da6eb79cfe20b117.

Result:

Cocoapods is less broken.