### PR TITLE
Remove HTTP1 types from the public server API

### DIFF
--- a/Sources/GRPC/CallHandlers/BidirectionalStreamingCallHandler.swift
+++ b/Sources/GRPC/CallHandlers/BidirectionalStreamingCallHandler.swift
@@ -16,7 +16,7 @@
 import Foundation
 import Logging
 import NIO
-import NIOHTTP1
+import NIOHPACK
 import SwiftProtobuf
 
 /// Handles bidirectional streaming calls. Forwards incoming messages and end-of-stream events to the observer block.
@@ -54,10 +54,10 @@ public class BidirectionalStreamingCallHandler<
     )
   }
 
-  override internal func processHead(_ head: HTTPRequestHead, context: ChannelHandlerContext) {
+  override internal func processHeaders(_ headers: HPACKHeaders, context: ChannelHandlerContext) {
     let callContext = StreamingResponseCallContextImpl<ResponsePayload>(
       channel: context.channel,
-      request: head,
+      headers: headers,
       errorDelegate: self.callHandlerContext.errorDelegate,
       logger: self.callHandlerContext.logger
     )
@@ -96,9 +96,9 @@ public class BidirectionalStreamingCallHandler<
     }
   }
 
-  override internal func sendErrorStatusAndMetadata(_ statusAndMetadata: GRPCStatusAndMetadata) {
-    if let metadata = statusAndMetadata.metadata {
-      self.callContext?.trailingMetadata.add(contentsOf: metadata)
+  override internal func sendErrorStatusAndMetadata(_ statusAndMetadata: GRPCStatusAndTrailers) {
+    if let trailers = statusAndMetadata.trailers {
+      self.callContext?.trailers.add(contentsOf: trailers)
     }
     self.callContext?.statusPromise.fail(statusAndMetadata.status)
   }

--- a/Sources/GRPC/CallHandlers/ClientStreamingCallHandler.swift
+++ b/Sources/GRPC/CallHandlers/ClientStreamingCallHandler.swift
@@ -16,6 +16,7 @@
 import Foundation
 import Logging
 import NIO
+import NIOHPACK
 import NIOHTTP1
 import SwiftProtobuf
 
@@ -52,10 +53,10 @@ public final class ClientStreamingCallHandler<
     )
   }
 
-  override internal func processHead(_ head: HTTPRequestHead, context: ChannelHandlerContext) {
+  override internal func processHeaders(_ headers: HPACKHeaders, context: ChannelHandlerContext) {
     let callContext = UnaryResponseCallContextImpl<ResponsePayload>(
       channel: context.channel,
-      request: head,
+      headers: headers,
       errorDelegate: self.errorDelegate,
       logger: self.logger
     )
@@ -96,9 +97,9 @@ public final class ClientStreamingCallHandler<
     }
   }
 
-  override internal func sendErrorStatusAndMetadata(_ statusAndMetadata: GRPCStatusAndMetadata) {
-    if let metadata = statusAndMetadata.metadata {
-      self.callContext?.trailingMetadata.add(contentsOf: metadata)
+  override internal func sendErrorStatusAndMetadata(_ statusAndMetadata: GRPCStatusAndTrailers) {
+    if let trailers = statusAndMetadata.trailers {
+      self.callContext?.trailers.add(contentsOf: trailers)
     }
     self.callContext?.responsePromise.fail(statusAndMetadata.status)
   }

--- a/Sources/GRPC/CallHandlers/ServerStreamingCallHandler.swift
+++ b/Sources/GRPC/CallHandlers/ServerStreamingCallHandler.swift
@@ -16,6 +16,7 @@
 import Foundation
 import Logging
 import NIO
+import NIOHPACK
 import NIOHTTP1
 import SwiftProtobuf
 
@@ -46,10 +47,10 @@ public final class ServerStreamingCallHandler<
     )
   }
 
-  override internal func processHead(_ head: HTTPRequestHead, context: ChannelHandlerContext) {
+  override internal func processHeaders(_ headers: HPACKHeaders, context: ChannelHandlerContext) {
     let callContext = StreamingResponseCallContextImpl<ResponsePayload>(
       channel: context.channel,
-      request: head,
+      headers: headers,
       errorDelegate: self.callHandlerContext.errorDelegate,
       logger: self.callHandlerContext.logger
     )
@@ -88,9 +89,9 @@ public final class ServerStreamingCallHandler<
     }
   }
 
-  override internal func sendErrorStatusAndMetadata(_ statusAndMetadata: GRPCStatusAndMetadata) {
-    if let metadata = statusAndMetadata.metadata {
-      self.callContext?.trailingMetadata.add(contentsOf: metadata)
+  override internal func sendErrorStatusAndMetadata(_ statusAndMetadata: GRPCStatusAndTrailers) {
+    if let trailers = statusAndMetadata.trailers {
+      self.callContext?.trailers.add(contentsOf: trailers)
     }
     self.callContext?.statusPromise.fail(statusAndMetadata.status)
   }

--- a/Sources/GRPC/CallHandlers/UnaryCallHandler.swift
+++ b/Sources/GRPC/CallHandlers/UnaryCallHandler.swift
@@ -16,6 +16,7 @@
 import Foundation
 import Logging
 import NIO
+import NIOHPACK
 import NIOHTTP1
 import SwiftProtobuf
 
@@ -46,10 +47,10 @@ public final class UnaryCallHandler<
     )
   }
 
-  override internal func processHead(_ head: HTTPRequestHead, context: ChannelHandlerContext) {
+  override internal func processHeaders(_ headers: HPACKHeaders, context: ChannelHandlerContext) {
     let callContext = UnaryResponseCallContextImpl<ResponsePayload>(
       channel: context.channel,
-      request: head,
+      headers: headers,
       errorDelegate: self.errorDelegate,
       logger: self.logger
     )
@@ -88,9 +89,9 @@ public final class UnaryCallHandler<
     }
   }
 
-  override internal func sendErrorStatusAndMetadata(_ statusAndMetadata: GRPCStatusAndMetadata) {
-    if let metadata = statusAndMetadata.metadata {
-      self.callContext?.trailingMetadata.add(contentsOf: metadata)
+  override internal func sendErrorStatusAndMetadata(_ statusAndMetadata: GRPCStatusAndTrailers) {
+    if let trailers = statusAndMetadata.trailers {
+      self.callContext?.trailers.add(contentsOf: trailers)
     }
     self.callContext?.responsePromise.fail(statusAndMetadata.status)
   }

--- a/Sources/GRPC/GRPCServerCodecHandler.swift
+++ b/Sources/GRPC/GRPCServerCodecHandler.swift
@@ -34,8 +34,8 @@ extension GRPCServerCodecHandler: ChannelInboundHandler {
 
   internal func channelRead(context: ChannelHandlerContext, data: NIOAny) {
     switch self.unwrapInboundIn(data) {
-    case let .head(head):
-      context.fireChannelRead(self.wrapInboundOut(.head(head)))
+    case let .headers(head):
+      context.fireChannelRead(self.wrapInboundOut(.headers(head)))
 
     case let .message(buffer):
       do {

--- a/Sources/GRPC/GRPCStatusAndMetadata.swift
+++ b/Sources/GRPC/GRPCStatusAndMetadata.swift
@@ -13,18 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import NIOHPACK
 import NIOHTTP1
 
-/// A simple struct holding a `GRPCStatus` and optionally metadata in the form of
-/// `HTTPHeaders`.
-public struct GRPCStatusAndMetadata: Equatable {
+/// A simple struct holding a `GRPCStatus` and optionally trailers in the form of
+/// `HPACKHeaders`.
+public struct GRPCStatusAndTrailers: Equatable {
   /// The status.
   public var status: GRPCStatus
-  /// The optional metadata.
-  public var metadata: HTTPHeaders?
 
-  public init(status: GRPCStatus, metadata: HTTPHeaders? = nil) {
+  /// The trailers.
+  public var trailers: HPACKHeaders?
+
+  public init(status: GRPCStatus, trailers: HPACKHeaders? = nil) {
     self.status = status
-    self.metadata = metadata
+    self.trailers = trailers
   }
 }

--- a/Sources/GRPC/HTTP1ToGRPCServerCodec.swift
+++ b/Sources/GRPC/HTTP1ToGRPCServerCodec.swift
@@ -17,6 +17,7 @@ import Foundation
 import Logging
 import NIO
 import NIOFoundationCompat
+import NIOHPACK
 import NIOHTTP1
 import SwiftProtobuf
 
@@ -24,7 +25,7 @@ import SwiftProtobuf
 ///
 /// - Important: This is **NOT** part of the public API.
 public enum _GRPCServerRequestPart<Request> {
-  case head(HTTPRequestHead)
+  case headers(HPACKHeaders)
   case message(Request)
   case end
 }
@@ -35,9 +36,9 @@ public typealias _RawGRPCServerRequestPart = _GRPCServerRequestPart<ByteBuffer>
 ///
 /// - Important: This is **NOT** part of the public API.
 public enum _GRPCServerResponsePart<Response> {
-  case headers(HTTPHeaders)
+  case headers(HPACKHeaders)
   case message(_MessageContext<Response>)
-  case statusAndTrailers(GRPCStatus, HTTPHeaders)
+  case statusAndTrailers(GRPCStatus, HPACKHeaders)
 }
 
 public typealias _RawGRPCServerResponsePart = _GRPCServerResponsePart<ByteBuffer>
@@ -202,7 +203,7 @@ extension HTTP1ToGRPCServerCodec: ChannelInboundHandler {
 
     case let .unsupported(header, acceptableEncoding):
       let message: String
-      let headers: HTTPHeaders
+      let headers: HPACKHeaders
       if acceptableEncoding.isEmpty {
         message = "compression is not supported"
         headers = .init()
@@ -235,7 +236,9 @@ extension HTTP1ToGRPCServerCodec: ChannelInboundHandler {
       self.responseEncodingHeader = nil
     }
 
-    context.fireChannelRead(self.wrapInboundOut(.head(requestHead)))
+    // We normalize in the 2-to-1 handler.
+    let headers = HPACKHeaders(httpHeaders: requestHead.headers, normalizeHTTPHeaders: false)
+    context.fireChannelRead(self.wrapInboundOut(.headers(headers)))
     return .expectingBody
   }
 
@@ -352,7 +355,7 @@ extension HTTP1ToGRPCServerCodec: ChannelOutboundHandler {
           .wrapOutboundOut(.head(HTTPResponseHead(
             version: version,
             status: .ok,
-            headers: headers
+            headers: HTTPHeaders(headers.map { ($0.name, $0.value) })
           ))),
         promise: promise
       )
@@ -405,7 +408,7 @@ extension HTTP1ToGRPCServerCodec: ChannelOutboundHandler {
       // NIOHTTP2 doesn't support sending a single frame as a "Trailers-Only" response so we still
       // need to loop back and send the request head first.
       if case .expectingHeaders = self.outboundState {
-        self.write(context: context, data: NIOAny(OutboundIn.headers(HTTPHeaders())), promise: nil)
+        self.write(context: context, data: NIOAny(OutboundIn.headers([:])), promise: nil)
       }
 
       var trailers = trailers
@@ -417,7 +420,7 @@ extension HTTP1ToGRPCServerCodec: ChannelOutboundHandler {
       if self.contentType == .webTextProtobuf {
         // Encode the trailers into the response byte stream as a length delimited message, as per
         // https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md
-        let textTrailers = trailers.map { name, value in "\(name): \(value)" }
+        let textTrailers = trailers.map { name, value, _ in "\(name): \(value)" }
           .joined(separator: "\r\n")
         var trailersBuffer = context.channel.allocator.buffer(capacity: 5 + textTrailers.utf8.count)
         trailersBuffer.writeInteger(UInt8(0x80))
@@ -466,7 +469,8 @@ extension HTTP1ToGRPCServerCodec: ChannelOutboundHandler {
         )
         context.write(self.wrapOutboundOut(.end(nil)), promise: promise)
       } else {
-        context.write(self.wrapOutboundOut(.end(trailers)), promise: promise)
+        let httpTrailers = HTTPHeaders(trailers.map { ($0.name, $0.value) })
+        context.write(self.wrapOutboundOut(.end(httpTrailers)), promise: promise)
       }
 
       // Log the call duration and status

--- a/Sources/GRPC/ServerErrorDelegate.swift
+++ b/Sources/GRPC/ServerErrorDelegate.swift
@@ -15,6 +15,7 @@
  */
 import Foundation
 import NIO
+import NIOHPACK
 import NIOHTTP1
 
 public protocol ServerErrorDelegate: AnyObject {
@@ -34,20 +35,13 @@ public protocol ServerErrorDelegate: AnyObject {
   /// This defaults to returning `nil`. In that case, if the original error conforms to `GRPCStatusTransformable`,
   /// that error's `asGRPCStatus()` result will be sent to the user. If that's not the case, either,
   /// `GRPCStatus.processingError` is returned.
-  func transformLibraryError(_ error: Error) -> GRPCStatusAndMetadata?
-
-  @available(
-    *,
-    deprecated,
-    message: "Please use the new transformLibraryError that returns a GRPCStatusAndMetadata instead."
-  )
-  func transformLibraryError(_ error: Error) -> GRPCStatus?
+  func transformLibraryError(_ error: Error) -> GRPCStatusAndTrailers?
 
   /// Called when a request's status or response promise is failed somewhere in the user-provided request handler code.
   /// - Parameters:
   ///   - error: The original error the status/response promise was failed with.
-  ///   - request: The headers of the request whose status/response promise was failed.
-  func observeRequestHandlerError(_ error: Error, request: HTTPRequestHead)
+  ///   - headers: The headers of the request whose status/response promise was failed.
+  func observeRequestHandlerError(_ error: Error, headers: HPACKHeaders)
 
   /// Transforms the given status or response promise failure into a new error.
   ///
@@ -64,28 +58,26 @@ public protocol ServerErrorDelegate: AnyObject {
   ///
   /// - Parameters:
   ///   - error: The original error the status/response promise was failed with.
-  ///   - request: The headers of the request whose status/response promise was failed.
-  func transformRequestHandlerError(_ error: Error, request: HTTPRequestHead)
-    -> GRPCStatusAndMetadata?
-
-  @available(
-    *,
-    deprecated,
-    message: "Please use the new transformLibraryError that returns a GRPCStatusAndMetadata instead."
-  )
-  func transformRequestHandlerError(_ error: Error, request: HTTPRequestHead) -> GRPCStatus?
+  ///   - headers: The headers of the request whose status/response promise was failed.
+  func transformRequestHandlerError(
+    _ error: Error,
+    headers: HPACKHeaders
+  ) -> GRPCStatusAndTrailers?
 }
 
 public extension ServerErrorDelegate {
   func observeLibraryError(_ error: Error) {}
-  func transformLibraryError(_ error: Error) -> GRPCStatusAndMetadata? { return nil }
-  func transformLibraryError(_ error: Error) -> GRPCStatus? { return nil }
 
-  func observeRequestHandlerError(_ error: Error, request: HTTPRequestHead) {}
+  func transformLibraryError(_ error: Error) -> GRPCStatusAndTrailers? {
+    return nil
+  }
+
+  func observeRequestHandlerError(_ error: Error, headers: HPACKHeaders) {}
+
   func transformRequestHandlerError(
     _ error: Error,
-    request: HTTPRequestHead
-  ) -> GRPCStatusAndMetadata? { return nil }
-  func transformRequestHandlerError(_ error: Error,
-                                    request: HTTPRequestHead) -> GRPCStatus? { return nil }
+    headers: HPACKHeaders
+  ) -> GRPCStatusAndTrailers? {
+    return nil
+  }
 }

--- a/Sources/GRPCInteroperabilityTestsImplementation/GRPCTestingConvenienceMethods.swift
+++ b/Sources/GRPCInteroperabilityTestsImplementation/GRPCTestingConvenienceMethods.swift
@@ -15,7 +15,7 @@
  */
 import Foundation
 import GRPCInteroperabilityTestModels
-import NIOHTTP1
+import NIOHPACK
 import SwiftProtobuf
 
 // MARK: - Payload creation
@@ -110,7 +110,7 @@ extension Grpc_Testing_StreamingInputCallRequest: PayloadRequest {}
 
 // MARK: - Echo metadata
 
-extension HTTPHeaders {
+extension HPACKHeaders {
   /// See `ServerFeatures.echoMetadata`.
   var shouldEchoMetadata: Bool {
     return self.contains(name: "x-grpc-test-echo-initial") || self

--- a/Sources/GRPCInteroperabilityTestsImplementation/TestServiceProvider.swift
+++ b/Sources/GRPCInteroperabilityTestsImplementation/TestServiceProvider.swift
@@ -70,7 +70,7 @@ public class TestServiceProvider: Grpc_Testing_TestServiceProvider {
     // We can't validate messages at the wire-encoding layer (i.e. where the compression byte is
     // set), so we have to check via the encoding header. Note that it is possible for the header
     // to be set and for the message to not be compressed.
-    if request.expectCompressed.value, !context.request.headers.contains(name: "grpc-encoding") {
+    if request.expectCompressed.value, !context.headers.contains(name: "grpc-encoding") {
       let status = GRPCStatus(
         code: .invalidArgument,
         message: "Expected compressed request, but 'grpc-encoding' was missing"
@@ -88,7 +88,7 @@ public class TestServiceProvider: Grpc_Testing_TestServiceProvider {
         .makeFailedFuture(GRPCStatus(code: code, message: request.responseStatus.message))
     }
 
-    if context.request.headers.shouldEchoMetadata {
+    if context.headers.shouldEchoMetadata {
       return context.eventLoop.makeFailedFuture(TestServiceProvider.echoMetadataNotImplemented)
     }
 
@@ -166,7 +166,7 @@ public class TestServiceProvider: Grpc_Testing_TestServiceProvider {
       switch event {
       case let .message(request):
         if request.expectCompressed.value,
-          !context.request.headers.contains(name: "grpc-encoding") {
+          !context.headers.contains(name: "grpc-encoding") {
           context.responseStatus = GRPCStatus(
             code: .invalidArgument,
             message: "Expected compressed request, but 'grpc-encoding' was missing"
@@ -193,7 +193,7 @@ public class TestServiceProvider: Grpc_Testing_TestServiceProvider {
     context: StreamingResponseCallContext<Grpc_Testing_StreamingOutputCallResponse>
   ) -> EventLoopFuture<(StreamEvent<Grpc_Testing_StreamingOutputCallRequest>) -> Void> {
     // We don't have support for this yet so just fail the call.
-    if context.request.headers.shouldEchoMetadata {
+    if context.headers.shouldEchoMetadata {
       return context.eventLoop.makeFailedFuture(TestServiceProvider.echoMetadataNotImplemented)
     }
 

--- a/Tests/GRPCTests/HTTP1ToGRPCServerCodecTests.swift
+++ b/Tests/GRPCTests/HTTP1ToGRPCServerCodecTests.swift
@@ -85,7 +85,7 @@ class HTTP1ToGRPCServerCodecTests: GRPCTestCase {
     let requestPart = try self.channel.readInbound(as: _RawGRPCServerRequestPart.self)
 
     switch requestPart {
-    case .some(.head):
+    case .some(.headers):
       ()
     default:
       XCTFail("Unexpected request part: \(String(describing: requestPart))")
@@ -128,7 +128,7 @@ class HTTP1ToGRPCServerCodecTests: GRPCTestCase {
     let requestPart = try self.channel.readInbound(as: _RawGRPCServerRequestPart.self)
 
     switch requestPart {
-    case .some(.head):
+    case .some(.headers):
       ()
     default:
       XCTFail("Unexpected request part: \(String(describing: requestPart))")
@@ -169,7 +169,7 @@ class HTTP1ToGRPCServerCodecTests: GRPCTestCase {
     let requestPart = try self.channel.readInbound(as: _RawGRPCServerRequestPart.self)
 
     switch requestPart {
-    case .some(.head):
+    case .some(.headers):
       ()
     default:
       XCTFail("Unexpected request part: \(String(describing: requestPart))")
@@ -219,7 +219,7 @@ class HTTP1ToGRPCServerCodecTests: GRPCTestCase {
     let requestPart = try self.channel.readInbound(as: _RawGRPCServerRequestPart.self)
 
     switch requestPart {
-    case .some(.head):
+    case .some(.headers):
       ()
     default:
       XCTFail("Unexpected request part: \(String(describing: requestPart))")

--- a/Tests/GRPCTests/ServerErrorDelegateTests.swift
+++ b/Tests/GRPCTests/ServerErrorDelegateTests.swift
@@ -23,13 +23,13 @@ import NIOHTTP1
 import XCTest
 
 private class ServerErrorDelegateMock: ServerErrorDelegate {
-  private let transformLibraryErrorHandler: (Error) -> (GRPCStatusAndMetadata?)
+  private let transformLibraryErrorHandler: (Error) -> (GRPCStatusAndTrailers?)
 
-  init(transformLibraryErrorHandler: @escaping ((Error) -> (GRPCStatusAndMetadata?))) {
+  init(transformLibraryErrorHandler: @escaping ((Error) -> (GRPCStatusAndTrailers?))) {
     self.transformLibraryErrorHandler = transformLibraryErrorHandler
   }
 
-  func transformLibraryError(_ error: Error) -> GRPCStatusAndMetadata? {
+  func transformLibraryError(_ error: Error) -> GRPCStatusAndTrailers? {
     return self.transformLibraryErrorHandler(error)
   }
 }
@@ -61,7 +61,7 @@ class ServerErrorDelegateTests: GRPCTestCase {
 
   private func testTransformLibraryError_whenTransformingErrorToStatus(uri: String) throws {
     self.setupChannelAndDelegate { _ in
-      GRPCStatusAndMetadata(status: .init(code: .notFound, message: "some error"))
+      GRPCStatusAndTrailers(status: .init(code: .notFound, message: "some error"))
     }
     let requestHead = HTTPRequestHead(
       version: .init(major: 2, minor: 0),
@@ -110,9 +110,9 @@ class ServerErrorDelegateTests: GRPCTestCase {
     uri: String
   ) throws {
     self.setupChannelAndDelegate { _ in
-      GRPCStatusAndMetadata(
+      GRPCStatusAndTrailers(
         status: .init(code: .notFound, message: "some error"),
-        metadata: ["some-metadata": "test"]
+        trailers: ["some-metadata": "test"]
       )
     }
     let requestHead = HTTPRequestHead(
@@ -140,7 +140,7 @@ class ServerErrorDelegateTests: GRPCTestCase {
 
   private func setupChannelAndDelegate(transformLibraryErrorHandler: @escaping (
     (Error)
-      -> (GRPCStatusAndMetadata?)
+      -> (GRPCStatusAndTrailers?)
   )) {
     let provider = EchoProvider()
     self

--- a/Tests/GRPCTests/ServerThrowingTests.swift
+++ b/Tests/GRPCTests/ServerThrowingTests.swift
@@ -25,7 +25,7 @@ import XCTest
 
 let thrownError = GRPCStatus(code: .internalError, message: "expected error")
 let transformedError = GRPCStatus(code: .aborted, message: "transformed error")
-let transformedMetadata = HTTPHeaders([("transformed", "header")])
+let transformedMetadata = HPACKHeaders([("transformed", "header")])
 
 // Motivation for two different providers: Throwing immediately causes the event observer future (in the
 // client-streaming and bidi-streaming cases) to throw immediately, _before_ the corresponding handler has even added
@@ -117,8 +117,8 @@ class ErrorReturningEchoProvider: ImmediateThrowingEchoProvider {
 
 private class ErrorTransformingDelegate: ServerErrorDelegate {
   func transformRequestHandlerError(_ error: Error,
-                                    request: HTTPRequestHead) -> GRPCStatusAndMetadata? {
-    return GRPCStatusAndMetadata(status: transformedError, metadata: transformedMetadata)
+                                    headers: HPACKHeaders) -> GRPCStatusAndTrailers? {
+    return GRPCStatusAndTrailers(status: transformedError, trailers: transformedMetadata)
   }
 }
 


### PR DESCRIPTION
Motivation:

Currently, on the server, we always operate on HTTP/1 types. The
advantage of this is that supporting gRPC-Web is trivial. However, the
vast majority of connections are HTTP/2 and this transformation
incurs a non-trivial performance cost.

In the future we'd like to change how we support gRPC-Web by always
operating on HTTP/2 types and converting to HTTP/1 types only when
necessary.

The first step in achieving this is removing HTTP/1 types from the
public server API.

Modifications:

- Remove 'request' (i.e. 'HTTPRequestHead') from the server call
  contexts and add 'headers' (as 'HPACKHeaders') in their place
- Modify the server request and response parts to use 'HPACKHeaders'
  rather than 'HTTPHeaders'.
- Renaming 'GRPCStatusAndMetadata' to 'GRPCStatusAndTrailers' adding a
  deprecated typealias to help
- Add 'trailers' as 'HPACKHeaders' to 'GRPCStatusAndTrailers' and
  deprecate 'metadata'
- Change the relevant 'ServerErrorDelegate' methods. Unforunately these
  all have default implementations, so deprecating them isn't useful
  (since the implementor will be unaware of the change).

Result:

Server API is free of `HTTPHeaders` and `HTTPRequestHead`