### PR TITLE
Add support for watchOS to the podspecs

### DIFF
--- a/CGRPCZlib.podspec
+++ b/CGRPCZlib.podspec
@@ -12,6 +12,7 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = '10.0'
     s.osx.deployment_target = '10.12'
     s.tvos.deployment_target = '10.0'
+    s.watchos.deployment_target = '6.0'
     s.source = { :git => "https://github.com/grpc/grpc-swift.git", :tag => s.version }
 
     s.source_files = 'Sources/CGRPCZlib/**/*.{swift,c,h}'

--- a/gRPC-Swift-Plugins.podspec
+++ b/gRPC-Swift-Plugins.podspec
@@ -11,6 +11,7 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = '10.0'
     s.osx.deployment_target = '10.12'
     s.tvos.deployment_target = '10.0'
+    s.watchos.deployment_target = '6.0'
     s.source = { :http => "https://github.com/grpc/grpc-swift/releases/download/#{s.version}/protoc-grpc-swift-plugins-#{s.version}.zip"}
 
     s.preserve_paths = '*'

--- a/gRPC-Swift.podspec
+++ b/gRPC-Swift.podspec
@@ -12,6 +12,7 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = '10.0'
     s.osx.deployment_target = '10.12'
     s.tvos.deployment_target = '10.0'
+    s.watchos.deployment_target = '6.0'
     s.source = { :git => "https://github.com/grpc/grpc-swift.git", :tag => s.version }
 
     s.source_files = 'Sources/GRPC/**/*.{swift,c,h}'

--- a/scripts/build_podspecs.py
+++ b/scripts/build_podspecs.py
@@ -71,6 +71,7 @@ class Pod:
         podspec += indent + "s.ios.deployment_target = '10.0'\n"
         podspec += indent + "s.osx.deployment_target = '10.12'\n"
         podspec += indent + "s.tvos.deployment_target = '10.0'\n"
+        podspec += indent + "s.watchos.deployment_target = '6.0'\n"
 
         if self.is_plugins_pod:
             podspec += indent + "s.source = { :http => \"https://github.com/grpc/grpc-swift/releases/download/#{s.version}/protoc-grpc-swift-plugins-#{s.version}.zip\"}\n\n"


### PR DESCRIPTION
grpc-swift is able to support watchOS 6+ with NIO Transport Services and Network.framework, but the podspecs do not declare such support, so it cannot be used in a watchOS app through CocoaPods. This PR adds the necessary support to each of the three podspecs.