### PR TITLE
Log some HTTP/2 information

### DIFF
--- a/Sources/GRPC/ClientCalls/ClientCallTransport.swift
+++ b/Sources/GRPC/ClientCalls/ClientCallTransport.swift
@@ -169,9 +169,7 @@ internal class ChannelTransport<Request, Response> {
         switch result {
         case let .success(mux):
           mux.createStreamChannel(promise: streamPromise) { stream in
-            logger.trace("created http/2 stream", source: "GRPC")
-
-            return stream.pipeline.addHandlers([
+            stream.pipeline.addHandlers([
               _GRPCClientChannelHandler(callType: callType, logger: logger),
               GRPCClientCodecHandler(serializer: serializer, deserializer: deserializer),
               GRPCClientCallHandler(call: call),
@@ -574,6 +572,7 @@ extension ChannelTransport: ClientCallInbound {
   /// Must be called on the event loop.
   internal func activate(stream: Channel) {
     self.eventLoop.preconditionInEventLoop()
+    self.logger.debug("activated stream channel", source: "GRPC")
 
     // The channel has become active: what now?
     switch self.state {

--- a/Sources/GRPC/ClientConnection.swift
+++ b/Sources/GRPC/ClientConnection.swift
@@ -166,7 +166,6 @@ extension ClientConnection: GRPCChannel {
     callOptions: CallOptions
   ) -> UnaryCall<Serializer.Input, Deserializer.Output> {
     let (logger, requestID) = self.populatedLoggerAndRequestID(from: callOptions)
-    logger.debug("starting rpc", metadata: ["path": "\(path)"])
 
     let call = UnaryCall<Serializer.Input, Deserializer.Output>.makeOnHTTP2Stream(
       multiplexer: self.multiplexer,
@@ -229,7 +228,6 @@ extension ClientConnection {
     callOptions: CallOptions
   ) -> ClientStreamingCall<Serializer.Input, Deserializer.Output> {
     let (logger, requestID) = self.populatedLoggerAndRequestID(from: callOptions)
-    logger.debug("starting rpc", metadata: ["path": "\(path)"])
 
     let call = ClientStreamingCall<Serializer.Input, Deserializer.Output>.makeOnHTTP2Stream(
       multiplexer: self.multiplexer,
@@ -290,7 +288,6 @@ extension ClientConnection {
     handler: @escaping (Deserializer.Output) -> Void
   ) -> ServerStreamingCall<Serializer.Input, Deserializer.Output> {
     let (logger, requestID) = self.populatedLoggerAndRequestID(from: callOptions)
-    logger.debug("starting rpc", metadata: ["path": "\(path)"])
 
     let call = ServerStreamingCall<Serializer.Input, Deserializer.Output>.makeOnHTTP2Stream(
       multiplexer: self.multiplexer,
@@ -362,7 +359,6 @@ extension ClientConnection {
     handler: @escaping (Deserializer.Output) -> Void
   ) -> BidirectionalStreamingCall<Serializer.Input, Deserializer.Output> {
     let (logger, requestID) = self.populatedLoggerAndRequestID(from: callOptions)
-    logger.debug("starting rpc", metadata: ["path": "\(path)"])
 
     let call = BidirectionalStreamingCall<Serializer.Input, Deserializer.Output>.makeOnHTTP2Stream(
       multiplexer: self.multiplexer,
@@ -688,7 +684,11 @@ extension Channel {
         self.pipeline.addHandlers(
           [
             GRPCClientKeepaliveHandler(configuration: connectionKeepalive),
-            GRPCIdleHandler(mode: .client(connectionManager), idleTimeout: connectionIdleTimeout),
+            GRPCIdleHandler(
+              mode: .client(connectionManager),
+              logger: logger,
+              idleTimeout: connectionIdleTimeout
+            ),
           ],
           position: .after(http2Handler)
         )

--- a/Sources/GRPC/GRPCTimeout.swift
+++ b/Sources/GRPC/GRPCTimeout.swift
@@ -42,8 +42,13 @@ public struct GRPCTimeout: CustomStringConvertible, Equatable {
   ///
   /// - Parameter deadline: The deadline to create a timeout from.
   internal init(deadline: NIODeadline, testingOnlyNow: NIODeadline? = nil) {
-    let timeAmountUntilDeadline = deadline - (testingOnlyNow ?? .now())
-    self.init(rounding: timeAmountUntilDeadline.nanoseconds, unit: .nanoseconds)
+    switch deadline {
+    case .distantFuture:
+      self = .infinite
+    default:
+      let timeAmountUntilDeadline = deadline - (testingOnlyNow ?? .now())
+      self.init(rounding: timeAmountUntilDeadline.nanoseconds, unit: .nanoseconds)
+    }
   }
 
   private init(nanoseconds: Int64, wireEncoding: String) {

--- a/Sources/GRPC/Logger.swift
+++ b/Sources/GRPC/Logger.swift
@@ -17,8 +17,18 @@ import Logging
 
 /// Keys for `Logger` metadata.
 enum MetadataKey {
-  static let streamID = "http2_stream_id"
-  static let requestID = "request_id"
-  static let connectionID = "connection_id"
+  static let requestID = "grpc_request_id"
+  static let connectionID = "grpc_connection_id"
+
+  static let eventLoop = "event_loop"
+  static let remoteAddress = "remote_address"
+
+  static let h2StreamID = "h2_stream_id"
+  static let h2ActiveStreams = "h2_active_streams"
+  static let h2EndStream = "h2_end_stream"
+  static let h2Payload = "h2_payload"
+  static let h2Headers = "h2_headers"
+  static let h2DataBytes = "h2_data_bytes"
+
   static let error = "error"
 }

--- a/Sources/GRPC/Server.swift
+++ b/Sources/GRPC/Server.swift
@@ -103,12 +103,17 @@ public final class Server {
       )
       // Set the handlers that are applied to the accepted Channels
       .childChannelInitializer { channel in
+        var logger = configuration.logger
+        logger[metadataKey: MetadataKey.connectionID] = "\(UUID().uuidString)"
+        logger[metadataKey: MetadataKey.remoteAddress] = channel.remoteAddress
+          .map { "\($0)" } ?? "n/a"
+
         let protocolSwitcher = HTTPProtocolSwitcher(
           errorDelegate: configuration.errorDelegate,
           httpTargetWindowSize: configuration.httpTargetWindowSize,
           keepAlive: configuration.connectionKeepalive,
           idleTimeout: configuration.connectionIdleTimeout,
-          logger: configuration.logger
+          logger: logger
         ) { (channel, logger) -> EventLoopFuture<Void> in
           let handler = GRPCServerRequestRoutingHandler(
             servicesByName: configuration.serviceProvidersByName,

--- a/Tests/GRPCTests/ConnectionManagerTests.swift
+++ b/Tests/GRPCTests/ConnectionManagerTests.swift
@@ -124,7 +124,7 @@ extension ConnectionManagerTests {
 
     // Setup the real channel and activate it.
     let channel = EmbeddedChannel(
-      handler: GRPCIdleHandler(mode: .client(manager)),
+      handler: GRPCIdleHandler(mode: .client(manager), logger: self.logger),
       loop: self.loop
     )
     channelPromise.succeed(channel)
@@ -165,7 +165,7 @@ extension ConnectionManagerTests {
 
     // Setup the channel.
     let channel = EmbeddedChannel(
-      handler: GRPCIdleHandler(mode: .client(manager)),
+      handler: GRPCIdleHandler(mode: .client(manager), logger: self.logger),
       loop: self.loop
     )
     channelPromise.succeed(channel)
@@ -215,7 +215,7 @@ extension ConnectionManagerTests {
 
     // Setup the channel.
     let channel = EmbeddedChannel(
-      handler: GRPCIdleHandler(mode: .client(manager)),
+      handler: GRPCIdleHandler(mode: .client(manager), logger: self.logger),
       loop: self.loop
     )
     channelPromise.succeed(channel)
@@ -278,7 +278,7 @@ extension ConnectionManagerTests {
 
     // Setup the channel.
     let channel = EmbeddedChannel(
-      handler: GRPCIdleHandler(mode: .client(manager)),
+      handler: GRPCIdleHandler(mode: .client(manager), logger: self.logger),
       loop: self.loop
     )
     channelPromise.succeed(channel)
@@ -337,7 +337,7 @@ extension ConnectionManagerTests {
 
     // Setup the actual channel and complete the promise.
     let channel = EmbeddedChannel(
-      handler: GRPCIdleHandler(mode: .client(manager)),
+      handler: GRPCIdleHandler(mode: .client(manager), logger: self.logger),
       loop: self.loop
     )
     channelPromise.succeed(channel)
@@ -444,7 +444,7 @@ extension ConnectionManagerTests {
 
     // Prepare the channel
     let channel = EmbeddedChannel(
-      handler: GRPCIdleHandler(mode: .client(manager)),
+      handler: GRPCIdleHandler(mode: .client(manager), logger: self.logger),
       loop: self.loop
     )
     channelPromise.succeed(channel)
@@ -508,7 +508,7 @@ extension ConnectionManagerTests {
 
     // Prepare the channel
     let firstChannel = EmbeddedChannel(
-      handler: GRPCIdleHandler(mode: .client(manager)),
+      handler: GRPCIdleHandler(mode: .client(manager), logger: self.logger),
       loop: self.loop
     )
     channelPromise.succeed(firstChannel)
@@ -572,7 +572,7 @@ extension ConnectionManagerTests {
 
     // Prepare the first channel
     let firstChannel = EmbeddedChannel(
-      handler: GRPCIdleHandler(mode: .client(manager)),
+      handler: GRPCIdleHandler(mode: .client(manager), logger: self.logger),
       loop: self.loop
     )
     firstChannelPromise.succeed(firstChannel)
@@ -602,7 +602,7 @@ extension ConnectionManagerTests {
 
     // Prepare the second channel
     let secondChannel = EmbeddedChannel(
-      handler: GRPCIdleHandler(mode: .client(manager)),
+      handler: GRPCIdleHandler(mode: .client(manager), logger: self.logger),
       loop: self.loop
     )
     secondChannelPromise.succeed(secondChannel)
@@ -643,7 +643,7 @@ extension ConnectionManagerTests {
 
     // Setup the channel.
     let channel = EmbeddedChannel(
-      handler: GRPCIdleHandler(mode: .client(manager)),
+      handler: GRPCIdleHandler(mode: .client(manager), logger: self.logger),
       loop: self.loop
     )
     channelPromise.succeed(channel)
@@ -791,7 +791,7 @@ extension ConnectionManagerTests {
     let channel = EmbeddedChannel(loop: self.loop)
     XCTAssertNoThrow(try channel.pipeline.addHandlers([
       CloseDroppingHandler(),
-      GRPCIdleHandler(mode: .client(manager)),
+      GRPCIdleHandler(mode: .client(manager), logger: manager.logger),
     ]).wait())
     channelPromise.succeed(channel)
     self.loop.run()

--- a/Tests/GRPCTests/GRPCTestCase.swift
+++ b/Tests/GRPCTests/GRPCTestCase.swift
@@ -116,7 +116,7 @@ class GRPCTestCase: XCTestCase {
         .map { key, value in "\(key)=\(value)" }
         .joined(separator: " ")
 
-      print("\(date) \(log.label) \(level):", log.message, formattedMetadata)
+      print("\(date) \(log.label) \(level):", log.message, "{", formattedMetadata, "}")
     }
 
     print("Test Case '\(self.name)' logs finished")

--- a/Tests/GRPCTests/GRPCTimeoutTests.swift
+++ b/Tests/GRPCTests/GRPCTimeoutTests.swift
@@ -124,4 +124,8 @@ class GRPCTimeoutTests: GRPCTestCase {
     let timeout = GRPCTimeout(deadline: deadline, testingOnlyNow: .uptimeNanoseconds(200))
     XCTAssertEqual(timeout.nanoseconds, 0)
   }
+
+  func testTimeoutFromDistantFuture() throws {
+    XCTAssertEqual(GRPCTimeout(deadline: .distantFuture), .infinite)
+  }
 }

--- a/Tests/GRPCTests/XCTestManifests.swift
+++ b/Tests/GRPCTests/XCTestManifests.swift
@@ -626,6 +626,7 @@ extension GRPCTimeoutTests {
         ("testRoundingNegativeTimeout", testRoundingNegativeTimeout),
         ("testRoundingSecondsTimeout", testRoundingSecondsTimeout),
         ("testTimeoutFromDeadline", testTimeoutFromDeadline),
+        ("testTimeoutFromDistantFuture", testTimeoutFromDistantFuture),
         ("testTimeoutFromPastDeadline", testTimeoutFromPastDeadline),
     ]
 }


### PR DESCRIPTION
Motivation:

Sometimes it's useful to know what's going on at the HTTP/2 layer, none
of our logs currently surface this information.

Modifications:

- Add logs for stream created/closed events (includes open stream count)
- Add logs for initial settings
- Add more logging for connection lifecycle
- Add trace logs to the stream for read/written frames
- Prefix request and connection ID metadata keys with "grpc_"
- Remove duplicated log messages

Result:

- Better insight for HTTP/2