### PR TITLE
Disable new swiftformat rule

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -24,3 +24,6 @@
 # treated as a trailing closure. This is relevant because the service provider
 # API for client streaming RPCs has this exact shape.
 --disable trailingClosures
+
+# Don't wrap the opening brace of multiline statements.
+--disable wrapMultilineStatementBraces

--- a/.travis-install.sh
+++ b/.travis-install.sh
@@ -37,7 +37,6 @@ PROTOBUF_VERSION=3.9.1
 # We need this to build gRPC C++ for the interop test server(s).
 BAZEL_VERSION=0.28.1
 GRPC_VERSION=1.23.0
-SWIFTFORMAT_VERSION=0.44.13
 
 info() {
   printf '\033[0;34m%s\033[0m\n' "$1"
@@ -183,20 +182,21 @@ function install_swiftformat() {
   echo -en 'travis_fold:start:install.swiftformat\\r'
   info "Installing swiftformat"
 
-  if [ ! -f "$BIN_CACHE/swiftformat-$SWIFTFORMAT_VERSION" ]; then
-    git clone -b "$SWIFTFORMAT_VERSION" --depth 1 "https://github.com/nicklockwood/SwiftFormat"
+  git clone --depth 1 "https://github.com/nicklockwood/SwiftFormat"
+  cd SwiftFormat
+  version=$(git rev-parse HEAD)
 
+  if [ ! -f "$BIN_CACHE/swiftformat-$version" ]; then
     info "Building swiftformat"
-    cd SwiftFormat
     swift build --product swiftformat
 
-    cp "$(swift build --show-bin-path)/swiftformat" "$BIN_CACHE/swiftformat-$SWIFTFORMAT_VERSION"
+    cp "$(swift build --show-bin-path)/swiftformat" "$BIN_CACHE/swiftformat-$version"
   else
-    info "Skipping download and build of SwiftFormat, using cached binaries"
+    info "Skipping build of SwiftFormat, using cached binaries"
   fi
 
   # We should have cached swiftformat now, copy it to $HOME/local/bin
-  cp "$BIN_CACHE/swiftformat-$SWIFTFORMAT_VERSION" "$HOME"/local/bin/swiftformat
+  cp "$BIN_CACHE/swiftformat-$version" "$HOME"/local/bin/swiftformat
 
   success "Installed swiftformat"
   echo -en 'travis_fold:end:install.swiftformat\\r'

--- a/Tests/GRPCTests/FakeResponseStreamTests.swift
+++ b/Tests/GRPCTests/FakeResponseStreamTests.swift
@@ -201,7 +201,7 @@ class FakeResponseStreamTests: GRPCTestCase {
 
 private extension EmbeddedChannel {
   func verifyInbound<Inbound>(as: Inbound.Type = Inbound.self, _ verify: (Inbound) -> Void = { _ in
-    }) {
+  }) {
     do {
       if let inbound = try self.readInbound(as: Inbound.self) {
         verify(inbound)

--- a/scripts/sanity.sh
+++ b/scripts/sanity.sh
@@ -43,7 +43,7 @@ function check_license_headers() {
 
 function check_formatting() {
   hash swiftformat 2> /dev/null || { printf "\033[0;31mERROR\033[0m swiftformat must be installed (see: https://github.com/nicklockwood/SwiftFormat)\n"; exit 1; }
-  run_logged "Checking formatting" "swiftformat --lint $HERE/.."
+  run_logged "Checking formatting (swiftformat $(swiftformat --version))" "swiftformat --lint --verbose $HERE/.."
 }
 
 errors=0


### PR DESCRIPTION
Motivation:

- SwiftFormat added a new rule but was pinned to an older version; this
  makes it harder for contributors to resolve issues.

Modifications:

- Disable the new rule
- Build the most recent formatter version; emit the version when running
  the script
- Run the lint check verbosely

Result:

- Less pain when new rules are added