### PR TITLE
Move idle handler state to closed on channelInactive

### DIFF
--- a/Sources/GRPC/GRPCIdleHandler.swift
+++ b/Sources/GRPC/GRPCIdleHandler.swift
@@ -117,6 +117,8 @@ internal class GRPCIdleHandler: ChannelInboundHandler {
 
   func handlerRemoved(context: ChannelHandlerContext) {
     self.scheduledIdle?.cancel()
+    self.scheduledIdle = nil
+    self.state = .closed
   }
 
   func channelInactive(context: ChannelHandlerContext) {
@@ -126,12 +128,13 @@ internal class GRPCIdleHandler: ChannelInboundHandler {
     switch (self.mode, self.state) {
     case let (.client(manager), .notReady),
          let (.client(manager), .ready):
+      self.state = .closed
       manager.channelInactive()
 
     case (.server, .notReady),
          (.server, .ready),
          (_, .closed):
-      ()
+      self.state = .closed
     }
 
     context.fireChannelInactive()

--- a/Sources/GRPC/GRPCKeepaliveHandlers.swift
+++ b/Sources/GRPC/GRPCKeepaliveHandlers.swift
@@ -101,6 +101,12 @@ extension _ChannelKeepaliveHandler {
     context.fireChannelRead(data)
   }
 
+  func channelInactive(context: ChannelHandlerContext) {
+    self.cancelScheduledPing()
+    self.cancelScheduledTimeout()
+    context.fireChannelInactive()
+  }
+
   func handlerRemoved(context: ChannelHandlerContext) {
     self.cancelScheduledPing()
     self.cancelScheduledTimeout()

--- a/Tests/GRPCTests/XCTestManifests.swift
+++ b/Tests/GRPCTests/XCTestManifests.swift
@@ -155,6 +155,7 @@ extension ConnectionManagerTests {
         ("testDoomedOptimisticChannelFromConnecting", testDoomedOptimisticChannelFromConnecting),
         ("testDoomedOptimisticChannelFromIdle", testDoomedOptimisticChannelFromIdle),
         ("testDoubleIdle", testDoubleIdle),
+        ("testForceIdleAfterInactive", testForceIdleAfterInactive),
         ("testGoAwayWhenReady", testGoAwayWhenReady),
         ("testIdleShutdown", testIdleShutdown),
         ("testIdleTimeoutWhenThereAreActiveStreams", testIdleTimeoutWhenThereAreActiveStreams),


### PR DESCRIPTION
Motivation:

Related to #949.

It's possible for the client's connection to be dropped, and for the
connection state to become idle, prior to the scheduled close from the
keepalive handler firing. As the idle handler never updates its state to
'closed' in 'channelInactive', when the scheduled close event is picked
up in the idle handler it effectively ask the connection manager to
double-idle, hitting a precondition failure.

Modifications:

- Move the 'GRPCIdleHandler' to '.closed' in 'channelInactive'
- Cancel scheduled pings and timeouts on 'channelInactive' in the
  'GRPCKeepaliveHandlers'

Result:

- We avoid another path to a precondition failure