### PR TITLE
Allow the server to be gracefully shutdown.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,6 +33,8 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.8.0"),
     // Support for Network.framework where possible.
     .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.6.0"),
+    // Extra NIO stuff; quiescing helpers.
+    .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.4.0"),
 
     // Official SwiftProtobuf library, for [de]serializing data to send on the wire.
     .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.9.0"),
@@ -50,6 +52,7 @@ let package = Package(
         "NIOTransportServices",
         "NIOHTTP1",
         "NIOHTTP2",
+        "NIOExtras",
         "NIOSSL",
         "CGRPCZlib",
         "SwiftProtobuf",

--- a/Sources/GRPC/CallHandlers/_BaseCallHandler.swift
+++ b/Sources/GRPC/CallHandlers/_BaseCallHandler.swift
@@ -666,9 +666,9 @@ extension _BaseCallHandler {
 
     switch part {
     case let .metadata(headers):
-      // Only flush if we're streaming responses, if we're not streaming responses then we'll wait
-      // for the response and end before emitting the flush.
-      flush = self.callType.isStreamingResponses
+      // Only flush if we're not unary: if we're unary we'll wait for the response and end before
+      // emitting the flush.
+      flush = self.callType != .unary
       context.write(self.wrapOutboundOut(.metadata(headers)), promise: promise)
 
     case let .message(message, metadata):

--- a/Sources/GRPC/ConnectionManager.swift
+++ b/Sources/GRPC/ConnectionManager.swift
@@ -676,6 +676,11 @@ internal class ConnectionManager {
       self.invalidState()
     }
   }
+
+  /// The connection has started quiescing: notify the connectivity monitor of this.
+  internal func beginQuiescing() {
+    self.monitor.beginQuiescing()
+  }
 }
 
 extension ConnectionManager {

--- a/Sources/GRPC/GRPCIdleHandler.swift
+++ b/Sources/GRPC/GRPCIdleHandler.swift
@@ -87,6 +87,8 @@ internal final class GRPCIdleHandler: ChannelInboundHandler {
         manager.channelInactive()
       case .ready:
         manager.ready()
+      case .quiescing:
+        manager.beginQuiescing()
       }
     }
 
@@ -140,6 +142,9 @@ internal final class GRPCIdleHandler: ChannelInboundHandler {
     } else if let closed = event as? StreamClosedEvent {
       self.perform(operations: self.stateMachine.streamClosed(withID: closed.streamID))
       context.fireUserInboundEventTriggered(event)
+    } else if event is ChannelShouldQuiesceEvent {
+      self.perform(operations: self.stateMachine.initiateGracefulShutdown())
+      // Swallow this event.
     } else if event is ConnectionIdledEvent {
       self.perform(operations: self.stateMachine.shutdownNow())
       // Swallow this event.

--- a/Tests/GRPCTests/GRPCIdleHandlerStateMachineTests.swift
+++ b/Tests/GRPCTests/GRPCIdleHandlerStateMachineTests.swift
@@ -111,7 +111,7 @@ class GRPCIdleHandlerStateMachineTests: GRPCTestCase {
     // (3) Peer initiates shutdown, streams are open.
     do {
       let op2 = stateMachine.receiveGoAway()
-      op2.assertGoAway(streamID: .rootStream)
+      op2.assertNoGoAway()
       op2.assertShouldNotClose()
 
       // We become inactive.
@@ -271,7 +271,7 @@ class GRPCIdleHandlerStateMachineTests: GRPCTestCase {
 
     // Receive a GOAWAY.
     let op2 = stateMachine.receiveGoAway()
-    op2.assertGoAway(streamID: .rootStream)
+    op2.assertNoGoAway()
 
     // Initiate shutdown from our side: we've already sent GOAWAY and have a stream open, we don't
     // need to do anything.

--- a/Tests/GRPCTests/ServerQuiescingTests.swift
+++ b/Tests/GRPCTests/ServerQuiescingTests.swift
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import EchoImplementation
+import EchoModel
+import GRPC
+import NIO
+import XCTest
+
+class ServerQuiescingTests: GRPCTestCase {
+  func testServerQuiescing() throws {
+    let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+    defer {
+      assertThat(try group.syncShutdownGracefully(), .doesNotThrow())
+    }
+
+    let server = try Server.insecure(group: group)
+      .withLogger(self.serverLogger)
+      .withServiceProviders([EchoProvider()])
+      .bind(host: "127.0.0.1", port: 0)
+      .wait()
+
+    let connectivityStateDelegate = RecordingConnectivityDelegate()
+    let connection = ClientConnection.insecure(group: group)
+      .withBackgroundActivityLogger(self.clientLogger)
+      .withErrorDelegate(LoggingClientErrorDelegate())
+      .withConnectivityStateDelegate(connectivityStateDelegate)
+      .connect(host: "127.0.0.1", port: server.channel.localAddress!.port!)
+    defer {
+      assertThat(try connection.close().wait(), .doesNotThrow())
+    }
+
+    let echo = Echo_EchoClient(channel: connection)
+
+    // Expect the connection to setup as normal.
+    connectivityStateDelegate.expectChanges(2) { changes in
+      XCTAssertEqual(changes[0], Change(from: .idle, to: .connecting))
+      XCTAssertEqual(changes[1], Change(from: .connecting, to: .ready))
+    }
+
+    // Fire up a handful of client streaming RPCs, this will start the connection.
+    let rpcs = (0 ..< 5).map { _ in
+      echo.collect()
+    }
+
+    // Wait for the connectivity changes.
+    connectivityStateDelegate.waitForExpectedChanges(timeout: .seconds(5))
+
+    // Wait for the response metadata so both peers know about all RPCs.
+    for rpc in rpcs {
+      assertThat(try rpc.initialMetadata.wait(), .doesNotThrow())
+    }
+
+    // Start shutting down the server.
+    let serverShutdown = server.initiateGracefulShutdown()
+
+    // We should observe that we're quiescing now: this is a signal to not start any new RPCs.
+    connectivityStateDelegate.waitForQuiescing(timeout: .seconds(5))
+
+    // Queue up the expected change back to idle (i.e. when the connection is quiesced).
+    connectivityStateDelegate.expectChange {
+      XCTAssertEqual($0, Change(from: .ready, to: .idle))
+    }
+
+    // Finish each RPC.
+    for (index, rpc) in rpcs.enumerated() {
+      assertThat(try rpc.sendMessage(.with { $0.text = "\(index)" }).wait(), .doesNotThrow())
+      assertThat(try rpc.sendEnd().wait(), .doesNotThrow())
+      assertThat(try rpc.response.wait(), .is(.with { $0.text = "Swift echo collect: \(index)" }))
+    }
+
+    // All RPCs are done, the connection should drop back to idle.
+    connectivityStateDelegate.waitForExpectedChanges(timeout: .seconds(5))
+
+    // The server should be shutdown now.
+    assertThat(try serverShutdown.wait(), .doesNotThrow())
+  }
+}

--- a/scripts/build_podspecs.py
+++ b/scripts/build_podspecs.py
@@ -152,6 +152,7 @@ def process_package(string):
     pod_mappings = {
         'swift-log': 'Logging',
         'swift-nio': 'SwiftNIO',
+        'swift-nio-extras': 'SwiftNIOExtras',
         'swift-nio-http2': 'SwiftNIOHTTP2',
         'swift-nio-ssl': 'SwiftNIOSSL',
         'swift-nio-transport-services': 'SwiftNIOTransportServices',


### PR DESCRIPTION
Motivation:

It should be possible to shutdown a server in a way which allows
existing connection to run to completion.

Modifications:

- Add new API to allow servers to be initiate a graceful shutdown.
- Add new API to the client connectivity delegate so that users can be
  informed that the connection is going away
- Fixed a bug in the idle state machine that sent a GOAWAY frame too soon
  in response to receiving GOAWAY frame

Result:

Servers can be shutdown gracefully