### PR TITLE
Reduce excessive server logging.

### DIFF
--- a/Sources/GRPC/HTTP1ToGRPCServerCodec.swift
+++ b/Sources/GRPC/HTTP1ToGRPCServerCodec.swift
@@ -130,12 +130,14 @@ extension HTTP1ToGRPCServerCodec: ChannelInboundHandler {
   public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
     let unwrappedData = self.unwrapInboundIn(data)
     if case .ignore = self.inboundState {
-        if case let .body(body) = unwrappedData, body.readableBytes == 0 {
-            return // Ignoring a read of zero bytes is always fine.
-        } else if case .end = unwrappedData {
-            return // Ignoring an end stream is not an event worth reporting.
-        }
-      self.logger.notice("ignoring read data", metadata: ["data": "\(data)"])
+      switch unwrappedData {
+      case let .body(body) where body.readableBytes == 0:
+        break // Ignoring a read of zero bytes is always fine.
+      case .end:
+        break // Ignoring an end stream is not an event worth reporting.
+      default:
+        self.logger.notice("ignoring read data", metadata: ["data": "\(unwrappedData)"])
+      }
       return
     }
 


### PR DESCRIPTION
Motivation:

When running a unary server, sending the response can put the
HTTP1ToGRPCServerCodec into ignore state.  This happens before
the end of stream is processed.  The 2 end stream messages
(empty buffer of data and end) then trigger logging.

Modifications:

Ignore end and empty data without logging when codec is in
ignore state.

Result:

Less logging and hence faster performance.