### PR TITLE
Fix incompatible code between main and the interceptors feature branch

### DIFF
--- a/Tests/GRPCTests/ClientTLSTests.swift
+++ b/Tests/GRPCTests/ClientTLSTests.swift
@@ -168,6 +168,8 @@ class ClientTLSHostnameOverrideTests: GRPCTestCase {
 }
 
 private class AuthorityCheckingEcho: Echo_EchoProvider {
+  var interceptors: Echo_EchoServerInterceptorFactoryProtocol?
+
   func get(
     request: Echo_EchoRequest,
     context: StatusOnlyCallContext


### PR DESCRIPTION
Motivation:

The generated code in the interceptors feature branch includes new
protocol requirements. Some tests added recently in #1033 to main don't
meet these requirements.

Modifications:

- Add the missing requirement

Result:

Feature branch compiles when rebased on 'main'.