### PR TITLE
A more general channel provider

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -19,6 +19,9 @@
 # Don't indent #if blocks
 --ifdef no-indent
 
+# Don't turn Optional<Foo> into Foo?
+--shortoptionals except-properties
+
 # This rule doesn't always work as we'd expect: specifically when we return a
 # succeeded future whose type is a closure then that closure is incorrectly
 # treated as a trailing closure. This is relevant because the service provider

--- a/Sources/GRPC/ConnectionManager.swift
+++ b/Sources/GRPC/ConnectionManager.swift
@@ -251,7 +251,7 @@ internal final class ConnectionManager {
   internal convenience init(configuration: ClientConnection.Configuration, logger: Logger) {
     self.init(
       configuration: configuration,
-      channelProvider: ClientConnection.ChannelProvider(configuration: configuration),
+      channelProvider: DefaultChannelProvider(configuration: configuration),
       logger: logger
     )
   }
@@ -297,7 +297,7 @@ internal final class ConnectionManager {
     )
   }
 
-  private init(
+  internal init(
     eventLoop: EventLoop,
     channelProvider: ConnectionManagerChannelProvider,
     callStartBehavior: CallStartBehavior.Behavior,


### PR DESCRIPTION
Motivation:

In #1158 we pulled connection creation of the connection manager into a
channel provider in order to loosen the coupling between the connection
manager and `ClientConnection`. This change further decouples the
`ConnectionManager` from the channel provider pulling out the relevant
configuration into a `DefaultChannelProvider`.

Modifications:

- Refactor `ClientConnection.ChannelProvider` to rely on the bits of
  configuration it actually requires rather than `ClientConnection.Configuration`
- Rename to `DefaultChannelProvider`

Result:

We can configure channels for the `ConnectionManager` without being tied
to `ClientConnection`.