### PR TITLE
Tolerate identity compression as no compression

### DIFF
--- a/Tests/GRPCTests/XCTestManifests.swift
+++ b/Tests/GRPCTests/XCTestManifests.swift
@@ -756,10 +756,12 @@ extension MessageCompressionTests {
     static let __allTests__MessageCompressionTests = [
         ("testCompressedRequestsUncompressedResponses", testCompressedRequestsUncompressedResponses),
         ("testCompressedRequestWithCompressionNotSupportedOnServer", testCompressedRequestWithCompressionNotSupportedOnServer),
+        ("testCompressedRequestWithDisabledServerCompressionAndUnknownCompressionAlgorithm", testCompressedRequestWithDisabledServerCompressionAndUnknownCompressionAlgorithm),
         ("testDecompressionLimitIsRespectedByClientForStreamingCall", testDecompressionLimitIsRespectedByClientForStreamingCall),
         ("testDecompressionLimitIsRespectedByClientForUnaryCall", testDecompressionLimitIsRespectedByClientForUnaryCall),
         ("testDecompressionLimitIsRespectedByServerForStreamingCall", testDecompressionLimitIsRespectedByServerForStreamingCall),
         ("testDecompressionLimitIsRespectedByServerForUnaryCall", testDecompressionLimitIsRespectedByServerForUnaryCall),
+        ("testIdentityCompressionIsntCompression", testIdentityCompressionIsntCompression),
         ("testServerCanDecompressNonAdvertisedButSupportedCompression", testServerCanDecompressNonAdvertisedButSupportedCompression),
         ("testServerCompressesResponseWithDifferentAlgorithmToRequest", testServerCompressesResponseWithDifferentAlgorithmToRequest),
         ("testUncompressedRequestsCompressedResponses", testUncompressedRequestsCompressedResponses),


### PR DESCRIPTION
Motivation:

The GRPC specification acknowledges that "identity" is a way to say "no
compression", but when the user has disabled compression support we
refuse it as a compression format. That's not right.

Modifications:

- Add code to validate that the compression format isn't identity.
- Add some tests for newly added code.

Results:

Resolves #1005.