### PR TITLE
Update NIO version to 2.22.0 and NIOHTTP2 to 1.14.1.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "8a865bd15e69526cbdfcfd7c47698eb20b2ba951",
-          "version": "2.19.0"
+          "revision": "5fc24345f92ec4c274121776c215ab0aa1ed4d50",
+          "version": "2.22.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
         "state": {
           "branch": null,
-          "revision": "e9627350bdb85bde7e0dc69a29799e40961ced72",
-          "version": "1.13.0"
+          "revision": "1e68e51752be0b43c5a0ef35818c1dd24d13e77c",
+          "version": "1.14.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -26,9 +26,9 @@ let package = Package(
   dependencies: [
     // GRPC dependencies:
     // Main SwiftNIO package
-    .package(url: "https://github.com/apple/swift-nio.git", from: "2.19.0"),
+    .package(url: "https://github.com/apple/swift-nio.git", from: "2.22.0"),
     // HTTP2 via SwiftNIO
-    .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.13.0"),
+    .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.14.1"),
     // TLS via SwiftNIO
     .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.8.0"),
     // Support for Network.framework where possible.

--- a/Sources/GRPC/HTTP1ToGRPCServerCodec.swift
+++ b/Sources/GRPC/HTTP1ToGRPCServerCodec.swift
@@ -266,7 +266,7 @@ extension HTTP1ToGRPCServerCodec: ChannelInboundHandler {
         throw GRPCError.Base64DecodeError().captureContext()
       }
 
-      body.writeBytes(decodedData)
+      body.writeContiguousBytes(decodedData)
     }
 
     self.messageReader.append(buffer: &body)
@@ -455,7 +455,7 @@ extension HTTP1ToGRPCServerCodec: ChannelOutboundHandler {
         let encodedData = accumulatedData.base64EncodedString()
 
         // Reuse our first buffer.
-        responseTextBuffer.clear(minimumCapacity: UInt32(encodedData.utf8.count))
+        responseTextBuffer.clear(minimumCapacity: Int(encodedData.utf8.count))
         responseTextBuffer.writeString(encodedData)
 
         // After collecting all response for gRPC Web connections, send one final aggregated

--- a/Sources/GRPC/Serialization.swift
+++ b/Sources/GRPC/Serialization.swift
@@ -48,11 +48,11 @@ internal struct ProtobufSerializer<Message: SwiftProtobuf.Message>: MessageSeria
     // prefixed message writer can re-use the leading 5 bytes without needing to allocate a new
     // buffer and copy over the serialized message.
     var buffer = allocator.buffer(capacity: serialized.count + 5)
-    buffer.writeBytes(Array(repeating: 0, count: 5))
+    buffer.writeRepeatingByte(0, count: 5)
     buffer.moveReaderIndex(forwardBy: 5)
 
     // Now write the serialized message.
-    buffer.writeBytes(serialized)
+    buffer.writeContiguousBytes(serialized)
 
     return buffer
   }

--- a/Sources/GRPCPerformanceTests/Benchmarks/EmbeddedClientThroughput.swift
+++ b/Sources/GRPCPerformanceTests/Benchmarks/EmbeddedClientThroughput.swift
@@ -66,7 +66,7 @@ class EmbeddedClientThroughput: Benchmark {
     var buffer = ByteBufferAllocator().buffer(capacity: serializedResponse.count + 5)
     buffer.writeInteger(UInt8(0)) // compression byte
     buffer.writeInteger(UInt32(serializedResponse.count))
-    buffer.writeBytes(serializedResponse)
+    buffer.writeContiguousBytes(serializedResponse)
 
     self.responseDataChunks = []
     while buffer.readableBytes > 0,


### PR DESCRIPTION
Motivation:

SwiftNIO 2.21.0 inlcudes a fast-path for writing `Data` into a
`ByteBuffer`, and SwiftNIO HTTP/2 1.14.0 contains a `reserveCapacity`
for `HPACKHeaders`.

Modifications:

- Replace a few occurrences of `writeBytes` with the new
  `writeContiguousBytes` instead.
- Reserve the capacity upfront when constructing request headers
- Stop using a deprecated function

Result:

- Perf win when serializing and writing protobuf messages into a buffer