### PR TITLE
Emit fewer flushes when handling RPCs on the server

### DIFF
--- a/Sources/GRPC/CallHandlers/BidirectionalStreamingServerHandler.swift
+++ b/Sources/GRPC/CallHandlers/BidirectionalStreamingServerHandler.swift
@@ -353,7 +353,7 @@ public final class BidirectionalStreamingServerHandler<
   ) {
     switch part {
     case let .metadata(headers):
-      self.context.responseWriter.sendMetadata(headers, promise: promise)
+      self.context.responseWriter.sendMetadata(headers, flush: true, promise: promise)
 
     case let .message(message, metadata):
       do {

--- a/Sources/GRPC/CallHandlers/ClientStreamingServerHandler.swift
+++ b/Sources/GRPC/CallHandlers/ClientStreamingServerHandler.swift
@@ -339,7 +339,7 @@ public final class ClientStreamingServerHandler<
   ) {
     switch part {
     case let .metadata(headers):
-      self.context.responseWriter.sendMetadata(headers, promise: promise)
+      self.context.responseWriter.sendMetadata(headers, flush: true, promise: promise)
 
     case let .message(message, metadata):
       do {

--- a/Sources/GRPC/CallHandlers/ServerHandlerProtocol.swift
+++ b/Sources/GRPC/CallHandlers/ServerHandlerProtocol.swift
@@ -49,8 +49,9 @@ internal protocol GRPCServerResponseWriter {
   /// Send the initial response metadata.
   /// - Parameters:
   ///   - metadata: The user-provided metadata to send to the client.
+  ///   - flush: Whether a flush should be emitted after writing the metadata.
   ///   - promise: A promise to complete once the metadata has been handled.
-  func sendMetadata(_ metadata: HPACKHeaders, promise: EventLoopPromise<Void>?)
+  func sendMetadata(_ metadata: HPACKHeaders, flush: Bool, promise: EventLoopPromise<Void>?)
 
   /// Send the serialized bytes of a response message.
   /// - Parameters:

--- a/Sources/GRPC/CallHandlers/ServerStreamingServerHandler.swift
+++ b/Sources/GRPC/CallHandlers/ServerStreamingServerHandler.swift
@@ -279,7 +279,7 @@ public final class ServerStreamingServerHandler<
   ) {
     switch part {
     case let .metadata(headers):
-      self.context.responseWriter.sendMetadata(headers, promise: promise)
+      self.context.responseWriter.sendMetadata(headers, flush: true, promise: promise)
 
     case let .message(message, metadata):
       do {

--- a/Sources/GRPC/CallHandlers/UnaryServerHandler.swift
+++ b/Sources/GRPC/CallHandlers/UnaryServerHandler.swift
@@ -262,7 +262,8 @@ public final class UnaryServerHandler<
   ) {
     switch part {
     case let .metadata(headers):
-      self.context.responseWriter.sendMetadata(headers, promise: promise)
+      // We can delay this flush until the end of the RPC.
+      self.context.responseWriter.sendMetadata(headers, flush: false, promise: promise)
 
     case let .message(message, metadata):
       do {

--- a/Tests/GRPCTests/HTTP2ToRawGRPCStateMachineTests.swift
+++ b/Tests/GRPCTests/HTTP2ToRawGRPCStateMachineTests.swift
@@ -656,7 +656,7 @@ extension ServerMessageEncoding {
 }
 
 class NoOpResponseWriter: GRPCServerResponseWriter {
-  func sendMetadata(_ metadata: HPACKHeaders, promise: EventLoopPromise<Void>?) {
+  func sendMetadata(_ metadata: HPACKHeaders, flush: Bool, promise: EventLoopPromise<Void>?) {
     promise?.succeed(())
   }
 

--- a/Tests/GRPCTests/UnaryServerHandlerTests.swift
+++ b/Tests/GRPCTests/UnaryServerHandlerTests.swift
@@ -27,7 +27,7 @@ final class ResponseRecorder: GRPCServerResponseWriter {
   var status: GRPCStatus?
   var trailers: HPACKHeaders?
 
-  func sendMetadata(_ metadata: HPACKHeaders, promise: EventLoopPromise<Void>?) {
+  func sendMetadata(_ metadata: HPACKHeaders, flush: Bool, promise: EventLoopPromise<Void>?) {
     XCTAssertNil(self.metadata)
     self.metadata = metadata
     promise?.succeed(())


### PR DESCRIPTION
Motivation:

The changes in #1101 included a change in when flushes were emitted.
For unary RPCs this led to an additional flush, which in some
circumstances led to a drop in QPS of approximately 5%.

Modifications:

- Introduce an option as to whether a flush should be emitted when
  writing initial response metadata
- Fix a bug where the request to flush or not for messages was ignored

Result:

A 5% increase in QPS for the unary-single benchmark (single connection,
one rpc at a time).