### PR TITLE
Fix some bugs with new handlers

### DIFF
--- a/Sources/GRPC/CallHandlers/BidirectionalStreamingCallHandler.swift
+++ b/Sources/GRPC/CallHandlers/BidirectionalStreamingCallHandler.swift
@@ -139,6 +139,7 @@ public class BidirectionalStreamingCallHandler<
         headers: headers,
         logger: self.logger,
         userInfoRef: self._userInfoRef,
+        compressionIsEnabled: self._callHandlerContext.encoding.isEnabled,
         sendResponse: self.sendResponse(_:metadata:promise:)
       )
       let observer = factory(context)

--- a/Sources/GRPC/CallHandlers/ServerStreamingCallHandler.swift
+++ b/Sources/GRPC/CallHandlers/ServerStreamingCallHandler.swift
@@ -145,6 +145,7 @@ public final class ServerStreamingCallHandler<
         headers: headers,
         logger: self.logger,
         userInfoRef: self._userInfoRef,
+        compressionIsEnabled: self._callHandlerContext.encoding.isEnabled,
         sendResponse: self.sendResponse(_:metadata:promise:)
       )
       let observer = factory(context)

--- a/Sources/GRPC/Compression/MessageEncoding.swift
+++ b/Sources/GRPC/Compression/MessageEncoding.swift
@@ -115,6 +115,16 @@ extension ClientMessageEncoding {
 public enum ServerMessageEncoding {
   case enabled(Configuration)
   case disabled
+
+  @usableFromInline
+  internal var isEnabled: Bool {
+    switch self {
+    case .enabled:
+      return true
+    case .disabled:
+      return false
+    }
+  }
 }
 
 extension ServerMessageEncoding {

--- a/Sources/GRPC/GRPCError.swift
+++ b/Sources/GRPC/GRPCError.swift
@@ -254,7 +254,7 @@ public enum GRPCError {
     public var message: String
 
     public init(_ message: String) {
-      self.message = message
+      self.message = "Invalid state: \(message)"
     }
 
     public var description: String {
@@ -262,7 +262,23 @@ public enum GRPCError {
     }
 
     public func makeGRPCStatus() -> GRPCStatus {
-      return GRPCStatus(code: .internalError, message: "Invalid state: \(self.message)")
+      return GRPCStatus(code: .internalError, message: self.message)
+    }
+  }
+
+  public struct ProtocolViolation: GRPCErrorProtocol {
+    public var message: String
+
+    public init(_ message: String) {
+      self.message = "Protocol violation: \(message)"
+    }
+
+    public var description: String {
+      return self.message
+    }
+
+    public func makeGRPCStatus() -> GRPCStatus {
+      return GRPCStatus(code: .internalError, message: self.message)
     }
   }
 }


### PR DESCRIPTION
Motivation:

Manually wiring up the new handlers to run the rest of the test suite
highlighted a few rough edges.

Modifications:

- Make sure compression is correctly set: it must be enabled on the
  server, in the call context, and - if applicable - on the individaul
  message. Add tests for this.
- Call the error delegate in the right place.
- Add a 'protocol violation' error.

Result:

Fewer bugs.