### PR TITLE
Update CocoaPods to alpha.20

### DIFF
--- a/CGRPCZlib.podspec
+++ b/CGRPCZlib.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
     s.name = 'CGRPCZlib'
     s.module_name = 'CGRPCZlib'
-    s.version = '1.0.0-alpha.19'
+    s.version = '1.0.0-alpha.20'
     s.license = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.summary = 'Compression library that provides in-memory compression and decompression functions'
     s.homepage = 'https://www.grpc.io'

--- a/Examples/Google/SpeechToText/Podfile
+++ b/Examples/Google/SpeechToText/Podfile
@@ -6,5 +6,5 @@ target 'SpeechToText-gRPC-iOS' do
   use_frameworks!
 
   pod 'SnapKit'
-  pod 'gRPC-Swift', '1.0.0-alpha.19'
+  pod 'gRPC-Swift', '1.0.0-alpha.20'
 end

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ necessary targets:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/grpc/grpc-swift.git", from: "1.0.0-alpha.19")
+  .package(url: "https://github.com/grpc/grpc-swift.git", from: "1.0.0-alpha.20")
 ]
 ```
 
@@ -96,7 +96,7 @@ gRPC Swift is currently available [from CocoaPods][pod-new]. To integrate, add
 the following line to your `Podfile`:
 
 ```ruby
-    pod 'gRPC-Swift', '~> 1.0.0-alpha.19'
+    pod 'gRPC-Swift', '~> 1.0.0-alpha.20'
 ```
 
 Then, run `pod install` from command line and use your project's generated

--- a/docs/basic-tutorial.md
+++ b/docs/basic-tutorial.md
@@ -39,7 +39,7 @@ To download the example, clone the latest release in `grpc-swift` repository by
 running the following command:
 
 ```sh
-$ git clone -b 1.0.0-alpha.9 https://github.com/grpc/grpc-swift
+$ git clone -b 1.0.0-alpha.20 https://github.com/grpc/grpc-swift
 ```
 
 Then change your current directory to `grpc-swift/Sources/Examples/RouteGuide`:

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -28,7 +28,7 @@ and other tutorials):
 
 ```sh
 $ # Clone the repository at the latest release to get the example code:
-$ git clone -b 1.0.0-alpha.9 https://github.com/grpc/grpc-swift
+$ git clone -b 1.0.0-alpha.20 https://github.com/grpc/grpc-swift
 $ # Navigate to the repository
 $ cd grpc-swift/
 ```

--- a/gRPC-Swift-Plugins.podspec
+++ b/gRPC-Swift-Plugins.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
     s.name = 'gRPC-Swift-Plugins'
-    s.version = '1.0.0-alpha.19'
+    s.version = '1.0.0-alpha.20'
     s.license = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.summary = 'Swift gRPC code generator plugin binaries'
     s.homepage = 'https://www.grpc.io'

--- a/gRPC-Swift.podspec
+++ b/gRPC-Swift.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
     s.name = 'gRPC-Swift'
     s.module_name = 'GRPC'
-    s.version = '1.0.0-alpha.19'
+    s.version = '1.0.0-alpha.20'
     s.license = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.summary = 'Swift gRPC code generator plugin and runtime library'
     s.homepage = 'https://www.grpc.io'


### PR DESCRIPTION
Motivation:

We tagged 1.0.0-alpha.20, let's update the in-repo podspecs too.

Modifications:

- Add an option to build_podspecs.py to start from a given Podspec, this
  is useful when an upload fails.
- Update docs to use latest version in a couple of places.
- Update pods to alpha.20

Result:

Our docs are more up to date.