### PR TITLE
Move client serialization into the transport handler

### DIFF
--- a/Sources/GRPC/FakeChannel.swift
+++ b/Sources/GRPC/FakeChannel.swift
@@ -99,7 +99,25 @@ public class FakeChannel: GRPCChannel {
     )
   }
 
-  private func _makeCall<Request, Response>(
+  private func _makeCall<Request: Message, Response: Message>(
+    path: String,
+    type: GRPCCallType,
+    callOptions: CallOptions,
+    interceptors: [ClientInterceptor<Request, Response>]
+  ) -> Call<Request, Response> {
+    let stream: _FakeResponseStream<Request, Response>? = self.dequeueResponseStream(forPath: path)
+    let eventLoop = stream?.channel.eventLoop ?? EmbeddedEventLoop()
+    return Call(
+      path: path,
+      type: type,
+      eventLoop: eventLoop,
+      options: callOptions,
+      interceptors: interceptors,
+      transportFactory: .fake(stream, on: eventLoop)
+    )
+  }
+
+  private func _makeCall<Request: GRPCPayload, Response: GRPCPayload>(
     path: String,
     type: GRPCCallType,
     callOptions: CallOptions,

--- a/Sources/GRPC/Serialization.swift
+++ b/Sources/GRPC/Serialization.swift
@@ -125,3 +125,31 @@ public struct GRPCPayloadDeserializer<Message: GRPCPayload>: MessageDeserializer
     return try Message(serializedByteBuffer: &buffer)
   }
 }
+
+// MARK: - Any Serializer/Deserializer
+
+internal struct AnySerializer<Input>: MessageSerializer {
+  private let _serialize: (Input, ByteBufferAllocator) throws -> ByteBuffer
+
+  init<Serializer: MessageSerializer>(wrapping other: Serializer) where Serializer.Input == Input {
+    self._serialize = other.serialize(_:allocator:)
+  }
+
+  internal func serialize(_ input: Input, allocator: ByteBufferAllocator) throws -> ByteBuffer {
+    return try self._serialize(input, allocator)
+  }
+}
+
+internal struct AnyDeserializer<Output>: MessageDeserializer {
+  private let _deserialize: (ByteBuffer) throws -> Output
+
+  init<Deserializer: MessageDeserializer>(
+    wrapping other: Deserializer
+  ) where Deserializer.Output == Output {
+    self._deserialize = other.deserialize(byteBuffer:)
+  }
+
+  internal func deserialize(byteBuffer: ByteBuffer) throws -> Output {
+    return try self._deserialize(byteBuffer)
+  }
+}

--- a/Sources/GRPCPerformanceTests/Benchmarks/UnaryThroughput.swift
+++ b/Sources/GRPCPerformanceTests/Benchmarks/UnaryThroughput.swift
@@ -54,7 +54,6 @@ class Unary: ServerProvidingBenchmark {
       let requests = (lowerBound ..< upperBound).map { _ in
         client.get(Echo_EchoRequest.with { $0.text = self.requestText }).response
       }
-
       try EventLoopFuture.andAllSucceed(requests, on: self.group.next()).wait()
     }
   }


### PR DESCRIPTION
Motivation:

Moving the client serialization into transport handler allows us to
get rid of an unspecialized generic handler.

Modifications:

- Add an 'AnySerializer' and 'AnyDeserializer', this is unfortunate but
  necessary since 'ClientTransport' is generic over 'Request' and
  'Response' rather than their respective (de/)serializer. Changing this
  would involve changing the generic constraints on all of the client call
  objects.
- Move (de/)serialization into the 'ClientTransport'
- Add a reverse codec for 'fake' transport

Result:

3.5% fewer instructions in the unary_10k_small_requests benchmark.