### PR TITLE
Make 'NIOSSLContext' ahead of time

### DIFF
--- a/Sources/GRPC/ClientConnection.swift
+++ b/Sources/GRPC/ClientConnection.swift
@@ -421,7 +421,7 @@ extension ChannelPipeline.SynchronousOperations {
   internal func configureGRPCClient(
     channel: Channel,
     httpTargetWindowSize: Int,
-    tlsConfiguration: TLSConfiguration?,
+    sslContext: Result<NIOSSLContext, Error>?,
     tlsServerHostname: String?,
     connectionManager: ConnectionManager,
     connectionKeepalive: ClientConnectionKeepalive,
@@ -439,17 +439,17 @@ extension ChannelPipeline.SynchronousOperations {
     }
     #endif
 
-    if let tlsConfiguration = tlsConfiguration {
+    if let sslContext = try sslContext?.get() {
       let sslClientHandler: NIOSSLClientHandler
       if let customVerificationCallback = customVerificationCallback {
         sslClientHandler = try NIOSSLClientHandler(
-          context: try NIOSSLContext(configuration: tlsConfiguration),
+          context: sslContext,
           serverHostname: tlsServerHostname,
           customVerificationCallback: customVerificationCallback
         )
       } else {
         sslClientHandler = try NIOSSLClientHandler(
-          context: try NIOSSLContext(configuration: tlsConfiguration),
+          context: sslContext,
           serverHostname: tlsServerHostname
         )
       }


### PR DESCRIPTION
Motivation:

A `NIOSSLContext` may be used for multiple connections. Moreover,
creating `NIOSSLContext`s is _expensive_ and we should avoid creating
them unnecessarily. At the moment we create one context per connection
for the client and the server.

Modifications:

- Make `NIOSSLContext`s when setting up the client (rather than when
  initializing a channel).
- Make `NIOSSLContext`s when preparing a server bootstrap

Result:

- We only create `NIOSSLContext` once per server/client connection