### PR TITLE
Pin the SwiftFormat version in CI

### DIFF
--- a/.travis-install.sh
+++ b/.travis-install.sh
@@ -37,6 +37,7 @@ PROTOBUF_VERSION=3.9.1
 # We need this to build gRPC C++ for the interop test server(s).
 BAZEL_VERSION=0.28.1
 GRPC_VERSION=1.23.0
+SWIFTFORMAT_VERSION=0.44.13
 
 info() {
   printf '\033[0;34m%s\033[0m\n' "$1"
@@ -182,21 +183,20 @@ function install_swiftformat() {
   echo -en 'travis_fold:start:install.swiftformat\\r'
   info "Installing swiftformat"
 
-
-  if [ ! -f "$BIN_CACHE/swiftformat" ]; then
-    git clone --depth 1 "https://github.com/nicklockwood/SwiftFormat"
+  if [ ! -f "$BIN_CACHE/swiftformat-$SWIFTFORMAT_VERSION" ]; then
+    git clone -b "$SWIFTFORMAT_VERSION" --depth 1 "https://github.com/nicklockwood/SwiftFormat"
 
     info "Building swiftformat"
     cd SwiftFormat
     swift build --product swiftformat
 
-    cp "$(swift build --show-bin-path)/swiftformat" "$BIN_CACHE/swiftformat"
+    cp "$(swift build --show-bin-path)/swiftformat" "$BIN_CACHE/swiftformat-$SWIFTFORMAT_VERSION"
   else
     info "Skipping download and build of SwiftFormat, using cached binaries"
   fi
 
   # We should have cached swiftformat now, copy it to $HOME/local/bin
-  cp "$BIN_CACHE/swiftformat" "$HOME"/local/bin/swiftformat
+  cp "$BIN_CACHE/swiftformat-$SWIFTFORMAT_VERSION" "$HOME"/local/bin/swiftformat
 
   success "Installed swiftformat"
   echo -en 'travis_fold:end:install.swiftformat\\r'

--- a/scripts/sanity.sh
+++ b/scripts/sanity.sh
@@ -29,6 +29,7 @@ function run_logged() {
   if $command > "$log" 2>&1; then
     printf "\033[0;32mOK\033[0m\n"
   else
+    errors=$(( errors + 1))
     printf "\033[0;31mFAILED\033[0m\n"
     echo "=== Captured output:"
     cat "$log"
@@ -45,5 +46,7 @@ function check_formatting() {
   run_logged "Checking formatting" "swiftformat --lint $HERE/.."
 }
 
+errors=0
 check_license_headers
 check_formatting
+exit $errors


### PR DESCRIPTION
Motivation:

Recent versions of SwiftFormat seem to have issues when loading
configuration files. This causes the lint check to unexpectedlty fail in
CI.

Modifications:

- Pin the SwiftFormat version in CI
- Ensure the exit code from the sanity script is bubbled up to the
  travis script

Result:

Formatting works in CI