### PR TITLE
Update the codegen to use the new handlers.

### DIFF
--- a/Performance/QPSBenchmark/Sources/QPSBenchmark/Runtime/BenchmarkServiceImpl.swift
+++ b/Performance/QPSBenchmark/Sources/QPSBenchmark/Runtime/BenchmarkServiceImpl.swift
@@ -20,6 +20,8 @@ import NIO
 
 /// Implementation of asynchronous service for benchmarking.
 final class AsyncQPSServerImpl: Grpc_Testing_BenchmarkServiceProvider {
+  let interceptors: Grpc_Testing_BenchmarkServiceServerInterceptorFactoryProtocol? = nil
+
   /// One request followed by one response.
   /// The server returns the client payload as-is.
   func unaryCall(request: Grpc_Testing_SimpleRequest,

--- a/Performance/QPSBenchmark/Sources/QPSBenchmark/Runtime/WorkerServiceImpl.swift
+++ b/Performance/QPSBenchmark/Sources/QPSBenchmark/Runtime/WorkerServiceImpl.swift
@@ -19,6 +19,8 @@ import NIO
 
 // Implementation of the control service for communication with the driver process.
 class WorkerServiceImpl: Grpc_Testing_WorkerServiceProvider {
+  let interceptors: Grpc_Testing_WorkerServiceServerInterceptorFactoryProtocol? = nil
+
   private let finishedPromise: EventLoopPromise<Void>
   private let serverPortOverride: Int?
 

--- a/Sources/Examples/Echo/Model/echo.grpc.swift
+++ b/Sources/Examples/Echo/Model/echo.grpc.swift
@@ -312,46 +312,46 @@ extension Echo_EchoProvider {
 
   /// Determines, calls and returns the appropriate request handler, depending on the request's method.
   /// Returns nil for methods not handled by this service.
-  public func handleMethod(
-    _ methodName: Substring,
-    callHandlerContext: CallHandlerContext
-  ) -> GRPCCallHandler? {
-    switch methodName {
+  public func handle(
+    method name: Substring,
+    context: CallHandlerContext
+  ) -> GRPCServerHandlerProtocol? {
+    switch name {
     case "Get":
-      return CallHandlerFactory.makeUnary(
-        callHandlerContext: callHandlerContext,
-        interceptors: self.interceptors?.makeGetInterceptors() ?? []
-      ) { context in
-        return { request in
-          self.get(request: request, context: context)
-        }
-      }
+      return UnaryServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Echo_EchoRequest>(),
+        responseSerializer: ProtobufSerializer<Echo_EchoResponse>(),
+        interceptors: self.interceptors?.makeGetInterceptors() ?? [],
+        userFunction: self.get(request:context:)
+      )
 
     case "Expand":
-      return CallHandlerFactory.makeServerStreaming(
-        callHandlerContext: callHandlerContext,
-        interceptors: self.interceptors?.makeExpandInterceptors() ?? []
-      ) { context in
-        return { request in
-          self.expand(request: request, context: context)
-        }
-      }
+      return ServerStreamingServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Echo_EchoRequest>(),
+        responseSerializer: ProtobufSerializer<Echo_EchoResponse>(),
+        interceptors: self.interceptors?.makeExpandInterceptors() ?? [],
+        userFunction: self.expand(request:context:)
+      )
 
     case "Collect":
-      return CallHandlerFactory.makeClientStreaming(
-        callHandlerContext: callHandlerContext,
-        interceptors: self.interceptors?.makeCollectInterceptors() ?? []
-      ) { context in
-        self.collect(context: context)
-      }
+      return ClientStreamingServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Echo_EchoRequest>(),
+        responseSerializer: ProtobufSerializer<Echo_EchoResponse>(),
+        interceptors: self.interceptors?.makeCollectInterceptors() ?? [],
+        observerFactory: self.collect(context:)
+      )
 
     case "Update":
-      return CallHandlerFactory.makeBidirectionalStreaming(
-        callHandlerContext: callHandlerContext,
-        interceptors: self.interceptors?.makeUpdateInterceptors() ?? []
-      ) { context in
-        self.update(context: context)
-      }
+      return BidirectionalStreamingServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Echo_EchoRequest>(),
+        responseSerializer: ProtobufSerializer<Echo_EchoResponse>(),
+        interceptors: self.interceptors?.makeUpdateInterceptors() ?? [],
+        observerFactory: self.update(context:)
+      )
 
     default:
       return nil

--- a/Sources/Examples/HelloWorld/Model/helloworld.grpc.swift
+++ b/Sources/Examples/HelloWorld/Model/helloworld.grpc.swift
@@ -105,20 +105,19 @@ extension Helloworld_GreeterProvider {
 
   /// Determines, calls and returns the appropriate request handler, depending on the request's method.
   /// Returns nil for methods not handled by this service.
-  public func handleMethod(
-    _ methodName: Substring,
-    callHandlerContext: CallHandlerContext
-  ) -> GRPCCallHandler? {
-    switch methodName {
+  public func handle(
+    method name: Substring,
+    context: CallHandlerContext
+  ) -> GRPCServerHandlerProtocol? {
+    switch name {
     case "SayHello":
-      return CallHandlerFactory.makeUnary(
-        callHandlerContext: callHandlerContext,
-        interceptors: self.interceptors?.makeSayHelloInterceptors() ?? []
-      ) { context in
-        return { request in
-          self.sayHello(request: request, context: context)
-        }
-      }
+      return UnaryServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Helloworld_HelloRequest>(),
+        responseSerializer: ProtobufSerializer<Helloworld_HelloReply>(),
+        interceptors: self.interceptors?.makeSayHelloInterceptors() ?? [],
+        userFunction: self.sayHello(request:context:)
+      )
 
     default:
       return nil

--- a/Sources/Examples/RouteGuide/Model/route_guide.grpc.swift
+++ b/Sources/Examples/RouteGuide/Model/route_guide.grpc.swift
@@ -230,46 +230,46 @@ extension Routeguide_RouteGuideProvider {
 
   /// Determines, calls and returns the appropriate request handler, depending on the request's method.
   /// Returns nil for methods not handled by this service.
-  public func handleMethod(
-    _ methodName: Substring,
-    callHandlerContext: CallHandlerContext
-  ) -> GRPCCallHandler? {
-    switch methodName {
+  public func handle(
+    method name: Substring,
+    context: CallHandlerContext
+  ) -> GRPCServerHandlerProtocol? {
+    switch name {
     case "GetFeature":
-      return CallHandlerFactory.makeUnary(
-        callHandlerContext: callHandlerContext,
-        interceptors: self.interceptors?.makeGetFeatureInterceptors() ?? []
-      ) { context in
-        return { request in
-          self.getFeature(request: request, context: context)
-        }
-      }
+      return UnaryServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Routeguide_Point>(),
+        responseSerializer: ProtobufSerializer<Routeguide_Feature>(),
+        interceptors: self.interceptors?.makeGetFeatureInterceptors() ?? [],
+        userFunction: self.getFeature(request:context:)
+      )
 
     case "ListFeatures":
-      return CallHandlerFactory.makeServerStreaming(
-        callHandlerContext: callHandlerContext,
-        interceptors: self.interceptors?.makeListFeaturesInterceptors() ?? []
-      ) { context in
-        return { request in
-          self.listFeatures(request: request, context: context)
-        }
-      }
+      return ServerStreamingServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Routeguide_Rectangle>(),
+        responseSerializer: ProtobufSerializer<Routeguide_Feature>(),
+        interceptors: self.interceptors?.makeListFeaturesInterceptors() ?? [],
+        userFunction: self.listFeatures(request:context:)
+      )
 
     case "RecordRoute":
-      return CallHandlerFactory.makeClientStreaming(
-        callHandlerContext: callHandlerContext,
-        interceptors: self.interceptors?.makeRecordRouteInterceptors() ?? []
-      ) { context in
-        self.recordRoute(context: context)
-      }
+      return ClientStreamingServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Routeguide_Point>(),
+        responseSerializer: ProtobufSerializer<Routeguide_RouteSummary>(),
+        interceptors: self.interceptors?.makeRecordRouteInterceptors() ?? [],
+        observerFactory: self.recordRoute(context:)
+      )
 
     case "RouteChat":
-      return CallHandlerFactory.makeBidirectionalStreaming(
-        callHandlerContext: callHandlerContext,
-        interceptors: self.interceptors?.makeRouteChatInterceptors() ?? []
-      ) { context in
-        self.routeChat(context: context)
-      }
+      return BidirectionalStreamingServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Routeguide_RouteNote>(),
+        responseSerializer: ProtobufSerializer<Routeguide_RouteNote>(),
+        interceptors: self.interceptors?.makeRouteChatInterceptors() ?? [],
+        observerFactory: self.routeChat(context:)
+      )
 
     default:
       return nil

--- a/Sources/GRPC/CallHandlers/CallHandlerFactory.swift
+++ b/Sources/GRPC/CallHandlers/CallHandlerFactory.swift
@@ -22,6 +22,7 @@ public enum CallHandlerFactory {
   public typealias UnaryContext<Response> = UnaryResponseCallContext<Response>
   public typealias UnaryEventObserver<Request, Response> = (Request) -> EventLoopFuture<Response>
 
+  @available(*, deprecated, message: "Please regenerate your server code.")
   @inlinable
   public static func makeUnary<Request: Message, Response: Message>(
     callHandlerContext: CallHandlerContext,
@@ -38,6 +39,7 @@ public enum CallHandlerFactory {
     )
   }
 
+  @available(*, deprecated, message: "Please regenerate your server code.")
   @inlinable
   public static func makeUnary<Request: GRPCPayload, Response: GRPCPayload>(
     callHandlerContext: CallHandlerContext,
@@ -58,6 +60,7 @@ public enum CallHandlerFactory {
   public typealias ClientStreamingEventObserver<Request> =
     EventLoopFuture<(StreamEvent<Request>) -> Void>
 
+  @available(*, deprecated, message: "Please regenerate your server code.")
   @inlinable
   public static func makeClientStreaming<Request: Message, Response: Message>(
     callHandlerContext: CallHandlerContext,
@@ -74,6 +77,7 @@ public enum CallHandlerFactory {
     )
   }
 
+  @available(*, deprecated, message: "Please regenerate your server code.")
   @inlinable
   public static func makeClientStreaming<Request: GRPCPayload, Response: GRPCPayload>(
     callHandlerContext: CallHandlerContext,
@@ -96,6 +100,7 @@ public enum CallHandlerFactory {
   public typealias ServerStreamingContext<Response> = StreamingResponseCallContext<Response>
   public typealias ServerStreamingEventObserver<Request> = (Request) -> EventLoopFuture<GRPCStatus>
 
+  @available(*, deprecated, message: "Please regenerate your server code.")
   @inlinable
   public static func makeServerStreaming<Request: Message, Response: Message>(
     callHandlerContext: CallHandlerContext,
@@ -112,6 +117,7 @@ public enum CallHandlerFactory {
     )
   }
 
+  @available(*, deprecated, message: "Please regenerate your server code.")
   @inlinable
   public static func makeServerStreaming<Request: GRPCPayload, Response: GRPCPayload>(
     callHandlerContext: CallHandlerContext,
@@ -135,6 +141,7 @@ public enum CallHandlerFactory {
   public typealias BidirectionalStreamingEventObserver<Request> =
     EventLoopFuture<(StreamEvent<Request>) -> Void>
 
+  @available(*, deprecated, message: "Please regenerate your server code.")
   @inlinable
   public static func makeBidirectionalStreaming<Request: Message, Response: Message>(
     callHandlerContext: CallHandlerContext,
@@ -154,6 +161,7 @@ public enum CallHandlerFactory {
     )
   }
 
+  @available(*, deprecated, message: "Please regenerate your server code.")
   @inlinable
   public static func makeBidirectionalStreaming<Request: GRPCPayload, Response: GRPCPayload>(
     callHandlerContext: CallHandlerContext,

--- a/Sources/GRPC/GRPCServerRequestRoutingHandler.swift
+++ b/Sources/GRPC/GRPCServerRequestRoutingHandler.swift
@@ -53,6 +53,14 @@ extension CallHandlerProvider {
   ) -> GRPCServerHandlerProtocol? {
     return nil
   }
+
+  // TODO: remove this once we've removed 'handleMethod(_:callHandlerContext:)'.
+  public func handleMethod(
+    _ methodName: Substring,
+    callHandlerContext: CallHandlerContext
+  ) -> GRPCCallHandler? {
+    return nil
+  }
 }
 
 // This is public because it will be passed into generated code, all members are `internal` because

--- a/Sources/GRPCInteroperabilityTestModels/Generated/test.grpc.swift
+++ b/Sources/GRPCInteroperabilityTestModels/Generated/test.grpc.swift
@@ -492,74 +492,73 @@ extension Grpc_Testing_TestServiceProvider {
 
   /// Determines, calls and returns the appropriate request handler, depending on the request's method.
   /// Returns nil for methods not handled by this service.
-  public func handleMethod(
-    _ methodName: Substring,
-    callHandlerContext: CallHandlerContext
-  ) -> GRPCCallHandler? {
-    switch methodName {
+  public func handle(
+    method name: Substring,
+    context: CallHandlerContext
+  ) -> GRPCServerHandlerProtocol? {
+    switch name {
     case "EmptyCall":
-      return CallHandlerFactory.makeUnary(
-        callHandlerContext: callHandlerContext,
-        interceptors: self.interceptors?.makeEmptyCallInterceptors() ?? []
-      ) { context in
-        return { request in
-          self.emptyCall(request: request, context: context)
-        }
-      }
+      return UnaryServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Grpc_Testing_Empty>(),
+        responseSerializer: ProtobufSerializer<Grpc_Testing_Empty>(),
+        interceptors: self.interceptors?.makeEmptyCallInterceptors() ?? [],
+        userFunction: self.emptyCall(request:context:)
+      )
 
     case "UnaryCall":
-      return CallHandlerFactory.makeUnary(
-        callHandlerContext: callHandlerContext,
-        interceptors: self.interceptors?.makeUnaryCallInterceptors() ?? []
-      ) { context in
-        return { request in
-          self.unaryCall(request: request, context: context)
-        }
-      }
+      return UnaryServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Grpc_Testing_SimpleRequest>(),
+        responseSerializer: ProtobufSerializer<Grpc_Testing_SimpleResponse>(),
+        interceptors: self.interceptors?.makeUnaryCallInterceptors() ?? [],
+        userFunction: self.unaryCall(request:context:)
+      )
 
     case "CacheableUnaryCall":
-      return CallHandlerFactory.makeUnary(
-        callHandlerContext: callHandlerContext,
-        interceptors: self.interceptors?.makeCacheableUnaryCallInterceptors() ?? []
-      ) { context in
-        return { request in
-          self.cacheableUnaryCall(request: request, context: context)
-        }
-      }
+      return UnaryServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Grpc_Testing_SimpleRequest>(),
+        responseSerializer: ProtobufSerializer<Grpc_Testing_SimpleResponse>(),
+        interceptors: self.interceptors?.makeCacheableUnaryCallInterceptors() ?? [],
+        userFunction: self.cacheableUnaryCall(request:context:)
+      )
 
     case "StreamingOutputCall":
-      return CallHandlerFactory.makeServerStreaming(
-        callHandlerContext: callHandlerContext,
-        interceptors: self.interceptors?.makeStreamingOutputCallInterceptors() ?? []
-      ) { context in
-        return { request in
-          self.streamingOutputCall(request: request, context: context)
-        }
-      }
+      return ServerStreamingServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Grpc_Testing_StreamingOutputCallRequest>(),
+        responseSerializer: ProtobufSerializer<Grpc_Testing_StreamingOutputCallResponse>(),
+        interceptors: self.interceptors?.makeStreamingOutputCallInterceptors() ?? [],
+        userFunction: self.streamingOutputCall(request:context:)
+      )
 
     case "StreamingInputCall":
-      return CallHandlerFactory.makeClientStreaming(
-        callHandlerContext: callHandlerContext,
-        interceptors: self.interceptors?.makeStreamingInputCallInterceptors() ?? []
-      ) { context in
-        self.streamingInputCall(context: context)
-      }
+      return ClientStreamingServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Grpc_Testing_StreamingInputCallRequest>(),
+        responseSerializer: ProtobufSerializer<Grpc_Testing_StreamingInputCallResponse>(),
+        interceptors: self.interceptors?.makeStreamingInputCallInterceptors() ?? [],
+        observerFactory: self.streamingInputCall(context:)
+      )
 
     case "FullDuplexCall":
-      return CallHandlerFactory.makeBidirectionalStreaming(
-        callHandlerContext: callHandlerContext,
-        interceptors: self.interceptors?.makeFullDuplexCallInterceptors() ?? []
-      ) { context in
-        self.fullDuplexCall(context: context)
-      }
+      return BidirectionalStreamingServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Grpc_Testing_StreamingOutputCallRequest>(),
+        responseSerializer: ProtobufSerializer<Grpc_Testing_StreamingOutputCallResponse>(),
+        interceptors: self.interceptors?.makeFullDuplexCallInterceptors() ?? [],
+        observerFactory: self.fullDuplexCall(context:)
+      )
 
     case "HalfDuplexCall":
-      return CallHandlerFactory.makeBidirectionalStreaming(
-        callHandlerContext: callHandlerContext,
-        interceptors: self.interceptors?.makeHalfDuplexCallInterceptors() ?? []
-      ) { context in
-        self.halfDuplexCall(context: context)
-      }
+      return BidirectionalStreamingServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Grpc_Testing_StreamingOutputCallRequest>(),
+        responseSerializer: ProtobufSerializer<Grpc_Testing_StreamingOutputCallResponse>(),
+        interceptors: self.interceptors?.makeHalfDuplexCallInterceptors() ?? [],
+        observerFactory: self.halfDuplexCall(context:)
+      )
 
     default:
       return nil
@@ -617,20 +616,19 @@ extension Grpc_Testing_UnimplementedServiceProvider {
 
   /// Determines, calls and returns the appropriate request handler, depending on the request's method.
   /// Returns nil for methods not handled by this service.
-  public func handleMethod(
-    _ methodName: Substring,
-    callHandlerContext: CallHandlerContext
-  ) -> GRPCCallHandler? {
-    switch methodName {
+  public func handle(
+    method name: Substring,
+    context: CallHandlerContext
+  ) -> GRPCServerHandlerProtocol? {
+    switch name {
     case "UnimplementedCall":
-      return CallHandlerFactory.makeUnary(
-        callHandlerContext: callHandlerContext,
-        interceptors: self.interceptors?.makeUnimplementedCallInterceptors() ?? []
-      ) { context in
-        return { request in
-          self.unimplementedCall(request: request, context: context)
-        }
-      }
+      return UnaryServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Grpc_Testing_Empty>(),
+        responseSerializer: ProtobufSerializer<Grpc_Testing_Empty>(),
+        interceptors: self.interceptors?.makeUnimplementedCallInterceptors() ?? [],
+        userFunction: self.unimplementedCall(request:context:)
+      )
 
     default:
       return nil
@@ -660,30 +658,28 @@ extension Grpc_Testing_ReconnectServiceProvider {
 
   /// Determines, calls and returns the appropriate request handler, depending on the request's method.
   /// Returns nil for methods not handled by this service.
-  public func handleMethod(
-    _ methodName: Substring,
-    callHandlerContext: CallHandlerContext
-  ) -> GRPCCallHandler? {
-    switch methodName {
+  public func handle(
+    method name: Substring,
+    context: CallHandlerContext
+  ) -> GRPCServerHandlerProtocol? {
+    switch name {
     case "Start":
-      return CallHandlerFactory.makeUnary(
-        callHandlerContext: callHandlerContext,
-        interceptors: self.interceptors?.makeStartInterceptors() ?? []
-      ) { context in
-        return { request in
-          self.start(request: request, context: context)
-        }
-      }
+      return UnaryServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Grpc_Testing_ReconnectParams>(),
+        responseSerializer: ProtobufSerializer<Grpc_Testing_Empty>(),
+        interceptors: self.interceptors?.makeStartInterceptors() ?? [],
+        userFunction: self.start(request:context:)
+      )
 
     case "Stop":
-      return CallHandlerFactory.makeUnary(
-        callHandlerContext: callHandlerContext,
-        interceptors: self.interceptors?.makeStopInterceptors() ?? []
-      ) { context in
-        return { request in
-          self.stop(request: request, context: context)
-        }
-      }
+      return UnaryServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Grpc_Testing_Empty>(),
+        responseSerializer: ProtobufSerializer<Grpc_Testing_ReconnectInfo>(),
+        interceptors: self.interceptors?.makeStopInterceptors() ?? [],
+        userFunction: self.stop(request:context:)
+      )
 
     default:
       return nil

--- a/dev/codegen-tests/01-echo/golden/echo.grpc.swift
+++ b/dev/codegen-tests/01-echo/golden/echo.grpc.swift
@@ -194,46 +194,46 @@ extension Echo_EchoProvider {
 
   /// Determines, calls and returns the appropriate request handler, depending on the request's method.
   /// Returns nil for methods not handled by this service.
-  internal func handleMethod(
-    _ methodName: Substring,
-    callHandlerContext: CallHandlerContext
-  ) -> GRPCCallHandler? {
-    switch methodName {
+  internal func handle(
+    method name: Substring,
+    context: CallHandlerContext
+  ) -> GRPCServerHandlerProtocol? {
+    switch name {
     case "Get":
-      return CallHandlerFactory.makeUnary(
-        callHandlerContext: callHandlerContext,
-        interceptors: self.interceptors?.makeGetInterceptors() ?? []
-      ) { context in
-        return { request in
-          self.get(request: request, context: context)
-        }
-      }
+      return UnaryServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Echo_EchoRequest>(),
+        responseSerializer: ProtobufSerializer<Echo_EchoResponse>(),
+        interceptors: self.interceptors?.makeGetInterceptors() ?? [],
+        userFunction: self.get(request:context:)
+      )
 
     case "Expand":
-      return CallHandlerFactory.makeServerStreaming(
-        callHandlerContext: callHandlerContext,
-        interceptors: self.interceptors?.makeExpandInterceptors() ?? []
-      ) { context in
-        return { request in
-          self.expand(request: request, context: context)
-        }
-      }
+      return ServerStreamingServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Echo_EchoRequest>(),
+        responseSerializer: ProtobufSerializer<Echo_EchoResponse>(),
+        interceptors: self.interceptors?.makeExpandInterceptors() ?? [],
+        userFunction: self.expand(request:context:)
+      )
 
     case "Collect":
-      return CallHandlerFactory.makeClientStreaming(
-        callHandlerContext: callHandlerContext,
-        interceptors: self.interceptors?.makeCollectInterceptors() ?? []
-      ) { context in
-        self.collect(context: context)
-      }
+      return ClientStreamingServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Echo_EchoRequest>(),
+        responseSerializer: ProtobufSerializer<Echo_EchoResponse>(),
+        interceptors: self.interceptors?.makeCollectInterceptors() ?? [],
+        observerFactory: self.collect(context:)
+      )
 
     case "Update":
-      return CallHandlerFactory.makeBidirectionalStreaming(
-        callHandlerContext: callHandlerContext,
-        interceptors: self.interceptors?.makeUpdateInterceptors() ?? []
-      ) { context in
-        self.update(context: context)
-      }
+      return BidirectionalStreamingServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Echo_EchoRequest>(),
+        responseSerializer: ProtobufSerializer<Echo_EchoResponse>(),
+        interceptors: self.interceptors?.makeUpdateInterceptors() ?? [],
+        observerFactory: self.update(context:)
+      )
 
     default:
       return nil

--- a/dev/codegen-tests/02-multifile/golden/a.grpc.swift
+++ b/dev/codegen-tests/02-multifile/golden/a.grpc.swift
@@ -100,20 +100,19 @@ extension A_ServiceAProvider {
 
   /// Determines, calls and returns the appropriate request handler, depending on the request's method.
   /// Returns nil for methods not handled by this service.
-  internal func handleMethod(
-    _ methodName: Substring,
-    callHandlerContext: CallHandlerContext
-  ) -> GRPCCallHandler? {
-    switch methodName {
+  internal func handle(
+    method name: Substring,
+    context: CallHandlerContext
+  ) -> GRPCServerHandlerProtocol? {
+    switch name {
     case "CallServiceA":
-      return CallHandlerFactory.makeUnary(
-        callHandlerContext: callHandlerContext,
-        interceptors: self.interceptors?.makeCallServiceAInterceptors() ?? []
-      ) { context in
-        return { request in
-          self.callServiceA(request: request, context: context)
-        }
-      }
+      return UnaryServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<A_MessageA>(),
+        responseSerializer: ProtobufSerializer<SwiftProtobuf.Google_Protobuf_Empty>(),
+        interceptors: self.interceptors?.makeCallServiceAInterceptors() ?? [],
+        userFunction: self.callServiceA(request:context:)
+      )
 
     default:
       return nil

--- a/dev/codegen-tests/02-multifile/golden/b.grpc.swift
+++ b/dev/codegen-tests/02-multifile/golden/b.grpc.swift
@@ -100,20 +100,19 @@ extension B_ServiceBProvider {
 
   /// Determines, calls and returns the appropriate request handler, depending on the request's method.
   /// Returns nil for methods not handled by this service.
-  internal func handleMethod(
-    _ methodName: Substring,
-    callHandlerContext: CallHandlerContext
-  ) -> GRPCCallHandler? {
-    switch methodName {
+  internal func handle(
+    method name: Substring,
+    context: CallHandlerContext
+  ) -> GRPCServerHandlerProtocol? {
+    switch name {
     case "CallServiceB":
-      return CallHandlerFactory.makeUnary(
-        callHandlerContext: callHandlerContext,
-        interceptors: self.interceptors?.makeCallServiceBInterceptors() ?? []
-      ) { context in
-        return { request in
-          self.callServiceB(request: request, context: context)
-        }
-      }
+      return UnaryServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<B_MessageB>(),
+        responseSerializer: ProtobufSerializer<SwiftProtobuf.Google_Protobuf_Empty>(),
+        interceptors: self.interceptors?.makeCallServiceBInterceptors() ?? [],
+        userFunction: self.callServiceB(request:context:)
+      )
 
     default:
       return nil

--- a/dev/codegen-tests/03-multifile-with-module-map/golden/a.grpc.swift
+++ b/dev/codegen-tests/03-multifile-with-module-map/golden/a.grpc.swift
@@ -101,20 +101,19 @@ extension A_ServiceAProvider {
 
   /// Determines, calls and returns the appropriate request handler, depending on the request's method.
   /// Returns nil for methods not handled by this service.
-  internal func handleMethod(
-    _ methodName: Substring,
-    callHandlerContext: CallHandlerContext
-  ) -> GRPCCallHandler? {
-    switch methodName {
+  internal func handle(
+    method name: Substring,
+    context: CallHandlerContext
+  ) -> GRPCServerHandlerProtocol? {
+    switch name {
     case "CallServiceA":
-      return CallHandlerFactory.makeUnary(
-        callHandlerContext: callHandlerContext,
-        interceptors: self.interceptors?.makeCallServiceAInterceptors() ?? []
-      ) { context in
-        return { request in
-          self.callServiceA(request: request, context: context)
-        }
-      }
+      return UnaryServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<A_MessageA>(),
+        responseSerializer: ProtobufSerializer<SwiftProtobuf.Google_Protobuf_Empty>(),
+        interceptors: self.interceptors?.makeCallServiceAInterceptors() ?? [],
+        userFunction: self.callServiceA(request:context:)
+      )
 
     default:
       return nil

--- a/dev/codegen-tests/03-multifile-with-module-map/golden/b.grpc.swift
+++ b/dev/codegen-tests/03-multifile-with-module-map/golden/b.grpc.swift
@@ -100,20 +100,19 @@ extension B_ServiceBProvider {
 
   /// Determines, calls and returns the appropriate request handler, depending on the request's method.
   /// Returns nil for methods not handled by this service.
-  internal func handleMethod(
-    _ methodName: Substring,
-    callHandlerContext: CallHandlerContext
-  ) -> GRPCCallHandler? {
-    switch methodName {
+  internal func handle(
+    method name: Substring,
+    context: CallHandlerContext
+  ) -> GRPCServerHandlerProtocol? {
+    switch name {
     case "CallServiceB":
-      return CallHandlerFactory.makeUnary(
-        callHandlerContext: callHandlerContext,
-        interceptors: self.interceptors?.makeCallServiceBInterceptors() ?? []
-      ) { context in
-        return { request in
-          self.callServiceB(request: request, context: context)
-        }
-      }
+      return UnaryServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<B_MessageB>(),
+        responseSerializer: ProtobufSerializer<SwiftProtobuf.Google_Protobuf_Empty>(),
+        interceptors: self.interceptors?.makeCallServiceBInterceptors() ?? [],
+        userFunction: self.callServiceB(request:context:)
+      )
 
     default:
       return nil

--- a/dev/codegen-tests/04-service-with-message-import/golden/service.grpc.swift
+++ b/dev/codegen-tests/04-service-with-message-import/golden/service.grpc.swift
@@ -100,20 +100,19 @@ extension Codegentest_FooProvider {
 
   /// Determines, calls and returns the appropriate request handler, depending on the request's method.
   /// Returns nil for methods not handled by this service.
-  internal func handleMethod(
-    _ methodName: Substring,
-    callHandlerContext: CallHandlerContext
-  ) -> GRPCCallHandler? {
-    switch methodName {
+  internal func handle(
+    method name: Substring,
+    context: CallHandlerContext
+  ) -> GRPCServerHandlerProtocol? {
+    switch name {
     case "Get":
-      return CallHandlerFactory.makeUnary(
-        callHandlerContext: callHandlerContext,
-        interceptors: self.interceptors?.makeGetInterceptors() ?? []
-      ) { context in
-        return { request in
-          self.get(request: request, context: context)
-        }
-      }
+      return UnaryServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Codegentest_FooMessage>(),
+        responseSerializer: ProtobufSerializer<Codegentest_FooMessage>(),
+        interceptors: self.interceptors?.makeGetInterceptors() ?? [],
+        userFunction: self.get(request:context:)
+      )
 
     default:
       return nil

--- a/dev/codegen-tests/05-service-only/golden/test.grpc.swift
+++ b/dev/codegen-tests/05-service-only/golden/test.grpc.swift
@@ -100,20 +100,19 @@ extension Codegentest_FooProvider {
 
   /// Determines, calls and returns the appropriate request handler, depending on the request's method.
   /// Returns nil for methods not handled by this service.
-  internal func handleMethod(
-    _ methodName: Substring,
-    callHandlerContext: CallHandlerContext
-  ) -> GRPCCallHandler? {
-    switch methodName {
+  internal func handle(
+    method name: Substring,
+    context: CallHandlerContext
+  ) -> GRPCServerHandlerProtocol? {
+    switch name {
     case "Bar":
-      return CallHandlerFactory.makeUnary(
-        callHandlerContext: callHandlerContext,
-        interceptors: self.interceptors?.makeBarInterceptors() ?? []
-      ) { context in
-        return { request in
-          self.bar(request: request, context: context)
-        }
-      }
+      return UnaryServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<SwiftProtobuf.Google_Protobuf_Empty>(),
+        responseSerializer: ProtobufSerializer<SwiftProtobuf.Google_Protobuf_Empty>(),
+        interceptors: self.interceptors?.makeBarInterceptors() ?? [],
+        userFunction: self.bar(request:context:)
+      )
 
     default:
       return nil


### PR DESCRIPTION
Motivation:

We have new server handlers; all we need to do is generate the code to
use them.

Modifications:

- Update codegen
- Deprecate `handleMethod` with a message to re-generate server code
- Regenerate our own code

Result:

Instruction count reductions:
- unary_10k_small_requests: -4.7%
- embedded_server_unary_10k_small_requests: -25.4%
- embedded_server_client_streaming_1_rpc_10k_small_requests: -35.6%
- embedded_server_client_streaming_10k_rpcs_1_small_requests: -25.1%
- embedded_server_server_streaming_1_rpc_10k_small_responses: -14.1%
- embedded_server_server_streaming_10k_rpcs_1_small_response: -21.1%
- embedded_server_bidi_1_rpc_10k_small_requests: -29.2%
- embedded_server_bidi_10k_rpcs_1_small_request: -23.9%