### PR TITLE
Add a 'version' identifier and a more specific user-agent

### DIFF
--- a/Sources/GRPC/GRPCClientStateMachine.swift
+++ b/Sources/GRPC/GRPCClientStateMachine.swift
@@ -167,6 +167,9 @@ struct GRPCClientStateMachine {
     }
   }
 
+  /// The default user-agent string.
+  private static let userAgent = "grpc-swift-nio/\(Version.versionString)"
+
   /// Creates a state machine representing a gRPC client's request and response stream state.
   ///
   /// - Parameter requestArity: The expected number of messages on the request stream.
@@ -613,9 +616,8 @@ extension GRPCClientStateMachine.State {
     })
 
     // Add default user-agent value, if `customMetadata` didn't contain user-agent
-    if !headers.contains(name: "user-agent") {
-      // TODO: Add a more specific user-agent.
-      headers.add(name: "user-agent", value: "grpc-swift-nio")
+    if !customMetadata.contains(name: "user-agent") {
+      headers.add(name: "user-agent", value: GRPCClientStateMachine.userAgent)
     }
 
     return headers

--- a/Sources/GRPC/Version.swift
+++ b/Sources/GRPC/Version.swift
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+internal struct Version {
+  /// The major version.
+  internal static let major = 1
+
+  /// The minor version.
+  internal static let minor = 0
+
+  /// The patch version.
+  internal static let patch = 0
+
+  /// The version string.
+  internal static let versionString = "\(major).\(minor).\(patch)"
+}


### PR DESCRIPTION
Motivation:

User-agent string should, ideally, contain a version number.

Modifications:

- Add a 'Version' struct
- Use the version string in the user-agent
- Only check user-provided headers for a user-agent string rather than
  all headers

Result:

- User-agent string includes version number