### PR TITLE
Split path strings using UTF8

### DIFF
--- a/Sources/GRPC/GRPCServerRequestRoutingHandler.swift
+++ b/Sources/GRPC/GRPCServerRequestRoutingHandler.swift
@@ -291,7 +291,7 @@ extension GRPCServerRequestRoutingHandler: ChannelInboundHandler, RemovableChann
 extension Collection where Self == Self.SubSequence, Self.Element: Equatable {
   /// Trims out the prefix up to `separator`, and returns it.
   /// Sets self to the subsequence after the separator, and returns the subsequence before the separator.
-  /// If the self is emtpy returns `nil`
+  /// If self is emtpy returns `nil`
   /// - parameters:
   ///     - separator : The Element between the head which is returned and the rest which is left in self.
   /// - returns: SubSequence containing everything between the beginnning and the first occurance of

--- a/Sources/GRPC/GRPCServerRequestRoutingHandler.swift
+++ b/Sources/GRPC/GRPCServerRequestRoutingHandler.swift
@@ -231,13 +231,14 @@ extension GRPCServerRequestRoutingHandler: ChannelInboundHandler, RemovableChann
     /// URI format: "/package.Servicename/MethodName"
     init?(requestURI: String) {
       var utf8View = requestURI.utf8[...]
-      guard utf8View.splitFirst(separator: self.pathSplitDelimiter)?.count == 0 else {
+      // Check and remove the split character at the beginning.
+      guard utf8View.trimPrefix(to: self.pathSplitDelimiter)?.isEmpty == true else {
         return nil
       }
-      guard let service = utf8View.splitFirst(separator: pathSplitDelimiter) else {
+      guard let service = utf8View.trimPrefix(to: pathSplitDelimiter) else {
         return nil
       }
-      guard let method = utf8View.splitFirst(separator: pathSplitDelimiter) else {
+      guard let method = utf8View.trimPrefix(to: pathSplitDelimiter) else {
         return nil
       }
 
@@ -297,7 +298,7 @@ extension Collection where Self == Self.SubSequence, Self.Element: Equatable {
   /// - returns: SubSequence containing everything between the beginnning and the first occurance of
   /// `separator`.  If `separator` is not found this will be the entire Collection. If the collection is empty
   /// returns `nil`
-  mutating func splitFirst(separator: Element) -> SubSequence? {
+  mutating func trimPrefix(to separator: Element) -> SubSequence? {
     guard !self.isEmpty else {
       return nil
     }

--- a/Sources/GRPC/GRPCServerRequestRoutingHandler.swift
+++ b/Sources/GRPC/GRPCServerRequestRoutingHandler.swift
@@ -216,38 +216,39 @@ extension GRPCServerRequestRoutingHandler: ChannelInboundHandler, RemovableChann
     }
   }
 
-    /// A call URI split into components.
-    struct CallPath {
-        /// The name of the service to call.
-        var service: String.UTF8View.SubSequence
-        /// The name of the method to call.
-        var method: String.UTF8View.SubSequence
+  /// A call URI split into components.
+  struct CallPath {
+    /// The name of the service to call.
+    var service: String.UTF8View.SubSequence
+    /// The name of the method to call.
+    var method: String.UTF8View.SubSequence
 
-        /// Charater used to split the path into components.
-        private let pathSplitDelimiter = UInt8(ascii: "/")
+    /// Charater used to split the path into components.
+    private let pathSplitDelimiter = UInt8(ascii: "/")
 
-        /// Split a path into service and method.
-        /// Split is done in UTF8 as this turns out to be approximately 10x faster than a simple split.
-        /// URI format: "/package.Servicename/MethodName"
-        init?(requestURI: String) {
-            let utf8View = requestURI.utf8
-            guard let firstIndex = utf8View.firstIndex(of: pathSplitDelimiter) else {
-                return nil
-            }
-            let afterFirstDelimiter = utf8View[utf8View.index(after: firstIndex)...]
-            guard let secondIndex = afterFirstDelimiter.firstIndex(of: pathSplitDelimiter) else {
-                return nil
-            }
+    /// Split a path into service and method.
+    /// Split is done in UTF8 as this turns out to be approximately 10x faster than a simple split.
+    /// URI format: "/package.Servicename/MethodName"
+    init?(requestURI: String) {
+      let utf8View = requestURI.utf8
+      guard let firstIndex = utf8View.firstIndex(of: pathSplitDelimiter) else {
+        return nil
+      }
+      let afterFirstDelimiter = utf8View[utf8View.index(after: firstIndex)...]
+      guard let secondIndex = afterFirstDelimiter.firstIndex(of: pathSplitDelimiter) else {
+        return nil
+      }
 
-            self.service = afterFirstDelimiter[..<secondIndex]
-            let afterSecondDelimiter = afterFirstDelimiter[afterFirstDelimiter.index(after: secondIndex)...]
-            if let thirdIndex = afterSecondDelimiter.firstIndex(of: pathSplitDelimiter) {
-                self.method = afterSecondDelimiter[..<thirdIndex]
-            } else {
-                self.method = afterSecondDelimiter
-            }
-        }
+      self.service = afterFirstDelimiter[..<secondIndex]
+      let afterSecondDelimiter =
+        afterFirstDelimiter[afterFirstDelimiter.index(after: secondIndex)...]
+      if let thirdIndex = afterSecondDelimiter.firstIndex(of: pathSplitDelimiter) {
+        self.method = afterSecondDelimiter[..<thirdIndex]
+      } else {
+        self.method = afterSecondDelimiter
+      }
     }
+  }
 
   private func makeCallHandler(channel: Channel, requestHead: HTTPRequestHead) -> GRPCCallHandler? {
     // URI format: "/package.Servicename/MethodName", resulting in the following components separated by a slash:
@@ -265,7 +266,7 @@ extension GRPCServerRequestRoutingHandler: ChannelInboundHandler, RemovableChann
     )
 
     guard let callPath = uriComponents,
-          let providerForServiceName = servicesByName[String.SubSequence(callPath.service)],
+      let providerForServiceName = servicesByName[String.SubSequence(callPath.service)],
       let callHandler = providerForServiceName.handleMethod(
         String.SubSequence(callPath.method),
         callHandlerContext: context

--- a/Sources/GRPC/GRPCServerRequestRoutingHandler.swift
+++ b/Sources/GRPC/GRPCServerRequestRoutingHandler.swift
@@ -232,7 +232,7 @@ extension GRPCServerRequestRoutingHandler: ChannelInboundHandler, RemovableChann
     init?(requestURI: String) {
       var utf8View = requestURI.utf8[...]
       // Check and remove the split character at the beginning.
-      guard utf8View.trimPrefix(to: self.pathSplitDelimiter)?.isEmpty == true else {
+      guard let prefix = utf8View.trimPrefix(to: self.pathSplitDelimiter), prefix.isEmpty else {
         return nil
       }
       guard let service = utf8View.trimPrefix(to: pathSplitDelimiter) else {

--- a/Sources/GRPC/GRPCServerRequestRoutingHandler.swift
+++ b/Sources/GRPC/GRPCServerRequestRoutingHandler.swift
@@ -224,18 +224,18 @@ extension GRPCServerRequestRoutingHandler: ChannelInboundHandler, RemovableChann
         var method: String.UTF8View.SubSequence
 
         /// Charater used to split the path into components.
-        private let pathSplitDelimiter = "/".utf8.first!
+        private let pathSplitDelimiter = UInt8(ascii: "/")
 
         /// Split a path into service and method.
         /// Split is done in UTF8 as this turns out to be approximately 10x faster than a simple split.
         /// URI format: "/package.Servicename/MethodName"
-        init?(requestUri: String) {
+        init?(requestURI: String) {
             let requestUriUTF8 = requestUri.utf8
             let maybeFirstIndex = requestUriUTF8.firstIndex(of: pathSplitDelimiter)
             guard let firstIndex = maybeFirstIndex else {
                 return nil
             }
-            let afterFirstDelimiter = requestUriUTF8[requestUriUTF8.index(after:firstIndex)...]
+            let afterFirstDelimiter = requestUriUTF8[requestUriUTF8.index(after: firstIndex)...]
             if let secondIndex = afterFirstDelimiter.firstIndex(of: pathSplitDelimiter) {
                 self.service = afterFirstDelimiter[..<secondIndex]
                 let afterSecondDelimiter = afterFirstDelimiter[afterFirstDelimiter.index(after: secondIndex)...]

--- a/Tests/GRPCTests/GRPCServerRequestRoutingHandlerTests.swift
+++ b/Tests/GRPCTests/GRPCServerRequestRoutingHandlerTests.swift
@@ -122,28 +122,28 @@ class GRPCServerRequestRoutingHandlerTests: GRPCTestCase {
     XCTAssertNoThrow(try unary.wait())
   }
 
-    func testSplitPathNormal() {
-        let path = "/server/method"
-        let parsedPath  = GRPCServerRequestRoutingHandler.CallPath(requestUri: path)
-        let splitPath = path.split(separator: "/")
+  func testSplitPathNormal() {
+    let path = "/server/method"
+    let parsedPath = GRPCServerRequestRoutingHandler.CallPath(requestUri: path)
+    let splitPath = path.split(separator: "/")
 
-        XCTAssertEqual(splitPath[0], String.SubSequence(parsedPath!.service))
-        XCTAssertEqual(splitPath[1], String.SubSequence(parsedPath!.method))
-    }
+    XCTAssertEqual(splitPath[0], String.SubSequence(parsedPath!.service))
+    XCTAssertEqual(splitPath[1], String.SubSequence(parsedPath!.method))
+  }
 
-    func testSplitPathTooShort() {
-        let path = "/badPath"
-        let parsedPath  = GRPCServerRequestRoutingHandler.CallPath(requestUri: path)
+  func testSplitPathTooShort() {
+    let path = "/badPath"
+    let parsedPath = GRPCServerRequestRoutingHandler.CallPath(requestUri: path)
 
-        XCTAssertNil(parsedPath)
-    }
+    XCTAssertNil(parsedPath)
+  }
 
-    func testSplitPathTooLong() {
-        let path = "/server/method/discard"
-        let parsedPath  = GRPCServerRequestRoutingHandler.CallPath(requestUri: path)
-        let splitPath = path.split(separator: "/")
+  func testSplitPathTooLong() {
+    let path = "/server/method/discard"
+    let parsedPath = GRPCServerRequestRoutingHandler.CallPath(requestUri: path)
+    let splitPath = path.split(separator: "/")
 
-        XCTAssertEqual(splitPath[0], String.SubSequence(parsedPath!.service))
-        XCTAssertEqual(splitPath[1], String.SubSequence(parsedPath!.method))
-    }
+    XCTAssertEqual(splitPath[0], String.SubSequence(parsedPath!.service))
+    XCTAssertEqual(splitPath[1], String.SubSequence(parsedPath!.method))
+  }
 }

--- a/Tests/GRPCTests/GRPCServerRequestRoutingHandlerTests.swift
+++ b/Tests/GRPCTests/GRPCServerRequestRoutingHandlerTests.swift
@@ -124,7 +124,7 @@ class GRPCServerRequestRoutingHandlerTests: GRPCTestCase {
 
   func testSplitPathNormal() {
     let path = "/server/method"
-    let parsedPath = GRPCServerRequestRoutingHandler.CallPath(requestUri: path)
+    let parsedPath = GRPCServerRequestRoutingHandler.CallPath(requestURI: path)
     let splitPath = path.split(separator: "/")
 
     XCTAssertEqual(splitPath[0], String.SubSequence(parsedPath!.service))
@@ -133,17 +133,40 @@ class GRPCServerRequestRoutingHandlerTests: GRPCTestCase {
 
   func testSplitPathTooShort() {
     let path = "/badPath"
-    let parsedPath = GRPCServerRequestRoutingHandler.CallPath(requestUri: path)
+    let parsedPath = GRPCServerRequestRoutingHandler.CallPath(requestURI: path)
 
     XCTAssertNil(parsedPath)
   }
 
   func testSplitPathTooLong() {
     let path = "/server/method/discard"
-    let parsedPath = GRPCServerRequestRoutingHandler.CallPath(requestUri: path)
+    let parsedPath = GRPCServerRequestRoutingHandler.CallPath(requestURI: path)
     let splitPath = path.split(separator: "/")
 
     XCTAssertEqual(splitPath[0], String.SubSequence(parsedPath!.service))
     XCTAssertEqual(splitPath[1], String.SubSequence(parsedPath!.method))
+  }
+
+  func testSplitFirstEmpty() {
+    var toSplit = "".utf8[...]
+    let head = toSplit.splitFirst(separator: UInt8(ascii: "/"))
+    XCTAssertNil(head)
+    XCTAssertEqual(toSplit.count, 0)
+  }
+
+  func testSplitFirstAll() {
+    let source = "words"
+    var toSplit = source.utf8[...]
+    let head = toSplit.splitFirst(separator: UInt8(ascii: "/"))
+    XCTAssertEqual(head?.count, source.utf8.count)
+    XCTAssertEqual(toSplit.count, 0)
+  }
+
+  func testSplitFirstAndRest() {
+    let source = "words/moreWords"
+    var toSplit = source.utf8[...]
+    let head = toSplit.splitFirst(separator: UInt8(ascii: "/"))
+    XCTAssertEqual(head?.count, "words".utf8.count)
+    XCTAssertEqual(toSplit.count, "moreWords".utf8.count)
   }
 }

--- a/Tests/GRPCTests/GRPCServerRequestRoutingHandlerTests.swift
+++ b/Tests/GRPCTests/GRPCServerRequestRoutingHandlerTests.swift
@@ -147,25 +147,25 @@ class GRPCServerRequestRoutingHandlerTests: GRPCTestCase {
     XCTAssertEqual(splitPath[1], String.SubSequence(parsedPath!.method))
   }
 
-  func testSplitFirstEmpty() {
+  func testTrimPrefixEmpty() {
     var toSplit = "".utf8[...]
-    let head = toSplit.splitFirst(separator: UInt8(ascii: "/"))
+    let head = toSplit.trimPrefix(to: UInt8(ascii: "/"))
     XCTAssertNil(head)
     XCTAssertEqual(toSplit.count, 0)
   }
 
-  func testSplitFirstAll() {
+  func testTrimPrefixAll() {
     let source = "words"
     var toSplit = source.utf8[...]
-    let head = toSplit.splitFirst(separator: UInt8(ascii: "/"))
+    let head = toSplit.trimPrefix(to: UInt8(ascii: "/"))
     XCTAssertEqual(head?.count, source.utf8.count)
     XCTAssertEqual(toSplit.count, 0)
   }
 
-  func testSplitFirstAndRest() {
+  func testTrimPrefixAndRest() {
     let source = "words/moreWords"
     var toSplit = source.utf8[...]
-    let head = toSplit.splitFirst(separator: UInt8(ascii: "/"))
+    let head = toSplit.trimPrefix(to: UInt8(ascii: "/"))
     XCTAssertEqual(head?.count, "words".utf8.count)
     XCTAssertEqual(toSplit.count, "moreWords".utf8.count)
   }

--- a/Tests/GRPCTests/GRPCServerRequestRoutingHandlerTests.swift
+++ b/Tests/GRPCTests/GRPCServerRequestRoutingHandlerTests.swift
@@ -16,7 +16,7 @@
 import EchoImplementation
 import EchoModel
 import Foundation
-import GRPC
+@testable import GRPC
 import Logging
 import NIO
 import NIOHTTP1
@@ -121,4 +121,29 @@ class GRPCServerRequestRoutingHandlerTests: GRPCTestCase {
       .handler(type: UnaryCallHandler<Echo_EchoRequest, Echo_EchoResponse>.self)
     XCTAssertNoThrow(try unary.wait())
   }
+
+    func testSplitPathNormal() {
+        let path = "/server/method"
+        let parsedPath  = GRPCServerRequestRoutingHandler.CallPath(requestUri: path)
+        let splitPath = path.split(separator: "/")
+
+        XCTAssertEqual(splitPath[0], String.SubSequence(parsedPath!.service))
+        XCTAssertEqual(splitPath[1], String.SubSequence(parsedPath!.method))
+    }
+
+    func testSplitPathTooShort() {
+        let path = "/badPath"
+        let parsedPath  = GRPCServerRequestRoutingHandler.CallPath(requestUri: path)
+
+        XCTAssertNil(parsedPath)
+    }
+
+    func testSplitPathTooLong() {
+        let path = "/server/method/discard"
+        let parsedPath  = GRPCServerRequestRoutingHandler.CallPath(requestUri: path)
+        let splitPath = path.split(separator: "/")
+
+        XCTAssertEqual(splitPath[0], String.SubSequence(parsedPath!.service))
+        XCTAssertEqual(splitPath[1], String.SubSequence(parsedPath!.method))
+    }
 }

--- a/Tests/GRPCTests/XCTestManifests.swift
+++ b/Tests/GRPCTests/XCTestManifests.swift
@@ -593,6 +593,12 @@ extension GRPCServerRequestRoutingHandlerTests {
     static let __allTests__GRPCServerRequestRoutingHandlerTests = [
         ("testImplementedMethodReconfiguresPipeline", testImplementedMethodReconfiguresPipeline),
         ("testInvalidGRPCContentTypeReturnsUnsupportedMediaType", testInvalidGRPCContentTypeReturnsUnsupportedMediaType),
+        ("testSplitPathNormal", testSplitPathNormal),
+        ("testSplitPathTooLong", testSplitPathTooLong),
+        ("testSplitPathTooShort", testSplitPathTooShort),
+        ("testTrimPrefixAll", testTrimPrefixAll),
+        ("testTrimPrefixAndRest", testTrimPrefixAndRest),
+        ("testTrimPrefixEmpty", testTrimPrefixEmpty),
         ("testUnimplementedMethodReturnsUnimplementedStatus", testUnimplementedMethodReturnsUnimplementedStatus),
     ]
 }


### PR DESCRIPTION
Motivation:

For unary calls there can be a lot of path manipulation.
Splitting in utf8 space is approximately 10x faster.

Modifications:

Hand craft a two part split using utf8.

Result:

Very small overall speed improvement (less than 1%)