### PR TITLE
Avoid the possibility of making outcalls in 'ClientCallTransport' before updating internal state

### DIFF
--- a/Sources/GRPC/ClientCalls/ClientCallTransport.swift
+++ b/Sources/GRPC/ClientCalls/ClientCallTransport.swift
@@ -545,13 +545,13 @@ extension ChannelTransport: ClientCallInbound {
         self.responseContainer.lazyTrailingMetadataPromise.succeed(metadata)
 
       case let .status(status):
-        // We're done; cancel the timeout.
-        self.scheduledTimeout?.cancel()
-        self.scheduledTimeout = nil
-
         // We're closed now.
         self.state = .closed
         self.stopTimer(status: status)
+
+        // We're done; cancel the timeout.
+        self.scheduledTimeout?.cancel()
+        self.scheduledTimeout = nil
 
         // We're not really failing the status here; in some cases the server may fast fail, in which
         // case we'll only see trailing metadata and status: we should fail the initial metadata and


### PR DESCRIPTION
Motivation:

A scheduled task being executed or cancelled may have arbitrary side
effects. In 'ClientCallTransport' when we receive a 'status' we cancel a
scheduled task before updating our internal state.

Modifications:

Transition to closed before cancelling the timeout.

Result:

Resolves #961