### PR TITLE
Add an option to set 'certificateVerification' to the client builder

### DIFF
--- a/Sources/GRPC/GRPCChannel/GRPCChannelBuilder.swift
+++ b/Sources/GRPC/GRPCChannel/GRPCChannelBuilder.swift
@@ -227,6 +227,14 @@ extension ClientConnection.Builder.Secure {
     self.tls.trustRoots = trustRoots
     return self
   }
+
+  /// Whether to verify remote certificates. Defaults to `.fullVerification` if not otherwise
+  /// configured.
+  @discardableResult
+  public func withTLS(certificateVerification: CertificateVerification) -> Self {
+    self.tls.certificateVerification = certificateVerification
+    return self
+  }
 }
 
 extension ClientConnection.Builder {

--- a/Tests/GRPCTests/XCTestManifests.swift
+++ b/Tests/GRPCTests/XCTestManifests.swift
@@ -96,6 +96,7 @@ extension ClientTLSHostnameOverrideTests {
     // to regenerate.
     static let __allTests__ClientTLSHostnameOverrideTests = [
         ("testTLSWithHostnameOverride", testTLSWithHostnameOverride),
+        ("testTLSWithNoCertificateVerification", testTLSWithNoCertificateVerification),
         ("testTLSWithoutHostnameOverride", testTLSWithoutHostnameOverride),
     ]
 }


### PR DESCRIPTION
Motivation:

We allow users to set the `certificateVerification` if they configure
their client directly using `ClientConnection.Configuration` but not via
the builder API.

Modifications:

- Add `withTLS(certificateVerification:)` to the client connection builder.
  (The same option is already available on the server builder)

Result:

Users can set the certificate verification mode on the client builder.