### PR TITLE
Add a per event loop connection pool

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
   dependencies: [
     // GRPC dependencies:
     // Main SwiftNIO package
-    .package(url: "https://github.com/apple/swift-nio.git", from: "2.27.0"),
+    .package(url: "https://github.com/apple/swift-nio.git", from: "2.28.0"),
     // HTTP2 via SwiftNIO
     .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.16.1"),
     // TLS via SwiftNIO

--- a/Sources/GRPC/ConnectionPool/ConnectionManagerID.swift
+++ b/Sources/GRPC/ConnectionPool/ConnectionManagerID.swift
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+internal struct ConnectionManagerID: Hashable, CustomStringConvertible {
+  private let id: ObjectIdentifier
+
+  internal init(_ manager: ConnectionManager) {
+    self.id = ObjectIdentifier(manager)
+  }
+
+  internal var description: String {
+    return String(describing: self.id)
+  }
+}
+
+extension ConnectionManager {
+  internal var id: ConnectionManagerID {
+    return ConnectionManagerID(self)
+  }
+}

--- a/Sources/GRPC/ConnectionPool/ConnectionPool+PerConnectionState.swift
+++ b/Sources/GRPC/ConnectionPool/ConnectionPool+PerConnectionState.swift
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2021, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import NIOHTTP2
+
+extension ConnectionPool {
+  internal struct PerConnectionState {
+    /// The connection manager for this connection.
+    internal var manager: ConnectionManager
+
+    /// Stream availability for this connection, `nil` if the connection is not available.
+    private var availability: StreamAvailability?
+
+    private struct StreamAvailability {
+      var multiplexer: HTTP2StreamMultiplexer
+      /// Maximum number of available streams.
+      var maxAvailable: Int
+      /// Number of streams reserved.
+      var reserved: Int = 0
+      /// Number of available streams.
+      var available: Int {
+        return self.maxAvailable - self.reserved
+      }
+
+      /// Increment the reserved streams and return the multiplexer.
+      mutating func reserve() -> HTTP2StreamMultiplexer {
+        self.reserved += 1
+        return self.multiplexer
+      }
+
+      /// Decrement the reserved streams by one.
+      mutating func `return`() {
+        self.reserved -= 1
+      }
+    }
+
+    init(manager: ConnectionManager) {
+      self.manager = manager
+      self.availability = nil
+    }
+
+    /// The number of reserved streams.
+    internal var reservedStreams: Int {
+      return self.availability?.reserved ?? 0
+    }
+
+    /// The number of streams available to reserve. If this value is greater than zero then it is
+    /// safe to call `reserveStream()` and force unwrap the result.
+    internal var availableStreams: Int {
+      return self.availability?.available ?? 0
+    }
+
+    /// Reserve a stream and return the stream multiplexer. Returns `nil` if it is not possible
+    /// to reserve a stream.
+    ///
+    /// The result may be safely unwrapped if `self.availableStreams > 0` when reserving a stream.
+    internal mutating func reserveStream() -> HTTP2StreamMultiplexer? {
+      return self.availability?.reserve()
+    }
+
+    /// Return a reserved stream to the connection.
+    internal mutating func returnStream() {
+      self.availability?.return()
+    }
+
+    internal mutating func updateMaxConcurrentStreams(_ maxConcurrentStreams: Int) {
+      self.availability?.maxAvailable = maxConcurrentStreams
+    }
+
+    /// Mark the connection as available for reservation.
+    internal mutating func available(maxConcurrentStreams: Int) {
+      assert(self.availability == nil)
+
+      self.availability = self.manager.sync.multiplexer.map {
+        StreamAvailability(multiplexer: $0, maxAvailable: maxConcurrentStreams)
+      }
+    }
+
+    /// Mark the connection as unavailable returning the number of reserved streams.
+    internal mutating func unavailable() -> Int {
+      defer {
+        self.availability = nil
+      }
+      return self.availability?.reserved ?? 0
+    }
+  }
+}

--- a/Sources/GRPC/ConnectionPool/ConnectionPool+PerConnectionState.swift
+++ b/Sources/GRPC/ConnectionPool/ConnectionPool+PerConnectionState.swift
@@ -1,7 +1,7 @@
 /*
  * Copyright 2021, gRPC Authors All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the License);
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/Sources/GRPC/ConnectionPool/ConnectionPool+PerConnectionState.swift
+++ b/Sources/GRPC/ConnectionPool/ConnectionPool+PerConnectionState.swift
@@ -81,8 +81,10 @@ extension ConnectionPool {
       self.availability?.return()
     }
 
-    /// Update the maximum concurrent streams available on the connection, marking is as available
-    /// if it was not previously available.
+    /// Update the maximum concurrent streams available on the connection, marking it as available
+    /// if it was not already.
+    ///
+    /// Returns the previous value for max concurrent streams if the connection was ready.
     internal mutating func updateMaxConcurrentStreams(_ maxConcurrentStreams: Int) -> Int? {
       if self.availability != nil {
         let oldValue = self.availability!.maxAvailable

--- a/Sources/GRPC/ConnectionPool/ConnectionPool+Waiter.swift
+++ b/Sources/GRPC/ConnectionPool/ConnectionPool+Waiter.swift
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2021, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import NIO
+import NIOHTTP2
+
+extension ConnectionPool {
+  internal struct Waiter {
+    /// A promise to complete with the initialized channel.
+    private let promise: EventLoopPromise<Channel>
+
+    fileprivate var channelFuture: EventLoopFuture<Channel> {
+      return self.promise.futureResult
+    }
+
+    /// The channel initializer.
+    private let channelInitializer: (Channel) -> EventLoopFuture<Void>
+
+    /// The deadline at which the timeout is scheduled.
+    private let deadline: NIODeadline
+
+    /// A scheduled task which fails the stream promise should the pool not provide
+    /// a stream in time.
+    private var scheduledTimeout: Scheduled<Void>?
+
+    /// An identifier for this waiter.
+    internal var id: ID {
+      return ID(self)
+    }
+
+    internal init(
+      deadline: NIODeadline,
+      promise: EventLoopPromise<Channel>,
+      channelInitializer: @escaping (Channel) -> EventLoopFuture<Void>
+    ) {
+      self.deadline = deadline
+      self.promise = promise
+      self.channelInitializer = channelInitializer
+      self.scheduledTimeout = nil
+    }
+
+    /// Schedule a timeout for this waiter. This task will be cancelled when the waiter is
+    /// succeeded or failed.
+    ///
+    /// - Parameters:
+    ///   - eventLoop: The `EventLoop` to run the timeout task on.
+    ///   - body: The closure to execute when the timeout is fired.
+    internal mutating func scheduleTimeout(
+      on eventLoop: EventLoop,
+      execute body: @escaping () -> Void
+    ) {
+      assert(self.scheduledTimeout == nil)
+      eventLoop.scheduleTask(deadline: self.deadline, body)
+    }
+
+    /// Returns a boolean value indicating whether the deadline for this waiter occurs after the
+    /// given deadline.
+    internal func deadlineIsAfter(_ other: NIODeadline) -> Bool {
+      return self.deadline > other
+    }
+
+    /// Succeed the waiter with the given multiplexer.
+    internal mutating func succeed(with multiplexer: HTTP2StreamMultiplexer) {
+      self.scheduledTimeout?.cancel()
+      self.scheduledTimeout = nil
+      multiplexer.createStreamChannel(promise: self.promise, self.channelInitializer)
+    }
+
+    /// Fail the waiter with `error`.
+    internal mutating func fail(_ error: Error) {
+      self.scheduledTimeout?.cancel()
+      self.scheduledTimeout = nil
+      self.promise.fail(error)
+    }
+
+    /// The ID of a waiter.
+    internal struct ID: Hashable, CustomStringConvertible {
+      private let id: ObjectIdentifier
+
+      fileprivate init(_ waiter: Waiter) {
+        self.id = ObjectIdentifier(waiter.channelFuture)
+      }
+
+      internal var description: String {
+        return String(describing: self.id)
+      }
+    }
+  }
+}

--- a/Sources/GRPC/ConnectionPool/ConnectionPool+Waiter.swift
+++ b/Sources/GRPC/ConnectionPool/ConnectionPool+Waiter.swift
@@ -17,7 +17,7 @@ import NIO
 import NIOHTTP2
 
 extension ConnectionPool {
-  internal struct Waiter {
+  internal final class Waiter {
     /// A promise to complete with the initialized channel.
     private let promise: EventLoopPromise<Channel>
 
@@ -57,7 +57,7 @@ extension ConnectionPool {
     /// - Parameters:
     ///   - eventLoop: The `EventLoop` to run the timeout task on.
     ///   - body: The closure to execute when the timeout is fired.
-    internal mutating func scheduleTimeout(
+    internal func scheduleTimeout(
       on eventLoop: EventLoop,
       execute body: @escaping () -> Void
     ) {
@@ -72,14 +72,14 @@ extension ConnectionPool {
     }
 
     /// Succeed the waiter with the given multiplexer.
-    internal mutating func succeed(with multiplexer: HTTP2StreamMultiplexer) {
+    internal func succeed(with multiplexer: HTTP2StreamMultiplexer) {
       self.scheduledTimeout?.cancel()
       self.scheduledTimeout = nil
       multiplexer.createStreamChannel(promise: self.promise, self.channelInitializer)
     }
 
     /// Fail the waiter with `error`.
-    internal mutating func fail(_ error: Error) {
+    internal func fail(_ error: Error) {
       self.scheduledTimeout?.cancel()
       self.scheduledTimeout = nil
       self.promise.fail(error)
@@ -90,7 +90,7 @@ extension ConnectionPool {
       private let id: ObjectIdentifier
 
       fileprivate init(_ waiter: Waiter) {
-        self.id = ObjectIdentifier(waiter.channelFuture)
+        self.id = ObjectIdentifier(waiter)
       }
 
       internal var description: String {

--- a/Sources/GRPC/ConnectionPool/ConnectionPool.swift
+++ b/Sources/GRPC/ConnectionPool/ConnectionPool.swift
@@ -340,6 +340,7 @@ internal final class ConnectionPool {
   private func computeStreamDemandAndCapacity() -> (demand: Int, capacity: Int) {
     let demand = self.sync.reservedStreams + self.sync.waiters
 
+    // TODO: make this cheaper by storing and incrementally updating the number of idle connections
     let capacity = self.connections.values.reduce(0) { sum, state in
       if state.manager.sync.isIdle {
         // Idle connection, no capacity.

--- a/Sources/GRPC/ConnectionPool/ConnectionPool.swift
+++ b/Sources/GRPC/ConnectionPool/ConnectionPool.swift
@@ -1,0 +1,660 @@
+/*
+ * Copyright 2021, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Logging
+import NIO
+import NIOConcurrencyHelpers
+import NIOHTTP2
+
+internal final class ConnectionPool {
+  /// The event loop all connections in this pool are running on.
+  internal let eventLoop: EventLoop
+
+  private enum State {
+    case active
+    case shuttingDown(EventLoopFuture<Void>)
+    case shutdown
+  }
+
+  /// The state of the connection pool.
+  private var state: State = .active
+
+  /// Connection managers and their stream availability state keyed by the ID of the connection
+  /// manager.
+  ///
+  /// Connections are accessed by their ID for connection state changes (infrequent) and when
+  /// streams are closed (frequent). However when choosing which connection to succeed a waiter
+  /// with (frequent) requires the connections to be ordered by their availability. A dictionary
+  /// might not be the most efficient data structure (a queue prioritised by stream availability may
+  /// be a better choice given the number of connections is likely to be very low in practice).
+  private var connections: [ConnectionManagerID: PerConnectionState]
+
+  /// The threshold which if exceeded when creating a stream determines whether the pool will
+  /// start connecting an idle connection (if one exists).
+  ///
+  /// The 'load' is calculated as the ratio of demand for streams (the sum of the number of waiters
+  /// and the number of reserved streams) and the total number of streams which non-idle connections
+  /// could support (this includes the streams that a connection in the connecting state could
+  /// support).
+  private let reservationLoadThreshold: Double
+
+  /// The maximum number of concurrent streams a connection can support. For simplicity, this
+  /// is _assumed_ to be the same for all connections in the pool.
+  private var maxConcurrentStreams: Int = 100
+
+  /// A queue of waiters which may or may not get a stream in the future.
+  private var waiters: CircularBuffer<Waiter>
+
+  /// The maximum number of waiters allowed, the size of `waiters` must not exceed this value. If
+  /// there are this many waiters in the queue then the next waiter will be failed immediately.
+  private let maxWaiters: Int
+
+  /// Provides a channel factory to the `ConnectionManager`.
+  private let channelProvider: ConnectionManagerChannelProvider
+
+  /// The object to notify about changes to stream reservations; in practice this is usually
+  /// the `PoolManager`.
+  private let streamLender: StreamLender
+
+  /// A logger which always sets "GRPC" as its source.
+  private let logger: GRPCLogger
+
+  /// Returns `NIODeadline` representing 'now'. This is useful for testing.
+  private let now: () -> NIODeadline
+
+  /// Logging metadata keys.
+  private enum Metadata {
+    /// The ID of this pool.
+    static let id = "pool.id"
+    /// The number of stream reservations (i.e. number of open streams + number of waiters).
+    static let reservationsCount = "pool.reservations.count"
+    /// The number of streams this pool can support with non-idle connections at this time.
+    static let reservationsCapacity = "pool.reservations.capacity"
+    /// The current reservation load (i.e. reservation count / reservation capacity)
+    static let reservationsLoad = "pool.reservations.load"
+    /// The reservation load threshold, above which a new connection will be created (if possible).
+    static let reservationsLoadThreshold = "pool.reservations.loadThreshold"
+    /// The current number of waiters in the pool.
+    static let waitersCount = "pool.waiters.count"
+    /// The maximum number of waiters the pool is configured to allow.
+    static let waitersMax = "pool.waiters.max"
+    /// The number of waiters which were successfully serviced.
+    static let waitersServiced = "pool.waiters.serviced"
+    /// The ID of waiter.
+    static let waiterID = "pool.waiter.id"
+  }
+
+  init(
+    eventLoop: EventLoop,
+    maxWaiters: Int,
+    reservationLoadThreshold: Double,
+    channelProvider: ConnectionManagerChannelProvider,
+    streamLender: StreamLender,
+    logger: GRPCLogger,
+    now: @escaping () -> NIODeadline = NIODeadline.now
+  ) {
+    precondition(
+      (0.0 ... 1.0).contains(reservationLoadThreshold),
+      "reservationLoadThreshold must be within the range 0.0 ... 1.0"
+    )
+    self.reservationLoadThreshold = reservationLoadThreshold
+
+    self.connections = [:]
+    self.maxWaiters = maxWaiters
+    self.waiters = CircularBuffer(initialCapacity: 16)
+
+    self.eventLoop = eventLoop
+    self.channelProvider = channelProvider
+    self.streamLender = streamLender
+    self.logger = logger
+    self.now = now
+  }
+
+  /// Initialize the connection pool.
+  ///
+  /// - Parameter connections: The number of connections to add to the pool.
+  internal func initialize(connections: Int) {
+    assert(self.connections.isEmpty)
+    self.connections.reserveCapacity(connections)
+    while self.connections.count < connections {
+      self.addConnectionToPool()
+    }
+  }
+
+  /// Make and add a new connection to the pool.
+  private func addConnectionToPool() {
+    let manager = ConnectionManager(
+      eventLoop: self.eventLoop,
+      channelProvider: self.channelProvider,
+      callStartBehavior: .waitsForConnectivity,
+      connectionBackoff: ConnectionBackoff(),
+      connectivityDelegate: self,
+      http2Delegate: self,
+      logger: self.logger.unwrapped
+    )
+    self.connections[manager.id] = PerConnectionState(manager: manager)
+  }
+
+  // MARK: - Called from the pool manager
+
+  /// Make and initialize an HTTP/2 stream `Channel`.
+  ///
+  /// - Parameters:
+  ///   - deadline: The point in time by which the `promise` must have been resolved.
+  ///   - promise: A promise for a `Channel`.
+  ///   - logger: A request logger.
+  ///   - initializer: A closure to initialize the `Channel` with.
+  internal func makeStream(
+    deadline: NIODeadline,
+    promise: EventLoopPromise<Channel>,
+    logger: GRPCLogger,
+    initializer: @escaping (Channel) -> EventLoopFuture<Void>
+  ) {
+    if self.eventLoop.inEventLoop {
+      self._makeStream(
+        deadline: deadline,
+        promise: promise,
+        logger: logger,
+        initializer: initializer
+      )
+    } else {
+      self.eventLoop.execute {
+        self._makeStream(
+          deadline: deadline,
+          promise: promise,
+          logger: logger,
+          initializer: initializer
+        )
+      }
+    }
+  }
+
+  /// See `makeStream(deadline:promise:logger:initializer:)`.
+  internal func makeStream(
+    deadline: NIODeadline,
+    logger: GRPCLogger,
+    initializer: @escaping (Channel) -> EventLoopFuture<Void>
+  ) -> EventLoopFuture<Channel> {
+    let promise = self.eventLoop.makePromise(of: Channel.self)
+    self.makeStream(deadline: deadline, promise: promise, logger: logger, initializer: initializer)
+    return promise.futureResult
+  }
+
+  /// Shutdown the connection pool.
+  ///
+  /// Existing waiters will be failed and all underlying connections will be shutdown. Subsequent
+  /// calls to `makeStream` will be failed immediately.
+  internal func shutdown() -> EventLoopFuture<Void> {
+    let promise = self.eventLoop.makePromise(of: Void.self)
+
+    if self.eventLoop.inEventLoop {
+      self._shutdown(promise: promise)
+    } else {
+      self.eventLoop.execute {
+        self._shutdown(promise: promise)
+      }
+    }
+
+    return promise.futureResult
+  }
+
+  /// See `makeStream(deadline:promise:logger:initializer:)`.
+  ///
+  /// - Important: Must be called on the pool's `EventLoop`.
+  private func _makeStream(
+    deadline: NIODeadline,
+    promise: EventLoopPromise<Channel>,
+    logger: GRPCLogger,
+    initializer: @escaping (Channel) -> EventLoopFuture<Void>
+  ) {
+    self.eventLoop.assertInEventLoop()
+
+    guard case .active = self.state else {
+      // Fail the promise right away if we're shutting down or already shut down.
+      promise.fail(ConnectionPoolError.shutdown)
+      return
+    }
+
+    // Try to make a stream on an existing connection.
+    let streamCreated = self.tryMakeStream(promise: promise, initializer: initializer)
+
+    if !streamCreated {
+      // No stream was created, wait for one.
+      self.enqueueWaiter(
+        deadline: deadline,
+        promise: promise,
+        logger: logger,
+        initializer: initializer
+      )
+    }
+  }
+
+  /// Try to find an existing connection on which we can make a stream.
+  ///
+  /// - Parameters:
+  ///   - promise: A promise to succeed if we can make a stream.
+  ///   - initializer: A closure to initialize the stream with.
+  /// - Returns: A boolean value indicating whether the stream was created or not.
+  private func tryMakeStream(
+    promise: EventLoopPromise<Channel>,
+    initializer: @escaping (Channel) -> EventLoopFuture<Void>
+  ) -> Bool {
+    // We shouldn't jump the queue.
+    guard self.waiters.isEmpty else {
+      return false
+    }
+
+    // Reserve a stream, if we can.
+    guard let multiplexer = self.reserveStreamFromMostAvailableConnection() else {
+      return false
+    }
+
+    multiplexer.createStreamChannel(promise: promise, initializer)
+
+    // Has reserving another stream tipped us over the limit for needing another connection?
+    if self.shouldBringUpAnotherConnection() {
+      self.startConnectingIdleConnection()
+    }
+
+    return true
+  }
+
+  /// Enqueue a waiter to be provided with a stream at some point in the future.
+  ///
+  /// - Parameters:
+  ///   - deadline: The point in time by which the promise should have been completed.
+  ///   - promise: The promise to complete with the `Channel`.
+  ///   - logger: A logger.
+  ///   - initializer: A closure to initialize the `Channel` with.
+  private func enqueueWaiter(
+    deadline: NIODeadline,
+    promise: EventLoopPromise<Channel>,
+    logger: GRPCLogger,
+    initializer: @escaping (Channel) -> EventLoopFuture<Void>
+  ) {
+    // Don't overwhelm the pool with too many waiters.
+    guard self.waiters.count < self.maxWaiters else {
+      logger.trace("connection pool has too many waiters", metadata: [
+        Metadata.waitersMax: "\(self.maxWaiters)",
+      ])
+      promise.fail(ConnectionPoolError.tooManyWaiters)
+      return
+    }
+
+    var waiter = Waiter(deadline: deadline, promise: promise, channelInitializer: initializer)
+
+    // Fail the waiter and punt it from the queue when it times out. It's okay that we schedule the
+    // timeout before appending it to the waiters, it wont run until the next event loop tick at the
+    // earliest (even if the deadline has already passed).
+    waiter.scheduleTimeout(on: self.eventLoop) {
+      waiter.fail(ConnectionPoolError.deadlineExceeded)
+      if let index = self.waiters.firstIndex(where: { $0.id == waiter.id }) {
+        self.waiters.remove(at: index)
+
+        logger.trace("timed out waiting for a connection", metadata: [
+          Metadata.waiterID: "\(waiter.id)",
+          Metadata.waitersCount: "\(self.waiters.count)",
+        ])
+      }
+    }
+
+    // request logger
+    logger.debug("waiting for a connection to become available", metadata: [
+      Metadata.waiterID: "\(waiter.id)",
+      Metadata.waitersCount: "\(self.waiters.count)",
+    ])
+
+    self.waiters.append(waiter)
+
+    // pool logger
+    self.logger.trace("enqueued connection waiter", metadata: [
+      Metadata.waitersCount: "\(self.waiters.count)",
+    ])
+
+    if self.shouldBringUpAnotherConnection() {
+      self.startConnectingIdleConnection()
+    }
+  }
+
+  /// Compute the current demand and capacity for streams.
+  ///
+  /// The 'demand' for streams is the number of reserved streams and the number of waiters. The
+  /// capacity for streams is the product of max concurrent streams and the number of non-idle
+  /// connections.
+  ///
+  /// - Returns: A tuple of the demand and capacity for streams.
+  private func computeStreamDemandAndCapacity() -> (demand: Int, capacity: Int) {
+    // TODO: make this cheaper by storing and incrementally updating the number of idle connections
+    let nonIdleConnections = self.connections.values.reduce(0) { sum, state in
+      if state.manager.sync.isIdle {
+        return sum
+      } else {
+        return sum &+ 1
+      }
+    }
+
+    let demand = self.sync.reservedStreams + self.sync.waiters
+
+    return (demand, nonIdleConnections * self.maxConcurrentStreams)
+  }
+
+  /// Returns whether the pool should start connecting an idle connection (if one exists).
+  private func shouldBringUpAnotherConnection() -> Bool {
+    let (demand, capacity) = self.computeStreamDemandAndCapacity()
+
+    // Infinite -- i.e. all connections are idle or no connections exist -- is okay here as it
+    // will always be greater than the threshold and a new connection will be spun up.
+    let load = Double(demand) / Double(capacity)
+    let loadExceedsThreshold = load >= self.reservationLoadThreshold
+
+    if loadExceedsThreshold {
+      self.logger.debug(
+        "stream reservation load factor greater than or equal to threshold, bringing up additional connection if available",
+        metadata: [
+          Metadata.reservationsCount: "\(demand)",
+          Metadata.reservationsCapacity: "\(capacity)",
+          Metadata.reservationsLoad: "\(load)",
+          Metadata.reservationsLoadThreshold: "\(self.reservationLoadThreshold)",
+        ]
+      )
+    }
+
+    return loadExceedsThreshold
+  }
+
+  /// Starts connecting an idle connection, if one exists.
+  private func startConnectingIdleConnection() {
+    if let index = self.connections.values.firstIndex(where: { $0.manager.sync.isIdle }) {
+      self.connections.values[index].manager.sync.startConnecting()
+    }
+  }
+
+  /// Returns the index in `self.connections.values` of the connection with the most available
+  /// streams. Returns `self.connections.endIndex` if no connection has at least one stream
+  /// available.
+  ///
+  /// - Note: this is linear in the number of connections.
+  private func mostAvailableConnectionIndex(
+  ) -> Dictionary<ConnectionManagerID, PerConnectionState>.Index {
+    var index = self.connections.values.startIndex
+    var selectedIndex = self.connections.values.endIndex
+    var mostAvailableStreams = 0
+
+    while index != self.connections.values.endIndex {
+      let availableStreams = self.connections.values[index].availableStreams
+      if availableStreams > mostAvailableStreams {
+        mostAvailableStreams = availableStreams
+        selectedIndex = index
+      }
+
+      self.connections.values.formIndex(after: &index)
+    }
+
+    return selectedIndex
+  }
+
+  /// Reserves a stream from the connection with the most available streams, if one exists.
+  ///
+  /// - Returns: The `HTTP2StreamMultiplexer` from the connection the stream was reserved from,
+  ///     or `nil` if no stream could be reserved.
+  private func reserveStreamFromMostAvailableConnection() -> HTTP2StreamMultiplexer? {
+    let index = self.mostAvailableConnectionIndex()
+
+    if index != self.connections.endIndex {
+      // '!' is okay here; the most available connection must have at least one stream available
+      // to reserve.
+      return self.connections.values[index].reserveStream()!
+    } else {
+      return nil
+    }
+  }
+
+  /// See `shutdown()`.
+  ///
+  /// - Parameter promise: A `promise` to complete when the pool has been shutdown.
+  private func _shutdown(promise: EventLoopPromise<Void>) {
+    self.eventLoop.assertInEventLoop()
+
+    switch self.state {
+    case .active:
+      self.logger.debug("shutting down connection pool")
+
+      // We're shutting down now and when that's done we'll be fully shutdown.
+      self.state = .shuttingDown(promise.futureResult)
+      promise.futureResult.whenComplete { _ in
+        self.state = .shutdown
+        self.logger.trace("finished shutting down connection pool")
+      }
+
+      // Shutdown all the connections and remove them from the pool.
+      let allShutdown: [EventLoopFuture<Void>] = self.connections.values.map {
+        return $0.manager.shutdown()
+      }
+      self.connections.removeAll()
+
+      // Fail the outstanding waiters.
+      while var waiter = self.waiters.popFirst() {
+        waiter.fail(ConnectionPoolError.shutdown)
+      }
+
+      // Cascade the result of the shutdown into the promise.
+      EventLoopFuture.andAllSucceed(allShutdown, promise: promise)
+
+    case let .shuttingDown(future):
+      // We're already shutting down, cascade the result.
+      promise.completeWith(future)
+
+    case .shutdown:
+      // Already shutdown, fine.
+      promise.succeed(())
+    }
+  }
+}
+
+extension ConnectionPool: ConnectionManagerConnectivityDelegate {
+  func connectionStateDidChange(
+    _ manager: ConnectionManager,
+    from oldState: ConnectivityState,
+    to newState: ConnectivityState
+  ) {
+    switch (oldState, newState) {
+    case (.connecting, .ready):
+      // This is the only valid transition to ready.
+      self.connectionAvailable(manager.id)
+
+    case (.ready, .transientFailure),
+         (.ready, .idle),
+         (.ready, .shutdown):
+      // The connection is no longer available.
+      self.connectionUnavailable(manager.id)
+
+    default:
+      // We're only interested in becoming 'ready' and no longer being 'ready'.
+      ()
+    }
+  }
+
+  func connectionIsQuiescing(_ manager: ConnectionManager) {
+    self.eventLoop.assertInEventLoop()
+    guard let removed = self.connections.removeValue(forKey: manager.id) else {
+      return
+    }
+
+    // Drop any delegates. We're no longer interested in these events.
+    removed.manager.sync.connectivityDelegate = nil
+    removed.manager.sync.http2Delegate = nil
+
+    // Replace the connection with a new idle one.
+    self.addConnectionToPool()
+
+    // Since we're removing this connection from the pool, the pool manager can ignore any streams
+    // reserved against this connection.
+    //
+    // Note: we don't need to adjust the number of available streams as the number of connections
+    // hasn't changed.
+    self.streamLender.returnStreams(removed.reservedStreams, to: self)
+  }
+
+  /// A connection is now in the ready state, it can provide streams to waiters.
+  private func connectionAvailable(_ id: ConnectionManagerID) {
+    self.eventLoop.assertInEventLoop()
+    self.connections[id]?.available(maxConcurrentStreams: self.maxConcurrentStreams)
+
+    // A connection becoming ready is usually followed by an update to max concurrent streams.
+    // Instead of servicing waiters right now we'll do this in a jiffy, i.e. once we receive the
+    // update to max concurrent streams. This allows us to avoid succeeding too many waiters if max
+    // concurrent streams is lower than we previously assumed.
+    self.eventLoop.execute {
+      self.tryServiceWaiters()
+    }
+  }
+
+  /// A connection has become unavailable.
+  private func connectionUnavailable(_ id: ConnectionManagerID) {
+    self.eventLoop.assertInEventLoop()
+    // The connection is no longer available: any streams which haven't been closed will be counted
+    // as a dropped reservation, we need to tell the pool manager about them.
+    if let droppedReservations = self.connections[id]?.unavailable(), droppedReservations > 0 {
+      self.streamLender.returnStreams(droppedReservations, to: self)
+    }
+  }
+}
+
+extension ConnectionPool: ConnectionManagerHTTP2Delegate {
+  internal func streamClosed(_ manager: ConnectionManager) {
+    self.eventLoop.assertInEventLoop()
+
+    // Return the stream the connection and to the pool manager.
+    self.connections[manager.id]?.returnStream()
+    self.streamLender.returnStreams(1, to: self)
+
+    // A stream was returned: we may be able to service a waiter now.
+    self.tryServiceWaiters()
+  }
+
+  internal func receivedSettingsMaxConcurrentStreams(
+    _ manager: ConnectionManager,
+    maxConcurrentStreams: Int
+  ) {
+    self.eventLoop.assertInEventLoop()
+    self.connections[manager.id]?.updateMaxConcurrentStreams(maxConcurrentStreams)
+
+    if maxConcurrentStreams != self.maxConcurrentStreams {
+      self.maxConcurrentStreams = maxConcurrentStreams
+      let maxAvailable = maxConcurrentStreams * self.connections.count
+      self.streamLender.updateStreamCapacity(to: maxAvailable, for: self)
+      self.tryServiceWaiters()
+    }
+  }
+}
+
+extension ConnectionPool {
+  // MARK: - Waiters
+
+  /// Try to service as many waiters as possible.
+  ///
+  /// This an expensive operation, in the worst case it will be `O(W ⨉ N)` where `W` is the number
+  /// of waiters and `N` is the number of connections.
+  private func tryServiceWaiters() {
+    if self.waiters.isEmpty { return }
+
+    self.logger.trace("servicing waiters", metadata: [
+      Metadata.waitersCount: "\(self.waiters.count)",
+    ])
+
+    let now = self.now()
+    var serviced = 0
+
+    while !self.waiters.isEmpty {
+      if self.waiters.first!.deadlineIsAfter(now) {
+        if let multiplexer = self.reserveStreamFromMostAvailableConnection() {
+          // The waiter's deadline is in the future, and we have a suitable connection. Remove and
+          // succeed the waiter.
+          var waiter = self.waiters.removeFirst()
+          serviced &+= 1
+          waiter.succeed(with: multiplexer)
+        } else {
+          // There are waiters but no available connections, we're done.
+          break
+        }
+      } else {
+        // The waiter's deadline has already expired, there's no point completing it. Remove it and
+        // let its scheduled timeout fail the promise.
+        self.waiters.removeFirst()
+      }
+    }
+
+    self.logger.trace("done servicing waiters", metadata: [
+      Metadata.waitersCount: "\(self.waiters.count)",
+      Metadata.waitersServiced: "\(serviced)",
+    ])
+  }
+}
+
+extension ConnectionPool {
+  /// Synchronous operations for the pool, mostly used by tests.
+  internal struct Sync {
+    private let pool: ConnectionPool
+
+    fileprivate init(_ pool: ConnectionPool) {
+      self.pool = pool
+    }
+
+    /// The number of outstanding connection waiters.
+    internal var waiters: Int {
+      self.pool.eventLoop.assertInEventLoop()
+      return self.pool.waiters.count
+    }
+
+    /// The number of connection currently in the pool (in any state).
+    internal var connections: Int {
+      self.pool.eventLoop.assertInEventLoop()
+      return self.pool.connections.count
+    }
+
+    /// The number of idle connections in the pool.
+    internal var idleConnections: Int {
+      self.pool.eventLoop.assertInEventLoop()
+      return self.pool.connections.values.reduce(0) { $0 &+ ($1.manager.sync.isIdle ? 1 : 0) }
+    }
+
+    /// The number of streams currently available to reserve across all connections in the pool.
+    internal var availableStreams: Int {
+      self.pool.eventLoop.assertInEventLoop()
+      return self.pool.connections.values.reduce(0) { $0 + $1.availableStreams }
+    }
+
+    /// The number of streams which have been reserved across all connections in the pool.
+    internal var reservedStreams: Int {
+      self.pool.eventLoop.assertInEventLoop()
+      return self.pool.connections.values.reduce(0) { $0 + $1.reservedStreams }
+    }
+  }
+
+  internal var sync: Sync {
+    return Sync(self)
+  }
+}
+
+internal enum ConnectionPoolError: Error {
+  /// The pool is shutdown or shutting down.
+  case shutdown
+
+  /// There are too many waiters in the pool.
+  case tooManyWaiters
+
+  /// The deadline for creating a stream has passed.
+  case deadlineExceeded
+}

--- a/Sources/GRPC/ConnectionPool/ConnectionPool.swift
+++ b/Sources/GRPC/ConnectionPool/ConnectionPool.swift
@@ -295,7 +295,7 @@ internal final class ConnectionPool {
       return
     }
 
-    var waiter = Waiter(deadline: deadline, promise: promise, channelInitializer: initializer)
+    let waiter = Waiter(deadline: deadline, promise: promise, channelInitializer: initializer)
 
     // Fail the waiter and punt it from the queue when it times out. It's okay that we schedule the
     // timeout before appending it to the waiters, it wont run until the next event loop tick at the
@@ -451,7 +451,7 @@ internal final class ConnectionPool {
       self.connections.removeAll()
 
       // Fail the outstanding waiters.
-      while var waiter = self.waiters.popFirst() {
+      while let waiter = self.waiters.popFirst() {
         waiter.fail(ConnectionPoolError.shutdown)
       }
 
@@ -555,6 +555,7 @@ extension ConnectionPool: ConnectionManagerHTTP2Delegate {
       self.streamLender.increaseStreamCapacity(by: delta, for: self)
     }
 
+    // We always check, even if `delta` isn't greater than zero as this might be a new connection.
     self.tryServiceWaiters()
   }
 }
@@ -581,7 +582,7 @@ extension ConnectionPool {
         if let multiplexer = self.reserveStreamFromMostAvailableConnection() {
           // The waiter's deadline is in the future, and we have a suitable connection. Remove and
           // succeed the waiter.
-          var waiter = self.waiters.removeFirst()
+          let waiter = self.waiters.removeFirst()
           serviced &+= 1
           waiter.succeed(with: multiplexer)
         } else {

--- a/Sources/GRPC/ConnectionPool/StreamLender.swift
+++ b/Sources/GRPC/ConnectionPool/StreamLender.swift
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+internal protocol StreamLender {
+  /// `count` streams are being returned to the given `pool`.
+  func returnStreams(_ count: Int, to pool: ConnectionPool)
+
+  /// Update the total number of streams which may be available at given time for `pool`
+  /// to `maximum`.
+  func updateStreamCapacity(to maximum: Int, for pool: ConnectionPool)
+}

--- a/Sources/GRPC/ConnectionPool/StreamLender.swift
+++ b/Sources/GRPC/ConnectionPool/StreamLender.swift
@@ -18,7 +18,6 @@ internal protocol StreamLender {
   /// `count` streams are being returned to the given `pool`.
   func returnStreams(_ count: Int, to pool: ConnectionPool)
 
-  /// Update the total number of streams which may be available at given time for `pool`
-  /// to `maximum`.
-  func updateStreamCapacity(to maximum: Int, for pool: ConnectionPool)
+  /// Update the total number of streams which may be available at given time for `pool` by `delta`.
+  func increaseStreamCapacity(by delta: Int, for pool: ConnectionPool)
 }

--- a/Sources/GRPC/GRPCLogger.swift
+++ b/Sources/GRPC/GRPCLogger.swift
@@ -72,3 +72,9 @@ internal struct GRPCLogger {
     )
   }
 }
+
+extension Logger {
+  internal var wrapped: GRPCLogger {
+    return GRPCLogger(wrapping: self)
+  }
+}

--- a/Tests/GRPCTests/ConnectionPool/ConnectionPoolTests.swift
+++ b/Tests/GRPCTests/ConnectionPool/ConnectionPoolTests.swift
@@ -1,0 +1,803 @@
+/*
+ * Copyright 2021, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@testable import GRPC
+import Logging
+import NIO
+import NIOHTTP2
+import XCTest
+
+final class ConnectionPoolTests: GRPCTestCase {
+  private enum TestError: Error {
+    case noChannelExpected
+  }
+
+  private var eventLoop: EmbeddedEventLoop!
+  private var tearDownBlocks: [() throws -> Void] = []
+
+  override func setUp() {
+    super.setUp()
+    self.eventLoop = EmbeddedEventLoop()
+  }
+
+  override func tearDown() {
+    XCTAssertNoThrow(try self.eventLoop.close())
+    self.tearDownBlocks.forEach { try? $0() }
+    super.tearDown()
+  }
+
+  private func noChannelExpected(
+    _: ConnectionManager,
+    _ eventLoop: EventLoop,
+    line: UInt = #line
+  ) -> EventLoopFuture<Channel> {
+    XCTFail("Channel unexpectedly created", line: line)
+    return eventLoop.makeFailedFuture(TestError.noChannelExpected)
+  }
+
+  private func makePool(
+    waiters: Int = 1000,
+    reservationLoadThreshold: Double = 0.9,
+    now: @escaping () -> NIODeadline = { .now() },
+    onReservationReturned: @escaping (Int) -> Void = { _ in },
+    onMaximumReservationsChange: @escaping (Int) -> Void = { _ in },
+    channelProvider: ConnectionManagerChannelProvider
+  ) -> ConnectionPool {
+    return ConnectionPool(
+      eventLoop: self.eventLoop,
+      maxWaiters: waiters,
+      reservationLoadThreshold: reservationLoadThreshold,
+      channelProvider: channelProvider,
+      streamLender: HookedStreamLender(
+        onReturnStreams: onReservationReturned,
+        onUpdateMaxAvailableStreams: onMaximumReservationsChange
+      ),
+      logger: self.logger.wrapped,
+      now: now
+    )
+  }
+
+  private func makePool(
+    waiters: Int = 1000,
+    makeChannel: @escaping (ConnectionManager, EventLoop) -> EventLoopFuture<Channel>
+  ) -> ConnectionPool {
+    return self.makePool(
+      waiters: waiters,
+      channelProvider: HookedChannelProvider(makeChannel)
+    )
+  }
+
+  private func setUpPoolAndController(
+    waiters: Int = 1000,
+    reservationLoadThreshold: Double = 0.9,
+    now: @escaping () -> NIODeadline = { .now() },
+    onReservationReturned: @escaping (Int) -> Void = { _ in },
+    onMaximumReservationsChange: @escaping (Int) -> Void = { _ in }
+  ) -> (ConnectionPool, ChannelController) {
+    let controller = ChannelController()
+    let pool = self.makePool(
+      waiters: waiters,
+      reservationLoadThreshold: reservationLoadThreshold,
+      now: now,
+      onReservationReturned: onReservationReturned,
+      onMaximumReservationsChange: onMaximumReservationsChange,
+      channelProvider: controller
+    )
+
+    self.tearDownBlocks.append {
+      let shutdown = pool.shutdown()
+      self.eventLoop.run()
+      XCTAssertNoThrow(try shutdown.wait())
+      controller.finish()
+    }
+
+    return (pool, controller)
+  }
+
+  func testEmptyConnectionPool() {
+    let pool = self.makePool {
+      self.noChannelExpected($0, $1)
+    }
+    XCTAssertEqual(pool.sync.connections, 0)
+    XCTAssertEqual(pool.sync.waiters, 0)
+    XCTAssertEqual(pool.sync.availableStreams, 0)
+    XCTAssertEqual(pool.sync.reservedStreams, 0)
+
+    pool.initialize(connections: 20)
+    XCTAssertEqual(pool.sync.connections, 20)
+    XCTAssertEqual(pool.sync.waiters, 0)
+    XCTAssertEqual(pool.sync.availableStreams, 0)
+    XCTAssertEqual(pool.sync.reservedStreams, 0)
+
+    XCTAssertNoThrow(try pool.shutdown().wait())
+  }
+
+  func testShutdownEmptyPool() {
+    let pool = self.makePool {
+      self.noChannelExpected($0, $1)
+    }
+    XCTAssertNoThrow(try pool.shutdown().wait())
+    // Shutting down twice should also be fine.
+    XCTAssertNoThrow(try pool.shutdown().wait())
+  }
+
+  func testMakeStreamWhenShutdown() {
+    let pool = self.makePool {
+      self.noChannelExpected($0, $1)
+    }
+    XCTAssertNoThrow(try pool.shutdown().wait())
+
+    let stream = pool.makeStream(deadline: .distantFuture, logger: self.logger.wrapped) {
+      $0.eventLoop.makeSucceededVoidFuture()
+    }
+
+    XCTAssertThrowsError(try stream.wait()) { error in
+      XCTAssertEqual(error as? ConnectionPoolError, .shutdown)
+    }
+  }
+
+  func testMakeStreamWhenWaiterQueueIsFull() {
+    let maxWaiters = 5
+    let pool = self.makePool(waiters: maxWaiters) {
+      self.noChannelExpected($0, $1)
+    }
+
+    let waiting = (0 ..< maxWaiters).map { _ in
+      return pool.makeStream(deadline: .distantFuture, logger: self.logger.wrapped) {
+        $0.eventLoop.makeSucceededVoidFuture()
+      }
+    }
+
+    let tooManyWaiters = pool.makeStream(deadline: .distantFuture, logger: self.logger.wrapped) {
+      $0.eventLoop.makeSucceededVoidFuture()
+    }
+
+    XCTAssertThrowsError(try tooManyWaiters.wait()) { error in
+      XCTAssertEqual(error as? ConnectionPoolError, .tooManyWaiters)
+    }
+
+    XCTAssertNoThrow(try pool.shutdown().wait())
+    // All 'waiting' futures will be failed by the shutdown promise.
+    for waiter in waiting {
+      XCTAssertThrowsError(try waiter.wait()) { error in
+        XCTAssertEqual(error as? ConnectionPoolError, .shutdown)
+      }
+    }
+  }
+
+  func testWaiterTimingOut() {
+    let pool = self.makePool {
+      self.noChannelExpected($0, $1)
+    }
+
+    let waiter = pool.makeStream(deadline: .uptimeNanoseconds(10), logger: self.logger.wrapped) {
+      $0.eventLoop.makeSucceededVoidFuture()
+    }
+    XCTAssertEqual(pool.sync.waiters, 1)
+
+    self.eventLoop.advanceTime(to: .uptimeNanoseconds(10))
+    XCTAssertThrowsError(try waiter.wait()) { error in
+      XCTAssertEqual(error as? ConnectionPoolError, .deadlineExceeded)
+    }
+
+    XCTAssertEqual(pool.sync.waiters, 0)
+  }
+
+  func testWaiterTimingOutInPast() {
+    let pool = self.makePool {
+      self.noChannelExpected($0, $1)
+    }
+
+    self.eventLoop.advanceTime(to: .uptimeNanoseconds(10))
+
+    let waiter = pool.makeStream(deadline: .uptimeNanoseconds(5), logger: self.logger.wrapped) {
+      $0.eventLoop.makeSucceededVoidFuture()
+    }
+    XCTAssertEqual(pool.sync.waiters, 1)
+
+    self.eventLoop.run()
+    XCTAssertThrowsError(try waiter.wait()) { error in
+      XCTAssertEqual(error as? ConnectionPoolError, .deadlineExceeded)
+    }
+
+    XCTAssertEqual(pool.sync.waiters, 0)
+  }
+
+  func testMakeStreamTriggersChannelCreation() {
+    let (pool, controller) = self.setUpPoolAndController()
+
+    pool.initialize(connections: 1)
+    XCTAssertEqual(pool.sync.connections, 1)
+    // No channels yet.
+    XCTAssertEqual(controller.count, 0)
+
+    let waiter = pool.makeStream(deadline: .distantFuture, logger: self.logger.wrapped) {
+      $0.eventLoop.makeSucceededVoidFuture()
+    }
+    // Start creating the channel.
+    self.eventLoop.run()
+
+    // We should have been asked for a channel now.
+    XCTAssertEqual(controller.count, 1)
+    // The connection isn't ready yet though, so no streams available.
+    XCTAssertEqual(pool.sync.availableStreams, 0)
+
+    // Make the connection 'ready'.
+    controller.connectChannel(atIndex: 0)
+    controller.sendSettingsToChannel(atIndex: 0, maxConcurrentStreams: 10)
+
+    // We have a multiplexer and a 'ready' connection.
+    XCTAssertEqual(pool.sync.reservedStreams, 1)
+    XCTAssertEqual(pool.sync.availableStreams, 9)
+    XCTAssertEqual(pool.sync.waiters, 0)
+
+    // Run the loop to create the stream, we need to fire the event too.
+    self.eventLoop.run()
+    XCTAssertNoThrow(try waiter.wait())
+    controller.openStreamInChannel(atIndex: 0)
+
+    // Now close the stream.
+    controller.closeStreamInChannel(atIndex: 0)
+    XCTAssertEqual(pool.sync.reservedStreams, 0)
+    XCTAssertEqual(pool.sync.availableStreams, 10)
+  }
+
+  func testMakeStreamWhenConnectionIsAlreadyAvailable() {
+    let (pool, controller) = self.setUpPoolAndController()
+    pool.initialize(connections: 1)
+
+    let waiter = pool.makeStream(deadline: .distantFuture, logger: self.logger.wrapped) {
+      $0.eventLoop.makeSucceededVoidFuture()
+    }
+    // Start creating the channel.
+    self.eventLoop.run()
+    XCTAssertEqual(controller.count, 1)
+
+    // Fire up the connection.
+    controller.connectChannel(atIndex: 0)
+    controller.sendSettingsToChannel(atIndex: 0, maxConcurrentStreams: 10)
+
+    // Run the loop to create the stream, we need to fire the stream creation event too.
+    self.eventLoop.run()
+    XCTAssertNoThrow(try waiter.wait())
+    controller.openStreamInChannel(atIndex: 0)
+
+    // Now we can create another stream, but as there's already an available stream on an active
+    // connection we won't have to wait.
+    XCTAssertEqual(pool.sync.waiters, 0)
+    XCTAssertEqual(pool.sync.reservedStreams, 1)
+    let notWaiting = pool.makeStream(deadline: .distantFuture, logger: self.logger.wrapped) {
+      $0.eventLoop.makeSucceededVoidFuture()
+    }
+    // Still no waiters.
+    XCTAssertEqual(pool.sync.waiters, 0)
+    XCTAssertEqual(pool.sync.reservedStreams, 2)
+
+    // Run the loop to create the stream, we need to fire the stream creation event too.
+    self.eventLoop.run()
+    XCTAssertNoThrow(try notWaiting.wait())
+    controller.openStreamInChannel(atIndex: 0)
+  }
+
+  func testMakeMoreWaitersThanConnectionCanHandle() {
+    var returnedStreams: [Int] = []
+    let (pool, controller) = self.setUpPoolAndController(onReservationReturned: {
+      returnedStreams.append($0)
+    })
+    pool.initialize(connections: 1)
+
+    // Enqueue twice as many waiters as the connection will be able to handle.
+    let maxConcurrentStreams = 10
+    let waiters = (0 ..< maxConcurrentStreams * 2).map { _ in
+      return pool.makeStream(deadline: .distantFuture, logger: self.logger.wrapped) {
+        $0.eventLoop.makeSucceededVoidFuture()
+      }
+    }
+
+    XCTAssertEqual(pool.sync.waiters, 2 * maxConcurrentStreams)
+
+    // Fire up the connection.
+    self.eventLoop.run()
+    controller.connectChannel(atIndex: 0)
+    controller.sendSettingsToChannel(atIndex: 0, maxConcurrentStreams: maxConcurrentStreams)
+
+    // We should have assigned a bunch of streams to waiters now.
+    XCTAssertEqual(pool.sync.waiters, maxConcurrentStreams)
+    XCTAssertEqual(pool.sync.reservedStreams, maxConcurrentStreams)
+    XCTAssertEqual(pool.sync.availableStreams, 0)
+
+    // Do the stream creation and make sure the first batch are succeeded.
+    self.eventLoop.run()
+    let firstBatch = waiters.prefix(maxConcurrentStreams)
+    var others = waiters.dropFirst(maxConcurrentStreams)
+
+    for waiter in firstBatch {
+      XCTAssertNoThrow(try waiter.wait())
+      controller.openStreamInChannel(atIndex: 0)
+    }
+
+    // Close a stream.
+    controller.closeStreamInChannel(atIndex: 0)
+    XCTAssertEqual(returnedStreams, [1])
+    // We have another stream so a waiter should be succeeded.
+    XCTAssertEqual(pool.sync.waiters, maxConcurrentStreams - 1)
+    self.eventLoop.run()
+    XCTAssertNoThrow(try others.popFirst()?.wait())
+
+    // Shutdown the pool: the remaining waiters should be failed.
+    let shutdown = pool.shutdown()
+    self.eventLoop.run()
+    XCTAssertNoThrow(try shutdown.wait())
+    for waiter in others {
+      XCTAssertThrowsError(try waiter.wait()) { error in
+        XCTAssertEqual(error as? ConnectionPoolError, .shutdown)
+      }
+    }
+  }
+
+  func testDropConnectionWithOutstandingReservations() {
+    var streamsReturned: [Int] = []
+    let (pool, controller) = self.setUpPoolAndController(
+      onReservationReturned: { streamsReturned.append($0) }
+    )
+    pool.initialize(connections: 1)
+
+    let waiter = pool.makeStream(deadline: .distantFuture, logger: self.logger.wrapped) {
+      $0.eventLoop.makeSucceededVoidFuture()
+    }
+    // Start creating the channel.
+    self.eventLoop.run()
+    XCTAssertEqual(controller.count, 1)
+
+    // Fire up the connection.
+    controller.connectChannel(atIndex: 0)
+    controller.sendSettingsToChannel(atIndex: 0, maxConcurrentStreams: 10)
+
+    // Run the loop to create the stream, we need to fire the stream creation event too.
+    self.eventLoop.run()
+    XCTAssertNoThrow(try waiter.wait())
+    controller.openStreamInChannel(atIndex: 0)
+
+    // Create a handful of streams.
+    XCTAssertEqual(pool.sync.availableStreams, 9)
+    for _ in 0 ..< 5 {
+      let notWaiting = pool.makeStream(deadline: .distantFuture, logger: self.logger.wrapped) {
+        $0.eventLoop.makeSucceededVoidFuture()
+      }
+      self.eventLoop.run()
+      XCTAssertNoThrow(try notWaiting.wait())
+      controller.openStreamInChannel(atIndex: 0)
+    }
+
+    XCTAssertEqual(pool.sync.availableStreams, 4)
+    XCTAssertEqual(pool.sync.reservedStreams, 6)
+
+    // Blast the connection away. We'll be notified about dropped reservations.
+    XCTAssertEqual(streamsReturned, [])
+    controller.throwError(ChannelError.ioOnClosedChannel, inChannelAtIndex: 0)
+    controller.fireChannelInactiveForChannel(atIndex: 0)
+    XCTAssertEqual(streamsReturned, [6])
+
+    XCTAssertEqual(pool.sync.availableStreams, 0)
+    XCTAssertEqual(pool.sync.reservedStreams, 0)
+  }
+
+  func testDropConnectionWithOutstandingReservationsAndWaiters() {
+    var streamsReturned: [Int] = []
+    let (pool, controller) = self.setUpPoolAndController(
+      onReservationReturned: { streamsReturned.append($0) }
+    )
+    pool.initialize(connections: 1)
+
+    // Reserve a bunch of streams.
+    let waiters = (0 ..< 10).map { _ in
+      return pool.makeStream(deadline: .distantFuture, logger: self.logger.wrapped) {
+        $0.eventLoop.makeSucceededVoidFuture()
+      }
+    }
+
+    // Connect and setup all the streams.
+    self.eventLoop.run()
+    controller.connectChannel(atIndex: 0)
+    controller.sendSettingsToChannel(atIndex: 0, maxConcurrentStreams: 10)
+    self.eventLoop.run()
+    for waiter in waiters {
+      XCTAssertNoThrow(try waiter.wait())
+      controller.openStreamInChannel(atIndex: 0)
+    }
+
+    // All streams should be reserved.
+    XCTAssertEqual(pool.sync.availableStreams, 0)
+    XCTAssertEqual(pool.sync.reservedStreams, 10)
+
+    // Add a waiter.
+    XCTAssertEqual(pool.sync.waiters, 0)
+    let waiter = pool.makeStream(deadline: .distantFuture, logger: self.logger.wrapped) {
+      $0.eventLoop.makeSucceededVoidFuture()
+    }
+    XCTAssertEqual(pool.sync.waiters, 1)
+
+    // Now bork the connection. We'll be notified about the 10 dropped reservation but not the one
+    // waiter .
+    XCTAssertEqual(streamsReturned, [])
+    controller.throwError(ChannelError.ioOnClosedChannel, inChannelAtIndex: 0)
+    controller.fireChannelInactiveForChannel(atIndex: 0)
+    XCTAssertEqual(streamsReturned, [10])
+
+    // The connection dropped, let the reconnect kick in.
+    self.eventLoop.run()
+    XCTAssertEqual(controller.count, 2)
+
+    controller.connectChannel(atIndex: 1)
+    controller.sendSettingsToChannel(atIndex: 1, maxConcurrentStreams: 10)
+    self.eventLoop.run()
+    XCTAssertNoThrow(try waiter.wait())
+    controller.openStreamInChannel(atIndex: 1)
+    controller.closeStreamInChannel(atIndex: 1)
+    XCTAssertEqual(streamsReturned, [10, 1])
+
+    XCTAssertEqual(pool.sync.availableStreams, 10)
+    XCTAssertEqual(pool.sync.reservedStreams, 0)
+  }
+
+  func testDeadlineExceededInSameTickAsSucceedingWaiters() {
+    // deadline must be exceeded just as servicing waiter is done
+
+    // - setup waiter with deadline x
+    // - start connecting
+    // - set time to x
+    // - finish connecting
+
+    let (pool, controller) = self.setUpPoolAndController(now: {
+      return NIODeadline.uptimeNanoseconds(12)
+    })
+    pool.initialize(connections: 1)
+
+    let waiter1 = pool.makeStream(deadline: .uptimeNanoseconds(10), logger: self.logger.wrapped) {
+      $0.eventLoop.makeSucceededVoidFuture()
+    }
+
+    let waiter2 = pool.makeStream(deadline: .uptimeNanoseconds(15), logger: self.logger.wrapped) {
+      $0.eventLoop.makeSucceededVoidFuture()
+    }
+
+    // Start creating the channel.
+    self.eventLoop.run()
+    XCTAssertEqual(controller.count, 1)
+
+    // Fire up the connection.
+    controller.connectChannel(atIndex: 0)
+    controller.sendSettingsToChannel(atIndex: 0, maxConcurrentStreams: 10)
+
+    // The deadline for the first waiter is already after 'now', so it'll fail with deadline
+    // exceeded.
+    self.eventLoop.run()
+    // We need to advance the time to fire the timeout to fail the waiter.
+    self.eventLoop.advanceTime(to: .uptimeNanoseconds(10))
+    XCTAssertThrowsError(try waiter1.wait()) { error in
+      XCTAssertEqual(error as? ConnectionPoolError, .deadlineExceeded)
+    }
+
+    self.eventLoop.run()
+    XCTAssertNoThrow(try waiter2.wait())
+    controller.openStreamInChannel(atIndex: 0)
+
+    XCTAssertEqual(pool.sync.waiters, 0)
+    XCTAssertEqual(pool.sync.reservedStreams, 1)
+    XCTAssertEqual(pool.sync.availableStreams, 9)
+
+    controller.closeStreamInChannel(atIndex: 0)
+    XCTAssertEqual(pool.sync.waiters, 0)
+    XCTAssertEqual(pool.sync.reservedStreams, 0)
+    XCTAssertEqual(pool.sync.availableStreams, 10)
+  }
+
+  func testConnectionsAreBroughtUpAtAppropriateTimes() {
+    let (pool, controller) = self.setUpPoolAndController(reservationLoadThreshold: 0.2)
+    // We'll allow 3 connections and configure max concurrent streams to 10. With our reservation
+    // threshold we'll bring up a new connection after enqueueing the 1st, 2nd and 4th waiters.
+    pool.initialize(connections: 3)
+    let maxConcurrentStreams = 10
+
+    // No demand so all three connections are idle.
+    XCTAssertEqual(pool.sync.idleConnections, 3)
+
+    let w1 = pool.makeStream(deadline: .distantFuture, logger: self.logger.wrapped) {
+      $0.eventLoop.makeSucceededVoidFuture()
+    }
+
+    // demand=1, available=0, load=infinite, one connection should be non-idle
+    XCTAssertEqual(pool.sync.idleConnections, 2)
+
+    // Connect the first channel and write the first settings frame; this allows us to lower the
+    // default max concurrent streams value (from 100).
+    self.eventLoop.run()
+    controller.connectChannel(atIndex: 0)
+    controller.sendSettingsToChannel(atIndex: 0, maxConcurrentStreams: maxConcurrentStreams)
+
+    self.eventLoop.run()
+    XCTAssertNoThrow(try w1.wait())
+    controller.openStreamInChannel(atIndex: 0)
+
+    let w2 = pool.makeStream(deadline: .distantFuture, logger: self.logger.wrapped) {
+      $0.eventLoop.makeSucceededVoidFuture()
+    }
+
+    self.eventLoop.run()
+    XCTAssertNoThrow(try w2.wait())
+    controller.openStreamInChannel(atIndex: 0)
+
+    // demand=2, available=10, load=0.2; only one idle connection now.
+    XCTAssertEqual(pool.sync.idleConnections, 1)
+
+    // Add more demand before the second connection comes up.
+    let w3 = pool.makeStream(deadline: .distantFuture, logger: self.logger.wrapped) {
+      $0.eventLoop.makeSucceededVoidFuture()
+    }
+
+    // demand=3, available=20, load=0.15; still one idle connection.
+    XCTAssertEqual(pool.sync.idleConnections, 1)
+
+    let w4 = pool.makeStream(deadline: .distantFuture, logger: self.logger.wrapped) {
+      $0.eventLoop.makeSucceededVoidFuture()
+    }
+
+    // demand=4, available=20, load=0.2; no idle connections.
+    XCTAssertEqual(pool.sync.idleConnections, 0)
+
+    // Connection the next channel
+    self.eventLoop.run()
+    controller.connectChannel(atIndex: 1)
+    controller.sendSettingsToChannel(atIndex: 1, maxConcurrentStreams: maxConcurrentStreams)
+
+    XCTAssertNoThrow(try w3.wait())
+    controller.openStreamInChannel(atIndex: 1)
+    XCTAssertNoThrow(try w4.wait())
+    controller.openStreamInChannel(atIndex: 1)
+  }
+
+  func testQuiescingConnectionIsReplaced() {
+    var reservationsReturned: [Int] = []
+    let (pool, controller) = self.setUpPoolAndController(onReservationReturned: {
+      reservationsReturned.append($0)
+    })
+    pool.initialize(connections: 1)
+    XCTAssertEqual(pool.sync.connections, 1)
+
+    let w1 = pool.makeStream(deadline: .distantFuture, logger: self.logger.wrapped) {
+      $0.eventLoop.makeSucceededVoidFuture()
+    }
+    // Start creating the channel.
+    self.eventLoop.run()
+
+    // Make the connection 'ready'.
+    controller.connectChannel(atIndex: 0)
+    controller.sendSettingsToChannel(atIndex: 0)
+
+    // Run the loop to create the stream.
+    self.eventLoop.run()
+    XCTAssertNoThrow(try w1.wait())
+    controller.openStreamInChannel(atIndex: 0)
+
+    // One stream reserved by 'w1' on the only connection in the pool (which isn't idle).
+    XCTAssertEqual(pool.sync.reservedStreams, 1)
+    XCTAssertEqual(pool.sync.connections, 1)
+    XCTAssertEqual(pool.sync.idleConnections, 0)
+
+    // Quiesce the connection. It should be punted from the pool and any active RPCs allowed to run
+    // their course. A new (idle) connection should replace it in the pool.
+    controller.sendGoAwayToChannel(atIndex: 0)
+
+    // The quiescing connection had 1 stream reserved, it's now returned to the outer pool and we
+    // have a new idle connection in place of the old one.
+    XCTAssertEqual(reservationsReturned, [1])
+    XCTAssertEqual(pool.sync.reservedStreams, 0)
+    XCTAssertEqual(pool.sync.availableStreams, 0)
+    XCTAssertEqual(pool.sync.idleConnections, 1)
+
+    // Ask for another stream: this will be on the new idle connection.
+    let w2 = pool.makeStream(deadline: .distantFuture, logger: self.logger.wrapped) {
+      $0.eventLoop.makeSucceededVoidFuture()
+    }
+    self.eventLoop.run()
+    XCTAssertEqual(controller.count, 2)
+
+    // Make the connection 'ready'.
+    controller.connectChannel(atIndex: 1)
+    controller.sendSettingsToChannel(atIndex: 1)
+
+    self.eventLoop.run()
+    XCTAssertNoThrow(try w2.wait())
+    controller.openStreamInChannel(atIndex: 1)
+
+    XCTAssertEqual(pool.sync.reservedStreams, 1)
+    XCTAssertEqual(pool.sync.availableStreams, 99)
+
+    // Return a stream for the _quiescing_ connection: nothing should change in the pool.
+    controller.closeStreamInChannel(atIndex: 0)
+
+    XCTAssertEqual(pool.sync.reservedStreams, 1)
+    XCTAssertEqual(pool.sync.availableStreams, 99)
+
+    // Return a stream for the new connection.
+    controller.closeStreamInChannel(atIndex: 1)
+
+    XCTAssertEqual(reservationsReturned, [1, 1])
+    XCTAssertEqual(pool.sync.reservedStreams, 0)
+    XCTAssertEqual(pool.sync.availableStreams, 100)
+  }
+}
+
+// MARK: - Helpers
+
+internal final class ChannelController {
+  private var channels: [EmbeddedChannel] = []
+
+  internal var count: Int {
+    return self.channels.count
+  }
+
+  internal func finish() {
+    while let channel = self.channels.popLast() {
+      // We're okay with this throwing: some channels are left in a bad state (i.e. with errors).
+      _ = try? channel.finish()
+    }
+  }
+
+  private func isValidIndex(
+    _ index: Int,
+    file: StaticString = #file,
+    line: UInt = #line
+  ) -> Bool {
+    let isValid = self.channels.indices.contains(index)
+    XCTAssertTrue(isValid, "Invalid connection index '\(index)'", file: file, line: line)
+    return isValid
+  }
+
+  internal func connectChannel(
+    atIndex index: Int,
+    file: StaticString = #file,
+    line: UInt = #line
+  ) {
+    guard self.isValidIndex(index, file: file, line: line) else { return }
+
+    XCTAssertNoThrow(
+      try self.channels[index].connect(to: .init(unixDomainSocketPath: "/")),
+      file: file,
+      line: line
+    )
+  }
+
+  internal func fireChannelInactiveForChannel(
+    atIndex index: Int,
+    file: StaticString = #file,
+    line: UInt = #line
+  ) {
+    guard self.isValidIndex(index, file: file, line: line) else { return }
+    self.channels[index].pipeline.fireChannelInactive()
+  }
+
+  internal func throwError(
+    _ error: Error,
+    inChannelAtIndex index: Int,
+    file: StaticString = #file,
+    line: UInt = #line
+  ) {
+    guard self.isValidIndex(index, file: file, line: line) else { return }
+    self.channels[index].pipeline.fireErrorCaught(error)
+  }
+
+  internal func sendSettingsToChannel(
+    atIndex index: Int,
+    maxConcurrentStreams: Int = 100,
+    file: StaticString = #file,
+    line: UInt = #line
+  ) {
+    guard self.isValidIndex(index, file: file, line: line) else { return }
+
+    let settings = [HTTP2Setting(parameter: .maxConcurrentStreams, value: maxConcurrentStreams)]
+    let settingsFrame = HTTP2Frame(streamID: .rootStream, payload: .settings(.settings(settings)))
+
+    XCTAssertNoThrow(try self.channels[index].writeInbound(settingsFrame), file: file, line: line)
+  }
+
+  internal func sendGoAwayToChannel(
+    atIndex index: Int,
+    file: StaticString = #file,
+    line: UInt = #line
+  ) {
+    guard self.isValidIndex(index, file: file, line: line) else { return }
+
+    let goAwayFrame = HTTP2Frame(
+      streamID: .rootStream,
+      payload: .goAway(lastStreamID: .maxID, errorCode: .noError, opaqueData: nil)
+    )
+
+    XCTAssertNoThrow(try self.channels[index].writeInbound(goAwayFrame), file: file, line: line)
+  }
+
+  internal func openStreamInChannel(
+    atIndex index: Int,
+    file: StaticString = #file,
+    line: UInt = #line
+  ) {
+    guard self.isValidIndex(index, file: file, line: line) else { return }
+
+    // The details don't matter here.
+    let event = NIOHTTP2StreamCreatedEvent(
+      streamID: .rootStream,
+      localInitialWindowSize: nil,
+      remoteInitialWindowSize: nil
+    )
+
+    self.channels[index].pipeline.fireUserInboundEventTriggered(event)
+  }
+
+  internal func closeStreamInChannel(
+    atIndex index: Int,
+    file: StaticString = #file,
+    line: UInt = #line
+  ) {
+    guard self.isValidIndex(index, file: file, line: line) else { return }
+
+    // The details don't matter here.
+    let event = StreamClosedEvent(streamID: .rootStream, reason: nil)
+    self.channels[index].pipeline.fireUserInboundEventTriggered(event)
+  }
+}
+
+extension ChannelController: ConnectionManagerChannelProvider {
+  internal func makeChannel(
+    managedBy connectionManager: ConnectionManager,
+    onEventLoop eventLoop: EventLoop,
+    connectTimeout: TimeAmount?,
+    logger: Logger
+  ) -> EventLoopFuture<Channel> {
+    let channel = EmbeddedChannel(loop: eventLoop as! EmbeddedEventLoop)
+    self.channels.append(channel)
+
+    let multiplexer = HTTP2StreamMultiplexer(
+      mode: .client,
+      channel: channel,
+      inboundStreamInitializer: nil
+    )
+
+    let idleHandler = GRPCIdleHandler(
+      connectionManager: connectionManager,
+      multiplexer: multiplexer,
+      idleTimeout: .minutes(5),
+      keepalive: ClientConnectionKeepalive(),
+      logger: logger
+    )
+
+    XCTAssertNoThrow(try channel.pipeline.syncOperations.addHandler(idleHandler))
+    XCTAssertNoThrow(try channel.pipeline.syncOperations.addHandler(multiplexer))
+
+    return eventLoop.makeSucceededFuture(channel)
+  }
+}
+
+internal struct HookedStreamLender: StreamLender {
+  internal var onReturnStreams: (Int) -> Void
+  internal var onUpdateMaxAvailableStreams: (Int) -> Void
+
+  internal func returnStreams(_ count: Int, to pool: ConnectionPool) {
+    self.onReturnStreams(count)
+  }
+
+  internal func updateStreamCapacity(to max: Int, for pool: ConnectionPool) {
+    self.onUpdateMaxAvailableStreams(max)
+  }
+}


### PR DESCRIPTION
Motivation:

One way of building up an client which efficiently pools connections is
to group connections by the event loop in which they run. Each sub-pool
can then synchronize on its event loop and run almost independently of
whatever is managing the sub-pools.

Modifications:

- Add a `ConnectionPool` (the 'sub-pool' mentioned above) which pools
  `ConnectionManager`s all running on the same event loop. Callers can
  ask the pool to create an HTTP/2 stream channel which will be made
  'now' if the pool has a connection with capacity, or queued to be made
  later when capacity becomes available. The pool also has API to
  'return' streams to an outer pool or pool manager.
- Add a `sync` view to `ConnectionManager` to expose some API which
  requires being on the correct event loop.
- `ConnectionManager.shutdown()` now checks if we're already on the
  right event loop before executing (rather than always `flatSubmit`ing
  onto the event loop)

Result:

We have a per event loop connection pool.