### PR TITLE
Add interceptor pipeline timeouts

### DIFF
--- a/Tests/GRPCTests/XCTestHelpers.swift
+++ b/Tests/GRPCTests/XCTestHelpers.swift
@@ -124,6 +124,24 @@ struct Matcher<Value> {
     }
   }
 
+  /// Matches if the value is `nil`.
+  static func `nil`<Value>() -> Matcher<Value?> {
+    return .init { actual in
+      actual == nil
+        ? .match
+        : .noMatch(actual: String(describing: actual), expected: "nil")
+    }
+  }
+
+  /// Matches if the value is not `nil`.
+  static func notNil<Value>() -> Matcher<Value?> {
+    return .init { actual in
+      actual != nil
+        ? .match
+        : .noMatch(actual: "nil", expected: "not nil")
+    }
+  }
+
   // MARK: Type
 
   /// Checks that the actual value is an instance of the given type.

--- a/Tests/GRPCTests/XCTestManifests.swift
+++ b/Tests/GRPCTests/XCTestManifests.swift
@@ -116,6 +116,8 @@ extension ClientInterceptorPipelineTests {
         ("testErrorDelegateIsCalled", testErrorDelegateIsCalled),
         ("testPipelineWhenClosed", testPipelineWhenClosed),
         ("testPipelineWithInterceptor", testPipelineWithInterceptor),
+        ("testPipelineWithTimeout", testPipelineWithTimeout),
+        ("testTimeoutIsCancelledOnCompletion", testTimeoutIsCancelledOnCompletion),
     ]
 }
 


### PR DESCRIPTION
Motivation:

Some RPCs set a deadline, we should support that!

Modifications:

- Add a deadline to the interceptor pipeline.
- Fixed a bug in ClientTransport where we may leave some buffered writes
  behind

Result:

Calls using the interceptor pipeline may timeout.