### PR TITLE
Remove the 'error' case from the 'GRPCClientResponsePart'

### DIFF
--- a/Sources/GRPC/ClientCalls/BidirectionalStreamingCall.swift
+++ b/Sources/GRPC/ClientCalls/BidirectionalStreamingCall.swift
@@ -78,7 +78,10 @@ public struct BidirectionalStreamingCall<
   }
 
   internal func invoke() {
-    self.call.invokeStreamingRequests(self.responseParts.handle(_:))
+    self.call.invokeStreamingRequests(
+      onError: self.responseParts.handleError(_:),
+      onResponsePart: self.responseParts.handle(_:)
+    )
   }
 
   // MARK: - Requests

--- a/Sources/GRPC/ClientCalls/ClientStreamingCall.swift
+++ b/Sources/GRPC/ClientCalls/ClientStreamingCall.swift
@@ -78,7 +78,10 @@ public struct ClientStreamingCall<RequestPayload, ResponsePayload>: StreamingReq
   }
 
   internal func invoke() {
-    self.call.invokeStreamingRequests(self.responseParts.handle(_:))
+    self.call.invokeStreamingRequests(
+      onError: self.responseParts.handleError(_:),
+      onResponsePart: self.responseParts.handle(_:)
+    )
   }
 
   // MARK: - Request

--- a/Sources/GRPC/ClientCalls/ResponseContainers.swift
+++ b/Sources/GRPC/ClientCalls/ResponseContainers.swift
@@ -79,15 +79,16 @@ internal class UnaryResponseParts<Response> {
 
       self.trailingMetadataPromise.succeed(trailers)
       self.statusPromise.succeed(status)
-
-    case let .error(error):
-      let withoutContext = error.removingContext()
-      let status = withoutContext.makeGRPCStatus()
-      self.initialMetadataPromise.fail(withoutContext)
-      self.responsePromise.fail(withoutContext)
-      self.trailingMetadataPromise.fail(withoutContext)
-      self.statusPromise.succeed(status)
     }
+  }
+
+  internal func handleError(_ error: Error) {
+    let withoutContext = error.removingContext()
+    let status = withoutContext.makeGRPCStatus()
+    self.initialMetadataPromise.fail(withoutContext)
+    self.responsePromise.fail(withoutContext)
+    self.trailingMetadataPromise.fail(withoutContext)
+    self.statusPromise.succeed(status)
   }
 }
 
@@ -144,14 +145,15 @@ internal class StreamingResponseParts<Response> {
       self.initialMetadataPromise.fail(status)
       self.trailingMetadataPromise.succeed(trailers)
       self.statusPromise.succeed(status)
-
-    case let .error(error):
-      let withoutContext = error.removingContext()
-      let status = withoutContext.makeGRPCStatus()
-      self.initialMetadataPromise.fail(withoutContext)
-      self.trailingMetadataPromise.fail(withoutContext)
-      self.statusPromise.succeed(status)
     }
+  }
+
+  internal func handleError(_ error: Error) {
+    let withoutContext = error.removingContext()
+    let status = withoutContext.makeGRPCStatus()
+    self.initialMetadataPromise.fail(withoutContext)
+    self.trailingMetadataPromise.fail(withoutContext)
+    self.statusPromise.succeed(status)
   }
 }
 

--- a/Sources/GRPC/ClientCalls/ServerStreamingCall.swift
+++ b/Sources/GRPC/ClientCalls/ServerStreamingCall.swift
@@ -73,6 +73,10 @@ public struct ServerStreamingCall<RequestPayload, ResponsePayload>: ClientCall {
   }
 
   internal func invoke(_ request: RequestPayload) {
-    self.call.invokeUnaryRequest(request, self.responseParts.handle(_:))
+    self.call.invokeUnaryRequest(
+      request,
+      onError: self.responseParts.handleError(_:),
+      onResponsePart: self.responseParts.handle(_:)
+    )
   }
 }

--- a/Sources/GRPC/ClientCalls/UnaryCall.swift
+++ b/Sources/GRPC/ClientCalls/UnaryCall.swift
@@ -77,6 +77,10 @@ public struct UnaryCall<RequestPayload, ResponsePayload>: UnaryResponseClientCal
   }
 
   internal func invoke(_ request: RequestPayload) {
-    self.call.invokeUnaryRequest(request, self.responseParts.handle(_:))
+    self.call.invokeUnaryRequest(
+      request,
+      onError: self.responseParts.handleError(_:),
+      onResponsePart: self.responseParts.handle(_:)
+    )
   }
 }

--- a/Sources/GRPC/Interceptor/ClientInterceptorContext.swift
+++ b/Sources/GRPC/Interceptor/ClientInterceptorContext.swift
@@ -83,6 +83,15 @@ public struct ClientInterceptorContext<Request, Response> {
     self.nextInbound?.invokeReceive(part)
   }
 
+  /// Forwards the error to the next inbound interceptor in the pipeline, if there is one.
+  ///
+  /// - Parameter error: The error to forward.
+  /// - Important: This *must* to be called from the `eventLoop`.
+  public func errorCaught(_ error: Error) {
+    self.eventLoop.assertInEventLoop()
+    self.nextInbound?.invokeErrorCaught(error)
+  }
+
   /// Forwards the request part to the next outbound interceptor in the pipeline, if there is one.
   ///
   /// - Parameters:
@@ -136,5 +145,10 @@ extension ClientInterceptorContext {
   internal func invokeCancel(promise: EventLoopPromise<Void>?) {
     self.eventLoop.assertInEventLoop()
     self.interceptor.cancel(promise: promise, context: self)
+  }
+
+  internal func invokeErrorCaught(_ error: Error) {
+    self.eventLoop.assertInEventLoop()
+    self.interceptor.errorCaught(error, context: self)
   }
 }

--- a/Sources/GRPC/Interceptor/ClientInterceptorProtocol.swift
+++ b/Sources/GRPC/Interceptor/ClientInterceptorProtocol.swift
@@ -25,6 +25,12 @@ internal protocol ClientInterceptorProtocol {
     context: ClientInterceptorContext<Request, Response>
   )
 
+  /// Called when the interceptor has received an error to handle.
+  func errorCaught(
+    _ error: Error,
+    context: ClientInterceptorContext<Request, Response>
+  )
+
   /// Called when the interceptor has received a request part to handle.
   func send(
     _ part: GRPCClientRequestPart<Request>,

--- a/Sources/GRPC/Interceptor/ClientTransport.swift
+++ b/Sources/GRPC/Interceptor/ClientTransport.swift
@@ -100,7 +100,8 @@ internal final class ClientTransport<Request, Response> {
     eventLoop: EventLoop,
     interceptors: [ClientInterceptor<Request, Response>],
     errorDelegate: ClientErrorDelegate?,
-    _ onResponsePart: @escaping (GRPCClientResponsePart<Response>) -> Void
+    onError: @escaping (Error) -> Void,
+    onResponsePart: @escaping (GRPCClientResponsePart<Response>) -> Void
   ) {
     self.eventLoop = eventLoop
     self.callDetails = details
@@ -109,6 +110,7 @@ internal final class ClientTransport<Request, Response> {
       details: details,
       interceptors: interceptors,
       errorDelegate: errorDelegate,
+      onError: onError,
       onCancel: self.cancelFromPipeline(promise:),
       onRequestPart: self.sendFromPipeline(_:promise:),
       onResponsePart: onResponsePart
@@ -799,7 +801,7 @@ extension ClientTransport {
   /// Forward the error to the interceptor pipeline.
   /// - Parameter error: The error to forward.
   private func forwardErrorToInterceptors(_ error: Error) {
-    self._pipeline?.receive(.error(error))
+    self._pipeline?.errorCaught(error)
   }
 }
 

--- a/Sources/GRPC/Interceptor/MessageParts.swift
+++ b/Sources/GRPC/Interceptor/MessageParts.swift
@@ -35,9 +35,6 @@ public enum GRPCClientResponsePart<Response> {
 
   /// The end of response stream sent by the server.
   case end(GRPCStatus, HPACKHeaders)
-
-  /// Error.
-  case error(Error)
 }
 
 public enum GRPCServerRequestPart<Request> {

--- a/Tests/GRPCTests/InterceptorsTests.swift
+++ b/Tests/GRPCTests/InterceptorsTests.swift
@@ -271,7 +271,7 @@ class NotReallyAuthClientInterceptor<Request: Message, Response: Message>:
         self.state = .retrying(call)
 
         // Invoke the call and redirect responses here.
-        call.invoke(context.receive(_:))
+        call.invoke(onError: context.errorCaught(_:), onResponsePart: context.receive(_:))
 
         // Parts must contain the metadata as the first item if we got that first response.
         if case var .some(.metadata(metadata)) = parts.first {


### PR DESCRIPTION
Motivation:

When implementing a bunch of interceptors I found it a little irksome
having to deal with errors along with response parts. It feels more
natural to deal with them separately.

Modifications:

- Remove 'error' from 'GRPCClientResponsePart'
- Add an 'errorCaught' client interceptor function

Result:

Errors are handled separately to response parts.