### PR TITLE
Raise minimum Swift version to 5.2

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,5 +1,5 @@
 # Language version.
---swiftversion 5.1
+--swiftversion 5.2
 
 # Ignore generated files.
 --exclude **/LinuxMain.swift,**/XCTestManifests.swift,**/*.grpc.swift,**/*.pb.swift
@@ -31,3 +31,6 @@
 # We used to support 5.0 and return is redundant in more places in 5.1: enabling
 # this rule creates a large (and unnecessary) diff.
 --disable redundantReturn
+
+# Don't prefer using key paths for trivial closures.
+--disable preferKeyPath

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,10 +41,6 @@ jobs:
       script: ./.travis-script.sh
       env: SWIFT_VERSION=5.2.5
     - <<: *tests
-      name: "Unit Tests: Ubuntu 18.04 (Swift 5.1)"
-      script: ./.travis-script.sh
-      env: SWIFT_VERSION=5.1.5
-    - <<: *tests
       name: "Unit Tests: Xcode 12.2"
       os: osx
       osx_image: xcode12.2
@@ -65,9 +61,6 @@ jobs:
     - <<: *interop_tests
       name: "Interoperability Tests: Ubuntu 18.04 (Swift 5.2)"
       env: SWIFT_VERSION=5.2.5
-    - <<: *interop_tests
-      name: "Interoperability Tests: Ubuntu 18.04 (Swift 5.1)"
-      env: SWIFT_VERSION=5.1.5
     - <<: *interop_tests
       name: "Interoperability Tests: Xcode 12.2"
       os: osx

--- a/Examples/PCAPExample/Package.swift
+++ b/Examples/PCAPExample/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.2
 /*
  * Copyright 2020, gRPC Authors All rights reserved.
  *
@@ -23,6 +23,12 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-nio-extras", from: "1.4.0"),
   ],
   targets: [
-    .target(name: "PCAPExample", dependencies: ["GRPC", "NIOExtras"]),
+    .target(
+      name: "PCAPExample",
+      dependencies: [
+        .product(name: "GRPC", package: "grpc-swift"),
+        .product(name: "NIOExtras", package: "swift-nio-extras"),
+      ]
+    ),
   ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.2
 /*
  * Copyright 2017, gRPC Authors All rights reserved.
  *
@@ -37,7 +37,11 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.4.0"),
 
     // Official SwiftProtobuf library, for [de]serializing data to send on the wire.
-    .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.9.0"),
+    .package(
+      name: "SwiftProtobuf",
+      url: "https://github.com/apple/swift-protobuf.git",
+      from: "1.9.0"
+    ),
 
     // Logging API.
     .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),
@@ -47,27 +51,27 @@ let package = Package(
     .target(
       name: "GRPC",
       dependencies: [
-        "NIO",
-        "NIOFoundationCompat",
-        "NIOTransportServices",
-        "NIOHTTP1",
-        "NIOHTTP2",
-        "NIOExtras",
-        "NIOSSL",
-        "CGRPCZlib",
-        "SwiftProtobuf",
-        "Logging",
+        .product(name: "NIO", package: "swift-nio"),
+        .product(name: "NIOFoundationCompat", package: "swift-nio"),
+        .product(name: "NIOTransportServices", package: "swift-nio-transport-services"),
+        .product(name: "NIOHTTP1", package: "swift-nio"),
+        .product(name: "NIOHTTP2", package: "swift-nio-http2"),
+        .product(name: "NIOExtras", package: "swift-nio-extras"),
+        .product(name: "NIOSSL", package: "swift-nio-ssl"),
+        .product(name: "SwiftProtobuf", package: "SwiftProtobuf"),
+        .product(name: "Logging", package: "swift-log"),
+        .target(name: "CGRPCZlib"),
       ]
     ), // and its tests.
     .testTarget(
       name: "GRPCTests",
       dependencies: [
-        "GRPC",
-        "EchoModel",
-        "EchoImplementation",
-        "GRPCSampleData",
-        "GRPCInteroperabilityTestsImplementation",
-        "HelloWorldModel",
+        .target(name: "GRPC"),
+        .target(name: "EchoModel"),
+        .target(name: "EchoImplementation"),
+        .target(name: "GRPCSampleData"),
+        .target(name: "GRPCInteroperabilityTestsImplementation"),
+        .target(name: "HelloWorldModel"),
       ]
     ),
 
@@ -82,9 +86,8 @@ let package = Package(
     .target(
       name: "protoc-gen-grpc-swift",
       dependencies: [
-        "SwiftProtobuf",
-        "SwiftProtobufPluginLibrary",
-        "protoc-gen-swift",
+        .product(name: "SwiftProtobuf", package: "SwiftProtobuf"),
+        .product(name: "SwiftProtobufPluginLibrary", package: "SwiftProtobuf"),
       ]
     ),
 
@@ -92,8 +95,8 @@ let package = Package(
     .target(
       name: "GRPCInteroperabilityTestsImplementation",
       dependencies: [
-        "GRPC",
-        "GRPCInteroperabilityTestModels",
+        .target(name: "GRPC"),
+        .target(name: "GRPCInteroperabilityTestModels"),
       ]
     ),
 
@@ -101,10 +104,10 @@ let package = Package(
     .target(
       name: "GRPCInteroperabilityTestModels",
       dependencies: [
-        "GRPC",
-        "NIO",
-        "NIOHTTP1",
-        "SwiftProtobuf",
+        .target(name: "GRPC"),
+        .product(name: "NIO", package: "swift-nio"),
+        .product(name: "NIOHTTP1", package: "swift-nio"),
+        .product(name: "SwiftProtobuf", package: "SwiftProtobuf"),
       ]
     ),
 
@@ -112,8 +115,7 @@ let package = Package(
     .target(
       name: "GRPCInteroperabilityTests",
       dependencies: [
-        "GRPCInteroperabilityTestsImplementation",
-        "Logging",
+        .target(name: "GRPCInteroperabilityTestsImplementation"),
       ]
     ),
 
@@ -121,9 +123,9 @@ let package = Package(
     .target(
       name: "GRPCConnectionBackoffInteropTest",
       dependencies: [
-        "GRPC",
-        "GRPCInteroperabilityTestModels",
-        "Logging",
+        .target(name: "GRPC"),
+        .target(name: "GRPCInteroperabilityTestModels"),
+        .product(name: "Logging", package: "swift-log"),
       ]
     ),
 
@@ -131,28 +133,29 @@ let package = Package(
     .target(
       name: "GRPCPerformanceTests",
       dependencies: [
-        "GRPC",
-        "EchoModel",
-        "NIO",
-        "NIOSSL",
+        .target(name: "GRPC"),
+        .target(name: "EchoModel"),
+        .product(name: "NIO", package: "swift-nio"),
       ]
     ),
 
     // Sample data, used in examples and tests.
     .target(
       name: "GRPCSampleData",
-      dependencies: ["NIOSSL"]
+      dependencies: [
+        .product(name: "NIOSSL", package: "swift-nio-ssl"),
+      ]
     ),
 
     // Echo example CLI.
     .target(
       name: "Echo",
       dependencies: [
-        "EchoModel",
-        "EchoImplementation",
-        "GRPC",
-        "GRPCSampleData",
-        "SwiftProtobuf",
+        .target(name: "EchoModel"),
+        .target(name: "EchoImplementation"),
+        .target(name: "GRPC"),
+        .target(name: "GRPCSampleData"),
+        .product(name: "SwiftProtobuf", package: "SwiftProtobuf"),
       ],
       path: "Sources/Examples/Echo/Runtime"
     ),
@@ -161,9 +164,9 @@ let package = Package(
     .target(
       name: "EchoImplementation",
       dependencies: [
-        "EchoModel",
-        "GRPC",
-        "SwiftProtobuf",
+        .target(name: "EchoModel"),
+        .target(name: "GRPC"),
+        .product(name: "SwiftProtobuf", package: "SwiftProtobuf"),
       ],
       path: "Sources/Examples/Echo/Implementation"
     ),
@@ -172,10 +175,9 @@ let package = Package(
     .target(
       name: "EchoModel",
       dependencies: [
-        "GRPC",
-        "NIO",
-        "NIOHTTP1",
-        "SwiftProtobuf",
+        .target(name: "GRPC"),
+        .product(name: "NIO", package: "swift-nio"),
+        .product(name: "SwiftProtobuf", package: "SwiftProtobuf"),
       ],
       path: "Sources/Examples/Echo/Model"
     ),
@@ -184,10 +186,9 @@ let package = Package(
     .target(
       name: "HelloWorldModel",
       dependencies: [
-        "GRPC",
-        "NIO",
-        "NIOHTTP1",
-        "SwiftProtobuf",
+        .target(name: "GRPC"),
+        .product(name: "NIO", package: "swift-nio"),
+        .product(name: "SwiftProtobuf", package: "SwiftProtobuf"),
       ],
       path: "Sources/Examples/HelloWorld/Model"
     ),
@@ -196,8 +197,8 @@ let package = Package(
     .target(
       name: "HelloWorldClient",
       dependencies: [
-        "GRPC",
-        "HelloWorldModel",
+        .target(name: "GRPC"),
+        .target(name: "HelloWorldModel"),
       ],
       path: "Sources/Examples/HelloWorld/Client"
     ),
@@ -206,9 +207,9 @@ let package = Package(
     .target(
       name: "HelloWorldServer",
       dependencies: [
-        "GRPC",
-        "NIO",
-        "HelloWorldModel",
+        .target(name: "GRPC"),
+        .product(name: "NIO", package: "swift-nio"),
+        .target(name: "HelloWorldModel"),
       ],
       path: "Sources/Examples/HelloWorld/Server"
     ),
@@ -217,10 +218,9 @@ let package = Package(
     .target(
       name: "RouteGuideModel",
       dependencies: [
-        "GRPC",
-        "NIO",
-        "NIOHTTP1",
-        "SwiftProtobuf",
+        .target(name: "GRPC"),
+        .product(name: "NIO", package: "swift-nio"),
+        .product(name: "SwiftProtobuf", package: "SwiftProtobuf"),
       ],
       path: "Sources/Examples/RouteGuide/Model"
     ),
@@ -229,8 +229,8 @@ let package = Package(
     .target(
       name: "RouteGuideClient",
       dependencies: [
-        "GRPC",
-        "RouteGuideModel",
+        .target(name: "GRPC"),
+        .target(name: "RouteGuideModel"),
       ],
       path: "Sources/Examples/RouteGuide/Client"
     ),
@@ -239,9 +239,9 @@ let package = Package(
     .target(
       name: "RouteGuideServer",
       dependencies: [
-        "GRPC",
-        "NIO",
-        "RouteGuideModel",
+        .target(name: "GRPC"),
+        .product(name: "NIO", package: "swift-nio"),
+        .target(name: "RouteGuideModel"),
       ],
       path: "Sources/Examples/RouteGuide/Server"
     ),

--- a/Performance/QPSBenchmark/Package.swift
+++ b/Performance/QPSBenchmark/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.2
 /*
  * Copyright 2020, gRPC Authors All rights reserved.
  *
@@ -32,24 +32,37 @@ let package = Package(
       url: "https://github.com/swift-server/swift-service-lifecycle.git",
       from: "1.0.0-alpha"
     ),
-    .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.9.0"),
+    .package(
+      name: "SwiftProtobuf",
+      url: "https://github.com/apple/swift-protobuf.git",
+      from: "1.9.0"
+    ),
   ],
   targets: [
-    .target(name: "QPSBenchmark", dependencies: [
-      "GRPC",
-      "NIO",
-      "ArgumentParser",
-      "Logging",
-      "Lifecycle",
-      "SwiftProtobuf",
-      "BenchmarkUtils",
-    ]),
-    .target(name: "BenchmarkUtils", dependencies: [
-      "GRPC",
-    ]),
-    .testTarget(name: "BenchmarkUtilsTests", dependencies: [
-      "GRPC",
-      "BenchmarkUtils",
-    ]),
+    .target(
+      name: "QPSBenchmark",
+      dependencies: [
+        .product(name: "GRPC", package: "grpc-swift"),
+        .product(name: "NIO", package: "swift-nio"),
+        .product(name: "ArgumentParser", package: "swift-argument-parser"),
+        .product(name: "Logging", package: "swift-log"),
+        .product(name: "Lifecycle", package: "swift-service-lifecycle"),
+        .product(name: "SwiftProtobuf", package: "SwiftProtobuf"),
+        .target(name: "BenchmarkUtils"),
+      ]
+    ),
+    .target(
+      name: "BenchmarkUtils",
+      dependencies: [
+        .product(name: "GRPC", package: "grpc-swift"),
+      ]
+    ),
+    .testTarget(
+      name: "BenchmarkUtilsTests",
+      dependencies: [
+        .product(name: "GRPC", package: "grpc-swift"),
+        .target(name: "BenchmarkUtils"),
+      ]
+    ),
   ]
 )

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The remainder of this README refers to the 1.x version of gRPC Swift.
 gRPC Swift's platform support is identical to the [platform support of Swift
 NIO][swift-nio-platforms].
 
-Note that gRPC Swift uses NIO 2 and requires Swift to be version 5.1 or higher.
+Note that gRPC Swift uses NIO 2 and requires Swift to be version 5.2 or higher.
 
 ## Getting gRPC Swift
 
@@ -45,8 +45,7 @@ There are two parts to gRPC Swift: the gRPC library and an API code generator.
 #### Swift Package Manager
 
 The Swift Package Manager is the preferred way to get gRPC Swift. Simply add the
-package dependency to your `Package.swift` and depend on `"GRPC"` in the
-necessary targets:
+package dependency to your `Package.swift`:
 
 ```swift
 dependencies: [
@@ -54,25 +53,13 @@ dependencies: [
 ]
 ```
 
-The syntax for target dependencies changed in Swift 5.2 and requires the package
-of each dependency to be specified.
-
-For Swift 5.2 (`swift-tools-version:5.2`) and later:
+...and depend on `"GRPC"` in the necessary targets:
 
 ```swift
 .target(
   name: ...,
   dependencies: [.product(name: "GRPC", package: "grpc-swift")]
-)
-```
-
-For Swift 5.1 (`swift-tools-version:5.1`):
-
-```swift
-.target(
-  name: ...,
-  dependencies: ["GRPC"]
-)
+]
 ```
 
 ##### Xcode


### PR DESCRIPTION
Motivation:

We recently raised the minimum Swift version to 5.1; the community are
okay with us raising this further. Raising the supported version lowers
our support burden and unlocks new language features.

Modifications:

- Use swift-tools-version:5.2, and update package description
- Update .swiftformat
- Update README
- Drop 5.1 CI

Result:

Resolves #1072