### PR TITLE
Make testClientReconnectsAutomatically less flaky

### DIFF
--- a/Tests/GRPCTests/ClientConnectionBackoffTests.swift
+++ b/Tests/GRPCTests/ClientConnectionBackoffTests.swift
@@ -166,9 +166,11 @@ class ClientConnectionBackoffTests: GRPCTestCase {
       .withConnectionBackoff(maximum: .seconds(2))
       .connect(host: "localhost", port: self.port)
 
-    // Start an RPC to trigger creating a channel.
+    // Start an RPC to trigger creating a channel, it's a streaming RPC so that when the server is
+    // killed, the client still has one active RPC and transitions to transient failure (rather than
+    // idle if there were no active RPCs).
     let echo = Echo_EchoClient(channel: self.client, defaultCallOptions: self.callOptionsWithLogger)
-    _ = echo.get(.with { $0.text = "foo" })
+    _ = echo.update { _ in }
 
     // Wait for the connection to be ready.
     self.connectionStateRecorder.waitForExpectedChanges(timeout: .seconds(5))


### PR DESCRIPTION
Motivation:

testClientReconnectsAutomatically waits on certain connectivity state
transitions. One of the expected state transitions requires there to
be an active RPC, however the test used a unary RPC so there was no
guarantee that the RPC would still be active and the test would
sometimes fail.

Modifications:

- Use a bidi RPC instead of a unary RPC

Result:

Less flaky test.