### PR TITLE
Fix compiler crash on Swift 5.2 when inlining test helper

### DIFF
--- a/Tests/GRPCTests/XCTestHelpers.swift
+++ b/Tests/GRPCTests/XCTestHelpers.swift
@@ -52,6 +52,9 @@ func assertNoThrow<Value>(
 
 // MARK: - Matchers.
 
+// The Swift 5.2 compiler will crash when trying to
+// inline this function if the tests are running in
+// release mode.
 @inline(never)
 func assertThat<Value>(
   _ expression: @autoclosure @escaping () throws -> Value,

--- a/Tests/GRPCTests/XCTestHelpers.swift
+++ b/Tests/GRPCTests/XCTestHelpers.swift
@@ -52,6 +52,7 @@ func assertNoThrow<Value>(
 
 // MARK: - Matchers.
 
+@inline(never)
 func assertThat<Value>(
   _ expression: @autoclosure @escaping () throws -> Value,
   _ matcher: Matcher<Value>,


### PR DESCRIPTION
Running the command
```
swift test -c release -Xswiftc -enable-testing --enable-test-discovery
```

On Linux with Swift 5.2 will result in a compiler crash. The bug in the compiler is to do with inlining a test helper. The solution is to make the helper never inline. This fixes the issue, so that the code is now testable on Swift 5.2.