### PR TITLE
Drop the message from the static 'ok' status.

### DIFF
--- a/Sources/GRPC/GRPCStatus.swift
+++ b/Sources/GRPC/GRPCStatus.swift
@@ -42,7 +42,7 @@ public struct GRPCStatus: Error {
   ///
   /// - Important: This should *not* be used when checking whether a returned status has an 'ok'
   ///   status code. Use `GRPCStatus.isOk` or check the code directly.
-  public static let ok = GRPCStatus(code: .ok, message: "OK")
+  public static let ok = GRPCStatus(code: .ok, message: nil)
   /// "Internal server error" status.
   public static let processingError = GRPCStatus(
     code: .internalError,

--- a/Tests/GRPCTests/ServerWebTests.swift
+++ b/Tests/GRPCTests/ServerWebTests.swift
@@ -38,8 +38,14 @@ class ServerWebTests: EchoTestCaseBase {
     return data
   }
 
-  private func gRPCWebTrailers(status: Int = 0, message: String = "OK") -> Data {
-    var data = "grpc-status: \(status)\r\ngrpc-message: \(message)".data(using: .utf8)!
+  private func gRPCWebTrailers(status: Int = 0, message: String? = nil) -> Data {
+    var data: Data
+    if let message = message {
+      data = "grpc-status: \(status)\r\ngrpc-message: \(message)".data(using: .utf8)!
+    } else {
+      data = "grpc-status: \(status)".data(using: .utf8)!
+    }
+
     // Add the gRPC prefix with the compression byte and the 4 length bytes.
     for i in 0 ..< 4 {
       data.insert(UInt8((data.count >> (i * 8)) & 0xFF), at: 0)


### PR DESCRIPTION
Motivation:

'GRPCStatus' has a public static 'ok' status defined which sets the
status message to 'OK'. This is used for all happy-path responses.
However, sending a status message is optional and in this case the message
doesn't tell us anything we didn't already know.

While sending a status message is relatively cheap, it still has some
cost and doing no work is better than doing some work!

Modifications:

- Remove the "OK" message from `GRPCStatus.ok`

Result:

A small decrease in instructions executed, about 1.5% in the
unary_10k_small_requests benchmark.