### PR TITLE
Pin formatter (#995)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ Examples/EchoWeb/dist
 Examples/EchoWeb/node_modules
 Examples/EchoWeb/package-lock.json
 dev/codegen-tests/**/generated/*
+/scripts/.swiftformat-source/

--- a/.travis-install.sh
+++ b/.travis-install.sh
@@ -182,7 +182,8 @@ function install_swiftformat() {
   echo -en 'travis_fold:start:install.swiftformat\\r'
   info "Installing swiftformat"
 
-  git clone --depth 1 "https://github.com/nicklockwood/SwiftFormat"
+  # If this version is updated, update the version in scripts/format.sh too.
+  git clone --depth 1 --branch 0.46.3 "https://github.com/nicklockwood/SwiftFormat"
   cd SwiftFormat
   version=$(git rev-parse HEAD)
 

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Copyright 2020, gRPC Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO="$HERE/.."
+SWIFTFORMAT_DIR="$HERE/.swiftformat-source"
+
+# Important: if this is changed then make sure to update the version
+# in .travis-install.sh as well!
+SWIFTFORMAT_VERSION=0.46.3
+
+# Clone SwiftFormat if we don't already have it.
+if [ ! -d "$SWIFTFORMAT_DIR" ]; then
+  echo "- Cloning SwiftFormat @ $SWIFTFORMAT_VERSION"
+  git clone \
+    --depth 1 \
+    --branch "$SWIFTFORMAT_VERSION" \
+    https://github.com/nicklockwood/SwiftFormat.git \
+    "$SWIFTFORMAT_DIR"
+fi
+
+cd "$SWIFTFORMAT_DIR"
+
+# Figure out the path for the binary.
+SWIFTFORMAT_BIN="$(swift build --show-bin-path -c release)/swiftformat-$SWIFTFORMAT_VERSION"
+
+# Build it if we don't already have it.
+if [ ! -f "$SWIFTFORMAT_BIN" ]; then
+  # We're not on the right tag, fetch and checkout the right one.
+  echo "- Fetching SwiftFormat @ $SWIFTFORMAT_VERSION"
+  git fetch --depth 1 origin "refs/tags/$SWIFTFORMAT_VERSION:refs/tags/$SWIFTFORMAT_VERSION"
+  git checkout "$SWIFTFORMAT_VERSION"
+
+  # Now build and name the bin appropriately.
+  echo "- Building SwiftFormat @ $SWIFTFORMAT_VERSION"
+  swift build -c release --product swiftformat
+  mv "$(swift build --show-bin-path -c release)/swiftformat" "$SWIFTFORMAT_BIN"
+
+  echo "- OK"
+fi
+
+# Now run it.
+$SWIFTFORMAT_BIN "$REPO"


### PR DESCRIPTION
Motivation:

We added SwiftFormat as part our CI to in order to keep formatting
consistent. However, new rules are often introduced and new behaviours
are added and the formatting can change quite significantly as a result.
In order to get stable formatting we need to pin the version we use or
include the tool as part of the project. This is somewhat annoying: in
the first case it requires the user to get the right version, in the
second case we add a depdendency which isn't required to consume the
library, that's a little silly! We can make the first case a little
nicer by providing a script to build the right version from source.

Modifications:

- Add scripts/format.sh which builds a predefined version of SwiftFormat
  and runs it
- Pin the version in .travis-install.sh to the same as in format.sh

Result:

- SwiftFormat is pinned to a version

(cherry picked from commit cdb46f4d24fc4aef5c6f4ef5ebf50215354c28bb)