### PR TITLE
Extract the connection monitor from the connection manager

### DIFF
--- a/Sources/GRPC/ClientConnection.swift
+++ b/Sources/GRPC/ClientConnection.swift
@@ -93,9 +93,7 @@ public class ClientConnection {
   internal let authority: String
 
   /// A monitor for the connectivity state.
-  public var connectivity: ConnectivityStateMonitor {
-    return self.connectionManager.monitor
-  }
+  public let connectivity: ConnectivityStateMonitor
 
   /// The `EventLoop` this connection is using.
   public var eventLoop: EventLoop {
@@ -112,8 +110,16 @@ public class ClientConnection {
     self.configuration = configuration
     self.scheme = configuration.tls == nil ? "http" : "https"
     self.authority = configuration.tls?.hostnameOverride ?? configuration.target.host
+
+    let monitor = ConnectivityStateMonitor(
+      delegate: configuration.connectivityStateDelegate,
+      queue: configuration.connectivityStateDelegateQueue
+    )
+
+    self.connectivity = monitor
     self.connectionManager = ConnectionManager(
       configuration: configuration,
+      connectivityDelegate: monitor,
       logger: configuration.backgroundActivityLogger
     )
   }

--- a/Sources/GRPC/ConnectionManager+Delegates.swift
+++ b/Sources/GRPC/ConnectionManager+Delegates.swift
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+internal protocol ConnectionManagerConnectivityDelegate {
+  /// The state of the connection changed.
+  ///
+  /// - Parameters:
+  ///   - connectionManager: The connection manager reporting the change of state.
+  ///   - oldState: The previous `ConnectivityState`.
+  ///   - newState: The current `ConnectivityState`.
+  func connectionStateDidChange(
+    _ connectionManager: ConnectionManager,
+    from oldState: ConnectivityState,
+    to newState: ConnectivityState
+  )
+
+  /// The connection is quiescing.
+  ///
+  /// - Parameters:
+  ///   - connectionManager: The connection manager whose connection is quiescing.
+  func connectionIsQuiescing(_ connectionManager: ConnectionManager)
+}
+
+internal protocol ConnectionManagerHTTP2Delegate {
+  /// An HTTP/2 stream was closed.
+  ///
+  /// - Parameters:
+  ///   - connectionManager: The connection manager reporting the closed stream.
+  func streamClosed(_ connectionManager: ConnectionManager)
+
+  /// The connection received a SETTINGS frame containing SETTINGS_MAX_CONCURRENT_STREAMS.
+  ///
+  /// - Parameters:
+  ///   - connectionManager: The connection manager which received the settings update.
+  ///   - maxConcurrentStreams: The value of SETTINGS_MAX_CONCURRENT_STREAMS.
+  func receivedSettingsMaxConcurrentStreams(
+    _ connectionManager: ConnectionManager,
+    maxConcurrentStreams: Int
+  )
+}

--- a/Sources/GRPC/ConnectivityState.swift
+++ b/Sources/GRPC/ConnectivityState.swift
@@ -82,7 +82,7 @@ public class ConnectivityStateMonitor {
   /// - Parameter queue: The `DispatchQueue` on which the delegate will be called.
   init(delegate: ConnectivityStateDelegate?, queue: DispatchQueue?) {
     self._delegate = delegate
-    self.delegateCallbackQueue = queue ?? DispatchQueue(label: "io.grpc.connectivity")
+    self.delegateCallbackQueue = DispatchQueue(label: "io.grpc.connectivity", target: queue)
   }
 
   /// The current state of connectivity.
@@ -138,5 +138,19 @@ public class ConnectivityStateMonitor {
         delegate.connectionStartedQuiescing()
       }
     }
+  }
+}
+
+extension ConnectivityStateMonitor: ConnectionManagerConnectivityDelegate {
+  internal func connectionStateDidChange(
+    _ connectionManager: ConnectionManager,
+    from oldState: ConnectivityState,
+    to newState: ConnectivityState
+  ) {
+    self.updateState(to: newState, logger: connectionManager.logger)
+  }
+
+  internal func connectionIsQuiescing(_ connectionManager: ConnectionManager) {
+    self.beginQuiescing()
   }
 }

--- a/Sources/GRPC/GRPCIdleHandler.swift
+++ b/Sources/GRPC/GRPCIdleHandler.swift
@@ -130,6 +130,12 @@ internal final class GRPCIdleHandler: ChannelInboundHandler {
       }
     }
 
+    // Max concurrent streams changed.
+    if let manager = self.mode.connectionManager,
+      let maxConcurrentStreams = operations.maxConcurrentStreamsChange {
+      manager.maxConcurrentStreamsChanged(maxConcurrentStreams)
+    }
+
     // Handle idle timeout creation/cancellation.
     if let idleTask = operations.idleTask {
       switch idleTask {
@@ -222,6 +228,7 @@ internal final class GRPCIdleHandler: ChannelInboundHandler {
     } else if let closed = event as? StreamClosedEvent {
       self.perform(operations: self.stateMachine.streamClosed(withID: closed.streamID))
       self.handlePingAction(self.pingHandler.streamClosed())
+      self.mode.connectionManager?.streamClosed()
       context.fireUserInboundEventTriggered(event)
     } else if event is ChannelShouldQuiesceEvent {
       self.perform(operations: self.stateMachine.initiateGracefulShutdown())

--- a/Sources/GRPC/GRPCIdleHandlerStateMachine.swift
+++ b/Sources/GRPC/GRPCIdleHandlerStateMachine.swift
@@ -177,6 +177,9 @@ struct GRPCIdleHandlerStateMachine {
     /// An event to notify the connection manager about.
     private(set) var connectionManagerEvent: ConnectionManagerEvent?
 
+    /// The value of HTTP/2 SETTINGS_MAX_CONCURRENT_STREAMS changed.
+    private(set) var maxConcurrentStreamsChange: Int?
+
     /// An idle task, either scheduling or cancelling an idle timeout.
     private(set) var idleTask: IdleTask?
 
@@ -206,6 +209,10 @@ struct GRPCIdleHandlerStateMachine {
 
     fileprivate mutating func notifyConnectionManager(about event: ConnectionManagerEvent) {
       self.connectionManagerEvent = event
+    }
+
+    fileprivate mutating func maxConcurrentStreamsChanged(_ newValue: Int) {
+      self.maxConcurrentStreamsChange = newValue
     }
 
     private init() {
@@ -502,6 +509,7 @@ struct GRPCIdleHandlerStateMachine {
 
       // Update max concurrent streams.
       if let maxStreams = settings.last(where: { $0.parameter == .maxConcurrentStreams })?.value {
+        operations.maxConcurrentStreamsChanged(maxStreams)
         state.maxConcurrentStreams = maxStreams
       }
       self.state = .operating(state)
@@ -509,6 +517,7 @@ struct GRPCIdleHandlerStateMachine {
     case var .waitingToIdle(state):
       // Update max concurrent streams.
       if let maxStreams = settings.last(where: { $0.parameter == .maxConcurrentStreams })?.value {
+        operations.maxConcurrentStreamsChanged(maxStreams)
         state.maxConcurrentStreams = maxStreams
       }
       self.state = .waitingToIdle(state)


### PR DESCRIPTION
Motivation:

The connection monitor allows users to register a delegate for changes
in connectivity state as well as access the current state. Because the
user code may call out it is executed on a `DispatchQueue` (rather than
the connection's `EventLoop`).

However, there are cases within gRPC where state change notifications
on the event loop are very useful (such as in a pool of connection
managers all running on the same event loop).

Moreover, it's not necessary for the connection manager to hold the
connection monitor, it just needs a way to inform it about any changes
so that it can call any user provided delegates.

Modifications:

- Extract the connectivity monitor from the connection manager
- Allow on-event-loop callbacks to be passed to the connection manager
  for connection state changes and for certain HTTP/2 events (stream
  closed and receiving max concurrent streams settings). While not
  strictly necessary for this change they will be helpful down the line.
- Update a bunch of tests.

Result:

The connection manager no longer holds a connection monitor and may
execute state change callbacks on the event loop.