### PR TITLE
Echo: add an --iterations option

### DIFF
--- a/Sources/Examples/Echo/Runtime/main.swift
+++ b/Sources/Examples/Echo/Runtime/main.swift
@@ -79,6 +79,9 @@ struct Echo: ParsableCommand {
     @Option(help: "RPC to call ('get', 'collect', 'expand', 'update').")
     var rpc: RPC = .get
 
+    @Option(help: "How many RPCs to do.")
+    var iterations: Int = 1
+
     @Argument(help: "Message to echo")
     var message: String
 
@@ -98,7 +101,9 @@ struct Echo: ParsableCommand {
         try! client.channel.close().wait()
       }
 
-      callRPC(self.rpc, using: client, message: self.message)
+      for _ in 0..<self.iterations {
+        callRPC(self.rpc, using: client, message: self.message)
+      }
     }
   }
 }

--- a/Sources/Examples/Echo/Runtime/main.swift
+++ b/Sources/Examples/Echo/Runtime/main.swift
@@ -101,7 +101,7 @@ struct Echo: ParsableCommand {
         try! client.channel.close().wait()
       }
 
-      for _ in 0..<self.iterations {
+      for _ in 0 ..< self.iterations {
         callRPC(self.rpc, using: client, message: self.message)
       }
     }


### PR DESCRIPTION
Motivation:

For performance analysis, it can be useful to have multiple iterations of RPCs. Especially in gRPC where you may want to ignore the connection setup overhead.

Modification:

Add `--iterations` to `Echo` which does the RPC that many times.

Result:

Pretty graphs (the one below shows all allocations made by one RPC).

<img width="1104" alt="Screenshot 2021-05-14 at 3 20 46 pm" src="https://user-images.githubusercontent.com/624238/118284088-f82b2200-b4c7-11eb-8309-0eecfee4f297.png">
