### PR TITLE
Update cocoapods and podspec script

### DIFF
--- a/CGRPCZlib.podspec
+++ b/CGRPCZlib.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
     s.name = 'CGRPCZlib'
     s.module_name = 'CGRPCZlib'
-    s.version = '1.0.0-alpha.23'
+    s.version = '1.0.0-alpha.24'
     s.license = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.summary = 'Compression library that provides in-memory compression and decompression functions'
     s.homepage = 'https://www.grpc.io'

--- a/gRPC-Swift-Plugins.podspec
+++ b/gRPC-Swift-Plugins.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
     s.name = 'gRPC-Swift-Plugins'
-    s.version = '1.0.0-alpha.23'
+    s.version = '1.0.0-alpha.24'
     s.license = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.summary = 'Swift gRPC code generator plugin binaries'
     s.homepage = 'https://www.grpc.io'

--- a/gRPC-Swift.podspec
+++ b/gRPC-Swift.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
     s.name = 'gRPC-Swift'
     s.module_name = 'GRPC'
-    s.version = '1.0.0-alpha.23'
+    s.version = '1.0.0-alpha.24'
     s.license = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.summary = 'Swift gRPC code generator plugin and runtime library'
     s.homepage = 'https://www.grpc.io'
@@ -17,13 +17,13 @@ Pod::Spec.new do |s|
 
     s.source_files = 'Sources/GRPC/**/*.{swift,c,h}'
 
-    s.dependency 'Logging', '>= 1.4.0', '< 2'
-    s.dependency 'SwiftNIO', '>= 2.25.0', '< 3'
-    s.dependency 'SwiftNIOExtras', '>= 1.7.0', '< 2'
-    s.dependency 'SwiftNIOHTTP2', '>= 1.16.2', '< 2'
-    s.dependency 'SwiftNIOSSL', '>= 2.10.1', '< 3'
-    s.dependency 'SwiftNIOTransportServices', '>= 1.9.1', '< 2'
-    s.dependency 'SwiftProtobuf', '>= 1.14.0', '< 2'
+    s.dependency 'SwiftProtobuf', '>= 1.9.0', '< 2.0.0'
+    s.dependency 'SwiftNIO', '>= 2.22.0', '< 3.0.0'
+    s.dependency 'SwiftNIOTransportServices', '>= 1.6.0', '< 2.0.0'
+    s.dependency 'SwiftNIOSSL', '>= 2.8.0', '< 3.0.0'
+    s.dependency 'SwiftNIOExtras', '>= 1.4.0', '< 2.0.0'
+    s.dependency 'Logging', '>= 1.4.0', '< 2.0.0'
+    s.dependency 'SwiftNIOHTTP2', '>= 1.16.1', '< 2.0.0'
     s.dependency 'CGRPCZlib', s.version.to_s
 
 end


### PR DESCRIPTION
Motivation:

The podspec script uses Package.resolved to determine dependencies for
the 'GRPC' module as well as version requirements. These version
requirements are wrong per se, but they are overly restrictire.
Additionally, while Package.resolved was previously correct, it no
longer takes into account dependencies resolved for non-product targets
(i.e. swift-argument-parser).

Modifications:

- Build podspec dependency requirements from 'swift package dump-package'
- Replace 'os.system' with 'subprocess.check_call'
- Update pods

Result:

Pod dependency requirementments match Package.swift