### PR TITLE
Fix 0.9.1 Carthage Support on Xcode 12.2

### DIFF
--- a/SwiftGRPC-Carthage.xcodeproj/xcshareddata/xcschemes/SwiftGRPC-Package.xcscheme
+++ b/SwiftGRPC-Carthage.xcodeproj/xcshareddata/xcschemes/SwiftGRPC-Package.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Run Script"
-               scriptText = "cd ${PROJECT_DIR}; swift package resolve; ruby fix-carthage-paths.rb SwiftGRPC-Carthage.xcodeproj">
+               scriptText = "cd ${PROJECT_DIR}; env -i PATH=/usr/bin swift package resolve; ruby fix-carthage-paths.rb SwiftGRPC-Carthage.xcodeproj&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/fix-carthage-paths.rb
+++ b/fix-carthage-paths.rb
@@ -8,7 +8,7 @@ project = Xcodeproj::Project.open(project_path)
 dependenciesGroup = project["Dependencies"]
 
 #Open dependencies-state.json file
-file = File.read(".build/dependencies-state.json")
+file = File.read(".build/workspace-state.json")
 json = JSON.parse(file)
 
 dependenciesGroup.recursive_children_groups.each do |child|
@@ -40,6 +40,6 @@ dependenciesGroup.recursive_children_groups.each do |child|
     end
 end
 
-File.open(".build/dependencies-state.json","w") do |f|
+File.open(".build/workspace-state.json","w") do |f|
     f.write(json.to_json)
 end


### PR DESCRIPTION
fixes #1051 

Xcode 12 (Xcode 12.2) has some build issues when `SwiftGRPC-Carthage.xcodeproj` runs its pre-action script. the script executes `swift package resolve` and is affected by some env when it's build on Xcode 12.x.

This PR applies a workaround for that. In addition, Swift Package Manager in Xcode 12 generates a different filename in the intermediate .build folder (.build/dependencies-state.json -> .build/workspace-state.json). This PR also fixes it.

grpc-swift may require Xcode 12.x after this PR is merged.