### PR TITLE
Make the description of 'RPCTimedOut' static

### DIFF
--- a/Sources/GRPC/GRPCError.swift
+++ b/Sources/GRPC/GRPCError.swift
@@ -62,7 +62,7 @@ public enum GRPCError {
     }
 
     public var description: String {
-      return "RPC timed out before completing (\(self.timeLimit))"
+      return "RPC timed out before completing"
     }
 
     public func makeGRPCStatus() -> GRPCStatus {


### PR DESCRIPTION
Motivation:

When printing the 'RPCTimedOut' error, the time limit is also included.
Since these are often deadline based limits, the message is often
unique: this makes it cumbersome to correlate timeout failures logs.

Modifications:

- Remove the `timeLimit` from the `description` of `RPCTimedOut`.

Result:

- `RPCTimedOut` failures are easier to correlate in logs.