### PR TITLE
Allow the gRPC module name to be customised when generating code

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ the following line to your `Podfile`:
 Then, run `pod install` from command line and use your project's generated
 `.xcworkspace` file. You might also need to add `use_frameworks!` to your `Podfile`.
 
+*⚠️ If you have conficting modules as a result of having a transitive
+dependency on '[gRPC-Core][grpc-core-pod]' see [grpc/grpc-swift#945][grpc-swift-945].*
+
 ### Getting the `protoc` Plugins
 
 Binary releases of `protoc`, the Protocol Buffer Compiler, are available on
@@ -171,6 +174,8 @@ Please get involved! See our [guidelines for contributing](CONTRIBUTING.md).
 [docs-keepalive]: ./docs/keepalive.md
 [docs-tutorial]: ./docs/basic-tutorial.md
 [grpc]: https://github.com/grpc/grpc
+[grpc-core-pod]: https://cocoapods.org/pods/gRPC-Core
+[grpc-swift-945]: https://github.com/grpc/grpc-swift/pull/945
 [protobuf-releases]: https://github.com/protocolbuffers/protobuf/releases
 [swift-nio-platforms]: https://github.com/apple/swift-nio#supported-platforms
 [swift-nio]: https://github.com/apple/swift-nio

--- a/Sources/Examples/Echo/Model/echo.grpc.swift
+++ b/Sources/Examples/Echo/Model/echo.grpc.swift
@@ -20,11 +20,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-import Foundation
 import GRPC
 import NIO
-import NIOHTTP1
-import SwiftProtobuf
 
 
 /// Usage: instantiate Echo_EchoClient, then call methods of this protocol to make API calls.

--- a/Sources/Examples/HelloWorld/Model/helloworld.grpc.swift
+++ b/Sources/Examples/HelloWorld/Model/helloworld.grpc.swift
@@ -20,11 +20,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-import Foundation
 import GRPC
 import NIO
-import NIOHTTP1
-import SwiftProtobuf
 
 
 /// Usage: instantiate Helloworld_GreeterClient, then call methods of this protocol to make API calls.

--- a/Sources/Examples/RouteGuide/Model/route_guide.grpc.swift
+++ b/Sources/Examples/RouteGuide/Model/route_guide.grpc.swift
@@ -20,11 +20,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-import Foundation
 import GRPC
 import NIO
-import NIOHTTP1
-import SwiftProtobuf
 
 
 /// Usage: instantiate Routeguide_RouteGuideClient, then call methods of this protocol to make API calls.

--- a/Sources/GRPCInteroperabilityTestModels/Generated/test.grpc.swift
+++ b/Sources/GRPCInteroperabilityTestModels/Generated/test.grpc.swift
@@ -20,11 +20,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-import Foundation
 import GRPC
 import NIO
-import NIOHTTP1
-import SwiftProtobuf
 
 
 /// Usage: instantiate Grpc_Testing_TestServiceClient, then call methods of this protocol to make API calls.

--- a/Sources/protoc-gen-grpc-swift/Generator.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator.swift
@@ -88,11 +88,8 @@ class Generator {
     """)
 
     let moduleNames = [
-      "Foundation",
+      self.options.gRPCModuleName,
       "NIO",
-      "NIOHTTP1",
-      "GRPC",
-      "SwiftProtobuf",
     ]
 
     for moduleName in (moduleNames + self.options.extraModuleImports).sorted() {

--- a/Sources/protoc-gen-grpc-swift/options.swift
+++ b/Sources/protoc-gen-grpc-swift/options.swift
@@ -58,6 +58,7 @@ final class GeneratorOptions {
   private(set) var protoToModuleMappings = ProtoFileToModuleMappings()
   private(set) var fileNaming = FileNaming.FullPath
   private(set) var extraModuleImports: [String] = []
+  private(set) var gRPCModuleName = "GRPC"
 
   init(parameter: String?) throws {
     for pair in GeneratorOptions.parseParameter(string: parameter) {
@@ -112,6 +113,13 @@ final class GeneratorOptions {
       case "ExtraModuleImports":
         if !pair.value.isEmpty {
           self.extraModuleImports.append(pair.value)
+        } else {
+          throw GenerationError.invalidParameterValue(name: pair.key, value: pair.value)
+        }
+
+      case "GRPCModuleName":
+        if !pair.value.isEmpty {
+          self.gRPCModuleName = pair.value
         } else {
           throw GenerationError.invalidParameterValue(name: pair.key, value: pair.value)
         }

--- a/dev/codegen-tests/01-echo/golden/echo.grpc.swift
+++ b/dev/codegen-tests/01-echo/golden/echo.grpc.swift
@@ -20,11 +20,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-import Foundation
 import GRPC
 import NIO
-import NIOHTTP1
-import SwiftProtobuf
 
 
 /// Usage: instantiate Echo_EchoClient, then call methods of this protocol to make API calls.

--- a/dev/codegen-tests/02-multifile/golden/a.grpc.swift
+++ b/dev/codegen-tests/02-multifile/golden/a.grpc.swift
@@ -20,11 +20,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-import Foundation
 import GRPC
 import NIO
-import NIOHTTP1
-import SwiftProtobuf
 
 
 /// Usage: instantiate A_ServiceAClient, then call methods of this protocol to make API calls.

--- a/dev/codegen-tests/02-multifile/golden/b.grpc.swift
+++ b/dev/codegen-tests/02-multifile/golden/b.grpc.swift
@@ -20,11 +20,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-import Foundation
 import GRPC
 import NIO
-import NIOHTTP1
-import SwiftProtobuf
 
 
 /// Usage: instantiate B_ServiceBClient, then call methods of this protocol to make API calls.

--- a/dev/codegen-tests/03-multifile-with-module-map/golden/a.grpc.swift
+++ b/dev/codegen-tests/03-multifile-with-module-map/golden/a.grpc.swift
@@ -20,11 +20,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-import Foundation
 import GRPC
 import NIO
-import NIOHTTP1
-import SwiftProtobuf
 import ModuleB
 
 

--- a/dev/codegen-tests/03-multifile-with-module-map/golden/b.grpc.swift
+++ b/dev/codegen-tests/03-multifile-with-module-map/golden/b.grpc.swift
@@ -20,11 +20,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-import Foundation
 import GRPC
 import NIO
-import NIOHTTP1
-import SwiftProtobuf
 
 
 /// Usage: instantiate B_ServiceBClient, then call methods of this protocol to make API calls.

--- a/dev/codegen-tests/04-service-with-message-import/golden/service.grpc.swift
+++ b/dev/codegen-tests/04-service-with-message-import/golden/service.grpc.swift
@@ -20,11 +20,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-import Foundation
 import GRPC
 import NIO
-import NIOHTTP1
-import SwiftProtobuf
 
 
 /// Usage: instantiate Codegentest_FooClient, then call methods of this protocol to make API calls.

--- a/dev/codegen-tests/05-service-only/golden/test.grpc.swift
+++ b/dev/codegen-tests/05-service-only/golden/test.grpc.swift
@@ -20,11 +20,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-import Foundation
 import GRPC
 import NIO
-import NIOHTTP1
-import SwiftProtobuf
 
 
 /// Usage: instantiate Codegentest_FooClient, then call methods of this protocol to make API calls.

--- a/dev/codegen-tests/06-test-client-only/golden/test.grpc.swift
+++ b/dev/codegen-tests/06-test-client-only/golden/test.grpc.swift
@@ -20,11 +20,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-import Foundation
 import GRPC
 import NIO
-import NIOHTTP1
-import SwiftProtobuf
 
 
 internal final class Codegentest_FooTestClient: Codegentest_FooClientProtocol {

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -74,6 +74,15 @@ The **FileNaming** option determines how generated source files should be named.
 The **ProtoPathModuleMappings** option allows module mappings to be specified.
 See the [SwiftProtobuf documentation][swift-protobuf-module-mappings].
 
+### GRPCModuleName
+
+The **GRPCModuleName** option allows the name of the gRPC Swift runtime module
+to be specified. The value, if not specified, defaults to "GRPC".
+
+*Note: most users will not need to use this option. It is intended as a
+workaround for CocoaPods users who may end up with a transitive dependency on
+the gRPC core C library whose module name is also "GRPC".*
+
 ## Specifying Options
 
 To pass extra parameters to the plugin, use a comma-separated parameter list


### PR DESCRIPTION
Motivation:

Some Cocoapods may find themselves in a situation where their dependency
graph contains both gRPC Swift and the gRPC core library. This is
problematic since both have the same module name ("GRPC"). Changing our
own module name is a very large breaking change and one we'd like to avoid.
As an escape valve, users who take a direct dependency on us may rename
our module via their Podfile; doing so would require their generated
code to depend on that module, rather than the currently hardcoded
'GRPC' module.

Modifications:

- Add an option to the codegen to specify the gRPC module name
- Remove a couple of imports which were previously used but are now no
  longer required
- Regenerate

Result:

It's possible for Cocoapods users to take a direct dependency on gRPC
Swift and libgrpc.