### PR TITLE
Drop support for the old way of handling RPCs on the server

### DIFF
--- a/Tests/GRPCTests/XCTestHelpers.swift
+++ b/Tests/GRPCTests/XCTestHelpers.swift
@@ -481,7 +481,7 @@ struct Matcher<Value> {
   static func configure() -> Matcher<HTTP2ToRawGRPCStateMachine.ReceiveHeadersAction> {
     return .init { actual in
       switch actual {
-      case .configureLegacy, .configure:
+      case .configure:
         return .match
       default:
         return .noMatch(actual: "\(actual)", expected: "configurePipeline")


### PR DESCRIPTION
Motivation:

We said in the last release that the old method of handling RPCs would
be dropped in a future release.

Modifications:

- Drop support for 'legacyHandler' in 'HTTP2ToRawGRPCServerCodec'
- Make 'HTTP2ToRawGRPCServerCodec' an 'InboundChannelHandler'

Result:

We no longer support the old way of doing RPCs.