### PR TITLE
Write alloc counter test output to stdout and file

### DIFF
--- a/Performance/allocations/test-allocation-counts.sh
+++ b/Performance/allocations/test-allocation-counts.sh
@@ -47,12 +47,10 @@ for file in "$here/tests/"test_*.swift; do
 done
 
 # Run all the tests.
-"$here/tests/run-allocation-counter-tests.sh" -t "$tmp" > "$tmp/output"
+"$here/tests/run-allocation-counter-tests.sh" -t "$tmp" | tee "$tmp/output"
 
 # Dump some output from each, check for allocations.
 for test in "${all_tests[@]}"; do
-  cat "$tmp/output"  # helps debugging
-
   while read -r test_case; do
     test_case=${test_case#test_*}
     total_allocations=$(grep "^test_$test_case.total_allocations:" "$tmp/output" | cut -d: -f2 | sed 's/ //g')


### PR DESCRIPTION
Motivation:

The allocation counting test harness writes output to a file and then
parses the file to check for allocations. However, this step includes
building a whole bunch of stuff which can take some time and since no
output is generated during that time it appears to some CI systems as if
there is no forward progress. Travis will kill CI jobs if there is no
output for 10 minutes.

Modifications:

- 'tee' the output from running the allocation counting tests

Result:

We see progress on stdout.