### PR TITLE
Make a bunch of server code inlinable

### DIFF
--- a/Sources/GRPC/CallHandlers/CallHandlerFactory.swift
+++ b/Sources/GRPC/CallHandlers/CallHandlerFactory.swift
@@ -22,6 +22,7 @@ public enum CallHandlerFactory {
   public typealias UnaryContext<Response> = UnaryResponseCallContext<Response>
   public typealias UnaryEventObserver<Request, Response> = (Request) -> EventLoopFuture<Response>
 
+  @inlinable
   public static func makeUnary<Request: Message, Response: Message>(
     callHandlerContext: CallHandlerContext,
     interceptors: [ServerInterceptor<Request, Response>] = [],
@@ -37,6 +38,7 @@ public enum CallHandlerFactory {
     )
   }
 
+  @inlinable
   public static func makeUnary<Request: GRPCPayload, Response: GRPCPayload>(
     callHandlerContext: CallHandlerContext,
     interceptors: [ServerInterceptor<Request, Response>] = [],
@@ -56,6 +58,7 @@ public enum CallHandlerFactory {
   public typealias ClientStreamingEventObserver<Request> =
     EventLoopFuture<(StreamEvent<Request>) -> Void>
 
+  @inlinable
   public static func makeClientStreaming<Request: Message, Response: Message>(
     callHandlerContext: CallHandlerContext,
     interceptors: [ServerInterceptor<Request, Response>] = [],
@@ -71,6 +74,7 @@ public enum CallHandlerFactory {
     )
   }
 
+  @inlinable
   public static func makeClientStreaming<Request: GRPCPayload, Response: GRPCPayload>(
     callHandlerContext: CallHandlerContext,
     interceptors: [ServerInterceptor<Request, Response>] = [],
@@ -92,6 +96,7 @@ public enum CallHandlerFactory {
   public typealias ServerStreamingContext<Response> = StreamingResponseCallContext<Response>
   public typealias ServerStreamingEventObserver<Request> = (Request) -> EventLoopFuture<GRPCStatus>
 
+  @inlinable
   public static func makeServerStreaming<Request: Message, Response: Message>(
     callHandlerContext: CallHandlerContext,
     interceptors: [ServerInterceptor<Request, Response>] = [],
@@ -107,6 +112,7 @@ public enum CallHandlerFactory {
     )
   }
 
+  @inlinable
   public static func makeServerStreaming<Request: GRPCPayload, Response: GRPCPayload>(
     callHandlerContext: CallHandlerContext,
     interceptors: [ServerInterceptor<Request, Response>] = [],
@@ -129,6 +135,7 @@ public enum CallHandlerFactory {
   public typealias BidirectionalStreamingEventObserver<Request> =
     EventLoopFuture<(StreamEvent<Request>) -> Void>
 
+  @inlinable
   public static func makeBidirectionalStreaming<Request: Message, Response: Message>(
     callHandlerContext: CallHandlerContext,
     interceptors: [ServerInterceptor<Request, Response>] = [],
@@ -147,6 +154,7 @@ public enum CallHandlerFactory {
     )
   }
 
+  @inlinable
   public static func makeBidirectionalStreaming<Request: GRPCPayload, Response: GRPCPayload>(
     callHandlerContext: CallHandlerContext,
     interceptors: [ServerInterceptor<Request, Response>] = [],

--- a/Sources/GRPC/CallHandlers/ClientStreamingCallHandler.swift
+++ b/Sources/GRPC/CallHandlers/ClientStreamingCallHandler.swift
@@ -30,21 +30,26 @@ public final class ClientStreamingCallHandler<
   RequestDeserializer: MessageDeserializer,
   ResponseSerializer: MessageSerializer
 >: _BaseCallHandler<RequestDeserializer, ResponseSerializer> {
-  private typealias Context = UnaryResponseCallContext<ResponsePayload>
-  private typealias Observer = EventLoopFuture<(StreamEvent<RequestPayload>) -> Void>
+  @usableFromInline
+  internal typealias _Context = UnaryResponseCallContext<ResponsePayload>
+  @usableFromInline
+  internal typealias _Observer = EventLoopFuture<(StreamEvent<RequestPayload>) -> Void>
 
-  private var state: State
+  @usableFromInline
+  internal var _callHandlerState: _CallHandlerState
 
   // See 'UnaryCallHandler.State'.
-  private enum State {
-    case requestIdleResponseIdle((Context) -> Observer)
-    case requestOpenResponseOpen(Context, Observer)
-    case requestClosedResponseOpen(Context)
+  @usableFromInline
+  internal enum _CallHandlerState {
+    case requestIdleResponseIdle((_Context) -> _Observer)
+    case requestOpenResponseOpen(_Context, _Observer)
+    case requestClosedResponseOpen(_Context)
     case requestClosedResponseClosed
   }
 
   // We ask for a future of type `EventObserver` to allow the framework user to e.g. asynchronously authenticate a call.
   // If authentication fails, they can simply fail the observer future, which causes the call to be terminated.
+  @inlinable
   internal init(
     serializer: ResponseSerializer,
     deserializer: RequestDeserializer,
@@ -53,7 +58,7 @@ public final class ClientStreamingCallHandler<
     eventObserverFactory: @escaping (UnaryResponseCallContext<ResponsePayload>)
       -> EventLoopFuture<(StreamEvent<RequestPayload>) -> Void>
   ) {
-    self.state = .requestIdleResponseIdle(eventObserverFactory)
+    self._callHandlerState = .requestIdleResponseIdle(eventObserverFactory)
     super.init(
       callHandlerContext: callHandlerContext,
       requestDeserializer: deserializer,
@@ -67,21 +72,21 @@ public final class ClientStreamingCallHandler<
     super.channelInactive(context: context)
 
     // Fail any remaining promise.
-    switch self.state {
+    switch self._callHandlerState {
     case .requestIdleResponseIdle,
          .requestClosedResponseClosed:
-      self.state = .requestClosedResponseClosed
+      self._callHandlerState = .requestClosedResponseClosed
 
     case let .requestOpenResponseOpen(context, _),
          let .requestClosedResponseOpen(context):
-      self.state = .requestClosedResponseClosed
+      self._callHandlerState = .requestClosedResponseClosed
       context.responsePromise.fail(GRPCError.AlreadyComplete())
     }
   }
 
   /// Handle an error from the event observer.
   private func handleObserverError(_ error: Error) {
-    switch self.state {
+    switch self._callHandlerState {
     case .requestIdleResponseIdle:
       preconditionFailure("Invalid state: request observer hasn't been created")
 
@@ -103,7 +108,7 @@ public final class ClientStreamingCallHandler<
 
   /// Handle a 'library' error, i.e. an error emanating from the `Channel`.
   private func handleLibraryError(_ error: Error) {
-    switch self.state {
+    switch self._callHandlerState {
     case .requestIdleResponseIdle,
          .requestOpenResponseOpen:
       // We'll never see a request message, so just send end.
@@ -128,19 +133,19 @@ public final class ClientStreamingCallHandler<
   }
 
   override internal func observeHeaders(_ headers: HPACKHeaders) {
-    switch self.state {
+    switch self._callHandlerState {
     case let .requestIdleResponseIdle(factory):
       let context = UnaryResponseCallContext<ResponsePayload>(
         eventLoop: self.eventLoop,
         headers: headers,
         logger: self.logger,
-        userInfoRef: self.userInfoRef
+        userInfoRef: self._userInfoRef
       )
 
       let observer = factory(context)
 
       // Fully open. We'll send the response headers back in a moment.
-      self.state = .requestOpenResponseOpen(context, observer)
+      self._callHandlerState = .requestOpenResponseOpen(context, observer)
 
       // Register a failure callback for the observer failing.
       observer.whenFailure(self.handleObserverError(_:))
@@ -167,7 +172,7 @@ public final class ClientStreamingCallHandler<
   }
 
   override internal func observeRequest(_ message: RequestPayload) {
-    switch self.state {
+    switch self._callHandlerState {
     case .requestIdleResponseIdle:
       preconditionFailure("Invalid state: request received before headers")
 
@@ -183,12 +188,12 @@ public final class ClientStreamingCallHandler<
   }
 
   override internal func observeEnd() {
-    switch self.state {
+    switch self._callHandlerState {
     case .requestIdleResponseIdle:
       preconditionFailure("Invalid state: no request headers received")
 
     case let .requestOpenResponseOpen(context, observer):
-      self.state = .requestClosedResponseOpen(context)
+      self._callHandlerState = .requestClosedResponseOpen(context)
       observer.whenSuccess {
         $0(.end)
       }
@@ -202,13 +207,13 @@ public final class ClientStreamingCallHandler<
   // MARK: - Outbound
 
   private func sendResponse(_ message: ResponsePayload) {
-    switch self.state {
+    switch self._callHandlerState {
     case .requestIdleResponseIdle:
       preconditionFailure("Invalid state: can't send response before receiving headers and request")
 
     case let .requestOpenResponseOpen(context, _),
          let .requestClosedResponseOpen(context):
-      self.state = .requestClosedResponseClosed
+      self._callHandlerState = .requestClosedResponseClosed
       self.sendResponsePartFromObserver(
         .message(message, .init(compress: context.compressionEnabled, flush: false)),
         promise: nil
@@ -226,14 +231,14 @@ public final class ClientStreamingCallHandler<
   }
 
   private func sendEnd(status: GRPCStatus, trailers: HPACKHeaders) {
-    switch self.state {
+    switch self._callHandlerState {
     case .requestIdleResponseIdle,
          .requestClosedResponseOpen:
-      self.state = .requestClosedResponseClosed
+      self._callHandlerState = .requestClosedResponseClosed
       self.sendResponsePartFromObserver(.end(status, trailers), promise: nil)
 
     case let .requestOpenResponseOpen(context, _):
-      self.state = .requestClosedResponseClosed
+      self._callHandlerState = .requestClosedResponseClosed
       self.sendResponsePartFromObserver(.end(status, trailers), promise: nil)
       // Fail the promise.
       context.responsePromise.fail(status)

--- a/Sources/GRPC/GRPCServerRequestRoutingHandler.swift
+++ b/Sources/GRPC/GRPCServerRequestRoutingHandler.swift
@@ -40,10 +40,15 @@ public protocol CallHandlerProvider: AnyObject {
 // the context will get passed from generated code back into gRPC library code and all members should
 // be considered an implementation detail to the user.
 public struct CallHandlerContext {
+  @usableFromInline
   internal var errorDelegate: ServerErrorDelegate?
+  @usableFromInline
   internal var logger: Logger
+  @usableFromInline
   internal var encoding: ServerMessageEncoding
+  @usableFromInline
   internal var eventLoop: EventLoop
+  @usableFromInline
   internal var path: String
 }
 

--- a/Sources/GRPC/Interceptor/ServerInterceptorPipeline.swift
+++ b/Sources/GRPC/Interceptor/ServerInterceptorPipeline.swift
@@ -16,36 +16,44 @@
 import Logging
 import NIO
 
+@usableFromInline
 internal final class ServerInterceptorPipeline<Request, Response> {
   /// The `EventLoop` this RPC is being executed on.
+  @usableFromInline
   internal let eventLoop: EventLoop
 
   /// The path of the RPC in the format "/Service/Method", e.g. "/echo.Echo/Get".
+  @usableFromInline
   internal let path: String
 
   /// The type of the RPC, e.g. "unary".
+  @usableFromInline
   internal let type: GRPCCallType
 
   /// A logger.
+  @usableFromInline
   internal let logger: Logger
 
   /// A reference to a 'UserInfo'.
+  @usableFromInline
   internal let userInfoRef: Ref<UserInfo>
 
   /// The contexts associated with the interceptors stored in this pipeline. Contexts will be
   /// removed once the RPC has completed. Contexts are ordered from inbound to outbound, that is,
   /// the head is first and the tail is last.
-  private var contexts: InterceptorContextList<ServerInterceptorContext<Request, Response>>?
+  @usableFromInline
+  internal var _contexts: InterceptorContextList<ServerInterceptorContext<Request, Response>>?
 
   /// Returns the next context in the outbound direction for the context at the given index, if one
   /// exists.
   /// - Parameter index: The index of the `ServerInterceptorContext` which is requesting the next
   ///   outbound context.
   /// - Returns: The `ServerInterceptorContext` or `nil` if one does not exist.
+  @inlinable
   internal func nextOutboundContext(
     forIndex index: Int
   ) -> ServerInterceptorContext<Request, Response>? {
-    return self.context(atIndex: index - 1)
+    return self._context(atIndex: index - 1)
   }
 
   /// Returns the next context in the inbound direction for the context at the given index, if one
@@ -53,31 +61,36 @@ internal final class ServerInterceptorPipeline<Request, Response> {
   /// - Parameter index: The index of the `ServerInterceptorContext` which is requesting the next
   ///   inbound context.
   /// - Returns: The `ServerInterceptorContext` or `nil` if one does not exist.
+  @inlinable
   internal func nextInboundContext(
     forIndex index: Int
   ) -> ServerInterceptorContext<Request, Response>? {
-    return self.context(atIndex: index + 1)
+    return self._context(atIndex: index + 1)
   }
 
   /// Returns the context for the given index, if one exists.
   /// - Parameter index: The index of the `ServerInterceptorContext` to return.
   /// - Returns: The `ServerInterceptorContext` or `nil` if one does not exist for the given index.
-  private func context(atIndex index: Int) -> ServerInterceptorContext<Request, Response>? {
-    return self.contexts?[checked: index]
+  @inlinable
+  internal func _context(atIndex index: Int) -> ServerInterceptorContext<Request, Response>? {
+    return self._contexts?[checked: index]
   }
 
   /// The context closest to the `NIO.Channel`, i.e. where inbound events originate. This will be
   /// `nil` once the RPC has completed.
+  @inlinable
   internal var head: ServerInterceptorContext<Request, Response>? {
-    return self.contexts?.first
+    return self._contexts?.first
   }
 
   /// The context closest to the application, i.e. where outbound events originate. This will be
   /// `nil` once the RPC has completed.
+  @inlinable
   internal var tail: ServerInterceptorContext<Request, Response>? {
-    return self.contexts?.last
+    return self._contexts?.last
   }
 
+  @inlinable
   internal init(
     logger: Logger,
     eventLoop: EventLoop,
@@ -95,7 +108,7 @@ internal final class ServerInterceptorPipeline<Request, Response> {
     self.userInfoRef = userInfoRef
 
     // We need space for the head and tail as well as any user provided interceptors.
-    self.contexts = InterceptorContextList(
+    self._contexts = InterceptorContextList(
       for: self,
       interceptors: interceptors,
       onRequestPart: onRequestPart,
@@ -107,6 +120,7 @@ internal final class ServerInterceptorPipeline<Request, Response> {
   ///
   /// - Parameter part: The part to emit into the pipeline.
   /// - Important: This *must* to be called from the `eventLoop`.
+  @inlinable
   internal func receive(_ part: GRPCServerRequestPart<Request>) {
     self.eventLoop.assertInEventLoop()
     self.head?.invokeReceive(part)
@@ -118,6 +132,7 @@ internal final class ServerInterceptorPipeline<Request, Response> {
   ///   - part: The response part to sent.
   ///   - promise: A promise to complete when the response part has been successfully written.
   /// - Important: This *must* to be called from the `eventLoop`.
+  @inlinable
   internal func send(_ part: GRPCServerResponsePart<Response>, promise: EventLoopPromise<Void>?) {
     self.eventLoop.assertInEventLoop()
 
@@ -128,13 +143,15 @@ internal final class ServerInterceptorPipeline<Request, Response> {
     }
   }
 
+  @inlinable
   internal func close() {
     self.eventLoop.assertInEventLoop()
-    self.contexts = nil
+    self._contexts = nil
   }
 }
 
-private extension InterceptorContextList {
+extension InterceptorContextList {
+  @inlinable
   init<Request, Response>(
     for pipeline: ServerInterceptorPipeline<Request, Response>,
     interceptors: [ServerInterceptor<Request, Response>],

--- a/Sources/GRPC/InterceptorContextList.swift
+++ b/Sources/GRPC/InterceptorContextList.swift
@@ -20,22 +20,29 @@
 /// `Array.first` and `Array.last` will allocate: unfortunately this currently happens to be the
 /// case for the interceptor pipelines. Storing the `first` and `last` directly allows us to avoid
 /// this. See also: https://bugs.swift.org/browse/SR-11262.
+@usableFromInline
 internal struct InterceptorContextList<Element> {
   /// The first element, stored at `middle.startIndex - 1`.
+  @usableFromInline
   internal var first: Element
 
   /// The last element, stored at the `middle.endIndex`.
+  @usableFromInline
   internal var last: Element
 
   /// The other elements.
-  private var middle: [Element]
+  @usableFromInline
+  internal var _middle: [Element]
 
   /// The index of `first`
-  private let firstIndex: Int
+  @usableFromInline
+  internal let firstIndex: Int
 
   /// The index of `last`.
-  private let lastIndex: Int
+  @usableFromInline
+  internal let lastIndex: Int
 
+  @usableFromInline
   internal subscript(checked index: Int) -> Element? {
     switch index {
     case self.firstIndex:
@@ -43,13 +50,14 @@ internal struct InterceptorContextList<Element> {
     case self.lastIndex:
       return self.last
     default:
-      return self.middle[checked: index]
+      return self._middle[checked: index]
     }
   }
 
+  @inlinable
   internal init(first: Element, middle: [Element], last: Element) {
     self.first = first
-    self.middle = middle
+    self._middle = middle
     self.last = last
     self.firstIndex = middle.startIndex - 1
     self.lastIndex = middle.endIndex

--- a/Sources/GRPC/Ref.swift
+++ b/Sources/GRPC/Ref.swift
@@ -14,8 +14,12 @@
  * limitations under the License.
  */
 
+@usableFromInline
 internal final class Ref<Value> {
+  @usableFromInline
   internal var value: Value
+
+  @inlinable
   internal init(_ value: Value) {
     self.value = value
   }

--- a/Sources/GRPC/Serialization.swift
+++ b/Sources/GRPC/Serialization.swift
@@ -25,6 +25,7 @@ public protocol MessageSerializer {
   /// - Parameters:
   ///   - input: The element to serialize.
   ///   - allocator: A `ByteBufferAllocator`.
+  @inlinable
   func serialize(_ input: Input, allocator: ByteBufferAllocator) throws -> ByteBuffer
 }
 
@@ -34,12 +35,17 @@ public protocol MessageDeserializer {
   /// Deserializes `byteBuffer` to produce a single `Output`.
   ///
   /// - Parameter byteBuffer: The `ByteBuffer` to deserialize.
+  @inlinable
   func deserialize(byteBuffer: ByteBuffer) throws -> Output
 }
 
 // MARK: Protobuf
 
 public struct ProtobufSerializer<Message: SwiftProtobuf.Message>: MessageSerializer {
+  @inlinable
+  public init() {}
+
+  @inlinable
   public func serialize(_ message: Message, allocator: ByteBufferAllocator) throws -> ByteBuffer {
     // Serialize the message.
     let serialized = try message.serializedData()
@@ -59,6 +65,10 @@ public struct ProtobufSerializer<Message: SwiftProtobuf.Message>: MessageSeriali
 }
 
 public struct ProtobufDeserializer<Message: SwiftProtobuf.Message>: MessageDeserializer {
+  @inlinable
+  public init() {}
+
+  @inlinable
   public func deserialize(byteBuffer: ByteBuffer) throws -> Message {
     var buffer = byteBuffer
     // '!' is okay; we can always read 'readableBytes'.
@@ -70,6 +80,10 @@ public struct ProtobufDeserializer<Message: SwiftProtobuf.Message>: MessageDeser
 // MARK: GRPCPayload
 
 public struct GRPCPayloadSerializer<Message: GRPCPayload>: MessageSerializer {
+  @inlinable
+  public init() {}
+
+  @inlinable
   public func serialize(_ message: Message, allocator: ByteBufferAllocator) throws -> ByteBuffer {
     // Reserve 5 leading bytes. This a minor optimisation win: the length prefixed message writer
     // can re-use the leading 5 bytes without needing to allocate a new buffer and copy over the
@@ -102,6 +116,10 @@ public struct GRPCPayloadSerializer<Message: GRPCPayload>: MessageSerializer {
 }
 
 public struct GRPCPayloadDeserializer<Message: GRPCPayload>: MessageDeserializer {
+  @inlinable
+  public init() {}
+
+  @inlinable
   public func deserialize(byteBuffer: ByteBuffer) throws -> Message {
     var buffer = byteBuffer
     return try Message(serializedByteBuffer: &buffer)


### PR DESCRIPTION
Motivation:

We spend a reasonable amount of time dealing with unspecialized generics
when processing requests on the server.

Modification:

- Make a whole heap of server processing code inlinable or
  usableFromInline

Results:

- A modest drop in instructions in the embedded server unary benchmark,
  about 7%.