### PR TITLE
Update the Podspecs to alpha18.

### DIFF
--- a/CGRPCZlib.podspec
+++ b/CGRPCZlib.podspec
@@ -1,19 +1,18 @@
 Pod::Spec.new do |s|
 
     s.name = 'CGRPCZlib'
-    s.module_name = 'CGRPCZlib'
-    s.version = '1.0.0-alpha.17'
+    s.version = '1.0.0-alpha.18'
     s.license = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.summary = 'Compression library that provides in-memory compression and decompression functions'
     s.homepage = 'https://www.grpc.io'
     s.authors  = { 'The gRPC contributors' => 'grpc-packages@google.com' }
 
-    s.source = { :git => "https://github.com/grpc/grpc-swift.git", :tag => s.version }
-
     s.swift_version = '5.0'
     s.ios.deployment_target = '10.0'
     s.osx.deployment_target = '10.12'
     s.tvos.deployment_target = '10.0'
+    s.source = { :git => "https://github.com/grpc/grpc-swift.git", :tag => s.version }
+
     s.source_files = 'Sources/CGRPCZlib/**/*.{swift,c,h}'
 
 end

--- a/gRPC-Swift-Plugins.podspec
+++ b/gRPC-Swift-Plugins.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
     s.name = 'gRPC-Swift-Plugins'
-    s.version = '1.0.0-alpha.17'
+    s.version = '1.0.0-alpha.18'
     s.license = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.summary = 'Swift gRPC code generator plugin binaries'
     s.homepage = 'https://www.grpc.io'

--- a/gRPC-Swift.podspec
+++ b/gRPC-Swift.podspec
@@ -1,24 +1,23 @@
 Pod::Spec.new do |s|
 
     s.name = 'gRPC-Swift'
-    s.module_name = 'GRPC'
-    s.version = '1.0.0-alpha.17'
+    s.version = '1.0.0-alpha.18'
     s.license = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.summary = 'Swift gRPC code generator plugin and runtime library'
     s.homepage = 'https://www.grpc.io'
     s.authors  = { 'The gRPC contributors' => 'grpc-packages@google.com' }
 
-    s.source = { :git => "https://github.com/grpc/grpc-swift.git", :tag => s.version }
-
     s.swift_version = '5.0'
     s.ios.deployment_target = '10.0'
     s.osx.deployment_target = '10.12'
     s.tvos.deployment_target = '10.0'
+    s.source = { :git => "https://github.com/grpc/grpc-swift.git", :tag => s.version }
+
     s.source_files = 'Sources/GRPC/**/*.{swift,c,h}'
 
-    s.dependency 'Logging', '>= 1.2.0', '< 2'
+    s.dependency 'Logging', '>= 1.4.0', '< 2'
     s.dependency 'SwiftNIO', '>= 2.19.0', '< 3'
-    s.dependency 'SwiftNIOHTTP2', '>= 1.12.2', '< 2'
+    s.dependency 'SwiftNIOHTTP2', '>= 1.13.0', '< 2'
     s.dependency 'SwiftNIOSSL', '>= 2.8.0', '< 3'
     s.dependency 'SwiftNIOTransportServices', '>= 1.6.0', '< 2'
     s.dependency 'SwiftProtobuf', '>= 1.9.0', '< 2'


### PR DESCRIPTION
This will become obsolete again very soon, but still be included for posterity, e.g. when including the Pod via

`pod 'gRPC-Swift', :git => 'https://github.com/grpc/grpc-swift', :branch => 'main'`