### PR TITLE
Added support for NIOSSLCustomVerificationCallback for client connection

### DIFF
--- a/Sources/GRPC/ConnectionManager.swift
+++ b/Sources/GRPC/ConnectionManager.swift
@@ -853,7 +853,8 @@ extension ConnectionManager {
             group: self.eventLoop,
             hasTLS: self.configuration.tls != nil
           ),
-          logger: self.logger
+          logger: self.logger,
+          customVerificationCallback: self.configuration.customVerificationCallback
         )
 
         // Run the debug initializer, if there is one.

--- a/Sources/GRPC/ConnectionManager.swift
+++ b/Sources/GRPC/ConnectionManager.swift
@@ -854,7 +854,7 @@ extension ConnectionManager {
             hasTLS: self.configuration.tls != nil
           ),
           logger: self.logger,
-          customVerificationCallback: self.configuration.customVerificationCallback
+          customVerificationCallback: self.configuration.tls?.customVerificationCallback
         )
 
         // Run the debug initializer, if there is one.

--- a/Sources/GRPC/GRPCChannel/GRPCChannelBuilder.swift
+++ b/Sources/GRPC/GRPCChannel/GRPCChannelBuilder.swift
@@ -235,6 +235,16 @@ extension ClientConnection.Builder.Secure {
     self.tls.certificateVerification = certificateVerification
     return self
   }
+
+  /// A custom verification callback that allows completely overriding the certificate verification logic.
+  @discardableResult
+  public func withCustomVerificationCallback(
+    _ callback: @escaping NIOSSLCustomVerificationCallback
+  )
+    -> Self {
+    self.tls.customVerificationCallback = callback
+    return self
+  }
 }
 
 extension ClientConnection.Builder {
@@ -269,16 +279,6 @@ extension ClientConnection.Builder {
     _ debugChannelInitializer: @escaping (Channel) -> EventLoopFuture<Void>
   ) -> Self {
     self.configuration.debugChannelInitializer = debugChannelInitializer
-    return self
-  }
-}
-
-extension ClientConnection.Builder {
-
-  /// A custom verification callback that allows completely overriding the certificate verification logic.
-  @discardableResult
-    public func withCustomVerification(callback: @escaping NIOSSLCustomVerificationCallback) -> Self {
-    self.configuration.customVerificationCallback = callback
     return self
   }
 }

--- a/Sources/GRPC/GRPCChannel/GRPCChannelBuilder.swift
+++ b/Sources/GRPC/GRPCChannel/GRPCChannelBuilder.swift
@@ -240,8 +240,7 @@ extension ClientConnection.Builder.Secure {
   @discardableResult
   public func withCustomVerificationCallback(
     _ callback: @escaping NIOSSLCustomVerificationCallback
-  )
-    -> Self {
+  ) -> Self {
     self.tls.customVerificationCallback = callback
     return self
   }

--- a/Sources/GRPC/GRPCChannel/GRPCChannelBuilder.swift
+++ b/Sources/GRPC/GRPCChannel/GRPCChannelBuilder.swift
@@ -238,7 +238,7 @@ extension ClientConnection.Builder.Secure {
 
   /// A custom verification callback that allows completely overriding the certificate verification logic.
   @discardableResult
-  public func withCustomVerificationCallback(
+  public func withTLSCustomVerificationCallback(
     _ callback: @escaping NIOSSLCustomVerificationCallback
   ) -> Self {
     self.tls.customVerificationCallback = callback

--- a/Sources/GRPC/GRPCChannel/GRPCChannelBuilder.swift
+++ b/Sources/GRPC/GRPCChannel/GRPCChannelBuilder.swift
@@ -273,6 +273,16 @@ extension ClientConnection.Builder {
   }
 }
 
+extension ClientConnection.Builder {
+
+  /// A custom verification callback that allows completely overriding the certificate verification logic.
+  @discardableResult
+    public func withCustomVerification(callback: @escaping NIOSSLCustomVerificationCallback) -> Self {
+    self.configuration.customVerificationCallback = callback
+    return self
+  }
+}
+
 private extension Double {
   static func seconds(from amount: TimeAmount) -> Double {
     return Double(amount.nanoseconds) / 1_000_000_000

--- a/Sources/GRPC/TLSConfiguration.swift
+++ b/Sources/GRPC/TLSConfiguration.swift
@@ -68,6 +68,9 @@ extension ClientConnection.Configuration {
       }
     }
 
+    /// A custom verification callback that allows completely overriding the certificate verification logic for this connection.
+    public var customVerificationCallback: NIOSSLCustomVerificationCallback?
+
     /// TLS Configuration with suitable defaults for clients.
     ///
     /// This is a wrapper around `NIOSSL.TLSConfiguration` to restrict input to values which comply
@@ -83,12 +86,15 @@ extension ClientConnection.Configuration {
     ///     `.fullVerification`.
     /// - Parameter hostnameOverride: Value to use for TLS SNI extension; this must not be an IP
     ///     address, defaults to `nil`.
+    /// - Parameter customVerificationCallback: A callback to provide to override the certificate verification logic,
+    ///     defaults to `nil`.
     public init(
       certificateChain: [NIOSSLCertificateSource] = [],
       privateKey: NIOSSLPrivateKeySource? = nil,
       trustRoots: NIOSSLTrustRoots = .default,
       certificateVerification: CertificateVerification = .fullVerification,
-      hostnameOverride: String? = nil
+      hostnameOverride: String? = nil,
+      customVerificationCallback: NIOSSLCustomVerificationCallback? = nil
     ) {
       self.configuration = .forClient(
         minimumTLSVersion: .tlsv12,
@@ -99,6 +105,7 @@ extension ClientConnection.Configuration {
         applicationProtocols: GRPCApplicationProtocolIdentifier.client
       )
       self.hostnameOverride = hostnameOverride
+      self.customVerificationCallback = customVerificationCallback
     }
 
     /// Creates a TLS Configuration using the given `NIOSSL.TLSConfiguration`.


### PR DESCRIPTION
Hi,

This PR adds the ability for client connections to override the certificate verification logic implemented in nio-ssl.

The main goal is to allow client apps to perform their own certificate verification logic, such as SSL public key pinning.
Nio-ssl provide this feature as described here: [nio-ssl-issue-25](https://github.com/apple/swift-nio-ssl/issues/25) 
But I wasn't able to use it through grpc-swift because the `NIOSSLCustomVerificationCallback` is not accessible when initializing a secure `ClientConnection`.

I exposed a `NIOSSLCustomVerificationCallback` property in `ClientConnection.Configuration` struct and provided a `ClientConnection.Builder` func as well.

## Usage example for client public key pinning

```swift
let myPublicKey = Array(Data(base64Encoded: """
.... (Your base64 encoded public key)
""", options: .ignoreUnknownCharacters)!)

ClientConnection.secure(group: PlatformSupport.makeEventLoopGroup(loopCount: 1))
            .withTLSCustomVerificationCallback({ cert, eventLoopVerification in
                // Extract the leaf certificate's public key,
                // then compare it to the one you have.
                if let leaf = cert.first,
                   let publicKey = try? leaf.extractPublicKey() {

                    if let certSPKI = try? publicKey.toSPKIBytes(),
                       myPublicKey == certSPKI {
                        eventLoopVerification.succeed(.certificateVerified)
                    } else {
                        eventLoopVerification.fail(NIOSSLError.unableToValidateCertificate)
                    }
                } else {
                    eventLoopVerification.fail(NIOSSLError.noCertificateToValidate)
                }
            })
            .connect(host: host, port: port)
```

This PR + the example above should resolve #723 and resolve #1104 