### PR TITLE
Prefix '{Client,Server}{Request,Response}Part' with 'GRPC'

### DIFF
--- a/Sources/GRPC/CallHandlers/_BaseCallHandler.swift
+++ b/Sources/GRPC/CallHandlers/_BaseCallHandler.swift
@@ -124,7 +124,7 @@ public class _BaseCallHandler<Request, Response>: GRPCCallHandler, ChannelInboun
   ///   - part: The response part to send.
   ///   - promise: A promise to complete once the response part has been written.
   internal func sendResponsePartFromObserver(
-    _ part: ServerResponsePart<Response>,
+    _ part: GRPCServerResponsePart<Response>,
     promise: EventLoopPromise<Void>?
   ) {
     self.act(on: self.state.sendResponsePartFromObserver(part, promise: promise))
@@ -204,7 +204,7 @@ public class _BaseCallHandler<Request, Response>: GRPCCallHandler, ChannelInboun
 extension _BaseCallHandler {
   /// Receive a request part from the interceptors pipeline to forward to the event observer.
   /// - Parameter part: The request part to forward.
-  private func receiveRequestPartFromInterceptors(_ part: ServerRequestPart<Request>) {
+  private func receiveRequestPartFromInterceptors(_ part: GRPCServerRequestPart<Request>) {
     self.act(on: self.state.receiveRequestPartFromInterceptors(part))
   }
 
@@ -214,7 +214,7 @@ extension _BaseCallHandler {
   ///   - part: The response part to send.
   ///   - promise: A promise to complete once the response part has been written.
   private func sendResponsePartFromInterceptors(
-    _ part: ServerResponsePart<Response>,
+    _ part: GRPCServerResponsePart<Response>,
     promise: EventLoopPromise<Void>?
   ) {
     self.act(on: self.state.sendResponsePartFromInterceptors(part, promise: promise))
@@ -374,21 +374,21 @@ extension _BaseCallHandler.State {
     case none
 
     /// Receive the request part in the interceptor pipeline.
-    case receiveRequestPartInInterceptors(ServerRequestPart<Request>)
+    case receiveRequestPartInInterceptors(GRPCServerRequestPart<Request>)
 
     /// Receive the request part in the observer.
-    case receiveRequestPartInObserver(ServerRequestPart<Request>)
+    case receiveRequestPartInObserver(GRPCServerRequestPart<Request>)
 
     /// Receive an error in the observer.
     case receiveLibraryErrorInObserver(Error)
 
     /// Send a response part to the interceptor pipeline.
-    case sendResponsePartToInterceptors(ServerResponsePart<Response>, EventLoopPromise<Void>?)
+    case sendResponsePartToInterceptors(GRPCServerResponsePart<Response>, EventLoopPromise<Void>?)
 
     /// Write the response part to the `Channel`.
     case writeResponsePartToChannel(
       ChannelHandlerContext,
-      ServerResponsePart<Response>,
+      GRPCServerResponsePart<Response>,
       promise: EventLoopPromise<Void>?
     )
 
@@ -441,7 +441,7 @@ extension _BaseCallHandler.State {
       self = .idle
 
       let filter: StreamState.Filter
-      let part: ServerRequestPart<Request>
+      let part: GRPCServerRequestPart<Request>
 
       switch requestPart {
       case let .headers(headers):
@@ -472,7 +472,7 @@ extension _BaseCallHandler.State {
 
   /// Send a response part from the observer to the interceptors.
   internal mutating func sendResponsePartFromObserver(
-    _ part: ServerResponsePart<Response>,
+    _ part: GRPCServerResponsePart<Response>,
     promise: EventLoopPromise<Void>?
   ) -> Action {
     switch self {
@@ -511,7 +511,7 @@ extension _BaseCallHandler.State {
 
   /// Send a response part from the interceptors to the `Channel`.
   internal mutating func sendResponsePartFromInterceptors(
-    _ part: ServerResponsePart<Response>,
+    _ part: GRPCServerResponsePart<Response>,
     promise: EventLoopPromise<Void>?
   ) -> Action {
     switch self {
@@ -552,7 +552,7 @@ extension _BaseCallHandler.State {
 
   /// A request part has traversed the interceptor pipeline, now send it to the observer.
   internal mutating func receiveRequestPartFromInterceptors(
-    _ part: ServerRequestPart<Request>
+    _ part: GRPCServerRequestPart<Request>
   ) -> Action {
     switch self {
     case .idle:
@@ -625,13 +625,13 @@ extension _BaseCallHandler {
   }
 
   /// Receives a request part in the interceptor pipeline.
-  private func receiveRequestPartInInterceptors(_ part: ServerRequestPart<Request>) {
+  private func receiveRequestPartInInterceptors(_ part: GRPCServerRequestPart<Request>) {
     self.pipeline?.receive(part)
   }
 
   /// Observe a request part. This just farms out to the subclass implementation for the
   /// appropriate part.
-  private func receiveRequestPartInObserver(_ part: ServerRequestPart<Request>) {
+  private func receiveRequestPartInObserver(_ part: GRPCServerRequestPart<Request>) {
     switch part {
     case let .metadata(headers):
       self.observeHeaders(headers)
@@ -644,7 +644,7 @@ extension _BaseCallHandler {
 
   /// Sends a response part into the interceptor pipeline.
   private func sendResponsePartToInterceptors(
-    _ part: ServerResponsePart<Response>,
+    _ part: GRPCServerResponsePart<Response>,
     promise: EventLoopPromise<Void>?
   ) {
     if let pipeline = self.pipeline {
@@ -657,7 +657,7 @@ extension _BaseCallHandler {
   /// Writes a response part to the `Channel`.
   private func writeResponsePartToChannel(
     context: ChannelHandlerContext,
-    part: ServerResponsePart<Response>,
+    part: GRPCServerResponsePart<Response>,
     promise: EventLoopPromise<Void>?
   ) {
     let flush: Bool

--- a/Sources/GRPC/ClientCalls/Call.swift
+++ b/Sources/GRPC/ClientCalls/Call.swift
@@ -112,7 +112,7 @@ public class Call<Request, Response> {
   /// - Parameter onResponsePart: A callback which is invoked on every response part.
   /// - Important: This function should only be called once. Subsequent calls will be ignored.
   @inlinable
-  public func invoke(_ onResponsePart: @escaping (ClientResponsePart<Response>) -> Void) {
+  public func invoke(_ onResponsePart: @escaping (GRPCClientResponsePart<Response>) -> Void) {
     self.options.logger.debug("starting rpc", metadata: ["path": "\(self.path)"], source: "GRPC")
 
     if self.eventLoop.inEventLoop {
@@ -130,7 +130,7 @@ public class Call<Request, Response> {
   ///   - promise: A promise which will be completed when the request part has been handled.
   /// - Note: Sending will always fail if `invoke(_:)` has not been called.
   @inlinable
-  public func send(_ part: ClientRequestPart<Request>, promise: EventLoopPromise<Void>?) {
+  public func send(_ part: GRPCClientRequestPart<Request>, promise: EventLoopPromise<Void>?) {
     if self.eventLoop.inEventLoop {
       self._send(part, promise: promise)
     } else {
@@ -161,7 +161,7 @@ extension Call {
   /// - Returns: A future which will be resolved when the request has been handled.
   /// - Note: Sending will always fail if `invoke(_:)` has not been called.
   @inlinable
-  public func send(_ part: ClientRequestPart<Request>) -> EventLoopFuture<Void> {
+  public func send(_ part: GRPCClientRequestPart<Request>) -> EventLoopFuture<Void> {
     let promise = self.eventLoop.makePromise(of: Void.self)
     self.send(part, promise: promise)
     return promise.futureResult
@@ -255,7 +255,7 @@ extension Call {
   /// - Important: This *must* to be called from the `eventLoop`.
   @usableFromInline
   internal func _invoke(
-    _ onResponsePart: @escaping (ClientResponsePart<Response>) -> Void
+    _ onResponsePart: @escaping (GRPCClientResponsePart<Response>) -> Void
   ) {
     self.eventLoop.assertInEventLoop()
 
@@ -279,7 +279,7 @@ extension Call {
   /// Send a request part on the transport.
   /// - Important: This *must* to be called from the `eventLoop`.
   @inlinable
-  internal func _send(_ part: ClientRequestPart<Request>, promise: EventLoopPromise<Void>?) {
+  internal func _send(_ part: GRPCClientRequestPart<Request>, promise: EventLoopPromise<Void>?) {
     self.eventLoop.assertInEventLoop()
 
     switch self._state {
@@ -343,7 +343,7 @@ extension Call {
   @inlinable
   internal func invokeUnaryRequest(
     _ request: Request,
-    _ onResponsePart: @escaping (ClientResponsePart<Response>) -> Void
+    _ onResponsePart: @escaping (GRPCClientResponsePart<Response>) -> Void
   ) {
     if self.eventLoop.inEventLoop {
       self._invokeUnaryRequest(request: request, onResponsePart)
@@ -360,7 +360,7 @@ extension Call {
   ///   - onResponsePart: A callback invoked for each response part received.
   @inlinable
   internal func invokeStreamingRequests(
-    _ onResponsePart: @escaping (ClientResponsePart<Response>) -> Void
+    _ onResponsePart: @escaping (GRPCClientResponsePart<Response>) -> Void
   ) {
     if self.eventLoop.inEventLoop {
       self._invokeStreamingRequests(onResponsePart)
@@ -375,7 +375,7 @@ extension Call {
   @usableFromInline
   internal func _invokeUnaryRequest(
     request: Request,
-    _ onResponsePart: @escaping (ClientResponsePart<Response>) -> Void
+    _ onResponsePart: @escaping (GRPCClientResponsePart<Response>) -> Void
   ) {
     self.eventLoop.assertInEventLoop()
     assert(self.type == .unary || self.type == .serverStreaming)
@@ -392,7 +392,7 @@ extension Call {
   /// On-`EventLoop` implementation of `invokeStreamingRequests(_:)`.
   @usableFromInline
   internal func _invokeStreamingRequests(
-    _ onResponsePart: @escaping (ClientResponsePart<Response>) -> Void
+    _ onResponsePart: @escaping (GRPCClientResponsePart<Response>) -> Void
   ) {
     self.eventLoop.assertInEventLoop()
     assert(self.type == .clientStreaming || self.type == .bidirectionalStreaming)

--- a/Sources/GRPC/ClientCalls/ResponseContainers.swift
+++ b/Sources/GRPC/ClientCalls/ResponseContainers.swift
@@ -61,7 +61,7 @@ internal class UnaryResponseParts<Response> {
 
   /// Handle the response part, completing any promises as necessary.
   /// - Important: This *must* be called on `eventLoop`.
-  internal func handle(_ part: ClientResponsePart<Response>) {
+  internal func handle(_ part: GRPCClientResponsePart<Response>) {
     self.eventLoop.assertInEventLoop()
 
     switch part {
@@ -130,7 +130,7 @@ internal class StreamingResponseParts<Response> {
     self.statusPromise = eventLoop.makeLazyPromise()
   }
 
-  internal func handle(_ part: ClientResponsePart<Response>) {
+  internal func handle(_ part: GRPCClientResponsePart<Response>) {
     self.eventLoop.assertInEventLoop()
 
     switch part {

--- a/Sources/GRPC/Interceptor/ClientInterceptorContext.swift
+++ b/Sources/GRPC/Interceptor/ClientInterceptorContext.swift
@@ -78,7 +78,7 @@ public struct ClientInterceptorContext<Request, Response> {
   ///
   /// - Parameter part: The response part to forward.
   /// - Important: This *must* to be called from the `eventLoop`.
-  public func receive(_ part: ClientResponsePart<Response>) {
+  public func receive(_ part: GRPCClientResponsePart<Response>) {
     self.eventLoop.assertInEventLoop()
     self.nextInbound?.invokeReceive(part)
   }
@@ -90,7 +90,7 @@ public struct ClientInterceptorContext<Request, Response> {
   ///   - promise: The promise the complete when the part has been written.
   /// - Important: This *must* to be called from the `eventLoop`.
   public func send(
-    _ part: ClientRequestPart<Request>,
+    _ part: GRPCClientRequestPart<Request>,
     promise: EventLoopPromise<Void>?
   ) {
     self.eventLoop.assertInEventLoop()
@@ -119,13 +119,16 @@ public struct ClientInterceptorContext<Request, Response> {
 }
 
 extension ClientInterceptorContext {
-  internal func invokeReceive(_ part: ClientResponsePart<Response>) {
+  internal func invokeReceive(_ part: GRPCClientResponsePart<Response>) {
     self.eventLoop.assertInEventLoop()
     self.interceptor.receive(part, context: self)
   }
 
   @inlinable
-  internal func invokeSend(_ part: ClientRequestPart<Request>, promise: EventLoopPromise<Void>?) {
+  internal func invokeSend(
+    _ part: GRPCClientRequestPart<Request>,
+    promise: EventLoopPromise<Void>?
+  ) {
     self.eventLoop.assertInEventLoop()
     self.interceptor.send(part, promise: promise, context: self)
   }

--- a/Sources/GRPC/Interceptor/ClientInterceptorPipeline.swift
+++ b/Sources/GRPC/Interceptor/ClientInterceptorPipeline.swift
@@ -128,8 +128,8 @@ internal final class ClientInterceptorPipeline<Request, Response> {
     interceptors: [ClientInterceptor<Request, Response>],
     errorDelegate: ClientErrorDelegate?,
     onCancel: @escaping (EventLoopPromise<Void>?) -> Void,
-    onRequestPart: @escaping (ClientRequestPart<Request>, EventLoopPromise<Void>?) -> Void,
-    onResponsePart: @escaping (ClientResponsePart<Response>) -> Void
+    onRequestPart: @escaping (GRPCClientRequestPart<Request>, EventLoopPromise<Void>?) -> Void,
+    onResponsePart: @escaping (GRPCClientResponsePart<Response>) -> Void
   ) {
     self.eventLoop = eventLoop
     self.details = details
@@ -177,7 +177,7 @@ internal final class ClientInterceptorPipeline<Request, Response> {
   ///
   /// - Parameter part: The part to emit into the pipeline.
   /// - Important: This *must* to be called from the `eventLoop`.
-  internal func receive(_ part: ClientResponsePart<Response>) {
+  internal func receive(_ part: GRPCClientResponsePart<Response>) {
     self.eventLoop.assertInEventLoop()
     self._head?.invokeReceive(part)
   }
@@ -191,7 +191,7 @@ internal final class ClientInterceptorPipeline<Request, Response> {
   ///   - promise: A promise to complete when the request part has been successfully written.
   /// - Important: This *must* to be called from the `eventLoop`.
   @inlinable
-  internal func send(_ part: ClientRequestPart<Request>, promise: EventLoopPromise<Void>?) {
+  internal func send(_ part: GRPCClientRequestPart<Request>, promise: EventLoopPromise<Void>?) {
     self.eventLoop.assertInEventLoop()
 
     if let tail = self._tail {

--- a/Sources/GRPC/Interceptor/ClientInterceptorProtocol.swift
+++ b/Sources/GRPC/Interceptor/ClientInterceptorProtocol.swift
@@ -21,13 +21,13 @@ internal protocol ClientInterceptorProtocol {
 
   /// Called when the interceptor has received a response part to handle.
   func receive(
-    _ part: ClientResponsePart<Response>,
+    _ part: GRPCClientResponsePart<Response>,
     context: ClientInterceptorContext<Request, Response>
   )
 
   /// Called when the interceptor has received a request part to handle.
   func send(
-    _ part: ClientRequestPart<Request>,
+    _ part: GRPCClientRequestPart<Request>,
     promise: EventLoopPromise<Void>?,
     context: ClientInterceptorContext<Request, Response>
   )

--- a/Sources/GRPC/Interceptor/ClientInterceptors.swift
+++ b/Sources/GRPC/Interceptor/ClientInterceptors.swift
@@ -55,7 +55,7 @@ open class ClientInterceptor<Request, Response> {
   ///   - part: The response part which has been received from the server.
   ///   - context: An interceptor context which may be used to forward the response part.
   open func receive(
-    _ part: ClientResponsePart<Response>,
+    _ part: GRPCClientResponsePart<Response>,
     context: ClientInterceptorContext<Request, Response>
   ) {
     context.receive(part)
@@ -67,7 +67,7 @@ open class ClientInterceptor<Request, Response> {
   ///   - promise: A promise which should be completed when the response part has been handled.
   ///   - context: An interceptor context which may be used to forward the request part.
   open func send(
-    _ part: ClientRequestPart<Request>,
+    _ part: GRPCClientRequestPart<Request>,
     promise: EventLoopPromise<Void>?,
     context: ClientInterceptorContext<Request, Response>
   ) {
@@ -97,11 +97,11 @@ internal struct HeadClientInterceptor<Request, Response>: ClientInterceptorProto
 
   /// Called when a request part has been written.
   @usableFromInline
-  internal let _onRequestPart: (ClientRequestPart<Request>, EventLoopPromise<Void>?) -> Void
+  internal let _onRequestPart: (GRPCClientRequestPart<Request>, EventLoopPromise<Void>?) -> Void
 
   init(
     onCancel: @escaping (EventLoopPromise<Void>?) -> Void,
-    onRequestPart: @escaping (ClientRequestPart<Request>, EventLoopPromise<Void>?) -> Void
+    onRequestPart: @escaping (GRPCClientRequestPart<Request>, EventLoopPromise<Void>?) -> Void
   ) {
     self.onCancel = onCancel
     self._onRequestPart = onRequestPart
@@ -109,7 +109,7 @@ internal struct HeadClientInterceptor<Request, Response>: ClientInterceptorProto
 
   @inlinable
   internal func send(
-    _ part: ClientRequestPart<Request>,
+    _ part: GRPCClientRequestPart<Request>,
     promise: EventLoopPromise<Void>?,
     context: ClientInterceptorContext<Request, Response>
   ) {
@@ -124,7 +124,7 @@ internal struct HeadClientInterceptor<Request, Response>: ClientInterceptorProto
   }
 
   internal func receive(
-    _ part: ClientResponsePart<Response>,
+    _ part: GRPCClientResponsePart<Response>,
     context: ClientInterceptorContext<Request, Response>
   ) {
     context.receive(part)
@@ -144,12 +144,12 @@ internal struct TailClientInterceptor<Request, Response>: ClientInterceptorProto
   /// A response part handler; typically this will complete some promises, for streaming responses
   /// it will also invoke a user-supplied handler. This closure may also be provided by the user.
   /// We need to be careful about re-entrancy.
-  private let onResponsePart: (ClientResponsePart<Response>) -> Void
+  private let onResponsePart: (GRPCClientResponsePart<Response>) -> Void
 
   internal init(
     for pipeline: ClientInterceptorPipeline<Request, Response>,
     errorDelegate: ClientErrorDelegate?,
-    _ onResponsePart: @escaping (ClientResponsePart<Response>) -> Void
+    _ onResponsePart: @escaping (GRPCClientResponsePart<Response>) -> Void
   ) {
     self.pipeline = pipeline
     self.errorDelegate = errorDelegate
@@ -157,7 +157,7 @@ internal struct TailClientInterceptor<Request, Response>: ClientInterceptorProto
   }
 
   internal func receive(
-    _ part: ClientResponsePart<Response>,
+    _ part: GRPCClientResponsePart<Response>,
     context: ClientInterceptorContext<Request, Response>
   ) {
     switch part {
@@ -200,7 +200,7 @@ internal struct TailClientInterceptor<Request, Response>: ClientInterceptorProto
 
   @inlinable
   internal func send(
-    _ part: ClientRequestPart<Request>,
+    _ part: GRPCClientRequestPart<Request>,
     promise: EventLoopPromise<Void>?,
     context: ClientInterceptorContext<Request, Response>
   ) {
@@ -235,7 +235,7 @@ internal struct AnyClientInterceptor<Request, Response>: ClientInterceptorProtoc
   /// - Returns: An `AnyClientInterceptor` which wraps a `HeadClientInterceptor`.
   internal static func head(
     onCancel: @escaping (EventLoopPromise<Void>?) -> Void,
-    onRequestPart: @escaping (ClientRequestPart<Request>, EventLoopPromise<Void>?) -> Void
+    onRequestPart: @escaping (GRPCClientRequestPart<Request>, EventLoopPromise<Void>?) -> Void
   ) -> AnyClientInterceptor<Request, Response> {
     return .init(.head(.init(onCancel: onCancel, onRequestPart: onRequestPart)))
   }
@@ -249,7 +249,7 @@ internal struct AnyClientInterceptor<Request, Response>: ClientInterceptorProtoc
   internal static func tail(
     for pipeline: ClientInterceptorPipeline<Request, Response>,
     errorDelegate: ClientErrorDelegate?,
-    _ onResponsePart: @escaping (ClientResponsePart<Response>) -> Void
+    _ onResponsePart: @escaping (GRPCClientResponsePart<Response>) -> Void
   ) -> AnyClientInterceptor<Request, Response> {
     let tail = TailClientInterceptor(for: pipeline, errorDelegate: errorDelegate, onResponsePart)
     return .init(.tail(tail))
@@ -269,7 +269,7 @@ internal struct AnyClientInterceptor<Request, Response>: ClientInterceptorProtoc
   }
 
   internal func receive(
-    _ part: ClientResponsePart<Response>,
+    _ part: GRPCClientResponsePart<Response>,
     context: ClientInterceptorContext<Request, Response>
   ) {
     switch self._implementation {
@@ -284,7 +284,7 @@ internal struct AnyClientInterceptor<Request, Response>: ClientInterceptorProtoc
 
   @inlinable
   internal func send(
-    _ part: ClientRequestPart<Request>,
+    _ part: GRPCClientRequestPart<Request>,
     promise: EventLoopPromise<Void>?,
     context: ClientInterceptorContext<Request, Response>
   ) {

--- a/Sources/GRPC/Interceptor/ClientTransportFactory.swift
+++ b/Sources/GRPC/Interceptor/ClientTransportFactory.swift
@@ -107,7 +107,7 @@ internal struct ClientTransportFactory<Request, Response> {
     for type: GRPCCallType,
     withOptions options: CallOptions,
     interceptedBy interceptors: [ClientInterceptor<Request, Response>],
-    _ onResponsePart: @escaping (ClientResponsePart<Response>) -> Void
+    _ onResponsePart: @escaping (GRPCClientResponsePart<Response>) -> Void
   ) -> ClientTransport<Request, Response> {
     switch self.factory {
     case let .http2(factory):
@@ -170,7 +170,7 @@ private struct HTTP2ClientTransportFactory<Request, Response> {
     for type: GRPCCallType,
     withOptions options: CallOptions,
     interceptedBy interceptors: [ClientInterceptor<Request, Response>],
-    _ onResponsePart: @escaping (ClientResponsePart<Response>) -> Void
+    _ onResponsePart: @escaping (GRPCClientResponsePart<Response>) -> Void
   ) -> ClientTransport<Request, Response> {
     return ClientTransport(
       details: self.makeCallDetails(type: type, path: path, options: options),
@@ -240,7 +240,7 @@ private struct FakeClientTransportFactory<Request, Response> {
     for type: GRPCCallType,
     withOptions options: CallOptions,
     interceptedBy interceptors: [ClientInterceptor<Request, Response>],
-    _ onResponsePart: @escaping (ClientResponsePart<Response>) -> Void
+    _ onResponsePart: @escaping (GRPCClientResponsePart<Response>) -> Void
   ) -> ClientTransport<Request, Response> {
     return ClientTransport(
       details: CallDetails(

--- a/Sources/GRPC/Interceptor/MessageParts.swift
+++ b/Sources/GRPC/Interceptor/MessageParts.swift
@@ -15,7 +15,7 @@
  */
 import NIOHPACK
 
-public enum ClientRequestPart<Request> {
+public enum GRPCClientRequestPart<Request> {
   /// User provided metadata sent at the start of the request stream.
   case metadata(HPACKHeaders)
 
@@ -26,7 +26,7 @@ public enum ClientRequestPart<Request> {
   case end
 }
 
-public enum ClientResponsePart<Response> {
+public enum GRPCClientResponsePart<Response> {
   /// The metadata returned by the server at the start of the RPC.
   case metadata(HPACKHeaders)
 
@@ -40,7 +40,7 @@ public enum ClientResponsePart<Response> {
   case error(Error)
 }
 
-public enum ServerRequestPart<Request> {
+public enum GRPCServerRequestPart<Request> {
   /// Metadata received from the client at the start of the RPC.
   case metadata(HPACKHeaders)
 
@@ -51,7 +51,7 @@ public enum ServerRequestPart<Request> {
   case end
 }
 
-public enum ServerResponsePart<Response> {
+public enum GRPCServerResponsePart<Response> {
   /// The metadata to send to the client at the start of the response stream.
   case metadata(HPACKHeaders)
 

--- a/Sources/GRPC/Interceptor/ServerInterceptorContext.swift
+++ b/Sources/GRPC/Interceptor/ServerInterceptorContext.swift
@@ -72,7 +72,7 @@ public struct ServerInterceptorContext<Request, Response> {
   ///
   /// - Parameter part: The request part to forward.
   /// - Important: This *must* to be called from the `eventLoop`.
-  public func receive(_ part: ServerRequestPart<Request>) {
+  public func receive(_ part: GRPCServerRequestPart<Request>) {
     self.nextInbound?.invokeReceive(part)
   }
 
@@ -83,7 +83,7 @@ public struct ServerInterceptorContext<Request, Response> {
   ///   - promise: The promise the complete when the part has been written.
   /// - Important: This *must* to be called from the `eventLoop`.
   public func send(
-    _ part: ServerResponsePart<Response>,
+    _ part: GRPCServerResponsePart<Response>,
     promise: EventLoopPromise<Void>?
   ) {
     if let outbound = self.nextOutbound {
@@ -95,12 +95,15 @@ public struct ServerInterceptorContext<Request, Response> {
 }
 
 extension ServerInterceptorContext {
-  internal func invokeReceive(_ part: ServerRequestPart<Request>) {
+  internal func invokeReceive(_ part: GRPCServerRequestPart<Request>) {
     self.eventLoop.assertInEventLoop()
     self.interceptor.receive(part, context: self)
   }
 
-  internal func invokeSend(_ part: ServerResponsePart<Response>, promise: EventLoopPromise<Void>?) {
+  internal func invokeSend(
+    _ part: GRPCServerResponsePart<Response>,
+    promise: EventLoopPromise<Void>?
+  ) {
     self.eventLoop.assertInEventLoop()
     self.interceptor.send(part, promise: promise, context: self)
   }

--- a/Sources/GRPC/Interceptor/ServerInterceptorPipeline.swift
+++ b/Sources/GRPC/Interceptor/ServerInterceptorPipeline.swift
@@ -81,8 +81,8 @@ internal final class ServerInterceptorPipeline<Request, Response> {
     path: String,
     callType: GRPCCallType,
     interceptors: [ServerInterceptor<Request, Response>],
-    onRequestPart: @escaping (ServerRequestPart<Request>) -> Void,
-    onResponsePart: @escaping (ServerResponsePart<Response>, EventLoopPromise<Void>?) -> Void
+    onRequestPart: @escaping (GRPCServerRequestPart<Request>) -> Void,
+    onResponsePart: @escaping (GRPCServerResponsePart<Response>, EventLoopPromise<Void>?) -> Void
   ) {
     self.logger = logger
     self.eventLoop = eventLoop
@@ -129,7 +129,7 @@ internal final class ServerInterceptorPipeline<Request, Response> {
   ///
   /// - Parameter part: The part to emit into the pipeline.
   /// - Important: This *must* to be called from the `eventLoop`.
-  internal func receive(_ part: ServerRequestPart<Request>) {
+  internal func receive(_ part: GRPCServerRequestPart<Request>) {
     self.eventLoop.assertInEventLoop()
     self.head?.invokeReceive(part)
   }
@@ -140,7 +140,7 @@ internal final class ServerInterceptorPipeline<Request, Response> {
   ///   - part: The response part to sent.
   ///   - promise: A promise to complete when the response part has been successfully written.
   /// - Important: This *must* to be called from the `eventLoop`.
-  internal func send(_ part: ServerResponsePart<Response>, promise: EventLoopPromise<Void>?) {
+  internal func send(_ part: GRPCServerResponsePart<Response>, promise: EventLoopPromise<Void>?) {
     self.eventLoop.assertInEventLoop()
 
     if let tail = self.tail {

--- a/Sources/GRPC/Interceptor/ServerInterceptors.swift
+++ b/Sources/GRPC/Interceptor/ServerInterceptors.swift
@@ -50,7 +50,7 @@ open class ServerInterceptor<Request, Response> {
   ///   - part: The request part which has been received from the client.
   ///   - context: An interceptor context which may be used to forward the response part.
   open func receive(
-    _ part: ServerRequestPart<Request>,
+    _ part: GRPCServerRequestPart<Request>,
     context: ServerInterceptorContext<Request, Response>
   ) {
     context.receive(part)
@@ -62,7 +62,7 @@ open class ServerInterceptor<Request, Response> {
   ///   - promise: A promise which should be completed when the response part has been written.
   ///   - context: An interceptor context which may be used to forward the request part.
   open func send(
-    _ part: ServerResponsePart<Response>,
+    _ part: GRPCServerResponsePart<Response>,
     promise: EventLoopPromise<Void>?,
     context: ServerInterceptorContext<Request, Response>
   ) {
@@ -76,23 +76,23 @@ open class ServerInterceptor<Request, Response> {
 /// to the rest of the pipeline.
 internal struct TailServerInterceptor<Request, Response> {
   /// Called when a request part has been received.
-  private let onRequestPart: (ServerRequestPart<Request>) -> Void
+  private let onRequestPart: (GRPCServerRequestPart<Request>) -> Void
 
   init(
-    _ onRequestPart: @escaping (ServerRequestPart<Request>) -> Void
+    _ onRequestPart: @escaping (GRPCServerRequestPart<Request>) -> Void
   ) {
     self.onRequestPart = onRequestPart
   }
 
   internal func receive(
-    _ part: ServerRequestPart<Request>,
+    _ part: GRPCServerRequestPart<Request>,
     context: ServerInterceptorContext<Request, Response>
   ) {
     self.onRequestPart(part)
   }
 
   internal func send(
-    _ part: ServerResponsePart<Response>,
+    _ part: GRPCServerResponsePart<Response>,
     promise: EventLoopPromise<Void>?,
     context: ServerInterceptorContext<Request, Response>
   ) {
@@ -105,25 +105,25 @@ internal struct HeadServerInterceptor<Request, Response> {
   private let pipeline: ServerInterceptorPipeline<Request, Response>
 
   /// Called when a response part has been received.
-  private let onResponsePart: (ServerResponsePart<Response>, EventLoopPromise<Void>?) -> Void
+  private let onResponsePart: (GRPCServerResponsePart<Response>, EventLoopPromise<Void>?) -> Void
 
   internal init(
     for pipeline: ServerInterceptorPipeline<Request, Response>,
-    _ onResponsePart: @escaping (ServerResponsePart<Response>, EventLoopPromise<Void>?) -> Void
+    _ onResponsePart: @escaping (GRPCServerResponsePart<Response>, EventLoopPromise<Void>?) -> Void
   ) {
     self.pipeline = pipeline
     self.onResponsePart = onResponsePart
   }
 
   internal func receive(
-    _ part: ServerRequestPart<Request>,
+    _ part: GRPCServerRequestPart<Request>,
     context: ServerInterceptorContext<Request, Response>
   ) {
     context.receive(part)
   }
 
   internal func send(
-    _ part: ServerResponsePart<Response>,
+    _ part: GRPCServerResponsePart<Response>,
     promise: EventLoopPromise<Void>?,
     context: ServerInterceptorContext<Request, Response>
   ) {
@@ -153,13 +153,13 @@ internal struct AnyServerInterceptor<Request, Response> {
 
   internal static func head(
     for pipeline: ServerInterceptorPipeline<Request, Response>,
-    _ onResponsePart: @escaping (ServerResponsePart<Response>, EventLoopPromise<Void>?) -> Void
+    _ onResponsePart: @escaping (GRPCServerResponsePart<Response>, EventLoopPromise<Void>?) -> Void
   ) -> AnyServerInterceptor<Request, Response> {
     return .init(.head(.init(for: pipeline, onResponsePart)))
   }
 
   internal static func tail(
-    _ onRequestPart: @escaping (ServerRequestPart<Request>) -> Void
+    _ onRequestPart: @escaping (GRPCServerRequestPart<Request>) -> Void
   ) -> AnyServerInterceptor<Request, Response> {
     return .init(.tail(.init(onRequestPart)))
   }
@@ -178,7 +178,7 @@ internal struct AnyServerInterceptor<Request, Response> {
   }
 
   internal func receive(
-    _ part: ServerRequestPart<Request>,
+    _ part: GRPCServerRequestPart<Request>,
     context: ServerInterceptorContext<Request, Response>
   ) {
     switch self._implementation {
@@ -192,7 +192,7 @@ internal struct AnyServerInterceptor<Request, Response> {
   }
 
   internal func send(
-    _ part: ServerResponsePart<Response>,
+    _ part: GRPCServerResponsePart<Response>,
     promise: EventLoopPromise<Void>?,
     context: ServerInterceptorContext<Request, Response>
   ) {

--- a/Tests/GRPCTests/ClientCallTests.swift
+++ b/Tests/GRPCTests/ClientCallTests.swift
@@ -80,7 +80,7 @@ class ClientCallTests: GRPCTestCase {
   private func makeResponsePartHandler<Response>(
     for: Response.Type = Response.self,
     completing promise: EventLoopPromise<GRPCStatus>
-  ) -> (ClientResponsePart<Response>) -> Void {
+  ) -> (GRPCClientResponsePart<Response>) -> Void {
     return { part in
       switch part {
       case .metadata, .message:

--- a/Tests/GRPCTests/ClientInterceptorPipelineTests.swift
+++ b/Tests/GRPCTests/ClientInterceptorPipelineTests.swift
@@ -34,8 +34,8 @@ class ClientInterceptorPipelineTests: GRPCTestCase {
     interceptors: [ClientInterceptor<Request, Response>] = [],
     errorDelegate: ClientErrorDelegate? = nil,
     onCancel: @escaping (EventLoopPromise<Void>?) -> Void = { _ in },
-    onRequestPart: @escaping (ClientRequestPart<Request>, EventLoopPromise<Void>?) -> Void,
-    onResponsePart: @escaping (ClientResponsePart<Response>) -> Void
+    onRequestPart: @escaping (GRPCClientRequestPart<Request>, EventLoopPromise<Void>?) -> Void,
+    onResponsePart: @escaping (GRPCClientResponsePart<Response>) -> Void
   ) -> ClientInterceptorPipeline<Request, Response> {
     return ClientInterceptorPipeline(
       eventLoop: self.embeddedEventLoop,
@@ -59,8 +59,8 @@ class ClientInterceptorPipelineTests: GRPCTestCase {
   }
 
   func testEmptyPipeline() throws {
-    var requestParts: [ClientRequestPart<String>] = []
-    var responseParts: [ClientResponsePart<String>] = []
+    var requestParts: [GRPCClientRequestPart<String>] = []
+    var responseParts: [GRPCClientResponsePart<String>] = []
 
     let pipeline = self.makePipeline(
       requests: String.self,
@@ -292,11 +292,11 @@ class ClientInterceptorPipelineTests: GRPCTestCase {
 
 /// A simple interceptor which records and then forwards and request and response parts it sees.
 class RecordingInterceptor<Request, Response>: ClientInterceptor<Request, Response> {
-  var requestParts: [ClientRequestPart<Request>] = []
-  var responseParts: [ClientResponsePart<Response>] = []
+  var requestParts: [GRPCClientRequestPart<Request>] = []
+  var responseParts: [GRPCClientResponsePart<Response>] = []
 
   override func send(
-    _ part: ClientRequestPart<Request>,
+    _ part: GRPCClientRequestPart<Request>,
     promise: EventLoopPromise<Void>?,
     context: ClientInterceptorContext<Request, Response>
   ) {
@@ -305,7 +305,7 @@ class RecordingInterceptor<Request, Response>: ClientInterceptor<Request, Respon
   }
 
   override func receive(
-    _ part: ClientResponsePart<Response>,
+    _ part: GRPCClientResponsePart<Response>,
     context: ClientInterceptorContext<Request, Response>
   ) {
     self.responseParts.append(part)
@@ -316,7 +316,7 @@ class RecordingInterceptor<Request, Response>: ClientInterceptor<Request, Respon
 /// An interceptor which reverses string request messages.
 class StringRequestReverser: ClientInterceptor<String, String> {
   override func send(
-    _ part: ClientRequestPart<String>,
+    _ part: GRPCClientRequestPart<String>,
     promise: EventLoopPromise<Void>?,
     context: ClientInterceptorContext<String, String>
   ) {
@@ -331,7 +331,7 @@ class StringRequestReverser: ClientInterceptor<String, String> {
 
 // MARK: - Request/Response part helpers
 
-extension ClientRequestPart {
+extension GRPCClientRequestPart {
   var metadata: HPACKHeaders? {
     switch self {
     case let .metadata(headers):
@@ -360,7 +360,7 @@ extension ClientRequestPart {
   }
 }
 
-extension ClientResponsePart {
+extension GRPCClientResponsePart {
   var metadata: HPACKHeaders? {
     switch self {
     case let .metadata(headers):

--- a/Tests/GRPCTests/ClientTransportTests.swift
+++ b/Tests/GRPCTests/ClientTransportTests.swift
@@ -45,7 +45,7 @@ class ClientTransportTests: GRPCTestCase {
   private func setUpTransport(
     details: CallDetails? = nil,
     interceptors: [ClientInterceptor<String, String>] = [],
-    onResponsePart: @escaping (ClientResponsePart<String>) -> Void = { _ in }
+    onResponsePart: @escaping (GRPCClientResponsePart<String>) -> Void = { _ in }
   ) {
     self.transport = .init(
       details: details ?? self.makeDetails(),
@@ -79,7 +79,7 @@ class ClientTransportTests: GRPCTestCase {
   }
 
   private func sendRequest(
-    _ part: ClientRequestPart<String>,
+    _ part: GRPCClientRequestPart<String>,
     promise: EventLoopPromise<Void>? = nil
   ) {
     self.transport.send(part, promise: promise)

--- a/Tests/GRPCTests/InterceptorsTests.swift
+++ b/Tests/GRPCTests/InterceptorsTests.swift
@@ -161,7 +161,7 @@ private class HelloWorldClientInterceptorFactory:
 class NotReallyAuthServerInterceptor<Request: Message, Response: Message>:
   ServerInterceptor<Request, Response> {
   override func receive(
-    _ part: ServerRequestPart<Request>,
+    _ part: GRPCServerRequestPart<Request>,
     context: ServerInterceptorContext<Request, Response>
   ) {
     switch part {
@@ -194,7 +194,7 @@ class NotReallyAuthClientInterceptor<Request: Message, Response: Message>:
 
   private enum State {
     // We're trying the call, these are the parts we've sent so far.
-    case trying([ClientRequestPart<Request>])
+    case trying([GRPCClientRequestPart<Request>])
     // We're retrying using this call.
     case retrying(Call<Request, Response>)
   }
@@ -220,7 +220,7 @@ class NotReallyAuthClientInterceptor<Request: Message, Response: Message>:
   }
 
   override func send(
-    _ part: ClientRequestPart<Request>,
+    _ part: GRPCClientRequestPart<Request>,
     promise: EventLoopPromise<Void>?,
     context: ClientInterceptorContext<Request, Response>
   ) {
@@ -239,7 +239,7 @@ class NotReallyAuthClientInterceptor<Request: Message, Response: Message>:
   }
 
   override func receive(
-    _ part: ClientResponsePart<Response>,
+    _ part: GRPCClientResponsePart<Response>,
     context: ClientInterceptorContext<Request, Response>
   ) {
     switch self.state {
@@ -293,7 +293,7 @@ class NotReallyAuthClientInterceptor<Request: Message, Response: Message>:
 
 class EchoReverseInterceptor: ClientInterceptor<Echo_EchoRequest, Echo_EchoResponse> {
   override func send(
-    _ part: ClientRequestPart<Echo_EchoRequest>,
+    _ part: GRPCClientRequestPart<Echo_EchoRequest>,
     promise: EventLoopPromise<Void>?,
     context: ClientInterceptorContext<Echo_EchoRequest, Echo_EchoResponse>
   ) {
@@ -307,7 +307,7 @@ class EchoReverseInterceptor: ClientInterceptor<Echo_EchoRequest, Echo_EchoRespo
   }
 
   override func receive(
-    _ part: ClientResponsePart<Echo_EchoResponse>,
+    _ part: GRPCClientResponsePart<Echo_EchoResponse>,
     context: ClientInterceptorContext<Echo_EchoRequest, Echo_EchoResponse>
   ) {
     switch part {

--- a/Tests/GRPCTests/ServerInterceptorPipelineTests.swift
+++ b/Tests/GRPCTests/ServerInterceptorPipelineTests.swift
@@ -32,8 +32,8 @@ class ServerInterceptorPipelineTests: GRPCTestCase {
     path: String = "/foo/bar",
     callType: GRPCCallType = .unary,
     interceptors: [ServerInterceptor<Request, Response>] = [],
-    onRequestPart: @escaping (ServerRequestPart<Request>) -> Void,
-    onResponsePart: @escaping (ServerResponsePart<Response>, EventLoopPromise<Void>?) -> Void
+    onRequestPart: @escaping (GRPCServerRequestPart<Request>) -> Void,
+    onResponsePart: @escaping (GRPCServerResponsePart<Response>, EventLoopPromise<Void>?) -> Void
   ) -> ServerInterceptorPipeline<Request, Response> {
     return ServerInterceptorPipeline(
       logger: self.logger,
@@ -47,8 +47,8 @@ class ServerInterceptorPipelineTests: GRPCTestCase {
   }
 
   func testEmptyPipeline() {
-    var requestParts: [ServerRequestPart<String>] = []
-    var responseParts: [ServerResponsePart<String>] = []
+    var requestParts: [GRPCServerRequestPart<String>] = []
+    var responseParts: [GRPCServerResponsePart<String>] = []
 
     let pipeline = self.makePipeline(
       requests: String.self,
@@ -120,11 +120,11 @@ class ServerInterceptorPipelineTests: GRPCTestCase {
 
 internal class RecordingServerInterceptor<Request, Response>:
   ServerInterceptor<Request, Response> {
-  var requestParts: [ServerRequestPart<Request>] = []
-  var responseParts: [ServerResponsePart<Response>] = []
+  var requestParts: [GRPCServerRequestPart<Request>] = []
+  var responseParts: [GRPCServerResponsePart<Response>] = []
 
   override func receive(
-    _ part: ServerRequestPart<Request>,
+    _ part: GRPCServerRequestPart<Request>,
     context: ServerInterceptorContext<Request, Response>
   ) {
     self.requestParts.append(part)
@@ -132,7 +132,7 @@ internal class RecordingServerInterceptor<Request, Response>:
   }
 
   override func send(
-    _ part: ServerResponsePart<Response>,
+    _ part: GRPCServerResponsePart<Response>,
     promise: EventLoopPromise<Void>?,
     context: ServerInterceptorContext<Request, Response>
   ) {
@@ -141,7 +141,7 @@ internal class RecordingServerInterceptor<Request, Response>:
   }
 }
 
-extension ServerRequestPart {
+extension GRPCServerRequestPart {
   var metadata: HPACKHeaders? {
     switch self {
     case let .metadata(metadata):
@@ -170,7 +170,7 @@ extension ServerRequestPart {
   }
 }
 
-extension ServerResponsePart {
+extension GRPCServerResponsePart {
   var metadata: HPACKHeaders? {
     switch self {
     case let .metadata(metadata):

--- a/Tests/GRPCTests/ServerInterceptorTests.swift
+++ b/Tests/GRPCTests/ServerInterceptorTests.swift
@@ -312,7 +312,7 @@ class ExtraRequestPartEmitter: ServerInterceptor<Echo_EchoRequest, Echo_EchoResp
   }
 
   override func receive(
-    _ part: ServerRequestPart<Echo_EchoRequest>,
+    _ part: GRPCServerRequestPart<Echo_EchoRequest>,
     context: ServerInterceptorContext<Echo_EchoRequest, Echo_EchoResponse>
   ) {
     let count: Int
@@ -389,7 +389,7 @@ class EchoFromInterceptor: Echo_EchoProvider {
     private var collectedRequests: [Echo_EchoRequest] = []
 
     override func receive(
-      _ part: ServerRequestPart<Echo_EchoRequest>,
+      _ part: GRPCServerRequestPart<Echo_EchoRequest>,
       context: ServerInterceptorContext<Echo_EchoRequest, Echo_EchoResponse>
     ) {
       switch part {

--- a/Tests/GRPCTests/XCTestHelpers.swift
+++ b/Tests/GRPCTests/XCTestHelpers.swift
@@ -192,7 +192,7 @@ struct Matcher<Value> {
 
   static func metadata<Request>(
     _ matcher: Matcher<HPACKHeaders>? = nil
-  ) -> Matcher<ServerRequestPart<Request>> {
+  ) -> Matcher<GRPCServerRequestPart<Request>> {
     return .init { actual in
       switch actual {
       case let .metadata(headers):
@@ -205,7 +205,7 @@ struct Matcher<Value> {
 
   static func message<Request>(
     _ matcher: Matcher<Request>? = nil
-  ) -> Matcher<ServerRequestPart<Request>> {
+  ) -> Matcher<GRPCServerRequestPart<Request>> {
     return .init { actual in
       switch actual {
       case let .message(message):
@@ -218,7 +218,7 @@ struct Matcher<Value> {
 
   static func metadata<Response>(
     _ matcher: Matcher<HPACKHeaders>? = nil
-  ) -> Matcher<ServerResponsePart<Response>> {
+  ) -> Matcher<GRPCServerResponsePart<Response>> {
     return .init { actual in
       switch actual {
       case let .metadata(headers):
@@ -231,7 +231,7 @@ struct Matcher<Value> {
 
   static func message<Response>(
     _ matcher: Matcher<Response>? = nil
-  ) -> Matcher<ServerResponsePart<Response>> {
+  ) -> Matcher<GRPCServerResponsePart<Response>> {
     return .init { actual in
       switch actual {
       case let .message(message, _):
@@ -245,7 +245,7 @@ struct Matcher<Value> {
   static func end<Response>(
     status statusMatcher: Matcher<GRPCStatus>? = nil,
     trailers trailersMatcher: Matcher<HPACKHeaders>? = nil
-  ) -> Matcher<ServerResponsePart<Response>> {
+  ) -> Matcher<GRPCServerResponsePart<Response>> {
     return .init { actual in
       switch actual {
       case let .end(status, trailers):


### PR DESCRIPTION
Motivation:

It should be clear what these request/response parts relate to.

Modifications:

- Prefix '{Client,Server}{Request,Response}Part' with 'GRPC'

Result:

Clearer names.