### PR TITLE
Adding Flatbuffers content-type

### DIFF
--- a/Sources/GRPC/GRPCClientStateMachine.swift
+++ b/Sources/GRPC/GRPCClientStateMachine.swift
@@ -629,7 +629,12 @@ extension GRPCClientStateMachine.State {
     headers.add(name: ":path", value: path)
     headers.add(name: ":authority", value: host)
     headers.add(name: ":scheme", value: scheme)
-    headers.add(name: "content-type", value: "application/grpc")
+
+    // Default to application/grpc if there is no content-type present.
+    if !customMetadata.contains(name: "content-type") {
+      headers.add(name: "content-type", value: "application/grpc")
+    }
+
     // Used to detect incompatible proxies, part of the gRPC specification.
     headers.add(name: "te", value: "trailers")
 

--- a/Sources/GRPC/GRPCContentType.swift
+++ b/Sources/GRPC/GRPCContentType.swift
@@ -18,6 +18,7 @@
 // - https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
 // - https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md
 internal enum ContentType {
+  case flatbuffers
   case protobuf
   case webProtobuf
   case webTextProtobuf
@@ -36,6 +37,9 @@ internal enum ContentType {
          "application/grpc-web-text+proto":
       self = .webTextProtobuf
 
+    case "application/grpc+flatbuffers":
+      self = .flatbuffers
+
     default:
       return nil
     }
@@ -52,6 +56,9 @@ internal enum ContentType {
 
     case .webTextProtobuf:
       return "application/grpc-web-text+proto"
+
+    case .flatbuffers:
+      return "application/grpc+flatbuffers"
     }
   }
 

--- a/Tests/GRPCTests/HTTP2ToRawGRPCStateMachineTests.swift
+++ b/Tests/GRPCTests/HTTP2ToRawGRPCStateMachineTests.swift
@@ -166,10 +166,10 @@ class HTTP2ToRawGRPCStateMachineTests: GRPCTestCase {
 
   // MARK: Receive Headers Tests
 
-  func testReceiveValidHeaders() {
+  func doTestReceiveHeadersWithContentType(_ contentType: ContentType) {
     var machine = StateMachine(services: self.services, encoding: .disabled)
     let action = machine.receive(
-      headers: self.viableHeaders,
+      headers: self.makeHeaders(contentType: contentType.canonicalValue),
       eventLoop: self.eventLoop,
       errorDelegate: nil,
       remoteAddress: nil,
@@ -179,6 +179,18 @@ class HTTP2ToRawGRPCStateMachineTests: GRPCTestCase {
       closeFuture: self.eventLoop.makeSucceededVoidFuture()
     )
     assertThat(action, .is(.configure()))
+  }
+
+  func testReceiveValidHeaders() {
+    self.doTestReceiveHeadersWithContentType(.protobuf)
+  }
+
+  func testReceiveValidWebProtoContentTypeHeaders() {
+    self.doTestReceiveHeadersWithContentType(.webProtobuf)
+  }
+
+  func testReceiveValidFlatbuffersContentTypeHeaders() {
+    self.doTestReceiveHeadersWithContentType(.flatbuffers)
   }
 
   func testReceiveInvalidContentType() {


### PR DESCRIPTION
The following PR adds the ability to send custom "implemented" content-types `application/grpc+{(proto || flatbuffers)}`. It does that by checking the `customMetadata` object for the type `content-type` on the sender side, If there is an object of type content-type we use that as the `content-type` for the request. However if `customMetadata` doesn't have any header for the content-type we default to `application/grpc`. 

- Tests implemented:
     - Checks for sending custom content-types and if they would be appended in the header
     - Checks if the server would be able to parse those content types.
 
Notes: Tests were implemented on the valid server state only.