### PR TITLE
Idle client connection on 'channelInactive' if there are no active RPCs

### DIFF
--- a/Sources/GRPC/ConnectionManager.swift
+++ b/Sources/GRPC/ConnectionManager.swift
@@ -423,7 +423,19 @@ internal class ConnectionManager {
     case .shutdown:
       channel.close(mode: .all, promise: nil)
 
-    case .idle, .active, .ready, .transientFailure:
+    // These cases are purposefully separated: some crash reporting services provide stack traces
+    // which don't include the precondition failure message (which contain the invalid state we were
+    // in). Keeping the cases separate allows us work out the state from the line number.
+    case .idle:
+      self.invalidState()
+
+    case .active:
+      self.invalidState()
+
+    case .ready:
+      self.invalidState()
+
+    case .transientFailure:
       self.invalidState()
     }
   }
@@ -479,7 +491,13 @@ internal class ConnectionManager {
     case .shutdown:
       ()
 
-    case .connecting, .transientFailure:
+    // These cases are purposefully separated: some crash reporting services provide stack traces
+    // which don't include the precondition failure message (which contain the invalid state we were
+    // in). Keeping the cases separate allows us work out the state from the line number.
+    case .connecting:
+      self.invalidState()
+
+    case .transientFailure:
       self.invalidState()
     }
   }
@@ -500,7 +518,19 @@ internal class ConnectionManager {
     case .shutdown:
       ()
 
-    case .idle, .transientFailure, .connecting, .ready:
+    // These cases are purposefully separated: some crash reporting services provide stack traces
+    // which don't include the precondition failure message (which contain the invalid state we were
+    // in). Keeping the cases separate allows us work out the state from the line number.
+    case .idle:
+      self.invalidState()
+
+    case .transientFailure:
+      self.invalidState()
+
+    case .connecting:
+      self.invalidState()
+
+    case .ready:
       self.invalidState()
     }
   }
@@ -523,7 +553,22 @@ internal class ConnectionManager {
     case let .ready(state):
       self.state = .idle(IdleState(configuration: state.configuration))
 
-    case .idle, .connecting, .transientFailure, .shutdown:
+    case .shutdown:
+      // This is expected when the connection is closed by the user: when the channel becomes
+      // inactive and there are no outstanding RPCs, 'idle()' will be called instead of
+      // 'channelInactive()'.
+      ()
+
+    // These cases are purposefully separated: some crash reporting services provide stack traces
+    // which don't include the precondition failure message (which contain the invalid state we were
+    // in). Keeping the cases separate allows us work out the state from the line number.
+    case .idle:
+      self.invalidState()
+
+    case .connecting:
+      self.invalidState()
+
+    case .transientFailure:
       self.invalidState()
     }
   }
@@ -560,7 +605,20 @@ extension ConnectionManager {
       ()
 
     // We can't fail to connect if we aren't trying.
-    case .idle, .active, .ready, .transientFailure:
+    //
+    // These cases are purposefully separated: some crash reporting services provide stack traces
+    // which don't include the precondition failure message (which contain the invalid state we were
+    // in). Keeping the cases separate allows us work out the state from the line number.
+    case .idle:
+      self.invalidState()
+
+    case .active:
+      self.invalidState()
+
+    case .ready:
+      self.invalidState()
+
+    case .transientFailure:
       self.invalidState()
     }
   }
@@ -590,7 +648,16 @@ extension ConnectionManager {
     case .shutdown:
       ()
 
-    case .connecting, .active, .ready:
+    // These cases are purposefully separated: some crash reporting services provide stack traces
+    // which don't include the precondition failure message (which contain the invalid state we were
+    // in). Keeping the cases separate allows us work out the state from the line number.
+    case .connecting:
+      self.invalidState()
+
+    case .active:
+      self.invalidState()
+
+    case .ready:
       self.invalidState()
     }
   }

--- a/Tests/GRPCTests/GRPCIdleTests.swift
+++ b/Tests/GRPCTests/GRPCIdleTests.swift
@@ -35,10 +35,6 @@ class GRPCIdleTests: GRPCTestCase {
   }
 
   func doTestIdleTimeout(serverIdle: TimeAmount, clientIdle: TimeAmount) throws {
-    // Is the server idling first? This determines what state change the client should see when the
-    // idle happens.
-    let isServerIdleFirst = serverIdle < clientIdle
-
     let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     defer {
       XCTAssertNoThrow(try group.syncShutdownGracefully())
@@ -61,7 +57,7 @@ class GRPCIdleTests: GRPCTestCase {
       XCTAssertEqual(changes, [
         Change(from: .idle, to: .connecting),
         Change(from: .connecting, to: .ready),
-        Change(from: .ready, to: isServerIdleFirst ? .transientFailure : .idle),
+        Change(from: .ready, to: .idle),
       ])
     }
 

--- a/Tests/GRPCTests/XCTestManifests.swift
+++ b/Tests/GRPCTests/XCTestManifests.swift
@@ -147,6 +147,7 @@ extension ConnectionManagerTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__ConnectionManagerTests = [
+        ("testCloseWithoutActiveRPCs", testCloseWithoutActiveRPCs),
         ("testConnectAndDisconnect", testConnectAndDisconnect),
         ("testConnectAndIdle", testConnectAndIdle),
         ("testConnectAndThenBecomeInactive", testConnectAndThenBecomeInactive),


### PR DESCRIPTION
Motivation:

Connections are idled if there are no RPCs for a given timeout. A
connection may also be idled if the remote sends it a GO_AWAY frame.
However, If the remote fails to send a GO_AWAY then from the perspective
of the client, the connection has been dropped and it will attempt
re-establish a connection. As a result a connection may bounce from
'ready' to 'transientFailure' to 'connecting' and back to 'ready' even
though there are no active RPCs.

Modifications:

- Idle the client connection on 'channelInactive' when there are no
  active RPCs and we know that the connection was previously up-and-running.
- Update tests.

Result:

We avoid creating unnecessary connections when the connection is dropped
and there are no active RPCs.