### PR TITLE
Add missing call to 'close()' in examples

### DIFF
--- a/Sources/Examples/Echo/Runtime/main.swift
+++ b/Sources/Examples/Echo/Runtime/main.swift
@@ -108,13 +108,6 @@ func main(args: [String]) {
     printUsageAndExit(program: program)
   }
 
-  // Reduce the logging verbosity.
-  LoggingSystem.bootstrap {
-    var handler = StreamLogHandler.standardOutput(label: $0)
-    handler.logLevel = .warning
-    return handler
-  }
-
   // Okay, we're nearly ready to start, create an `EventLoopGroup` most suitable for our platform.
   let group = PlatformSupport.makeEventLoopGroup(loopCount: 1)
   defer {
@@ -132,6 +125,9 @@ func main(args: [String]) {
 
   case let .client(host: host, port: port, useTLS: useTLS, rpc: rpc, message: message):
     let client = makeClient(group: group, host: host, port: port, useTLS: useTLS)
+    defer {
+      try! client.channel.close().wait()
+    }
     callRPC(rpc, using: client, message: message)
   }
 }

--- a/Sources/Examples/HelloWorld/Client/main.swift
+++ b/Sources/Examples/HelloWorld/Client/main.swift
@@ -18,13 +18,6 @@ import HelloWorldModel
 import Logging
 import NIO
 
-// Quieten the logs.
-LoggingSystem.bootstrap {
-  var handler = StreamLogHandler.standardOutput(label: $0)
-  handler.logLevel = .critical
-  return handler
-}
-
 func greet(name: String?, client greeter: Helloworld_GreeterClient) {
   // Form the request with the name, if one was provided.
   let request = Helloworld_HelloRequest.with {
@@ -68,6 +61,11 @@ func main(args: [String]) {
     // Configure the channel, we're not using TLS so the connection is `insecure`.
     let channel = ClientConnection.insecure(group: group)
       .connect(host: "localhost", port: port)
+
+    // Close the connection when we're done with it.
+    defer {
+      try! channel.close().wait()
+    }
 
     // Provide the connection to the generated client.
     let greeter = Helloworld_GreeterClient(channel: channel)

--- a/Sources/Examples/HelloWorld/Server/main.swift
+++ b/Sources/Examples/HelloWorld/Server/main.swift
@@ -18,13 +18,6 @@ import HelloWorldModel
 import Logging
 import NIO
 
-// Quieten the logs.
-LoggingSystem.bootstrap {
-  var handler = StreamLogHandler.standardOutput(label: $0)
-  handler.logLevel = .critical
-  return handler
-}
-
 let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 defer {
   try! group.syncShutdownGracefully()

--- a/Sources/Examples/RouteGuide/Client/main.swift
+++ b/Sources/Examples/RouteGuide/Client/main.swift
@@ -19,13 +19,6 @@ import Logging
 import NIO
 import RouteGuideModel
 
-// Quieten the logs.
-LoggingSystem.bootstrap {
-  var handler = StreamLogHandler.standardOutput(label: $0)
-  handler.logLevel = .critical
-  return handler
-}
-
 /// Makes a `RouteGuide` client for a service hosted on "localhost" and listening on the given port.
 func makeClient(port: Int, group: EventLoopGroup) -> Routeguide_RouteGuideClient {
   let channel = ClientConnection.insecure(group: group)

--- a/Sources/Examples/RouteGuide/Server/main.swift
+++ b/Sources/Examples/RouteGuide/Server/main.swift
@@ -20,13 +20,6 @@ import NIO
 import RouteGuideModel
 import SwiftProtobuf
 
-// Quieten the logs.
-LoggingSystem.bootstrap {
-  var handler = StreamLogHandler.standardOutput(label: $0)
-  handler.logLevel = .critical
-  return handler
-}
-
 /// Loads the features from `route_guide_db.json`, assumed to be in the directory above this file.
 func loadFeatures() throws -> [Routeguide_Feature] {
   let url = URL(fileURLWithPath: #file)


### PR DESCRIPTION
Motivation:

Some of the examples are bad examples: they fail to close connections
which they create even though they close the event loop that they run
on. As such the connection manager has no idea that it no longer needs
to manage a connection which can result in a leaking promise.

Modifications:

- add a defer block to `close()` the connection after we're done with it
  to the echo and hello world examples
- remove the bootstrapping of the logging system (this is no longer
  required in order to quieten the logs since the user must provide the
  logger)

Result:

- HelloWorld example does not leak a promise on shutdown
- Resolves #963