### PR TITLE
Fix a few incorrect source locations in logs

### DIFF
--- a/Sources/GRPC/CallHandlers/BidirectionalStreamingCallHandler.swift
+++ b/Sources/GRPC/CallHandlers/BidirectionalStreamingCallHandler.swift
@@ -78,7 +78,7 @@ public class BidirectionalStreamingCallHandler<
 
   override internal func processMessage(_ message: RequestPayload) {
     guard let eventObserver = self.eventObserver else {
-      self.logger.warning("eventObserver is nil; ignoring message")
+      self.logger.warning("eventObserver is nil; ignoring message", source: "GRPC")
       return
     }
     eventObserver.whenSuccess { observer in
@@ -88,7 +88,7 @@ public class BidirectionalStreamingCallHandler<
 
   override internal func endOfStreamReceived() throws {
     guard let eventObserver = self.eventObserver else {
-      self.logger.warning("eventObserver is nil; ignoring end-of-stream")
+      self.logger.warning("eventObserver is nil; ignoring end-of-stream", source: "GRPC")
       return
     }
     eventObserver.whenSuccess { observer in

--- a/Sources/GRPC/CallHandlers/ClientStreamingCallHandler.swift
+++ b/Sources/GRPC/CallHandlers/ClientStreamingCallHandler.swift
@@ -78,7 +78,7 @@ public final class ClientStreamingCallHandler<
 
   override internal func processMessage(_ message: RequestPayload) {
     guard let eventObserver = self.eventObserver else {
-      self.logger.warning("eventObserver is nil; ignoring message")
+      self.logger.warning("eventObserver is nil; ignoring message", source: "GRPC")
       return
     }
     eventObserver.whenSuccess { observer in
@@ -88,7 +88,7 @@ public final class ClientStreamingCallHandler<
 
   override internal func endOfStreamReceived() throws {
     guard let eventObserver = self.eventObserver else {
-      self.logger.warning("eventObserver is nil; ignoring end-of-stream")
+      self.logger.warning("eventObserver is nil; ignoring end-of-stream", source: "GRPC")
       return
     }
     eventObserver.whenSuccess { observer in

--- a/Sources/GRPC/CallHandlers/ServerStreamingCallHandler.swift
+++ b/Sources/GRPC/CallHandlers/ServerStreamingCallHandler.swift
@@ -68,8 +68,10 @@ public final class ServerStreamingCallHandler<
   override internal func processMessage(_ message: RequestPayload) throws {
     guard let eventObserver = self.eventObserver,
       let callContext = self.callContext else {
-      self.logger
-        .error("processMessage(_:) called before the call started or after the call completed")
+      self.logger.error(
+        "processMessage(_:) called before the call started or after the call completed",
+        source: "GRPC"
+      )
       throw GRPCError.StreamCardinalityViolation.request.captureContext()
     }
 

--- a/Sources/GRPC/CallHandlers/UnaryCallHandler.swift
+++ b/Sources/GRPC/CallHandlers/UnaryCallHandler.swift
@@ -68,8 +68,10 @@ public final class UnaryCallHandler<
   override internal func processMessage(_ message: RequestPayload) throws {
     guard let eventObserver = self.eventObserver,
       let context = self.callContext else {
-      self.logger
-        .error("processMessage(_:) called before the call started or after the call completed")
+      self.logger.error(
+        "processMessage(_:) called before the call started or after the call completed",
+        source: "GRPC"
+      )
       throw GRPCError.StreamCardinalityViolation.request.captureContext()
     }
 

--- a/Sources/GRPC/CallHandlers/_BaseCallHandler.swift
+++ b/Sources/GRPC/CallHandlers/_BaseCallHandler.swift
@@ -115,7 +115,8 @@ extension _BaseCallHandler: ChannelInboundHandler {
       } catch {
         self.logger.error(
           "error caught while user handler was processing message",
-          metadata: [MetadataKey.error: "\(error)"]
+          metadata: [MetadataKey.error: "\(error)"],
+          source: "GRPC"
         )
         self.errorCaught(context: context, error: error)
       }
@@ -126,7 +127,8 @@ extension _BaseCallHandler: ChannelInboundHandler {
       } catch {
         self.logger.error(
           "error caught on receiving end of stream",
-          metadata: [MetadataKey.error: "\(error)"]
+          metadata: [MetadataKey.error: "\(error)"],
+          source: "GRPC"
         )
         self.errorCaught(context: context, error: error)
       }

--- a/Sources/GRPC/ClientErrorDelegate.swift
+++ b/Sources/GRPC/ClientErrorDelegate.swift
@@ -49,6 +49,7 @@ public class LoggingClientErrorDelegate: ClientErrorDelegate {
     logger.error(
       "grpc client error",
       metadata: [MetadataKey.error: "\(error)"],
+      source: "GRPC",
       file: "\(file)",
       function: "<unknown>",
       line: UInt(line)

--- a/Tests/GRPCTests/CapturingLogHandler.swift
+++ b/Tests/GRPCTests/CapturingLogHandler.swift
@@ -47,6 +47,7 @@ internal struct CapturedLog {
   var level: Logger.Level
   var message: Logger.Message
   var metadata: Logger.Metadata
+  var source: String
   var file: String
   var function: String
   var line: UInt
@@ -70,6 +71,7 @@ internal struct CapturingLogHandler: LogHandler {
     level: Logger.Level,
     message: Logger.Message,
     metadata: Logger.Metadata?,
+    source: String,
     file: String,
     function: String,
     line: UInt
@@ -87,6 +89,7 @@ internal struct CapturingLogHandler: LogHandler {
       level: level,
       message: message,
       metadata: merged,
+      source: source,
       file: file,
       function: function,
       line: line,

--- a/Tests/GRPCTests/GRPCTestCase.swift
+++ b/Tests/GRPCTests/GRPCTestCase.swift
@@ -36,8 +36,20 @@ class GRPCTestCase: XCTestCase {
   }
 
   override func tearDown() {
+    let logs = self.capturedLogs()
+
+    // The default source emitted by swift-log is the directory containing the '#file' in which the
+    // log was emitted. It's meant to represent the system which emitted the log, typically the
+    // module name. In most cases it's right but in a few places, i.e. where the source lives in
+    // child directories below 'GRPC', it isn't. We'll use this as a sanity check.
+    //
+    // See also: https://github.com/apple/swift-log/issues/145
+    for log in logs {
+      XCTAssertEqual(log.source, "GRPC", "Incorrect log source in \(log.file) on line \(log.line)")
+    }
+
     if GRPCTestCase.alwaysLog || (self.testRun.map { $0.totalFailureCount > 0 } ?? false) {
-      self.printCapturedLogs()
+      self.printCapturedLogs(logs)
     }
 
     super.tearDown()
@@ -86,9 +98,7 @@ class GRPCTestCase: XCTestCase {
   }
 
   /// Prints all captured logs.
-  private func printCapturedLogs() {
-    let logs = self.capturedLogs()
-
+  private func printCapturedLogs(_ logs: [CapturedLog]) {
     let formatter = DateFormatter()
     // We don't care about the date.
     formatter.dateFormat = "HH:mm:ss.SSS"


### PR DESCRIPTION
Motivation:

swift-log 1.3.0 introduced a new concepct: the source of a log. This
identifies the creator of the emitted log, typically the module or
system that emitted the log.

The default value is currently (meant to be) the module name. This is
found by parsing the '#file' to find the directory the file is
contained in. However, this isn't always the module.

Modifications:

- Capture the log source in tests
- Validate the source in test tear down
- Fix up incorrect sources

Result:

- gRPC more uniformly emits a useful log source