### PR TITLE
Clarify logging from client

### DIFF
--- a/Performance/QPSBenchmark/Sources/QPSBenchmark/Runtime/AsyncClient.swift
+++ b/Performance/QPSBenchmark/Sources/QPSBenchmark/Runtime/AsyncClient.swift
@@ -94,7 +94,7 @@ final class AsyncQPSClient<RequestMakerType: RequestMaker>: QPSClient {
     }
     result.stats.latencies = Grpc_Testing_HistogramData(from: latencyHistogram)
     result.stats.requestResults = statusCounts.toRequestResultCounts()
-    self.logger.info("Sending response")
+    self.logger.info("Sending client status")
     _ = context.sendResponse(result)
 
     if reset {


### PR DESCRIPTION
Motivation:

When testing there are connection to driver and other workers.
It is not clear who the response is being sent to and what about.

Modifications:

Change the log message to clarify what is being sent.

Result:

Clearer log messages