### PR TITLE
Update paths to protoc-gen-swift in basic-tutorial

### DIFF
--- a/docs/basic-tutorial.md
+++ b/docs/basic-tutorial.md
@@ -162,10 +162,10 @@ Let's look at how to run the same command manually:
 ```sh
 $ protoc Sources/Examples/RouteGuide/Model/route_guide.proto \
     --proto_path=Sources/Examples/RouteGuide/Model \
-    --plugin=./.build/debug/protoc-gen-swift \
+    --plugin=./.build/release/protoc-gen-swift \
     --swift_opt=Visibility=Public \
     --swift_out=Sources/Examples/RouteGuide/Model \
-    --plugin=./.build/debug/protoc-gen-grpc-swift \
+    --plugin=./.build/release/protoc-gen-grpc-swift \
     --grpc-swift_opt=Visibility=Public \
     --grpc-swift_out=Sources/Examples/RouteGuide/Model
 ```


### PR DESCRIPTION
Based on https://github.com/grpc/grpc-swift/blob/main/Makefile#L11 the plugins are placed in `./build/release` not `./build/debug`. These changes fixes the documentation to point to the correct path of the plugin.