### PR TITLE
Use the server hostname override as the :authority, if present

### DIFF
--- a/Sources/GRPC/ClientConnection.swift
+++ b/Sources/GRPC/ClientConnection.swift
@@ -116,7 +116,7 @@ public class ClientConnection {
   public init(configuration: Configuration) {
     self.configuration = configuration
     self.scheme = configuration.tls == nil ? "http" : "https"
-    self.authority = configuration.target.host
+    self.authority = configuration.tls?.hostnameOverride ?? configuration.target.host
     self.connectionManager = ConnectionManager(
       configuration: configuration,
       logger: configuration.backgroundActivityLogger

--- a/Tests/GRPCTests/XCTestManifests.swift
+++ b/Tests/GRPCTests/XCTestManifests.swift
@@ -96,6 +96,7 @@ extension ClientTLSHostnameOverrideTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__ClientTLSHostnameOverrideTests = [
+        ("testAuthorityUsesTLSHostnameOverride", testAuthorityUsesTLSHostnameOverride),
         ("testTLSWithHostnameOverride", testTLSWithHostnameOverride),
         ("testTLSWithNoCertificateVerification", testTLSWithNoCertificateVerification),
         ("testTLSWithoutHostnameOverride", testTLSWithoutHostnameOverride),


### PR DESCRIPTION
Motivation:

When using a secured connection to a server, the client may present a
server hostname as part of the TLS SNI extension. However, the
':authority' header sent by the client will still just be the host the
caller specified, rather than the server hostname.

Modifications:

- User the TLS server hostname override, if present, in prefernce to the
  hostname when setting the authority.

Result:

- Resolves #1029