### PR TITLE
Support new handlers in the server codec + state machine

### DIFF
--- a/Tests/GRPCTests/XCTestHelpers.swift
+++ b/Tests/GRPCTests/XCTestHelpers.swift
@@ -481,7 +481,7 @@ struct Matcher<Value> {
   static func configure() -> Matcher<HTTP2ToRawGRPCStateMachine.ReceiveHeadersAction> {
     return .init { actual in
       switch actual {
-      case .configurePipeline:
+      case .configureLegacy, .configure:
         return .match
       default:
         return .noMatch(actual: "\(actual)", expected: "configurePipeline")


### PR DESCRIPTION
Motivation:

We have new ways of handling RPCs on the server, the server codec and
state machine should use them!

Modifications:

- In the state machine: try to handle an RPC using the new API, falling
  back to the old way
- In the codec: store a mode, i.e. how we're handling the RPC.
- Flushing has become the responsibility of the server codec (as opposed
  to the RPC-specific channel handler): now we only flush at the end of
  'channelReadComplete' (if a flush is pending), or on calls to
  'flush(context:)' if we aren't currently reading.

Result:

The server supports the new RPC handlers.