### PR TITLE
Update allocation limits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,34 +37,34 @@ jobs:
       script: ./.travis-script.sh -t -a # tests with tsan, run allocation tests
       env:
         - SWIFT_VERSION=5.4
-        - MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests=531000
-        - MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request=243000
+        - MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests=513000
+        - MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request=225000
         - MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests=112000
         - MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request=67000
         - MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request=63000
-        - MAX_ALLOCS_ALLOWED_unary_1k_ping_pong=234000
+        - MAX_ALLOCS_ALLOWED_unary_1k_ping_pong=214000
     - <<: *tests
       name: "Unit Tests: Ubuntu 18.04 (Swift 5.3)"
       script: ./.travis-script.sh -t -a # test with tsan, run allocation tests
       env:
         - SWIFT_VERSION=5.3.3
-        - MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests=531000
-        - MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request=243000
+        - MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests=513000
+        - MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request=225000
         - MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests=112000
         - MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request=67000
         - MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request=63000
-        - MAX_ALLOCS_ALLOWED_unary_1k_ping_pong=234000
+        - MAX_ALLOCS_ALLOWED_unary_1k_ping_pong=214000
     - <<: *tests
       name: "Unit Tests: Ubuntu 18.04 (Swift 5.2)"
       script: ./.travis-script.sh -a # run allocation tests
       env:
         - SWIFT_VERSION=5.2.5
-        - MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests=542000
-        - MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request=245000
+        - MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests=524000
+        - MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request=227000
         - MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests=112000
         - MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request=67000
         - MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request=63000
-        - MAX_ALLOCS_ALLOWED_unary_1k_ping_pong=235000
+        - MAX_ALLOCS_ALLOWED_unary_1k_ping_pong=215000
     - <<: *tests
       name: "Unit Tests: Xcode 12.2"
       os: osx


### PR DESCRIPTION
Motivation:

A new version of NIO was released which killed a bunch of allocations
and now our CI is failing.

Modifications:

- Update allocation limits.

Result:

CI passes.