### PR TITLE
Use swift-argument-parser for examples etc

### DIFF
--- a/.travis-script.sh
+++ b/.travis-script.sh
@@ -108,9 +108,9 @@ run_interop_tests() {
   # Run the tests; logs are written to stderr, capture them per-test.
   for test in "${TESTS[@]}"; do
     info "Running $test"
-    $BUILD_OUTPUT/GRPCInteroperabilityTests run_test \
-      "localhost" \
-      "$INTEROP_TEST_SERVER_PORT" \
+    $BUILD_OUTPUT/GRPCInteroperabilityTests run-test \
+      --host "localhost" \
+      --port "$INTEROP_TEST_SERVER_PORT" \
       "$test" \
         2> "interop.$test.log"
     success "PASSED $test"
@@ -142,8 +142,8 @@ run_interop_reconnect_test() {
   info "Running connection backoff interop test"
   # Run the test; logs are written to stderr, redirect them to a file.
   ${BUILD_OUTPUT}/GRPCConnectionBackoffInteropTest \
-    ${INTEROP_TEST_SERVER_CONTROL_PORT} \
-    ${INTEROP_TEST_SERVER_RETRY_PORT} \
+    --control-port ${INTEROP_TEST_SERVER_CONTROL_PORT} \
+    --retry-port ${INTEROP_TEST_SERVER_RETRY_PORT} \
       2> "interop.connection_backoff.log"
   success "connection backoff interop test PASSED"
 

--- a/Package.swift
+++ b/Package.swift
@@ -45,6 +45,10 @@ let package = Package(
 
     // Logging API.
     .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),
+
+    // Argument parsering: only for internal targets (i.e. examples).
+    // swift-argument-parser only provides source compatability guarantees between minor version.
+    .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.3.0")),
   ],
   targets: [
     // The main GRPC module.
@@ -116,6 +120,7 @@ let package = Package(
       name: "GRPCInteroperabilityTests",
       dependencies: [
         .target(name: "GRPCInteroperabilityTestsImplementation"),
+        .product(name: "ArgumentParser", package: "swift-argument-parser"),
       ]
     ),
 
@@ -126,6 +131,7 @@ let package = Package(
         .target(name: "GRPC"),
         .target(name: "GRPCInteroperabilityTestModels"),
         .product(name: "Logging", package: "swift-log"),
+        .product(name: "ArgumentParser", package: "swift-argument-parser"),
       ]
     ),
 
@@ -136,6 +142,7 @@ let package = Package(
         .target(name: "GRPC"),
         .target(name: "EchoModel"),
         .product(name: "NIO", package: "swift-nio"),
+        .product(name: "ArgumentParser", package: "swift-argument-parser"),
       ]
     ),
 
@@ -156,6 +163,7 @@ let package = Package(
         .target(name: "GRPC"),
         .target(name: "GRPCSampleData"),
         .product(name: "SwiftProtobuf", package: "SwiftProtobuf"),
+        .product(name: "ArgumentParser", package: "swift-argument-parser"),
       ],
       path: "Sources/Examples/Echo/Runtime"
     ),
@@ -199,6 +207,7 @@ let package = Package(
       dependencies: [
         .target(name: "GRPC"),
         .target(name: "HelloWorldModel"),
+        .product(name: "ArgumentParser", package: "swift-argument-parser"),
       ],
       path: "Sources/Examples/HelloWorld/Client"
     ),
@@ -210,6 +219,7 @@ let package = Package(
         .target(name: "GRPC"),
         .product(name: "NIO", package: "swift-nio"),
         .target(name: "HelloWorldModel"),
+        .product(name: "ArgumentParser", package: "swift-argument-parser"),
       ],
       path: "Sources/Examples/HelloWorld/Server"
     ),
@@ -231,6 +241,7 @@ let package = Package(
       dependencies: [
         .target(name: "GRPC"),
         .target(name: "RouteGuideModel"),
+        .product(name: "ArgumentParser", package: "swift-argument-parser"),
       ],
       path: "Sources/Examples/RouteGuide/Client"
     ),
@@ -242,6 +253,7 @@ let package = Package(
         .target(name: "GRPC"),
         .product(name: "NIO", package: "swift-nio"),
         .target(name: "RouteGuideModel"),
+        .product(name: "ArgumentParser", package: "swift-argument-parser"),
       ],
       path: "Sources/Examples/RouteGuide/Server"
     ),

--- a/Sources/Examples/Echo/README.md
+++ b/Sources/Examples/Echo/README.md
@@ -9,42 +9,40 @@ There are three subdirectories:
 * `Implementation` containing the server implementation of the generated model,
 * `Runtime` containing a CLI for the server and client.
 
-## Running
-
 ### Server
 
-To start the server on a free port run:
+To start the server run:
 
 ```sh
-swift run Echo server 0
+swift run Echo server
 ```
 
-To start the server with TLS enabled on port 1234:
+By default the server listens on port 1234. The port may also be specified by
+passing the `--port` option. Other options may be found by running:
 
 ```sh
-swift run Echo server --tls 1234
+swift run Echo server --help
 ```
 
 ### Client
 
-To invoke the 'get' (unary) RPC with the message "Hello, World!" against a
-server listening on port 5678 run:
+To invoke the 'get' (unary) RPC with the message "Hello, World!" against the
+server:
 
 ```sh
-swift run Echo 5678 get "Hello, World!"
+swift run Echo client "Hello, World!"
 ```
 
-To invoke the 'update' (bidirectional streaming) RPC against a server with TLS
-enabled listening on port 1234 run:
+Different RPC types can be called using the `--rpc` flag (which defaults to
+'get'):
+- 'get': a unary RPC; one request and one response
+- 'collect': a client streaming RPC; multiple requests and one response
+- 'expand': a server streaming RPC; one request and multiple responses
+- 'update': a bidirectional streaming RPC; multiple requests and multiple
+  responses
+
+Additional options may be found by running:
 
 ```sh
-swift run Echo --tls 1234 update "Hello from the client!"
-```
-
-The client may also be run with an `--intercept` flag, this will print
-additional information about each RPC and is covered in more detail in the
-interceptors tutorial (in the `docs` directory of this project):
-
-```sh
-swift run Echo --tls --intercept 1234 get "Hello from the interceptors!"
+swift run Echo client --help
 ```

--- a/Sources/Examples/HelloWorld/Client/main.swift
+++ b/Sources/Examples/HelloWorld/Client/main.swift
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import ArgumentParser
 import GRPC
 import HelloWorldModel
 import Logging
@@ -36,18 +37,14 @@ func greet(name: String?, client greeter: Helloworld_GreeterClient) {
   }
 }
 
-func main(args: [String]) {
-  // arg0 (dropped) is the program name. We expect arg1 to be the port, and arg2 (optional) to be
-  // the name sent in the request.
-  let arg1 = args.dropFirst(1).first
-  let arg2 = args.dropFirst(2).first
+struct HelloWorld: ParsableCommand {
+  @Option(help: "The port to connect to")
+  var port: Int = 1234
 
-  switch (arg1.flatMap(Int.init), arg2) {
-  case (.none, _):
-    print("Usage: PORT [NAME]")
-    exit(1)
+  @Argument(help: "The name to greet")
+  var name: String?
 
-  case let (.some(port), name):
+  func run() throws {
     // Setup an `EventLoopGroup` for the connection to run on.
     //
     // See: https://github.com/apple/swift-nio#eventloops-and-eventloopgroups
@@ -60,7 +57,7 @@ func main(args: [String]) {
 
     // Configure the channel, we're not using TLS so the connection is `insecure`.
     let channel = ClientConnection.insecure(group: group)
-      .connect(host: "localhost", port: port)
+      .connect(host: "localhost", port: self.port)
 
     // Close the connection when we're done with it.
     defer {
@@ -71,8 +68,8 @@ func main(args: [String]) {
     let greeter = Helloworld_GreeterClient(channel: channel)
 
     // Do the greeting.
-    greet(name: name, client: greeter)
+    greet(name: self.name, client: greeter)
   }
 }
 
-main(args: CommandLine.arguments)
+HelloWorld.main()

--- a/Sources/Examples/HelloWorld/README.md
+++ b/Sources/Examples/HelloWorld/README.md
@@ -14,21 +14,17 @@ To start the server run:
 swift run HelloWorldServer
 ```
 
-Note the port the server is listening on.
-
 ### Client
 
-To send a message to the server run the following, replacing `<PORT>` with the
-port the server is listening on:
+To send a message to the server run the following:
 
 ```sh
-swift run HelloWorldClient <PORT>
+swift run HelloWorldClient
 ```
 
 You may also greet a particular person (or dog). For example, to greet
-[PanCakes](https://grpc.io/blog/hello-pancakes/) on a server listening on port
-1234 run:
+[PanCakes](https://grpc.io/blog/hello-pancakes/) run:
 
 ```sh
-swift run HelloWorldClient 1234 "PanCakes"
+swift run HelloWorldClient PanCakes
 ```

--- a/Sources/Examples/HelloWorld/Server/main.swift
+++ b/Sources/Examples/HelloWorld/Server/main.swift
@@ -13,28 +13,38 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import ArgumentParser
 import GRPC
 import HelloWorldModel
 import Logging
 import NIO
 
-let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-defer {
-  try! group.syncShutdownGracefully()
+struct HelloWorld: ParsableCommand {
+  @Option(help: "The port to listen on for new connections")
+  var port = 1234
+
+  func run() throws {
+    let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    defer {
+      try! group.syncShutdownGracefully()
+    }
+
+    // Start the server and print its address once it has started.
+    let server = Server.insecure(group: group)
+      .withServiceProviders([GreeterProvider()])
+      .bind(host: "localhost", port: self.port)
+
+    server.map {
+      $0.channel.localAddress
+    }.whenSuccess { address in
+      print("server started on port \(address!.port!)")
+    }
+
+    // Wait on the server's `onClose` future to stop the program from exiting.
+    _ = try server.flatMap {
+      $0.onClose
+    }.wait()
+  }
 }
 
-// Start the server and print its address once it has started.
-let server = Server.insecure(group: group)
-  .withServiceProviders([GreeterProvider()])
-  .bind(host: "localhost", port: 0)
-
-server.map {
-  $0.channel.localAddress
-}.whenSuccess { address in
-  print("server started on port \(address!.port!)")
-}
-
-// Wait on the server's `onClose` future to stop the program from exiting.
-_ = try server.flatMap {
-  $0.onClose
-}.wait()
+HelloWorld.main()

--- a/Sources/Examples/RouteGuide/README.md
+++ b/Sources/Examples/RouteGuide/README.md
@@ -14,11 +14,10 @@ To start the server, from the root of this package run:
 $ swift run RouteGuideServer
 ```
 
-Once the server has started it will print out the port is listening on. This
-must be passed to the client.
+From another terminal, run the client:
 
 ```sh
-$ swift run RouteGuideClient <PORT>
+$ swift run RouteGuideClient
 ```
 
 ## Regenerating client and server code

--- a/Sources/GRPCConnectionBackoffInteropTest/main.swift
+++ b/Sources/GRPCConnectionBackoffInteropTest/main.swift
@@ -13,17 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import ArgumentParser
 import Foundation
 import GRPC
 import GRPCInteroperabilityTestModels
 import Logging
 import NIO
-
-let args = CommandLine.arguments
-guard args.count == 3, let controlPort = Int(args[1]), let retryPort = Int(args[2]) else {
-  print("Usage: \(args[0]) <server_control_port> <server_retry_port>")
-  exit(1)
-}
 
 // Notes from the test procedure are inline.
 // See: https://github.com/grpc/grpc/blob/master/doc/connection-backoff-interop-test-description.md
@@ -39,68 +34,81 @@ class PrintingConnectivityStateDelegate: ConnectivityStateDelegate {
   }
 }
 
-// Reduce stdout noise.
-LoggingSystem.bootstrap(StreamLogHandler.standardError)
+func runTest(controlPort: Int, retryPort: Int) throws {
+  let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+  defer {
+    try! group.syncShutdownGracefully()
+  }
 
-let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-defer {
-  try! group.syncShutdownGracefully()
+  // MARK: - Test Procedure
+
+  print("[\(Date())] Starting connection backoff interoperability test...")
+
+  // 1. Call 'Start' on server control port with a large deadline or no deadline, wait for it to
+  //    finish and check it succeeded.
+  let controlConnection = ClientConnection.insecure(group: group)
+    .connect(host: "localhost", port: controlPort)
+  let controlClient = Grpc_Testing_ReconnectServiceClient(channel: controlConnection)
+  print("[\(Date())] Control 'Start' call started")
+  let controlStart = controlClient.start(.init(), callOptions: .init(timeLimit: .none))
+  let controlStartStatus = try controlStart.status.wait()
+  assert(controlStartStatus.code == .ok, "Control Start rpc failed: \(controlStartStatus.code)")
+  print("[\(Date())] Control 'Start' call succeeded")
+
+  // 2. Initiate a channel connection to server retry port, which should perform reconnections with
+  //    proper backoffs. A convenient way to achieve this is to call 'Start' with a deadline of 540s.
+  //    The rpc should fail with deadline exceeded.
+  print("[\(Date())] Retry 'Start' call started")
+  let retryConnection = ClientConnection.secure(group: group)
+    .withConnectivityStateDelegate(PrintingConnectivityStateDelegate())
+    .connect(host: "localhost", port: retryPort)
+  let retryClient = Grpc_Testing_ReconnectServiceClient(
+    channel: retryConnection,
+    defaultCallOptions: CallOptions(timeLimit: .timeout(.seconds(540)))
+  )
+  let retryStart = retryClient.start(.init())
+  // We expect this to take some time!
+  let retryStartStatus = try retryStart.status.wait()
+  assert(
+    retryStartStatus.code == .deadlineExceeded,
+    "Retry Start rpc status was not 'deadlineExceeded': \(retryStartStatus.code)"
+  )
+  print("[\(Date())] Retry 'Start' call terminated with expected status")
+
+  // 3. Call 'Stop' on server control port and check it succeeded.
+  print("[\(Date())] Control 'Stop' call started")
+  let controlStop = controlClient.stop(.init())
+  let controlStopStatus = try controlStop.status.wait()
+  assert(controlStopStatus.code == .ok, "Control Stop rpc failed: \(controlStopStatus.code)")
+  print("[\(Date())] Control 'Stop' call succeeded")
+
+  // 4. Check the response to see whether the server thinks the backoffs passed the test.
+  let controlResponse = try controlStop.response.wait()
+  assert(controlResponse.passed, "TEST FAILED")
+  print("[\(Date())] TEST PASSED")
+
+  // MARK: - Tear down
+
+  // Close the connections.
+
+  // We expect close to fail on the retry connection because the channel should never be successfully
+  // started.
+  print("[\(Date())] Closing Retry connection")
+  try? retryConnection.close().wait()
+  print("[\(Date())] Closing Control connection")
+  try controlConnection.close().wait()
 }
 
-// MARK: - Test Procedure
+struct ConnectionBackoffInteropTest: ParsableCommand {
+  @Option
+  var controlPort: Int
 
-print("[\(Date())] Starting connection backoff interoperability test...")
+  @Option
+  var retryPort: Int
 
-// 1. Call 'Start' on server control port with a large deadline or no deadline, wait for it to
-//    finish and check it succeeded.
-let controlConnection = ClientConnection.insecure(group: group)
-  .connect(host: "localhost", port: controlPort)
-let controlClient = Grpc_Testing_ReconnectServiceClient(channel: controlConnection)
-print("[\(Date())] Control 'Start' call started")
-let controlStart = controlClient.start(.init(), callOptions: .init(timeLimit: .none))
-let controlStartStatus = try controlStart.status.wait()
-assert(controlStartStatus.code == .ok, "Control Start rpc failed: \(controlStartStatus.code)")
-print("[\(Date())] Control 'Start' call succeeded")
+  func run() throws {
+    try runTest(controlPort: self.controlPort, retryPort: self.retryPort)
+  }
+}
 
-// 2. Initiate a channel connection to server retry port, which should perform reconnections with
-//    proper backoffs. A convenient way to achieve this is to call 'Start' with a deadline of 540s.
-//    The rpc should fail with deadline exceeded.
-print("[\(Date())] Retry 'Start' call started")
-let retryConnection = ClientConnection.secure(group: group)
-  .withConnectivityStateDelegate(PrintingConnectivityStateDelegate())
-  .connect(host: "localhost", port: retryPort)
-let retryClient = Grpc_Testing_ReconnectServiceClient(
-  channel: retryConnection,
-  defaultCallOptions: CallOptions(timeLimit: .timeout(.seconds(540)))
-)
-let retryStart = retryClient.start(.init())
-// We expect this to take some time!
-let retryStartStatus = try retryStart.status.wait()
-assert(
-  retryStartStatus.code == .deadlineExceeded,
-  "Retry Start rpc status was not 'deadlineExceeded': \(retryStartStatus.code)"
-)
-print("[\(Date())] Retry 'Start' call terminated with expected status")
-
-// 3. Call 'Stop' on server control port and check it succeeded.
-print("[\(Date())] Control 'Stop' call started")
-let controlStop = controlClient.stop(.init())
-let controlStopStatus = try controlStop.status.wait()
-assert(controlStopStatus.code == .ok, "Control Stop rpc failed: \(controlStopStatus.code)")
-print("[\(Date())] Control 'Stop' call succeeded")
-
-// 4. Check the response to see whether the server thinks the backoffs passed the test.
-let controlResponse = try controlStop.response.wait()
-assert(controlResponse.passed, "TEST FAILED")
-print("[\(Date())] TEST PASSED")
-
-// MARK: - Tear down
-
-// Close the connections.
-
-// We expect close to fail on the retry connection because the channel should never be successfully
-// started.
-print("[\(Date())] Closing Retry connection")
-try? retryConnection.close().wait()
-print("[\(Date())] Closing Control connection")
-try controlConnection.close().wait()
+ConnectionBackoffInteropTest.main()

--- a/Sources/GRPCInteroperabilityTests/main.swift
+++ b/Sources/GRPCInteroperabilityTests/main.swift
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import ArgumentParser
 import Foundation
 import GRPC
 import GRPCInteroperabilityTestsImplementation
@@ -90,122 +91,81 @@ func makeRunnableTest(name: String) throws -> InteroperabilityTest {
 
 // MARK: - Command line options and "main".
 
-func printUsageAndExit(program: String) -> Never {
-  print("""
-  Usage: \(program) COMMAND [OPTIONS...]
+struct InteroperabilityTests: ParsableCommand {
+  static var configuration = CommandConfiguration(
+    abstract: "gRPC Swift Interoperability Runner",
+    subcommands: [StartServer.self, RunTest.self, ListTests.self]
+  )
 
-  Commands:
-    start_server [--tls|--notls] PORT         Starts the interoperability test server.
+  struct StartServer: ParsableCommand {
+    static var configuration = CommandConfiguration(
+      abstract: "Start the gRPC Swift interoperability test server."
+    )
 
-    run_test [--tls|--notls] HOST PORT NAME   Run an interoperability test.
+    @Option(help: "The port to listen on for new connections")
+    var port: Int
 
-    list_tests                                List all interoperability test names.
-  """)
-  exit(1)
-}
+    @Flag(help: "Whether TLS should be used or not")
+    var tls = false
 
-enum Command {
-  case startServer(port: Int, useTLS: Bool)
-  case runTest(name: String, host: String, port: Int, useTLS: Bool)
-  case listTests
-
-  init?(from args: [String]) {
-    guard !args.isEmpty else {
-      return nil
-    }
-
-    var args = args
-    let command = args.removeFirst()
-    switch command {
-    case "start_server":
-      guard args.count == 1 || args.count == 2,
-        let port = args.popLast().flatMap(Int.init),
-        let useTLS = Command.parseTLSArg(args.popLast())
-      else {
-        return nil
+    func run() throws {
+      let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+      defer {
+        try! group.syncShutdownGracefully()
       }
-      self = .startServer(port: port, useTLS: useTLS)
 
-    case "run_test":
-      guard args.count == 3 || args.count == 4,
-        let name = args.popLast(),
-        let port = args.popLast().flatMap(Int.init),
-        let host = args.popLast(),
-        let useTLS = Command.parseTLSArg(args.popLast())
-      else {
-        return nil
-      }
-      self = .runTest(name: name, host: host, port: port, useTLS: useTLS)
-
-    case "list_tests":
-      self = .listTests
-
-    default:
-      return nil
-    }
-  }
-
-  private static func parseTLSArg(_ arg: String?) -> Bool? {
-    switch arg {
-    case .some("--tls"):
-      return true
-    case .none, .some("--notls"):
-      return false
-    default:
-      return nil
-    }
-  }
-}
-
-func main(args: [String]) {
-  let program = args.first ?? "GRPC Interoperability Tests"
-  guard let command = Command(from: .init(args.dropFirst())) else {
-    printUsageAndExit(program: program)
-  }
-
-  switch command {
-  case .listTests:
-    InteroperabilityTestCase.allCases.forEach {
-      print($0.name)
-    }
-
-  case let .startServer(port: port, useTLS: useTLS):
-    let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-    defer {
-      try! group.syncShutdownGracefully()
-    }
-
-    do {
       let server = try makeInteroperabilityTestServer(
-        port: port,
+        port: self.port,
         eventLoopGroup: group,
-        useTLS: useTLS
+        useTLS: self.tls
       ).wait()
       print("server started: \(server.channel.localAddress!)")
 
       // We never call close; run until we get killed.
       try server.onClose.wait()
-    } catch {
-      print("unable to start interoperability test server")
     }
+  }
 
-  case let .runTest(name: name, host: host, port: port, useTLS: useTLS):
-    let test: InteroperabilityTest
-    do {
-      test = try makeRunnableTest(name: name)
-    } catch {
-      print("\(error)")
-      exit(1)
+  struct RunTest: ParsableCommand {
+    static var configuration = CommandConfiguration(
+      abstract: "Runs a gRPC interoperability test using a gRPC Swift client."
+    )
+
+    @Flag(help: "Whether TLS should be used or not")
+    var tls = false
+
+    @Option(help: "The host the server is running on")
+    var host: String
+
+    @Option(help: "The port to connect to")
+    var port: Int
+
+    @Argument(help: "The name of the test to run")
+    var testName: String
+
+    func run() throws {
+      let test = try makeRunnableTest(name: self.testName)
+      try runTest(
+        test,
+        name: self.testName,
+        host: self.host,
+        port: self.port,
+        useTLS: self.tls
+      )
     }
+  }
 
-    do {
-      // Provide some basic configuration. Some tests may override this.
-      try runTest(test, name: name, host: host, port: port, useTLS: useTLS)
-    } catch {
-      print("Error running test: \(error)")
-      exit(1)
+  struct ListTests: ParsableCommand {
+    static var configuration = CommandConfiguration(
+      abstract: "List all interoperability test names."
+    )
+
+    func run() throws {
+      InteroperabilityTestCase.allCases.forEach {
+        print($0.name)
+      }
     }
   }
 }
 
-main(args: CommandLine.arguments)
+InteroperabilityTests.main()

--- a/docs/interceptors-tutorial.md
+++ b/docs/interceptors-tutorial.md
@@ -251,16 +251,14 @@ it, from the root of your gRPC-Swift checkout start the Echo server on a free
 port by running:
 
 ```
-$ swift run Echo server 0
+$ swift run Echo server
 starting insecure server
-started server: [IPv6]::1/::1:51274
 ```
 
-Note the port that your server started on. In another terminal run the client
-without the interceptors with:
+In another terminal run the client without the interceptors with:
 
 ```
-$ swift run Echo client <PORT> get "Hello"
+$ swift run Echo client "Hello"
 get receieved: Swift echo get: Hello
 get completed with status: ok (0)
 ```
@@ -269,7 +267,7 @@ This calls the unary "Get" RPC and prints the response and status from the RPC.
 Let's run it with our interceptor enabled by adding the `--intercept` flag:
 
 ```
-$ swift run Echo client --intercept <PORT> get "Hello"
+$ swift run Echo client --intercept "Hello"
 > Starting '/echo.Echo/Get' RPC, headers: []
 > Sending request with text 'Hello'
 > Closing request stream

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -41,14 +41,12 @@ From the `grpc-swift` directory:
 
    ```sh
    $ swift run HelloWorldServer
-   server started on port 52200
-   $ # Note: the port may be different on your machine.
    ```
 
 2. In another terminal, compile and run the client
 
    ```sh
-   $ swift run HelloWorldClient 52200
+   $ swift run HelloWorldClient
    Greeter received: Hello stranger!
    ```
 
@@ -201,14 +199,12 @@ Just like we did before, from the top level `grpc-swift` directory:
 
    ```sh
    $ swift run HelloWorldServer
-   server started on port 52416
-   $ # Note: the port may be different on your machine.
    ```
 
 2. In another terminal, compile and run the client
 
    ```sh
-   $ swift run HelloWorldClient 52416
+   $ swift run HelloWorldClient
    Greeter received: Hello stranger!
    Greeter received: Hello again stranger!
    ```


### PR DESCRIPTION
Motivation:

We have a bunch of hand rolled argument parsing code for each example
and various tooling. We did this because we didn't want to burden users
of the 'GRPC' module with additional depdendencies.

Now that Swift 5.2 is our minimum supported version, we have target
based depdendency resolution. This means we can use depdendencies for
targets which aren't products of the package without burdening
dependents of the 'GRPC' module with unnecessary depdendencies.

Modifications:

- Use swift-argument-parser for all examples, performance and interop tests
- Update use of interop tests in CI

Result:

- Less hand rolled code
- Examples are easier to use: they have help messages and so on.