### PR TITLE
Get QPS Benchmark to run on Linux

### DIFF
--- a/Performance/QPSBenchmark/README.md
+++ b/Performance/QPSBenchmark/README.md
@@ -56,7 +56,7 @@ For examples of running benchmarking tests proceed as follows.
 4. Invoke the driver with a scenario file, for example:
 
    ```sh
-   /path/to/qps_json_driver --scenario_file=/path/to/scenario.json
+   /path/to/qps_json_driver --scenarios_file=/path/to/scenario.json
    ```
 
 ### Scenarios

--- a/Performance/QPSBenchmark/Sources/QPSBenchmark/Runtime/ResourceUsage.swift
+++ b/Performance/QPSBenchmark/Sources/QPSBenchmark/Runtime/ResourceUsage.swift
@@ -38,11 +38,17 @@ struct CPUTime {
   var systemTime: TimeInterval
 }
 
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+fileprivate let OUR_RUSAGE_SELF: Int32 = RUSAGE_SELF
+#elseif os(Linux) || os(FreeBSD) || os(Android)
+fileprivate let OUR_RUSAGE_SELF: Int32 = RUSAGE_SELF.rawValue
+#endif
+
 /// Get resource usage for this process.
 /// - returns: The amount of CPU resource consumed.
 func getResourceUsage() -> CPUTime {
   var usage = rusage()
-  if getrusage(RUSAGE_SELF, &usage) == 0 {
+  if getrusage(OUR_RUSAGE_SELF, &usage) == 0 {
     return CPUTime(
       userTime: TimeInterval(usage.ru_utime),
       systemTime: TimeInterval(usage.ru_stime)


### PR DESCRIPTION
Motivation:

Linux is a major platform - the benchmarking application should run.

Modifications:

Tweak the typing for the parameters getting resource usage.
Also fix a minor typo in the run instructions.

Result:

Benchmarking application runs on linux.