### PR TITLE
Avoid unnecessary arrays.

### DIFF
--- a/Tests/GRPCTests/XCTestManifests.swift
+++ b/Tests/GRPCTests/XCTestManifests.swift
@@ -646,7 +646,9 @@ extension HTTP1ToGRPCServerCodecTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__HTTP1ToGRPCServerCodecTests = [
+        ("testErrorsOnlyHappenOnce", testErrorsOnlyHappenOnce),
         ("testMultipleMessagesFromSingleBodyPart", testMultipleMessagesFromSingleBodyPart),
+        ("testReentrantMessageDelivery", testReentrantMessageDelivery),
         ("testSingleMessageFromMultipleBodyParts", testSingleMessageFromMultipleBodyParts),
     ]
 }


### PR DESCRIPTION
Motivation:

HTTP1ToGRPCServerCodec currently creates a temporary array for parsing
all messages into before it forwards them on. This is both a minor perf
drain (due to the extra allocations) and a correctness problem, as it
makes this channel handler non-reentrant-safe. We should fix both
issues.

Modifications:

- Replace the temporary array with a simple loop.
- Add tests that validates correct behaviour on reentrancy.

Result:

Better re-entrancy behaviour! Verrrry slightly better perf.