### PR TITLE
Add allocation counting tests

### DIFF
--- a/.travis-script.sh
+++ b/.travis-script.sh
@@ -56,6 +56,15 @@ make_test() {
   echo -en 'travis_fold:end:make.test\\r'
 }
 
+run_allocation_tests() {
+  echo -en 'travis_fold:start:allocation_tests\\r'
+
+  info "Running allocation counter tests"
+  ./Performance/allocations/test-allocation-counts.sh
+
+  echo -en 'travis_fold:end:allocation_tests\\r'
+}
+
 make_test_plugin() {
   echo -en 'travis_fold:start:make.test_plugin\\r'
   info "Validating protoc plugins on the Echo service"
@@ -152,10 +161,11 @@ run_interop_reconnect_test() {
 }
 
 just_sanity=false
+allocation_tests=false
 just_interop_tests=false
 tsan=false
 
-while getopts "sit" optname; do
+while getopts "sita" optname; do
   case $optname in
     s)
       just_sanity=true
@@ -165,6 +175,9 @@ while getopts "sit" optname; do
       ;;
     t)
       tsan=true
+      ;;
+    a)
+      allocation_tests=true
       ;;
     \?)
       echo "Uknown option $optname"
@@ -183,6 +196,9 @@ elif $just_interop_tests; then
 else
   make_all
   make_test $tsan
+  if $allocation_tests; then
+    run_allocation_tests
+  fi
   make_test_plugin
   make_project
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ jobs:
       dist: bionic
       install: ./.travis-install.sh -f  # install swiftformat
       script: ./.travis-script.sh -s  # just sanity
-      env: SWIFT_VERSION=5.3.1
+      env: SWIFT_VERSION=5.3.3
     # Tests for each PR.
     - &tests
       stage: "Test"
@@ -34,12 +34,20 @@ jobs:
       os: linux
       dist: bionic
       install: ./.travis-install.sh -p  # install protoc
-      script: ./.travis-script.sh -t  # with tsan
-      env: SWIFT_VERSION=5.3.1
+      script: ./.travis-script.sh -t -a # tests with tsan, run allocation tests
+      env:
+        - SWIFT_VERSION=5.3.3
+        - MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests=113000
+        - MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request=68000
+        - MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request=64000
     - <<: *tests
       name: "Unit Tests: Ubuntu 18.04 (Swift 5.2)"
-      script: ./.travis-script.sh
-      env: SWIFT_VERSION=5.2.5
+      script: ./.travis-script.sh -a # run allocation tests
+      env:
+        - SWIFT_VERSION=5.2.5
+        - MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests=113000
+        - MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request=68000
+        - MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request=64000
     - <<: *tests
       name: "Unit Tests: Xcode 12.2"
       os: osx
@@ -57,7 +65,7 @@ jobs:
       dist: bionic
       install: ./.travis-install.sh -p -i # install protoc and interop server
       script: ./.travis-script.sh -i  # interop tests
-      env: SWIFT_VERSION=5.3.1
+      env: SWIFT_VERSION=5.3.3
     - <<: *interop_tests
       name: "Interoperability Tests: Ubuntu 18.04 (Swift 5.2)"
       env: SWIFT_VERSION=5.2.5

--- a/NOTICES.txt
+++ b/NOTICES.txt
@@ -1,0 +1,27 @@
+                          The gRPC Swift Project
+                          ======================
+
+Copyright 2021 The gRPC Swift Project
+
+The gRPC Swift project licenses this file to you under the Apache License,
+version 2.0 (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at:
+
+  https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+-------------------------------------------------------------------------------
+
+This product uses scripts derived from SwiftNIO's integration testing
+framework: 'test_01_allocation_counts.sh', 'run-nio-alloc-counter-tests.sh' and
+'test_functions.sh'.
+
+  * LICENSE (Apache License 2.0):
+    * https://github.com/apple/swift-nio/blob/main/LICENSE.txt
+  * HOMEPAGE:
+    * https://github.com/apple/swift-nio

--- a/Package.swift
+++ b/Package.swift
@@ -140,7 +140,6 @@ let package = Package(
       name: "GRPCPerformanceTests",
       dependencies: [
         .target(name: "GRPC"),
-        .target(name: "EchoModel"),
         .product(name: "NIO", package: "swift-nio"),
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
       ]

--- a/Performance/allocations/test-allocation-counts.sh
+++ b/Performance/allocations/test-allocation-counts.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# Copyright 2021, gRPC Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script was adapted from SwiftNIO's test_01_allocation_counts.sh. The
+# license for the original work is reproduced below. See NOTICES.txt for more.
+
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+set -eu
+here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+tmp="/tmp"
+
+source "$here/test-utils.sh"
+
+all_tests=()
+for file in "$here/tests/"test_*.swift; do
+  # Extract the "TESTNAME" from "test_TESTNAME.swift"
+  test_name=$(basename "$file")
+  test_name=${test_name#test_*}
+  test_name=${test_name%*.swift}
+  all_tests+=( "$test_name" )
+done
+
+# Run all the tests.
+"$here/tests/run-allocation-counter-tests.sh" -t "$tmp" > "$tmp/output"
+
+# Dump some output from each, check for allocations.
+for test in "${all_tests[@]}"; do
+  cat "$tmp/output"  # helps debugging
+
+  while read -r test_case; do
+    test_case=${test_case#test_*}
+    total_allocations=$(grep "^test_$test_case.total_allocations:" "$tmp/output" | cut -d: -f2 | sed 's/ //g')
+    not_freed_allocations=$(grep "^test_$test_case.remaining_allocations:" "$tmp/output" | cut -d: -f2 | sed 's/ //g')
+    max_allowed_env_name="MAX_ALLOCS_ALLOWED_$test_case"
+
+    info "$test_case: allocations not freed: $not_freed_allocations"
+    info "$test_case: total number of mallocs: $total_allocations"
+
+    assert_less_than "$not_freed_allocations" 5     # allow some slack
+    assert_greater_than "$not_freed_allocations" -5 # allow some slack
+    if [[ -z "${!max_allowed_env_name+x}" ]]; then
+      if [[ -z "${!max_allowed_env_name+x}" ]]; then
+        warn "no reference number of allocations set (set to \$$max_allowed_env_name)"
+        warn "to set current number:"
+        warn "    export $max_allowed_env_name=$total_allocations"
+      fi
+    else
+      max_allowed=${!max_allowed_env_name}
+      assert_less_than_or_equal "$total_allocations" "$max_allowed"
+      assert_greater_than "$total_allocations" "$(( max_allowed - 1000))"
+    fi
+  done < <(grep "^test_$test[^\W]*.total_allocations:" "$tmp/output" | cut -d: -f1 | cut -d. -f1 | sort | uniq)
+done

--- a/Performance/allocations/test-utils.sh
+++ b/Performance/allocations/test-utils.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Copyright 2021, gRPC Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script contains part of SwiftNIO's test_functions.sh script. The license
+# for the original work is reproduced below. See NOTICES.txt for more.
+
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+function fail() {
+  echo >&2 "FAILURE: $*"
+  false
+}
+
+function assert_less_than() {
+  if [[ ! "$1" -lt "$2" ]]; then
+    fail "assertion '$1' < '$2' failed"
+  fi
+}
+
+function assert_less_than_or_equal() {
+  if [[ ! "$1" -le "$2" ]]; then
+    fail "assertion '$1' <= '$2' failed"
+  fi
+}
+
+function assert_greater_than() {
+  if [[ ! "$1" -gt "$2" ]]; then
+    fail "assertion '$1' > '$2' failed"
+  fi
+}
+
+g_has_previously_infoed=false
+
+function info() {
+  if ! $g_has_previously_infoed; then
+    echo || true # echo an extra newline so it looks better
+    g_has_previously_infoed=true
+  fi
+  echo "info: $*" || true
+}
+
+function warn() {
+  echo "warning: $*"
+}

--- a/Performance/allocations/tests/run-allocation-counter-tests.sh
+++ b/Performance/allocations/tests/run-allocation-counter-tests.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# Copyright 2021, gRPC Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script was adapted from SwiftNIO's 'run-nio-alloc-counter-tests.sh'
+# script. The license for the original work is reproduced below. See NOTICES.txt
+# for more.
+
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+set -eu
+here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+tmp_dir="/tmp"
+
+while getopts "t:" opt; do
+  case "$opt" in
+    t)
+      tmp_dir="$OPTARG"
+      ;;
+    *)
+      exit 1
+      ;;
+  esac
+done
+
+nio_checkout=$(mktemp -d "$tmp_dir/.swift-nio_XXXXXX")
+(
+cd "$nio_checkout"
+git clone --depth 1 https://github.com/apple/swift-nio
+)
+
+shift $((OPTIND-1))
+
+tests_to_run=("$here"/test_*.swift)
+
+if [[ $# -gt 0 ]]; then
+  tests_to_run=("$@")
+fi
+
+# We symlink in a bunch of components from the GRPCPerformanceTests target to
+# avoid duplicating a bunch of code.
+"$nio_checkout/swift-nio/IntegrationTests/allocation-counter-tests-framework/run-allocation-counter.sh" \
+  -p "$here/../../.." \
+  -m GRPC \
+  -t "$tmp_dir" \
+  -s "$here/shared/Benchmark.swift" \
+  -s "$here/shared/echo.pb.swift" \
+  -s "$here/shared/echo.grpc.swift" \
+  -s "$here/shared/MinimalEchoProvider.swift" \
+  -s "$here/shared/EmbeddedServer.swift" \
+  "${tests_to_run[@]}"

--- a/Performance/allocations/tests/shared/Benchmark.swift
+++ b/Performance/allocations/tests/shared/Benchmark.swift
@@ -1,0 +1,1 @@
+../../../../Sources/GRPCPerformanceTests/Benchmark.swift

--- a/Performance/allocations/tests/shared/EmbeddedServer.swift
+++ b/Performance/allocations/tests/shared/EmbeddedServer.swift
@@ -1,0 +1,1 @@
+../../../../Sources/GRPCPerformanceTests/Benchmarks/EmbeddedServer.swift

--- a/Performance/allocations/tests/shared/MinimalEchoProvider.swift
+++ b/Performance/allocations/tests/shared/MinimalEchoProvider.swift
@@ -1,0 +1,1 @@
+../../../../Sources/GRPCPerformanceTests/Benchmarks/MinimalEchoProvider.swift

--- a/Performance/allocations/tests/shared/echo.grpc.swift
+++ b/Performance/allocations/tests/shared/echo.grpc.swift
@@ -1,0 +1,1 @@
+../../../../Sources/GRPCPerformanceTests/Benchmarks/echo.grpc.swift

--- a/Performance/allocations/tests/shared/echo.pb.swift
+++ b/Performance/allocations/tests/shared/echo.pb.swift
@@ -1,0 +1,1 @@
+../../../../Sources/GRPCPerformanceTests/Benchmarks/echo.pb.swift

--- a/Performance/allocations/tests/test_embedded_server_bidi_1k_rpcs_10_small_requests.swift
+++ b/Performance/allocations/tests/test_embedded_server_bidi_1k_rpcs_10_small_requests.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, gRPC Authors All rights reserved.
+ * Copyright 2021, gRPC Authors All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,18 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-protocol Benchmark: AnyObject {
-  func setUp() throws
-  func tearDown() throws
-  func run() throws -> Int
-}
-
-extension Benchmark {
-  func runOnce() throws -> Int {
-    try self.setUp()
-    let result = try self.run()
-    try self.tearDown()
-    return result
+func run(identifier: String) {
+  measure(identifier: identifier) {
+    let benchmark = EmbeddedServerChildChannelBenchmark(
+      mode: .bidirectional(rpcs: 1000, requestsPerRPC: 10),
+      text: ""
+    )
+    return try! benchmark.runOnce()
   }
 }

--- a/Performance/allocations/tests/test_embedded_server_bidi_1k_rpcs_1_small_request.swift
+++ b/Performance/allocations/tests/test_embedded_server_bidi_1k_rpcs_1_small_request.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, gRPC Authors All rights reserved.
+ * Copyright 2021, gRPC Authors All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,18 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-protocol Benchmark: AnyObject {
-  func setUp() throws
-  func tearDown() throws
-  func run() throws -> Int
-}
-
-extension Benchmark {
-  func runOnce() throws -> Int {
-    try self.setUp()
-    let result = try self.run()
-    try self.tearDown()
-    return result
+func run(identifier: String) {
+  measure(identifier: identifier) {
+    let benchmark = EmbeddedServerChildChannelBenchmark(
+      mode: .bidirectional(rpcs: 1000, requestsPerRPC: 1),
+      text: ""
+    )
+    return try! benchmark.runOnce()
   }
 }

--- a/Performance/allocations/tests/test_embedded_server_unary_1k_rpcs_1_small_request.swift
+++ b/Performance/allocations/tests/test_embedded_server_unary_1k_rpcs_1_small_request.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, gRPC Authors All rights reserved.
+ * Copyright 2021, gRPC Authors All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,18 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-protocol Benchmark: AnyObject {
-  func setUp() throws
-  func tearDown() throws
-  func run() throws -> Int
-}
-
-extension Benchmark {
-  func runOnce() throws -> Int {
-    try self.setUp()
-    let result = try self.run()
-    try self.tearDown()
-    return result
+func run(identifier: String) {
+  measure(identifier: identifier) {
+    let benchmark = EmbeddedServerChildChannelBenchmark(mode: .unary(rpcs: 1000), text: "")
+    return try! benchmark.runOnce()
   }
 }

--- a/Sources/GRPCPerformanceTests/BenchmarkUtils.swift
+++ b/Sources/GRPCPerformanceTests/BenchmarkUtils.swift
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2021, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Dispatch
+
+/// The results of a benchmark.
+struct BenchmarkResults {
+  /// The description of the benchmark.
+  var desc: String
+
+  /// The duration of each run of the benchmark in milliseconds.
+  var milliseconds: [UInt64]
+}
+
+extension BenchmarkResults: CustomStringConvertible {
+  var description: String {
+    return "\(self.desc): \(self.milliseconds.map(String.init).joined(separator: ","))"
+  }
+}
+
+/// Runs the benchmark and prints the duration in milliseconds for each run.
+///
+/// - Parameters:
+///   - description: A description of the benchmark.
+///   - benchmark: The benchmark which should be run.
+///   - spec: The specification for the test run.
+func measureAndPrint(description: String, benchmark: Benchmark, spec: TestSpec) {
+  switch spec.action {
+  case .list:
+    print(description)
+  case let .run(filter):
+    guard filter.shouldRun(description) else {
+      return
+    }
+    #if CACHEGRIND
+    _ = measure(description, benchmark: benchmark, repeats: 1)
+    #else
+    print(measure(description, benchmark: benchmark, repeats: spec.repeats))
+    #endif
+  }
+}
+
+/// Runs the given benchmark multiple times, recording the wall time for each iteration.
+///
+/// - Parameters:
+///   - description: A description of the benchmark.
+///   - benchmark: The benchmark to run.
+///   - repeats: the number of times to run the benchmark.
+func measure(_ description: String, benchmark: Benchmark, repeats: Int) -> BenchmarkResults {
+  var milliseconds: [UInt64] = []
+  for _ in 0 ..< repeats {
+    do {
+      try benchmark.setUp()
+
+      #if !CACHEGRIND
+      let start = DispatchTime.now().uptimeNanoseconds
+      #endif
+      _ = try benchmark.run()
+
+      #if !CACHEGRIND
+      let end = DispatchTime.now().uptimeNanoseconds
+
+      milliseconds.append((end - start) / 1_000_000)
+      #endif
+    } catch {
+      // If tearDown fails now then there's not a lot we can do!
+      try? benchmark.tearDown()
+      return BenchmarkResults(desc: description, milliseconds: [])
+    }
+
+    do {
+      try benchmark.tearDown()
+    } catch {
+      return BenchmarkResults(desc: description, milliseconds: [])
+    }
+  }
+
+  return BenchmarkResults(desc: description, milliseconds: milliseconds)
+}

--- a/Sources/GRPCPerformanceTests/Benchmarks/EmbeddedClientThroughput.swift
+++ b/Sources/GRPCPerformanceTests/Benchmarks/EmbeddedClientThroughput.swift
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import EchoModel
 import struct Foundation.Data
 import GRPC
 import Logging
@@ -77,7 +76,9 @@ class EmbeddedClientThroughput: Benchmark {
 
   func tearDown() throws {}
 
-  func run() throws {
+  func run() throws -> Int {
+    var messages = 0
+
     for _ in 0 ..< self.requestCount {
       let channel = EmbeddedChannel()
 
@@ -93,12 +94,11 @@ class EmbeddedClientThroughput: Benchmark {
 
       // Write the request parts.
       try channel.writeOutbound(_GRPCClientRequestPart<Echo_EchoRequest>.head(self.requestHead))
-      try channel
-        .writeOutbound(
-          _GRPCClientRequestPart<Echo_EchoRequest>
-            .message(.init(self.request, compressed: false))
-        )
+      try channel.writeOutbound(
+        _GRPCClientRequestPart<Echo_EchoRequest>.message(.init(self.request, compressed: false))
+      )
       try channel.writeOutbound(_GRPCClientRequestPart<Echo_EchoRequest>.end)
+      messages += 1
 
       // Read out the request frames.
       var requestFrames = 0
@@ -140,5 +140,7 @@ class EmbeddedClientThroughput: Benchmark {
 
       precondition(responseParts == 4, "received \(responseParts) response parts")
     }
+
+    return messages
   }
 }

--- a/Sources/GRPCPerformanceTests/Benchmarks/MinimalEchoProvider.swift
+++ b/Sources/GRPCPerformanceTests/Benchmarks/MinimalEchoProvider.swift
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import EchoModel
 import GRPC
 import NIO
 

--- a/Sources/GRPCPerformanceTests/Benchmarks/PercentEncoding.swift
+++ b/Sources/GRPCPerformanceTests/Benchmarks/PercentEncoding.swift
@@ -38,7 +38,7 @@ class PercentEncoding: Benchmark {
 
   func tearDown() throws {}
 
-  func run() throws {
+  func run() throws -> Int {
     var totalLength: Int = 0
 
     for _ in 0 ..< self.iterations {
@@ -50,5 +50,7 @@ class PercentEncoding: Benchmark {
 
       totalLength += unmarshalled.count
     }
+
+    return totalLength
   }
 }

--- a/Sources/GRPCPerformanceTests/Benchmarks/ServerProvidingBenchmark.swift
+++ b/Sources/GRPCPerformanceTests/Benchmarks/ServerProvidingBenchmark.swift
@@ -41,7 +41,7 @@ class ServerProvidingBenchmark: Benchmark {
     try self.group.syncShutdownGracefully()
   }
 
-  func run() throws {
-    // no-op
+  func run() throws -> Int {
+    return 0
   }
 }

--- a/Sources/GRPCPerformanceTests/Benchmarks/echo.grpc.swift
+++ b/Sources/GRPCPerformanceTests/Benchmarks/echo.grpc.swift
@@ -1,0 +1,1 @@
+../../Examples/Echo/Model/echo.grpc.swift

--- a/Sources/GRPCPerformanceTests/Benchmarks/echo.pb.swift
+++ b/Sources/GRPCPerformanceTests/Benchmarks/echo.pb.swift
@@ -1,0 +1,1 @@
+../../Examples/Echo/Model/echo.pb.swift

--- a/Sources/GRPCPerformanceTests/main.swift
+++ b/Sources/GRPCPerformanceTests/main.swift
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import ArgumentParser
-import EchoModel
 import Foundation
 import GRPC
 import Logging

--- a/scripts/alloc-limits.sh
+++ b/scripts/alloc-limits.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Copyright 2021, gRPC Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script parses output from the SwiftNIO allocation counter framework to
+# generate a list of per-test limits for total_allocations.
+#
+# Input is like:
+#   ...
+#   test_embedded_server_unary_1k_rpcs_1_small_request.total_allocated_bytes: 5992858
+#   test_embedded_server_unary_1k_rpcs_1_small_request.total_allocations: 63000
+#   test_embedded_server_unary_1k_rpcs_1_small_request.remaining_allocations: 0
+#   DEBUG: [["total_allocated_bytes": 5992858, "total_allocations": ...
+#
+# Output:
+#   MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request=64000
+
+grep 'test_.*\.total_allocations: ' \
+  | sed 's/^test_/MAX_ALLOCS_ALLOWED_/' \
+  | sed 's/.total_allocations://' \
+  | awk '{ print $1 "=" ((int($2 / 1000) + 1) * 1000) }' \
+  | sort


### PR DESCRIPTION
Motivation:

Memory allocations are a useful tool when evaluating performance. As
such it's useful to have a framework where tests can run continually and
be checked against an expected limit.

Modifications:

There are three groups of related changes in this PR.

First, shuffling existing performance test code so that it may be used
with NIOs allocation counting test framework. This includes dropping the
dependency on the 'EchoModel' target and symlinking in the generated
protobuf and gRPC code services instead. Some of the benchmark code was
split into separate files as well (we'll symlink some code to the
allocation counting test). The 'Benchmark' protocol for the tests now
returns an 'Int' from the 'run' function (a requirement of the NIO
allocation counting test framework).

Second, the addition of various scripts to run allocation counting
tests. These were lifted from SwiftNIO and slightly modified to fit our
use case. As such a NOTICES.txt was also added. Three tests were also
added which make use of code from the existing performance tests. The
shared code is symlinked in (to avoid adding an additional library
product to the package).

Third, the Travis configuration was updated to run the tests on 5.2 and
5.3 on Linux only. A script was also added to parse the output from
running tests and produce an allocation limit.

Result:

We can track our allocation counts.