### PR TITLE
Import SwiftProtobuf in generated code

### DIFF
--- a/Sources/Examples/Echo/Model/echo.grpc.swift
+++ b/Sources/Examples/Echo/Model/echo.grpc.swift
@@ -22,6 +22,7 @@
 //
 import GRPC
 import NIO
+import SwiftProtobuf
 
 
 /// Usage: instantiate Echo_EchoClient, then call methods of this protocol to make API calls.

--- a/Sources/Examples/HelloWorld/Model/helloworld.grpc.swift
+++ b/Sources/Examples/HelloWorld/Model/helloworld.grpc.swift
@@ -22,6 +22,7 @@
 //
 import GRPC
 import NIO
+import SwiftProtobuf
 
 
 /// Usage: instantiate Helloworld_GreeterClient, then call methods of this protocol to make API calls.

--- a/Sources/Examples/RouteGuide/Model/route_guide.grpc.swift
+++ b/Sources/Examples/RouteGuide/Model/route_guide.grpc.swift
@@ -22,6 +22,7 @@
 //
 import GRPC
 import NIO
+import SwiftProtobuf
 
 
 /// Usage: instantiate Routeguide_RouteGuideClient, then call methods of this protocol to make API calls.

--- a/Sources/protoc-gen-grpc-swift/Generator.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator.swift
@@ -90,6 +90,7 @@ class Generator {
     let moduleNames = [
       self.options.gRPCModuleName,
       "NIO",
+      "SwiftProtobuf",
     ]
 
     for moduleName in (moduleNames + self.options.extraModuleImports).sorted() {

--- a/dev/codegen-tests/01-echo/golden/echo.grpc.swift
+++ b/dev/codegen-tests/01-echo/golden/echo.grpc.swift
@@ -22,6 +22,7 @@
 //
 import GRPC
 import NIO
+import SwiftProtobuf
 
 
 /// Usage: instantiate Echo_EchoClient, then call methods of this protocol to make API calls.

--- a/dev/codegen-tests/02-multifile/golden/a.grpc.swift
+++ b/dev/codegen-tests/02-multifile/golden/a.grpc.swift
@@ -22,6 +22,7 @@
 //
 import GRPC
 import NIO
+import SwiftProtobuf
 
 
 /// Usage: instantiate A_ServiceAClient, then call methods of this protocol to make API calls.

--- a/dev/codegen-tests/02-multifile/golden/b.grpc.swift
+++ b/dev/codegen-tests/02-multifile/golden/b.grpc.swift
@@ -22,6 +22,7 @@
 //
 import GRPC
 import NIO
+import SwiftProtobuf
 
 
 /// Usage: instantiate B_ServiceBClient, then call methods of this protocol to make API calls.

--- a/dev/codegen-tests/03-multifile-with-module-map/golden/a.grpc.swift
+++ b/dev/codegen-tests/03-multifile-with-module-map/golden/a.grpc.swift
@@ -22,6 +22,7 @@
 //
 import GRPC
 import NIO
+import SwiftProtobuf
 import ModuleB
 
 

--- a/dev/codegen-tests/03-multifile-with-module-map/golden/b.grpc.swift
+++ b/dev/codegen-tests/03-multifile-with-module-map/golden/b.grpc.swift
@@ -22,6 +22,7 @@
 //
 import GRPC
 import NIO
+import SwiftProtobuf
 
 
 /// Usage: instantiate B_ServiceBClient, then call methods of this protocol to make API calls.

--- a/dev/codegen-tests/04-service-with-message-import/golden/service.grpc.swift
+++ b/dev/codegen-tests/04-service-with-message-import/golden/service.grpc.swift
@@ -22,6 +22,7 @@
 //
 import GRPC
 import NIO
+import SwiftProtobuf
 
 
 /// Usage: instantiate Codegentest_FooClient, then call methods of this protocol to make API calls.

--- a/dev/codegen-tests/05-service-only/golden/test.grpc.swift
+++ b/dev/codegen-tests/05-service-only/golden/test.grpc.swift
@@ -22,6 +22,7 @@
 //
 import GRPC
 import NIO
+import SwiftProtobuf
 
 
 /// Usage: instantiate Codegentest_FooClient, then call methods of this protocol to make API calls.

--- a/dev/codegen-tests/06-test-client-only/golden/test.grpc.swift
+++ b/dev/codegen-tests/06-test-client-only/golden/test.grpc.swift
@@ -22,6 +22,7 @@
 //
 import GRPC
 import NIO
+import SwiftProtobuf
 
 
 internal final class Codegentest_FooTestClient: Codegentest_FooClientProtocol {


### PR DESCRIPTION
Motivation:

Generated code may rely on messages which ship with SwiftProtobuf, as
such we should always import SwiftProtobuf.

Modifications:

- Import SwiftProtobuf in codegen

Result:

Resolves #951