### PR TITLE
Handle multiple requests for gRPC-Web

### DIFF
--- a/Sources/GRPC/GRPCWebToHTTP2ServerCodec.swift
+++ b/Sources/GRPC/GRPCWebToHTTP2ServerCodec.swift
@@ -67,12 +67,16 @@ internal final class GRPCWebToHTTP2ServerCodec: ChannelDuplexHandler {
     case let .fireChannelRead(payload):
       context.fireChannelRead(self.wrapInboundOut(payload))
 
-    case let .write(part1, part2, promise):
-      if let part2 = part2 {
-        context.write(self.wrapOutboundOut(part1), promise: nil)
-        context.write(self.wrapOutboundOut(part2), promise: promise)
+    case let .write(write):
+      if let additionalPart = write.additionalPart {
+        context.write(self.wrapOutboundOut(write.part), promise: nil)
+        context.write(self.wrapOutboundOut(additionalPart), promise: write.promise)
       } else {
-        context.write(self.wrapOutboundOut(part1), promise: promise)
+        context.write(self.wrapOutboundOut(write.part), promise: write.promise)
+      }
+
+      if write.closeChannel {
+        context.close(mode: .all, promise: nil)
       }
 
     case let .completePromise(promise, result):
@@ -82,12 +86,14 @@ internal final class GRPCWebToHTTP2ServerCodec: ChannelDuplexHandler {
 }
 
 extension GRPCWebToHTTP2ServerCodec {
-  struct StateMachine {
+  internal struct StateMachine {
     /// The current state.
     private var state: State
+    private let scheme: String
 
-    fileprivate init(scheme: String) {
-      self.state = .idle(scheme: scheme)
+    internal init(scheme: String) {
+      self.state = .idle
+      self.scheme = scheme
     }
 
     private mutating func withStateAvoidingCoWs(_ body: (inout State) -> Action) -> Action {
@@ -100,17 +106,22 @@ extension GRPCWebToHTTP2ServerCodec {
     }
 
     /// Process the inbound `HTTPServerRequestPart`.
-    fileprivate mutating func processInbound(
+    internal mutating func processInbound(
       serverRequestPart: HTTPServerRequestPart,
       allocator: ByteBufferAllocator
     ) -> Action {
+      let scheme = self.scheme
       return self.withStateAvoidingCoWs { state in
-        state.processInbound(serverRequestPart: serverRequestPart, allocator: allocator)
+        state.processInbound(
+          serverRequestPart: serverRequestPart,
+          scheme: scheme,
+          allocator: allocator
+        )
       }
     }
 
     /// Process the outbound `HTTP2Frame.FramePayload`.
-    fileprivate mutating func processOutbound(
+    internal mutating func processOutbound(
       framePayload: HTTP2Frame.FramePayload,
       promise: EventLoopPromise<Void>?,
       allocator: ByteBufferAllocator
@@ -121,55 +132,75 @@ extension GRPCWebToHTTP2ServerCodec {
     }
 
     /// An action to take as a result of interaction with the state machine.
-    fileprivate enum Action {
+    internal enum Action {
       case none
       case fireChannelRead(HTTP2Frame.FramePayload)
-      case write(HTTPServerResponsePart, HTTPServerResponsePart?, EventLoopPromise<Void>?)
+      case write(Write)
       case completePromise(EventLoopPromise<Void>?, Result<Void, Error>)
+
+      internal struct Write {
+        internal var part: HTTPServerResponsePart
+        internal var additionalPart: HTTPServerResponsePart?
+        internal var promise: EventLoopPromise<Void>?
+        internal var closeChannel: Bool
+
+        internal init(
+          part: HTTPServerResponsePart,
+          additionalPart: HTTPServerResponsePart? = nil,
+          promise: EventLoopPromise<Void>?,
+          closeChannel: Bool
+        ) {
+          self.part = part
+          self.additionalPart = additionalPart
+          self.promise = promise
+          self.closeChannel = closeChannel
+        }
+      }
     }
 
     fileprivate enum State {
-      /// Idle; nothing has been received or sent. The only valid transition is to 'open' when
+      /// Idle; nothing has been received or sent. The only valid transition is to 'fullyOpen' when
       /// receiving request headers.
-      case idle(scheme: String)
+      case idle
 
-      /// Open; the request headers have been received and we have not sent the end of the response
-      /// stream.
-      case open(OpenState)
+      /// Received request headers. Waiting for the end of request and response streams.
+      case fullyOpen(InboundState, OutboundState)
 
-      /// Closed; the response stream (and therefore the request stream) has been closed.
-      case closed
+      /// The server has closed the response stream, we may receive other request parts from the client.
+      case clientOpenServerClosed
+
+      /// The client has sent everything, the server still needs to close the response stream.
+      case clientClosedServerOpen(OutboundState)
 
       /// Not a real state.
       case _modifying
     }
 
-    fileprivate struct OpenState {
+    fileprivate struct InboundState {
       /// A `ByteBuffer` containing the base64 encoded bytes of the request stream if gRPC Web Text
       /// is being used, `nil` otherwise.
       var requestBuffer: ByteBuffer?
 
+      init(isTextEncoded: Bool, allocator: ByteBufferAllocator) {
+        self.requestBuffer = isTextEncoded ? allocator.buffer(capacity: 0) : nil
+      }
+    }
+
+    fileprivate struct OutboundState {
       /// A `CircularBuffer` holding any response messages if gRPC Web Text is being used, `nil`
       /// otherwise.
       var responseBuffer: CircularBuffer<ByteBuffer>?
 
-      /// True if the end of the request stream has been received.
-      var requestEndSeen: Bool
-
       /// True if the response headers have been sent.
       var responseHeadersSent: Bool
 
-      init(isTextEncoded: Bool, allocator: ByteBufferAllocator) {
-        self.requestEndSeen = false
-        self.responseHeadersSent = false
+      /// True if the server should close the connection when this request is done.
+      var closeConnection: Bool
 
-        if isTextEncoded {
-          self.requestBuffer = allocator.buffer(capacity: 0)
-          self.responseBuffer = CircularBuffer()
-        } else {
-          self.requestBuffer = nil
-          self.responseBuffer = nil
-        }
+      init(isTextEncoded: Bool, closeConnection: Bool) {
+        self.responseHeadersSent = false
+        self.responseBuffer = isTextEncoded ? CircularBuffer() : nil
+        self.closeConnection = closeConnection
       }
     }
   }
@@ -178,11 +209,12 @@ extension GRPCWebToHTTP2ServerCodec {
 extension GRPCWebToHTTP2ServerCodec.StateMachine.State {
   fileprivate mutating func processInbound(
     serverRequestPart: HTTPServerRequestPart,
+    scheme: String,
     allocator: ByteBufferAllocator
   ) -> GRPCWebToHTTP2ServerCodec.StateMachine.Action {
     switch serverRequestPart {
     case let .head(head):
-      return self.processRequestHead(head, allocator: allocator)
+      return self.processRequestHead(head, scheme: scheme, allocator: allocator)
     case var .body(buffer):
       return self.processRequestBody(&buffer)
     case .end:
@@ -221,10 +253,11 @@ extension GRPCWebToHTTP2ServerCodec.StateMachine.State {
 extension GRPCWebToHTTP2ServerCodec.StateMachine.State {
   private mutating func processRequestHead(
     _ head: HTTPRequestHead,
+    scheme: String,
     allocator: ByteBufferAllocator
   ) -> GRPCWebToHTTP2ServerCodec.StateMachine.Action {
     switch self {
-    case let .idle(scheme):
+    case .idle:
       let normalized = HPACKHeaders(httpHeaders: head.headers, normalizeHTTPHeaders: true)
 
       // Regular headers need to come after the pseudo headers. Unfortunately, this means we need to
@@ -247,10 +280,15 @@ extension GRPCWebToHTTP2ServerCodec.StateMachine.State {
       let contentType = headers.first(name: GRPCHeaderName.contentType).flatMap(ContentType.init)
       let isWebText = contentType == .some(.webTextProtobuf)
 
-      self = .open(.init(isTextEncoded: isWebText, allocator: allocator))
+      let closeConnection = head.headers[canonicalForm: "connection"].contains("close")
+
+      self = .fullyOpen(
+        .init(isTextEncoded: isWebText, allocator: allocator),
+        .init(isTextEncoded: isWebText, closeConnection: closeConnection)
+      )
       return .fireChannelRead(.headers(.init(headers: headers)))
 
-    case .open, .closed:
+    case .fullyOpen, .clientOpenServerClosed, .clientClosedServerOpen:
       preconditionFailure("Invalid state: already received request head")
 
     case ._modifying:
@@ -265,28 +303,26 @@ extension GRPCWebToHTTP2ServerCodec.StateMachine.State {
     case .idle:
       preconditionFailure("Invalid state: haven't received request head")
 
-    case var .open(state):
-      assert(!state.requestEndSeen, "Invalid state: request stream closed")
-
-      if state.requestBuffer == nil {
+    case .fullyOpen(var inbound, let outbound):
+      if inbound.requestBuffer == nil {
         // We're not dealing with gRPC Web Text: just forward the buffer.
         return .fireChannelRead(.data(.init(data: .byteBuffer(buffer))))
       }
 
-      if state.requestBuffer!.readableBytes == 0 {
-        state.requestBuffer = buffer
+      if inbound.requestBuffer!.readableBytes == 0 {
+        inbound.requestBuffer = buffer
       } else {
-        state.requestBuffer!.writeBuffer(&buffer)
+        inbound.requestBuffer!.writeBuffer(&buffer)
       }
 
-      let readableBytes = state.requestBuffer!.readableBytes
+      let readableBytes = inbound.requestBuffer!.readableBytes
       // The length of base64 encoded data must be a multiple of 4.
       let bytesToRead = readableBytes - (readableBytes % 4)
 
       let action: GRPCWebToHTTP2ServerCodec.StateMachine.Action
 
       if bytesToRead > 0,
-        let base64Encoded = state.requestBuffer!.readString(length: bytesToRead),
+        let base64Encoded = inbound.requestBuffer!.readString(length: bytesToRead),
         let base64Decoded = Data(base64Encoded: base64Encoded) {
         // Recycle the input buffer and restore the request buffer.
         buffer.clear()
@@ -296,11 +332,15 @@ extension GRPCWebToHTTP2ServerCodec.StateMachine.State {
         action = .none
       }
 
-      self = .open(state)
+      self = .fullyOpen(inbound, outbound)
       return action
 
-    case .closed:
+    case .clientOpenServerClosed:
+      // The server is already done; so drop the request.
       return .none
+
+    case .clientClosedServerOpen:
+      preconditionFailure("End of request stream already received")
 
     case ._modifying:
       preconditionFailure("Left in modifying state")
@@ -314,16 +354,20 @@ extension GRPCWebToHTTP2ServerCodec.StateMachine.State {
     case .idle:
       preconditionFailure("Invalid state: haven't received request head")
 
-    case var .open(state):
-      assert(!state.requestEndSeen, "Invalid state: already seen end stream ")
-      state.requestEndSeen = true
-      self = .open(state)
+    case let .fullyOpen(_, outbound):
+      // We're done with inbound state.
+      self = .clientClosedServerOpen(outbound)
 
       // Send an empty DATA frame with the end stream flag set.
       let empty = allocator.buffer(capacity: 0)
       return .fireChannelRead(.data(.init(data: .byteBuffer(empty), endStream: true)))
 
-    case .closed:
+    case .clientClosedServerOpen:
+      preconditionFailure("End of request stream already received")
+
+    case .clientOpenServerClosed:
+      // Both sides are closed now, back to idle.
+      self = .idle
       return .none
 
     case ._modifying:
@@ -335,6 +379,174 @@ extension GRPCWebToHTTP2ServerCodec.StateMachine.State {
 // MARK: - Outbound
 
 extension GRPCWebToHTTP2ServerCodec.StateMachine.State {
+  private mutating func processResponseTrailers(
+    _ trailers: HPACKHeaders,
+    promise: EventLoopPromise<Void>?,
+    allocator: ByteBufferAllocator
+  ) -> GRPCWebToHTTP2ServerCodec.StateMachine.Action {
+    switch self {
+    case .idle:
+      preconditionFailure("Invalid state: haven't received request head")
+
+    case var .fullyOpen(_, outbound):
+      // Double check these are trailers.
+      assert(outbound.responseHeadersSent)
+
+      // We haven't seen the end of the request stream yet.
+      self = .clientOpenServerClosed
+
+      // Avoid CoW-ing the buffers.
+      let responseBuffers = outbound.responseBuffer
+      outbound.responseBuffer = nil
+
+      return self.processTrailers(
+        responseBuffers: responseBuffers,
+        trailers: trailers,
+        promise: promise,
+        allocator: allocator,
+        closeChannel: outbound.closeConnection
+      )
+
+    case var .clientClosedServerOpen(state):
+      // Client is closed and now so is the server.
+      self = .idle
+
+      // Avoid CoW-ing the buffers.
+      let responseBuffers = state.responseBuffer
+      state.responseBuffer = nil
+
+      return self.processTrailers(
+        responseBuffers: responseBuffers,
+        trailers: trailers,
+        promise: promise,
+        allocator: allocator,
+        closeChannel: state.closeConnection
+      )
+
+    case .clientOpenServerClosed:
+      preconditionFailure("Already seen end of response stream")
+
+    case ._modifying:
+      preconditionFailure("Left in modifying state")
+    }
+  }
+
+  private func processTrailers(
+    responseBuffers: CircularBuffer<ByteBuffer>?,
+    trailers: HPACKHeaders,
+    promise: EventLoopPromise<Void>?,
+    allocator: ByteBufferAllocator,
+    closeChannel: Bool
+  ) -> GRPCWebToHTTP2ServerCodec.StateMachine.Action {
+    if var responseBuffers = responseBuffers {
+      let buffer = GRPCWebToHTTP2ServerCodec.encodeResponsesAndTrailers(
+        &responseBuffers,
+        trailers: trailers,
+        allocator: allocator
+      )
+      return .write(
+        .init(
+          part: .body(.byteBuffer(buffer)),
+          additionalPart: .end(nil),
+          promise: promise,
+          closeChannel: closeChannel
+        )
+      )
+    } else {
+      // No response buffer; plain gRPC Web.
+      let trailers = HTTPHeaders(hpackHeaders: trailers)
+      return .write(.init(part: .end(trailers), promise: promise, closeChannel: closeChannel))
+    }
+  }
+
+  private mutating func processResponseTrailersOnly(
+    _ trailers: HPACKHeaders,
+    promise: EventLoopPromise<Void>?
+  ) -> GRPCWebToHTTP2ServerCodec.StateMachine.Action {
+    switch self {
+    case .idle:
+      preconditionFailure("Invalid state: haven't received request head")
+
+    case let .fullyOpen(_, outbound):
+      // We still haven't seen the end of the request stream.
+      self = .clientOpenServerClosed
+
+      let head = GRPCWebToHTTP2ServerCodec.makeResponseHead(
+        hpackHeaders: trailers,
+        closeConnection: outbound.closeConnection
+      )
+
+      return .write(
+        .init(
+          part: .head(head),
+          additionalPart: .end(nil),
+          promise: promise,
+          closeChannel: outbound.closeConnection
+        )
+      )
+
+    case let .clientClosedServerOpen(outbound):
+      // We're done, back to idle.
+      self = .idle
+
+      let head = GRPCWebToHTTP2ServerCodec.makeResponseHead(
+        hpackHeaders: trailers,
+        closeConnection: outbound.closeConnection
+      )
+
+      return .write(
+        .init(
+          part: .head(head),
+          additionalPart: .end(nil),
+          promise: promise,
+          closeChannel: outbound.closeConnection
+        )
+      )
+
+    case .clientOpenServerClosed:
+      preconditionFailure("Already seen end of response stream")
+
+    case ._modifying:
+      preconditionFailure("Left in modifying state")
+    }
+  }
+
+  private mutating func processResponseHeaders(
+    _ headers: HPACKHeaders,
+    promise: EventLoopPromise<Void>?
+  ) -> GRPCWebToHTTP2ServerCodec.StateMachine.Action {
+    switch self {
+    case .idle:
+      preconditionFailure("Invalid state: haven't received request head")
+
+    case .fullyOpen(let inbound, var outbound):
+      outbound.responseHeadersSent = true
+      self = .fullyOpen(inbound, outbound)
+
+      let head = GRPCWebToHTTP2ServerCodec.makeResponseHead(
+        hpackHeaders: headers,
+        closeConnection: outbound.closeConnection
+      )
+      return .write(.init(part: .head(head), promise: promise, closeChannel: false))
+
+    case var .clientClosedServerOpen(outbound):
+      outbound.responseHeadersSent = true
+      self = .clientClosedServerOpen(outbound)
+
+      let head = GRPCWebToHTTP2ServerCodec.makeResponseHead(
+        hpackHeaders: headers,
+        closeConnection: outbound.closeConnection
+      )
+      return .write(.init(part: .head(head), promise: promise, closeChannel: false))
+
+    case .clientOpenServerClosed:
+      preconditionFailure("Already seen end of response stream")
+
+    case ._modifying:
+      preconditionFailure("Left in modifying state")
+    }
+  }
+
   private mutating func processResponseHeaders(
     _ payload: HTTP2Frame.FramePayload.Headers,
     promise: EventLoopPromise<Void>?,
@@ -344,51 +556,49 @@ extension GRPCWebToHTTP2ServerCodec.StateMachine.State {
     case .idle:
       preconditionFailure("Invalid state: haven't received request head")
 
-    case var .open(state):
-      let action: GRPCWebToHTTP2ServerCodec.StateMachine.Action
-
-      if state.responseHeadersSent {
+    case let .fullyOpen(_, outbound),
+         let .clientClosedServerOpen(outbound):
+      if outbound.responseHeadersSent {
         // Headers have been sent, these must be trailers, so end stream must be set.
         assert(payload.endStream)
-
-        if var responseBuffer = state.responseBuffer {
-          // We have a response buffer; we're doing gRPC Web Text. Nil out the buffer to avoid CoWs.
-          state.responseBuffer = nil
-
-          let buffer = GRPCWebToHTTP2ServerCodec.encodeResponsesAndTrailers(
-            &responseBuffer,
-            trailers: payload.headers,
-            allocator: allocator
-          )
-
-          self = .closed
-          action = .write(.body(.byteBuffer(buffer)), .end(nil), promise)
-        } else {
-          // No response buffer; plain gRPC Web.
-          let trailers = HTTPHeaders(hpackHeaders: payload.headers)
-          self = .closed
-          action = .write(.end(trailers), nil, promise)
-        }
+        return self.processResponseTrailers(payload.headers, promise: promise, allocator: allocator)
       } else if payload.endStream {
         // Headers haven't been sent yet and end stream is set: this is a trailers only response
         // so we need to send 'end' as well.
-        let head = GRPCWebToHTTP2ServerCodec.makeResponseHead(hpackHeaders: payload.headers)
-        self = .closed
-        action = .write(.head(head), .end(nil), promise)
+        return self.processResponseTrailersOnly(payload.headers, promise: promise)
       } else {
-        // Headers haven't been sent, end stream isn't set. Just send response head.
-        state.responseHeadersSent = true
-        let head = GRPCWebToHTTP2ServerCodec.makeResponseHead(hpackHeaders: payload.headers)
-        self = .open(state)
-        action = .write(.head(head), nil, promise)
+        return self.processResponseHeaders(payload.headers, promise: promise)
       }
-      return action
 
-    case .closed:
+    case .clientOpenServerClosed:
+      // We've already sent end.
       return .completePromise(promise, .failure(GRPCError.AlreadyComplete()))
 
     case ._modifying:
       preconditionFailure("Left in modifying state")
+    }
+  }
+
+  private func processResponseData(
+    _ payload: HTTP2Frame.FramePayload.Data,
+    promise: EventLoopPromise<Void>?,
+    state: inout GRPCWebToHTTP2ServerCodec.StateMachine.OutboundState
+  ) -> GRPCWebToHTTP2ServerCodec.StateMachine.Action {
+    if state.responseBuffer == nil {
+      // Not gRPC Web Text; just write the body.
+      return .write(.init(part: .body(payload.data), promise: promise, closeChannel: false))
+    } else {
+      switch payload.data {
+      case let .byteBuffer(buffer):
+        // '!' is fine, we checked above.
+        state.responseBuffer!.append(buffer)
+
+      case .fileRegion:
+        preconditionFailure("Unexpected IOData.fileRegion")
+      }
+
+      // The response is buffered, we can consider it dealt with.
+      return .completePromise(promise, .success(()))
     }
   }
 
@@ -400,26 +610,17 @@ extension GRPCWebToHTTP2ServerCodec.StateMachine.State {
     case .idle:
       preconditionFailure("Invalid state: haven't received request head")
 
-    case var .open(state):
-      if state.responseBuffer == nil {
-        // Not gRPC Web Text; just write the body.
-        return .write(.body(payload.data), nil, promise)
-      } else {
-        switch payload.data {
-        case let .byteBuffer(buffer):
-          // '!' is fine, we checked above.
-          state.responseBuffer!.append(buffer)
+    case .fullyOpen(let inbound, var outbound):
+      let action = self.processResponseData(payload, promise: promise, state: &outbound)
+      self = .fullyOpen(inbound, outbound)
+      return action
 
-        case .fileRegion:
-          preconditionFailure("Unexpected IOData.fileRegion")
-        }
+    case var .clientClosedServerOpen(outbound):
+      let action = self.processResponseData(payload, promise: promise, state: &outbound)
+      self = .clientClosedServerOpen(outbound)
+      return action
 
-        self = .open(state)
-        // The response is buffered, we can consider it dealt with.
-        return .completePromise(promise, .success(()))
-      }
-
-    case .closed:
+    case .clientOpenServerClosed:
       return .completePromise(promise, .failure(GRPCError.AlreadyComplete()))
 
     case ._modifying:
@@ -431,8 +632,15 @@ extension GRPCWebToHTTP2ServerCodec.StateMachine.State {
 // MARK: - Helpers
 
 extension GRPCWebToHTTP2ServerCodec {
-  private static func makeResponseHead(hpackHeaders: HPACKHeaders) -> HTTPResponseHead {
-    let headers = HTTPHeaders(hpackHeaders: hpackHeaders)
+  private static func makeResponseHead(
+    hpackHeaders: HPACKHeaders,
+    closeConnection: Bool
+  ) -> HTTPResponseHead {
+    var headers = HTTPHeaders(hpackHeaders: hpackHeaders)
+
+    if closeConnection {
+      headers.add(name: "connection", value: "close")
+    }
 
     // Grab the status, if this is missing we've messed up in another handler.
     guard let statusCode = hpackHeaders.first(name: ":status").flatMap(Int.init) else {

--- a/Sources/GRPC/HTTP2ToRawGRPCServerCodec.swift
+++ b/Sources/GRPC/HTTP2ToRawGRPCServerCodec.swift
@@ -27,8 +27,12 @@ internal final class HTTP2ToRawGRPCServerCodec: ChannelInboundHandler, GRPCServe
   private let errorDelegate: ServerErrorDelegate?
   private var context: ChannelHandlerContext!
 
-  /// The mode we're operating in.
-  private var mode: Mode = .notConfigured
+  private let servicesByName: [Substring: CallHandlerProvider]
+  private let encoding: ServerMessageEncoding
+  private let normalizeHeaders: Bool
+
+  /// The configuration state of the handler.
+  private var configurationState: Configuration = .notConfigured
 
   /// Whether we are currently reading data from the `Channel`. Should be set to `false` once a
   /// burst of reading has completed.
@@ -38,9 +42,18 @@ internal final class HTTP2ToRawGRPCServerCodec: ChannelInboundHandler, GRPCServe
   /// then it is held until the read completes in order to elide unnecessary flushes.
   private var flushPending = false
 
-  private enum Mode {
+  private enum Configuration {
     case notConfigured
-    case handler(GRPCServerHandlerProtocol)
+    case configured(GRPCServerHandlerProtocol)
+
+    var isConfigured: Bool {
+      switch self {
+      case .configured:
+        return true
+      case .notConfigured:
+        return false
+      }
+    }
   }
 
   init(
@@ -52,11 +65,10 @@ internal final class HTTP2ToRawGRPCServerCodec: ChannelInboundHandler, GRPCServe
   ) {
     self.logger = logger
     self.errorDelegate = errorDelegate
-    self.state = HTTP2ToRawGRPCStateMachine(
-      services: servicesByName,
-      encoding: encoding,
-      normalizeHeaders: normalizeHeaders
-    )
+    self.servicesByName = servicesByName
+    self.encoding = encoding
+    self.normalizeHeaders = normalizeHeaders
+    self.state = HTTP2ToRawGRPCStateMachine()
   }
 
   internal func handlerAdded(context: ChannelHandlerContext) {
@@ -65,23 +77,23 @@ internal final class HTTP2ToRawGRPCServerCodec: ChannelInboundHandler, GRPCServe
 
   internal func handlerRemoved(context: ChannelHandlerContext) {
     self.context = nil
-    self.mode = .notConfigured
+    self.configurationState = .notConfigured
   }
 
   internal func errorCaught(context: ChannelHandlerContext, error: Error) {
-    switch self.mode {
+    switch self.configurationState {
     case .notConfigured:
       context.close(mode: .all, promise: nil)
-    case let .handler(hander):
+    case let .configured(hander):
       hander.receiveError(error)
     }
   }
 
   internal func channelInactive(context: ChannelHandlerContext) {
-    switch self.mode {
+    switch self.configurationState {
     case .notConfigured:
       context.fireChannelInactive()
-    case let .handler(handler):
+    case let .configured(handler):
       handler.finish()
     }
   }
@@ -100,15 +112,20 @@ internal final class HTTP2ToRawGRPCServerCodec: ChannelInboundHandler, GRPCServe
         logger: self.logger,
         allocator: context.channel.allocator,
         responseWriter: self,
-        closeFuture: context.channel.closeFuture
+        closeFuture: context.channel.closeFuture,
+        services: self.servicesByName,
+        encoding: self.encoding,
+        normalizeHeaders: self.normalizeHeaders
       )
 
       switch receiveHeaders {
       case let .configure(handler):
-        self.mode = .handler(handler)
+        assert(!self.configurationState.isConfigured)
+        self.configurationState = .configured(handler)
         self.configured()
 
       case let .rejectRPC(trailers):
+        assert(!self.configurationState.isConfigured)
         // We're not handling this request: write headers and end stream.
         let payload = HTTP2Frame.FramePayload.headers(.init(headers: trailers, endStream: true))
         context.writeAndFlush(self.wrapOutboundOut(payload), promise: nil)
@@ -155,18 +172,18 @@ internal final class HTTP2ToRawGRPCServerCodec: ChannelInboundHandler, GRPCServe
   private func configured() {
     switch self.state.pipelineConfigured() {
     case let .forwardHeaders(headers):
-      switch self.mode {
+      switch self.configurationState {
       case .notConfigured:
         preconditionFailure()
-      case let .handler(handler):
+      case let .configured(handler):
         handler.receiveMetadata(headers)
       }
 
     case let .forwardHeadersAndRead(headers):
-      switch self.mode {
+      switch self.configurationState {
       case .notConfigured:
         preconditionFailure()
-      case let .handler(handler):
+      case let .configured(handler):
         handler.receiveMetadata(headers)
       }
       self.tryReadingMessage()
@@ -181,44 +198,44 @@ internal final class HTTP2ToRawGRPCServerCodec: ChannelInboundHandler, GRPCServe
       ()
 
     case let .forwardMessage(buffer):
-      switch self.mode {
+      switch self.configurationState {
       case .notConfigured:
         preconditionFailure()
-      case let .handler(handler):
+      case let .configured(handler):
         handler.receiveMessage(buffer)
       }
 
     case let .forwardMessageAndEnd(buffer):
-      switch self.mode {
+      switch self.configurationState {
       case .notConfigured:
         preconditionFailure()
-      case let .handler(handler):
+      case let .configured(handler):
         handler.receiveMessage(buffer)
         handler.receiveEnd()
       }
 
     case let .forwardMessageThenReadNextMessage(buffer):
-      switch self.mode {
+      switch self.configurationState {
       case .notConfigured:
         preconditionFailure()
-      case let .handler(handler):
+      case let .configured(handler):
         handler.receiveMessage(buffer)
       }
       self.tryReadingMessage()
 
     case .forwardEnd:
-      switch self.mode {
+      switch self.configurationState {
       case .notConfigured:
         preconditionFailure()
-      case let .handler(handler):
+      case let .configured(handler):
         handler.receiveEnd()
       }
 
     case let .errorCaught(error):
-      switch self.mode {
+      switch self.configurationState {
       case .notConfigured:
         preconditionFailure()
-      case let .handler(handler):
+      case let .configured(handler):
         handler.receiveError(error)
       }
     }
@@ -273,6 +290,9 @@ internal final class HTTP2ToRawGRPCServerCodec: ChannelInboundHandler, GRPCServe
   ) {
     switch self.state.send(status: status, trailers: trailers) {
     case let .success(trailers):
+      // Drop the request handler.
+      self.configurationState = .notConfigured
+
       // Always end stream for status and trailers.
       let payload = HTTP2Frame.FramePayload.headers(.init(headers: trailers, endStream: true))
       self.context.write(self.wrapOutboundOut(payload), promise: promise)

--- a/Tests/GRPCTests/GRPCWebToHTTP2StateMachineTests.swift
+++ b/Tests/GRPCTests/GRPCWebToHTTP2StateMachineTests.swift
@@ -1,0 +1,662 @@
+/*
+ * Copyright 2021, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@testable import GRPC
+import NIO
+import NIOHPACK
+import NIOHTTP1
+import NIOHTTP2
+import XCTest
+
+final class GRPCWebToHTTP2StateMachineTests: GRPCTestCase {
+  fileprivate typealias StateMachine = GRPCWebToHTTP2ServerCodec.StateMachine
+
+  private let allocator = ByteBufferAllocator()
+
+  private func makeStateMachine(scheme: String = "http") -> StateMachine {
+    return StateMachine(scheme: scheme)
+  }
+
+  private func makeRequestHead(
+    version: HTTPVersion = .http1_1,
+    method: HTTPMethod = .POST,
+    uri: String,
+    headers: HTTPHeaders = [:]
+  ) -> HTTPServerRequestPart {
+    return .head(.init(version: version, method: method, uri: uri, headers: headers))
+  }
+
+  // MARK: - grpc-web
+
+  func test_gRPCWeb_requestHeaders() {
+    var state = self.makeStateMachine(scheme: "http")
+    let head = self.makeRequestHead(method: .POST, uri: "foo", headers: ["host": "localhost"])
+
+    let action = state.processInbound(serverRequestPart: head, allocator: self.allocator)
+    action.assertRead { payload in
+      payload.assertHeaders { payload in
+        XCTAssertFalse(payload.endStream)
+        XCTAssertEqual(payload.headers[canonicalForm: ":path"], ["foo"])
+        XCTAssertEqual(payload.headers[canonicalForm: ":method"], ["POST"])
+        XCTAssertEqual(payload.headers[canonicalForm: ":scheme"], ["http"])
+        XCTAssertEqual(payload.headers[canonicalForm: ":authority"], ["localhost"])
+      }
+    }
+  }
+
+  func test_gRPCWeb_requestBody() {
+    var state = self.makeStateMachine()
+    let head = self.makeRequestHead(
+      uri: "foo",
+      headers: ["content-type": "application/grpc-web"]
+    )
+
+    state.processInbound(serverRequestPart: head, allocator: self.allocator).assertRead {
+      $0.assertHeaders()
+    }
+
+    let b1 = ByteBuffer(string: "hello")
+    for _ in 0 ..< 5 {
+      state.processInbound(serverRequestPart: .body(b1), allocator: self.allocator).assertRead {
+        $0.assertData {
+          XCTAssertFalse($0.endStream)
+          $0.data.assertByteBuffer { buffer in
+            var buffer = buffer
+            XCTAssertEqual(buffer.readString(length: buffer.readableBytes), "hello")
+          }
+        }
+      }
+    }
+
+    state.processInbound(serverRequestPart: .end(nil), allocator: self.allocator).assertRead {
+      $0.assertEmptyDataWithEndStream()
+    }
+  }
+
+  private func checkResponseHeaders(
+    from state: StateMachine,
+    expectConnectionCloseHeader: Bool,
+    line: UInt = #line
+  ) {
+    var state = state
+    state.processOutbound(
+      framePayload: .headers(.init(headers: [":status": "200"])),
+      promise: nil,
+      allocator: self.allocator
+    ).assertWrite { write in
+      write.part.assertHead {
+        XCTAssertEqual($0.status, .ok, line: line)
+        XCTAssertFalse($0.headers.contains(name: ":status"), line: line)
+
+        if expectConnectionCloseHeader {
+          XCTAssertEqual($0.headers[canonicalForm: "connection"], ["close"], line: line)
+        } else {
+          XCTAssertFalse($0.headers.contains(name: "connection"), line: line)
+        }
+      }
+      XCTAssertNil(write.additionalPart, line: line)
+      XCTAssertFalse(write.closeChannel, line: line)
+    }
+  }
+
+  func test_gRPCWeb_responseHeaders() {
+    for connectionClose in [true, false] {
+      let headers: HTTPHeaders = connectionClose ? ["connection": "close"] : [:]
+      let requestHead = self.makeRequestHead(uri: "/echo", headers: headers)
+
+      var state = self.makeStateMachine()
+      state.processInbound(serverRequestPart: requestHead, allocator: self.allocator).assertRead()
+      self.checkResponseHeaders(from: state, expectConnectionCloseHeader: connectionClose)
+
+      // Do it again with the request stream closed.
+      state.processInbound(serverRequestPart: .end(nil), allocator: self.allocator).assertRead()
+      self.checkResponseHeaders(from: state, expectConnectionCloseHeader: connectionClose)
+    }
+  }
+
+  private func checkTrailersOnlyResponse(
+    from state: StateMachine,
+    expectConnectionCloseHeader: Bool,
+    line: UInt = #line
+  ) {
+    var state = state
+
+    state.processOutbound(
+      framePayload: .headers(.init(headers: [":status": "415"], endStream: true)),
+      promise: nil,
+      allocator: self.allocator
+    ).assertWrite { write in
+      write.part.assertHead {
+        XCTAssertEqual($0.status, .unsupportedMediaType, line: line)
+        XCTAssertFalse($0.headers.contains(name: ":status"), line: line)
+
+        if expectConnectionCloseHeader {
+          XCTAssertEqual($0.headers[canonicalForm: "connection"], ["close"], line: line)
+        } else {
+          XCTAssertFalse($0.headers.contains(name: "connection"), line: line)
+        }
+      }
+
+      // Should also send end.
+      write.additionalPart.assertSome { $0.assertEnd() }
+      XCTAssertEqual(write.closeChannel, expectConnectionCloseHeader, line: line)
+    }
+  }
+
+  func test_gRPCWeb_responseTrailersOnly() {
+    for connectionClose in [true, false] {
+      let headers: HTTPHeaders = connectionClose ? ["connection": "close"] : [:]
+      let requestHead = self.makeRequestHead(uri: "/echo", headers: headers)
+
+      var state = self.makeStateMachine()
+      state.processInbound(serverRequestPart: requestHead, allocator: self.allocator).assertRead()
+      self.checkTrailersOnlyResponse(from: state, expectConnectionCloseHeader: connectionClose)
+
+      // Do it again with the request stream closed.
+      state.processInbound(serverRequestPart: .end(nil), allocator: self.allocator).assertRead()
+      self.checkTrailersOnlyResponse(from: state, expectConnectionCloseHeader: connectionClose)
+    }
+  }
+
+  private func checkGRPCWebResponseData(from state: StateMachine, line: UInt = #line) {
+    var state = state
+
+    for i in 0 ..< 10 {
+      let buffer = ByteBuffer(string: "foo-\(i)")
+      state.processOutbound(
+        framePayload: .data(.init(data: .byteBuffer(buffer))),
+        promise: nil,
+        allocator: self.allocator
+      ).assertWrite { write in
+        write.part.assertBody {
+          XCTAssertEqual($0, buffer, line: line)
+        }
+        XCTAssertNil(write.additionalPart, line: line)
+        XCTAssertFalse(write.closeChannel, line: line)
+      }
+    }
+  }
+
+  func test_gRPCWeb_responseData() {
+    var state = self.makeStateMachine()
+    let requestHead = self.makeRequestHead(
+      uri: "/echo",
+      headers: ["content-type": "application/grpc-web"]
+    )
+    state.processInbound(serverRequestPart: requestHead, allocator: self.allocator).assertRead()
+    state.processOutbound(
+      framePayload: .headers(.init(headers: [":status": "200"])),
+      promise: nil,
+      allocator: self.allocator
+    ).assertWrite()
+
+    // Request stream is open.
+    self.checkGRPCWebResponseData(from: state)
+
+    // Close request stream and test again.
+    state.processInbound(serverRequestPart: .end(nil), allocator: self.allocator).assertRead()
+    self.checkGRPCWebResponseData(from: state)
+  }
+
+  private func checkGRPCWebResponseTrailers(
+    from state: StateMachine,
+    expectChannelClose: Bool,
+    line: UInt = #line
+  ) {
+    var state = state
+
+    state.processOutbound(
+      framePayload: .headers(.init(headers: ["grpc-status": "0"], endStream: true)),
+      promise: nil,
+      allocator: self.allocator
+    ).assertWrite { write in
+      write.part.assertEnd {
+        $0.assertSome { trailers in
+          XCTAssertEqual(trailers[canonicalForm: "grpc-status"], ["0"])
+        }
+      }
+
+      XCTAssertEqual(write.closeChannel, expectChannelClose)
+    }
+  }
+
+  func test_gRPCWeb_responseTrailers() {
+    for connectionClose in [true, false] {
+      let headers: HTTPHeaders = connectionClose ? ["connection": "close"] : [:]
+      let requestHead = self.makeRequestHead(uri: "/echo", headers: headers)
+
+      var state = self.makeStateMachine()
+      state.processInbound(serverRequestPart: requestHead, allocator: self.allocator).assertRead()
+      state.processOutbound(
+        framePayload: .headers(.init(headers: [":status": "200"])),
+        promise: nil,
+        allocator: self.allocator
+      ).assertWrite()
+
+      // Request stream is open.
+      self.checkGRPCWebResponseTrailers(from: state, expectChannelClose: connectionClose)
+
+      // Check again with request stream closed.
+      state.processInbound(serverRequestPart: .end(nil), allocator: self.allocator).assertRead()
+      self.checkGRPCWebResponseTrailers(from: state, expectChannelClose: connectionClose)
+    }
+  }
+
+  // MARK: - grpc-web-text
+
+  func test_gRPCWebText_requestBody() {
+    var state = self.makeStateMachine()
+    let head = self.makeRequestHead(
+      uri: "foo",
+      headers: ["content-type": "application/grpc-web-text"]
+    )
+
+    state.processInbound(serverRequestPart: head, allocator: self.allocator).assertRead {
+      $0.assertHeaders()
+    }
+
+    let expected = ["hel", "lo"]
+    let buffers = [ByteBuffer(string: "aGVsb"), ByteBuffer(string: "G8=")]
+
+    for (buffer, expected) in zip(buffers, expected) {
+      state.processInbound(serverRequestPart: .body(buffer), allocator: self.allocator).assertRead {
+        $0.assertData {
+          XCTAssertFalse($0.endStream)
+          $0.data.assertByteBuffer { buffer in
+            var buffer = buffer
+            XCTAssertEqual(buffer.readString(length: buffer.readableBytes), expected)
+          }
+        }
+      }
+    }
+
+    // If there's not enough to decode, there's nothing to do.
+    let buffer = ByteBuffer(string: "a")
+    state.processInbound(serverRequestPart: .body(buffer), allocator: self.allocator).assertNone()
+
+    state.processInbound(serverRequestPart: .end(nil), allocator: self.allocator).assertRead {
+      $0.assertEmptyDataWithEndStream()
+    }
+  }
+
+  private func checkResponseDataAndTrailersForGRPCWebText(
+    from state: StateMachine,
+    line: UInt = #line
+  ) {
+    var state = state
+
+    state.processOutbound(
+      framePayload: .headers(.init(headers: [":status": "200"])),
+      promise: nil,
+      allocator: self.allocator
+    ).assertWrite()
+
+    // Write some bytes.
+    for text in ["hello", ", world!"] {
+      let buffer = ByteBuffer(string: text)
+      state.processOutbound(
+        framePayload: .data(.init(data: .byteBuffer(buffer))),
+        promise: nil,
+        allocator: self.allocator
+      ).assertCompletePromise { error in
+        XCTAssertNil(error)
+      }
+    }
+
+    state.processOutbound(
+      framePayload: .headers(.init(headers: ["grpc-status": "0"], endStream: true)),
+      promise: nil,
+      allocator: self.allocator
+    ).assertWrite { write in
+      // The response is encoded by:
+      // - accumulating the bytes of request messages (these would normally be gRPC length prefixed
+      //   messages)
+      // - appending a 'trailers' byte (0x80)
+      // - appending the UInt32 length of the trailers when encoded as HTTP/1 header lines
+      // - the encoded headers
+      write.part.assertBody { buffer in
+        var buffer = buffer
+        let base64Encoded = buffer.readString(length: buffer.readableBytes)!
+        XCTAssertEqual(base64Encoded, "aGVsbG8sIHdvcmxkIYAAAAAOZ3JwYy1zdGF0dXM6IDA=")
+
+        let data = Data(base64Encoded: base64Encoded)!
+        buffer.writeData(data)
+
+        XCTAssertEqual(buffer.readString(length: 13), "hello, world!")
+        XCTAssertEqual(buffer.readInteger(), UInt8(0x80))
+        XCTAssertEqual(buffer.readInteger(), UInt32(14))
+        XCTAssertEqual(buffer.readString(length: 14), "grpc-status: 0")
+        XCTAssertEqual(buffer.readableBytes, 0)
+      }
+
+      // There should be an end now.
+      write.additionalPart.assertSome { $0.assertEnd() }
+
+      XCTAssertFalse(write.closeChannel)
+    }
+  }
+
+  func test_gRPCWebText_responseDataAndTrailers() {
+    var state = self.makeStateMachine()
+    let requestHead = self.makeRequestHead(
+      uri: "/echo",
+      headers: ["content-type": "application/grpc-web-text"]
+    )
+    state.processInbound(serverRequestPart: requestHead, allocator: self.allocator).assertRead()
+
+    // Request stream is still open.
+    self.checkResponseDataAndTrailersForGRPCWebText(from: state)
+
+    // Check again with request stream closed.
+    state.processInbound(serverRequestPart: .end(nil), allocator: self.allocator).assertRead()
+    self.checkResponseDataAndTrailersForGRPCWebText(from: state)
+  }
+
+  // MARK: - General
+
+  func test_requestPartsAfterServerClosed() {
+    var state = self.makeStateMachine()
+    let requestHead = self.makeRequestHead(uri: "/echo")
+    state.processInbound(serverRequestPart: requestHead, allocator: self.allocator).assertRead()
+
+    // Close the response stream.
+    state.processOutbound(
+      framePayload: .headers(.init(headers: [":status": "415"], endStream: true)),
+      promise: nil,
+      allocator: self.allocator
+    ).assertWrite()
+
+    state.processInbound(serverRequestPart: .body(.init()), allocator: self.allocator).assertNone()
+    state.processInbound(serverRequestPart: .end(nil), allocator: self.allocator).assertNone()
+  }
+
+  func test_responsePartsAfterServerClosed() {
+    var state = self.makeStateMachine()
+    let requestHead = self.makeRequestHead(uri: "/echo")
+    state.processInbound(serverRequestPart: requestHead, allocator: self.allocator).assertRead()
+
+    // Close the response stream.
+    state.processOutbound(
+      framePayload: .headers(.init(headers: [":status": "415"], endStream: true)),
+      promise: nil,
+      allocator: self.allocator
+    ).assertWrite()
+
+    // More writes should be told to fail their promise.
+    state.processOutbound(
+      framePayload: .headers(.init(headers: .init())), promise: nil, allocator: self.allocator
+    ).assertCompletePromise { error in
+      XCTAssertNotNil(error)
+    }
+
+    state.processOutbound(
+      framePayload: .data(.init(data: .byteBuffer(.init()))),
+      promise: nil,
+      allocator: self.allocator
+    ).assertCompletePromise { error in
+      XCTAssertNotNil(error)
+    }
+  }
+
+  func test_handleMultipleRequests() {
+    func sendRequestHead(_ state: inout StateMachine, contentType: ContentType) -> StateMachine
+      .Action {
+      let requestHead = self.makeRequestHead(
+        uri: "/echo", headers: ["content-type": contentType.canonicalValue]
+      )
+      return state.processInbound(serverRequestPart: requestHead, allocator: self.allocator)
+    }
+
+    func sendRequestBody(_ state: inout StateMachine, buffer: ByteBuffer) -> StateMachine.Action {
+      return state.processInbound(serverRequestPart: .body(buffer), allocator: self.allocator)
+    }
+
+    func sendRequestEnd(_ state: inout StateMachine) -> StateMachine.Action {
+      return state.processInbound(serverRequestPart: .end(nil), allocator: self.allocator)
+    }
+
+    func sendResponseHeaders(
+      _ state: inout StateMachine,
+      headers: HPACKHeaders,
+      endStream: Bool = false
+    ) -> StateMachine.Action {
+      return state.processOutbound(
+        framePayload: .headers(.init(headers: headers, endStream: endStream)),
+        promise: nil,
+        allocator: self.allocator
+      )
+    }
+
+    func sendResponseData(
+      _ state: inout StateMachine,
+      buffer: ByteBuffer
+    ) -> StateMachine.Action {
+      return state.processOutbound(
+        framePayload: .data(.init(data: .byteBuffer(buffer))),
+        promise: nil,
+        allocator: self.allocator
+      )
+    }
+
+    var state = self.makeStateMachine()
+
+    // gRPC-Web, all request parts then all response parts.
+    sendRequestHead(&state, contentType: .webProtobuf).assertRead()
+    sendRequestBody(&state, buffer: .init(string: "hello")).assertRead()
+    sendRequestEnd(&state).assertRead()
+    sendResponseHeaders(&state, headers: [":status": "200"]).assertWrite()
+    sendResponseData(&state, buffer: .init(string: "bye")).assertWrite()
+    sendResponseHeaders(&state, headers: ["grpc-status": "0"], endStream: true).assertWrite()
+
+    // gRPC-Web text, all requests then all response parts.
+    sendRequestHead(&state, contentType: .webTextProtobuf).assertRead()
+    sendRequestBody(&state, buffer: .init(string: "hello")).assertRead()
+    sendRequestEnd(&state).assertRead()
+    sendResponseHeaders(&state, headers: [":status": "200"]).assertWrite()
+    // nothing; buffered and sent with end.
+    sendResponseData(&state, buffer: .init(string: "bye")).assertCompletePromise()
+    sendResponseHeaders(&state, headers: ["grpc-status": "0"], endStream: true).assertWrite()
+
+    // gRPC-Web, interleaving
+    sendRequestHead(&state, contentType: .webProtobuf).assertRead()
+    sendResponseHeaders(&state, headers: [":status": "200"]).assertWrite()
+    sendRequestBody(&state, buffer: .init(string: "hello")).assertRead()
+    sendResponseData(&state, buffer: .init(string: "bye")).assertWrite()
+    sendRequestEnd(&state).assertRead()
+    sendResponseHeaders(&state, headers: ["grpc-status": "0"], endStream: true).assertWrite()
+
+    // gRPC-Web text, interleaving
+    sendRequestHead(&state, contentType: .webTextProtobuf).assertRead()
+    sendResponseHeaders(&state, headers: [":status": "200"]).assertWrite()
+    sendRequestBody(&state, buffer: .init(string: "hello")).assertRead()
+    sendResponseData(&state, buffer: .init(string: "bye")).assertCompletePromise()
+    sendRequestEnd(&state).assertRead()
+    sendResponseHeaders(&state, headers: ["grpc-status": "0"], endStream: true).assertWrite()
+
+    // gRPC-Web, server closes immediately.
+    sendRequestHead(&state, contentType: .webProtobuf).assertRead()
+    sendResponseHeaders(&state, headers: [":status": "415"], endStream: true).assertWrite()
+    sendRequestBody(&state, buffer: .init(string: "hello")).assertNone()
+    sendRequestEnd(&state).assertNone()
+
+    // gRPC-Web text, server closes immediately.
+    sendRequestHead(&state, contentType: .webTextProtobuf).assertRead()
+    sendResponseHeaders(&state, headers: [":status": "415"], endStream: true).assertWrite()
+    sendRequestBody(&state, buffer: .init(string: "hello")).assertNone()
+    sendRequestEnd(&state).assertNone()
+  }
+}
+
+// MARK: - Assertions
+
+extension GRPCWebToHTTP2ServerCodec.StateMachine.Action {
+  func assertRead(
+    file: StaticString = #file,
+    line: UInt = #line,
+    verify: (HTTP2Frame.FramePayload) -> Void = { _ in }
+  ) {
+    if case let .fireChannelRead(payload) = self {
+      verify(payload)
+    } else {
+      XCTFail("Expected '.fireChannelRead' but got '\(self)'", file: file, line: line)
+    }
+  }
+
+  func assertWrite(
+    file: StaticString = #file,
+    line: UInt = #line,
+    verify: (Write) -> Void = { _ in }
+  ) {
+    if case let .write(write) = self {
+      verify(write)
+    } else {
+      XCTFail("Expected '.write' but got '\(self)'", file: file, line: line)
+    }
+  }
+
+  func assertCompletePromise(
+    file: StaticString = #file,
+    line: UInt = #line,
+    verify: (Error?) -> Void = { _ in }
+  ) {
+    if case let .completePromise(_, result) = self {
+      do {
+        try result.get()
+        verify(nil)
+      } catch {
+        verify(error)
+      }
+    } else {
+      XCTFail("Expected '.completePromise' but got '\(self)'", file: file, line: line)
+    }
+  }
+
+  func assertNone(
+    file: StaticString = #file,
+    line: UInt = #line
+  ) {
+    if case .none = self {
+      ()
+    } else {
+      XCTFail("Expected '.none' but got '\(self)'", file: file, line: line)
+    }
+  }
+}
+
+extension HTTP2Frame.FramePayload {
+  func assertHeaders(
+    file: StaticString = #file,
+    line: UInt = #line,
+    verify: (Headers) -> Void = { _ in }
+  ) {
+    if case let .headers(headers) = self {
+      verify(headers)
+    } else {
+      XCTFail("Expected '.headers' but got '\(self)'", file: file, line: line)
+    }
+  }
+
+  func assertData(
+    file: StaticString = #file,
+    line: UInt = #line,
+    verify: (Data) -> Void = { _ in }
+  ) {
+    if case let .data(data) = self {
+      verify(data)
+    } else {
+      XCTFail("Expected '.data' but got '\(self)'", file: file, line: line)
+    }
+  }
+
+  func assertEmptyDataWithEndStream(
+    file: StaticString = #file,
+    line: UInt = #line
+  ) {
+    self.assertData(file: file, line: line) {
+      XCTAssertTrue($0.endStream)
+      $0.data.assertByteBuffer { buffer in
+        XCTAssertEqual(buffer.readableBytes, 0)
+      }
+    }
+  }
+}
+
+extension HTTPServerResponsePart {
+  func assertHead(
+    file: StaticString = #file,
+    line: UInt = #line,
+    verify: (HTTPResponseHead) -> Void = { _ in }
+  ) {
+    if case let .head(head) = self {
+      verify(head)
+    } else {
+      XCTFail("Expected '.head' but got '\(self)'", file: file, line: line)
+    }
+  }
+
+  func assertBody(
+    file: StaticString = #file,
+    line: UInt = #line,
+    verify: (ByteBuffer) -> Void = { _ in }
+  ) {
+    if case let .body(.byteBuffer(buffer)) = self {
+      verify(buffer)
+    } else {
+      XCTFail("Expected '.body(.byteBuffer)' but got '\(self)'", file: file, line: line)
+    }
+  }
+
+  func assertEnd(
+    file: StaticString = #file,
+    line: UInt = #line,
+    verify: (HTTPHeaders?) -> Void = { _ in }
+  ) {
+    if case let .end(trailers) = self {
+      verify(trailers)
+    } else {
+      XCTFail("Expected '.end' but got '\(self)'", file: file, line: line)
+    }
+  }
+}
+
+extension IOData {
+  func assertByteBuffer(
+    file: StaticString = #file,
+    line: UInt = #line,
+    verify: (ByteBuffer) -> Void = { _ in }
+  ) {
+    if case let .byteBuffer(buffer) = self {
+      verify(buffer)
+    } else {
+      XCTFail("Expected '.byteBuffer' but got '\(self)'", file: file, line: line)
+    }
+  }
+}
+
+extension Optional {
+  func assertSome(
+    file: StaticString = #file,
+    line: UInt = #line,
+    verify: (Wrapped) -> Void = { _ in }
+  ) {
+    switch self {
+    case let .some(wrapped):
+      verify(wrapped)
+    case .none:
+      XCTFail("Expected '.some' but got 'nil'", file: file, line: line)
+    }
+  }
+}

--- a/Tests/GRPCTests/XCTestHelpers.swift
+++ b/Tests/GRPCTests/XCTestHelpers.swift
@@ -319,6 +319,51 @@ struct Matcher<Value> {
     }
   }
 
+  static func sendTrailers(
+    _ matcher: Matcher<HPACKHeaders>? = nil
+  ) -> Matcher<HTTP2ToRawGRPCStateMachine.SendEndAction> {
+    return .init { actual in
+      switch actual {
+      case let .sendTrailers(trailers):
+        return matcher?.evaluate(trailers) ?? .match
+      case .sendTrailersAndFinish:
+        return .noMatch(actual: "sendTrailersAndFinish", expected: "sendTrailers")
+      case let .failure(error):
+        return .noMatch(actual: "\(error)", expected: "sendTrailers")
+      }
+    }
+  }
+
+  static func sendTrailersAndFinish(
+    _ matcher: Matcher<HPACKHeaders>? = nil
+  ) -> Matcher<HTTP2ToRawGRPCStateMachine.SendEndAction> {
+    return .init { actual in
+      switch actual {
+      case let .sendTrailersAndFinish(trailers):
+        return matcher?.evaluate(trailers) ?? .match
+      case .sendTrailers:
+        return .noMatch(actual: "sendTrailers", expected: "sendTrailersAndFinish")
+      case let .failure(error):
+        return .noMatch(actual: "\(error)", expected: "sendTrailersAndFinish")
+      }
+    }
+  }
+
+  static func failure(
+    _ matcher: Matcher<Error>? = nil
+  ) -> Matcher<HTTP2ToRawGRPCStateMachine.SendEndAction> {
+    return .init { actual in
+      switch actual {
+      case .sendTrailers:
+        return .noMatch(actual: "sendTrailers", expected: "failure")
+      case .sendTrailersAndFinish:
+        return .noMatch(actual: "sendTrailersAndFinish", expected: "failure")
+      case let .failure(error):
+        return matcher?.evaluate(error) ?? .match
+      }
+    }
+  }
+
   // MARK: HTTP/1
 
   static func head(
@@ -542,17 +587,6 @@ struct Matcher<Value> {
         return .match
       default:
         return .noMatch(actual: "\(actual)", expected: "forwardEnd")
-      }
-    }
-  }
-
-  static func forwardMessageAndEnd() -> Matcher<HTTP2ToRawGRPCStateMachine.ReadNextMessageAction> {
-    return .init { actual in
-      switch actual {
-      case .forwardMessageAndEnd:
-        return .match
-      default:
-        return .noMatch(actual: "\(actual)", expected: "forwardMessageAndEnd")
       }
     }
   }


### PR DESCRIPTION
Motivation:

Our gRPC Web implementation was _somewhat_ underbaked. It would, for
example, disregard the 'connection' header and was not able to handle
multiple requests. That's pretty bad!

Modifications:

- Rework part of the grpc-web state machine
- Extend the http/2 to grpc state machine and codec to support multiple
  requests per instance
- grpc-web state machine tests

Result:

gRPC Web is better tested and supports multiple requests.