### PR TITLE
Don't log to file in CI

### DIFF
--- a/.travis-script.sh
+++ b/.travis-script.sh
@@ -111,8 +111,7 @@ run_interop_tests() {
     $BUILD_OUTPUT/GRPCInteroperabilityTests run-test \
       --host "localhost" \
       --port "$INTEROP_TEST_SERVER_PORT" \
-      "$test" \
-        2> "interop.$test.log"
+      "$test"
     success "PASSED $test"
   done
 
@@ -143,8 +142,7 @@ run_interop_reconnect_test() {
   # Run the test; logs are written to stderr, redirect them to a file.
   ${BUILD_OUTPUT}/GRPCConnectionBackoffInteropTest \
     --control-port ${INTEROP_TEST_SERVER_CONTROL_PORT} \
-    --retry-port ${INTEROP_TEST_SERVER_RETRY_PORT} \
-      2> "interop.connection_backoff.log"
+    --retry-port ${INTEROP_TEST_SERVER_RETRY_PORT}
   success "connection backoff interop test PASSED"
 
   info "Stopping C++ reconnect interop server"

--- a/Sources/GRPCConnectionBackoffInteropTest/main.swift
+++ b/Sources/GRPCConnectionBackoffInteropTest/main.swift
@@ -107,7 +107,12 @@ struct ConnectionBackoffInteropTest: ParsableCommand {
   var retryPort: Int
 
   func run() throws {
-    try runTest(controlPort: self.controlPort, retryPort: self.retryPort)
+    do {
+      try runTest(controlPort: self.controlPort, retryPort: self.retryPort)
+    } catch {
+      print("[\(Date())] Unexpected error: \(error)")
+      throw error
+    }
   }
 }
 


### PR DESCRIPTION
Motivation:

The connection backoff interop test periodically fails in CI when
tearing down. In CI we currently capture the logs to file, this isn't
too sensible: we can't access them from Travis.

Modifications:

- Don't log interop test output to file in CI
- Print all thrown errors in the connection backoff interop test

Result:

Some visibilitiy into why the test is occasionally failing