### PR TITLE
Only generate services described in files in the codegen request

### DIFF
--- a/Sources/protoc-gen-grpc-swift/main.swift
+++ b/Sources/protoc-gen-grpc-swift/main.swift
@@ -116,17 +116,20 @@ func main() throws {
   let descriptorSet = DescriptorSet(protos: request.protoFile)
 
   // Only generate output for services.
-  for fileDescriptor in descriptorSet.files where !fileDescriptor.services.isEmpty {
-    let grpcFileName = uniqueOutputFileName(
-      component: "grpc",
-      fileDescriptor: fileDescriptor,
-      fileNamingOption: options.fileNaming
-    )
-    let grpcGenerator = Generator(fileDescriptor, options: options)
-    var grpcFile = Google_Protobuf_Compiler_CodeGeneratorResponse.File()
-    grpcFile.name = grpcFileName
-    grpcFile.content = grpcGenerator.code
-    response.file.append(grpcFile)
+  for name in request.fileToGenerate {
+    let fileDescriptor = descriptorSet.lookupFileDescriptor(protoName: name)
+    if !fileDescriptor.services.isEmpty {
+      let grpcFileName = uniqueOutputFileName(
+        component: "grpc",
+        fileDescriptor: fileDescriptor,
+        fileNamingOption: options.fileNaming
+      )
+      let grpcGenerator = Generator(fileDescriptor, options: options)
+      var grpcFile = Google_Protobuf_Compiler_CodeGeneratorResponse.File()
+      grpcFile.name = grpcFileName
+      grpcFile.content = grpcGenerator.code
+      response.file.append(grpcFile)
+    }
   }
 
   // return everything to the caller


### PR DESCRIPTION
Motivation:

Code should only be generated for files listed in the codegen request.
This regressed in #889.

Modifications:

- Drive code generation from files to generate

Result:

Resolves #1057