### PR TITLE
Use `PlatformSupport.makeEventLoopGroup` on BasicTutorial

### DIFF
--- a/Sources/Examples/RouteGuide/Client/main.swift
+++ b/Sources/Examples/RouteGuide/Client/main.swift
@@ -201,7 +201,7 @@ struct RouteGuide: ParsableCommand {
     // Load the features.
     let features = try loadFeatures()
 
-    let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    let group = PlatformSupport.makeEventLoopGroup(loopCount: 1)
     defer {
       try? group.syncShutdownGracefully()
     }

--- a/docs/basic-tutorial.md
+++ b/docs/basic-tutorial.md
@@ -473,7 +473,7 @@ use the `insecure` builder and specify the server address and port we want to
 connect to:
 
 ```swift
-let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+let group = PlatformSupport.makeEventLoopGroup(loopCount: 1)
 defer {
   try? group.syncShutdownGracefully()
 }


### PR DESCRIPTION
Even though [Apple Platform](https://github.com/grpc/grpc-swift/blob/master/docs/apple-platforms.md) documentation is suggesting to use `PlatformSupport.makeEventLoopGroup` where possible, I'm afraid it may not be obvious for beginners to checkout that documentation. 

I think it would be better if we use `PlatformSupport.makeEventLoopGroup` API in [Basic-Tutorial](https://github.com/grpc/grpc-swift/blob/master/docs/basic-tutorial.md) document which is much more approachable. 

How do you think about this idea?