### PR TITLE
Provide 'default' static functions for making client/server configuration

### DIFF
--- a/FuzzTesting/Sources/ServerFuzzer/main.swift
+++ b/FuzzTesting/Sources/ServerFuzzer/main.swift
@@ -26,7 +26,7 @@ public func test(_ start: UnsafeRawPointer, _ count: Int) -> CInt {
     _ = try? channel.finish()
   }
 
-  let configuration = Server.Configuration(
+  let configuration = Server.Configuration.default(
     target: .unixDomainSocket("/ignored"),
     eventLoopGroup: channel.eventLoop,
     serviceProviders: [EchoProvider()]

--- a/Sources/GRPC/ClientErrorDelegate.swift
+++ b/Sources/GRPC/ClientErrorDelegate.swift
@@ -42,7 +42,10 @@ extension ClientErrorDelegate {
 }
 
 /// A `ClientErrorDelegate` which logs errors.
-public class LoggingClientErrorDelegate: ClientErrorDelegate {
+public final class LoggingClientErrorDelegate: ClientErrorDelegate {
+  /// A shared instance of this class.
+  public static let shared = LoggingClientErrorDelegate()
+
   public init() {}
 
   public func didCatchError(_ error: Error, logger: Logger, file: StaticString, line: Int) {

--- a/Sources/GRPC/GRPCChannel/GRPCChannelBuilder.swift
+++ b/Sources/GRPC/GRPCChannel/GRPCChannelBuilder.swift
@@ -41,7 +41,7 @@ extension ClientConnection {
     fileprivate init(group: EventLoopGroup) {
       // This is okay: the configuration is only consumed on a call to `connect` which sets the host
       // and port.
-      self.configuration = Configuration(target: .hostAndPort("", .max), eventLoopGroup: group)
+      self.configuration = .default(target: .hostAndPort("", .max), eventLoopGroup: group)
     }
 
     public func connect(host: String, port: Int) -> ClientConnection {

--- a/Sources/GRPC/ServerBuilder.swift
+++ b/Sources/GRPC/ServerBuilder.swift
@@ -23,7 +23,7 @@ extension Server {
     private var maybeTLS: Server.Configuration.TLS? { return nil }
 
     fileprivate init(group: EventLoopGroup) {
-      self.configuration = Configuration(
+      self.configuration = .default(
         // This is okay: the configuration is only consumed on a call to `bind` which sets the host
         // and port.
         target: .hostAndPort("", .max),

--- a/Tests/GRPCTests/ClientTLSFailureTests.swift
+++ b/Tests/GRPCTests/ClientTLSFailureTests.swift
@@ -71,14 +71,17 @@ class ClientTLSFailureTests: GRPCTestCase {
   func makeClientConfiguration(
     tls: ClientConnection.Configuration.TLS
   ) -> ClientConnection.Configuration {
-    return .init(
+    var configuration = ClientConnection.Configuration.default(
       target: .hostAndPort("localhost", self.port),
-      eventLoopGroup: self.clientEventLoopGroup,
-      tls: tls,
-      // No need to retry connecting.
-      connectionBackoff: nil,
-      backgroundActivityLogger: self.clientLogger
+      eventLoopGroup: self.clientEventLoopGroup
     )
+
+    configuration.tls = tls
+    // No need to retry connecting.
+    configuration.connectionBackoff = nil
+    configuration.backgroundActivityLogger = self.clientLogger
+
+    return configuration
   }
 
   func makeClientConnectionExpectation() -> XCTestExpectation {

--- a/Tests/GRPCTests/ConnectionManagerTests.swift
+++ b/Tests/GRPCTests/ConnectionManagerTests.swift
@@ -26,13 +26,15 @@ class ConnectionManagerTests: GRPCTestCase {
   private var monitor: ConnectivityStateMonitor!
 
   private var defaultConfiguration: ClientConnection.Configuration {
-    return ClientConnection.Configuration(
+    var configuration = ClientConnection.Configuration.default(
       target: .unixDomainSocket("/ignored"),
-      eventLoopGroup: self.loop,
-      connectivityStateDelegate: nil,
-      connectionBackoff: nil,
-      backgroundActivityLogger: self.clientLogger
+      eventLoopGroup: self.loop
     )
+
+    configuration.connectionBackoff = nil
+    configuration.backgroundActivityLogger = self.clientLogger
+
+    return configuration
   }
 
   override func setUp() {

--- a/Tests/GRPCTests/GRPCServerPipelineConfiguratorTests.swift
+++ b/Tests/GRPCTests/GRPCServerPipelineConfiguratorTests.swift
@@ -46,12 +46,13 @@ class GRPCServerPipelineConfiguratorTests: GRPCTestCase {
   private func setUp(tls: Bool, requireALPN: Bool = true) {
     self.channel = EmbeddedChannel()
 
-    var configuration = Server.Configuration(
+    var configuration = Server.Configuration.default(
       target: .unixDomainSocket("/ignored"),
       eventLoopGroup: self.channel.eventLoop,
-      serviceProviders: [],
-      logger: self.serverLogger
+      serviceProviders: []
     )
+
+    configuration.logger = self.serverLogger
 
     if tls {
       configuration.tls = .init(

--- a/Tests/GRPCTests/ServerFuzzingRegressionTests.swift
+++ b/Tests/GRPCTests/ServerFuzzingRegressionTests.swift
@@ -34,7 +34,7 @@ final class ServerFuzzingRegressionTests: GRPCTestCase {
       _ = try? channel.finish()
     }
 
-    let configuration = Server.Configuration(
+    let configuration = Server.Configuration.default(
       target: .unixDomainSocket("/ignored"),
       eventLoopGroup: channel.eventLoop,
       serviceProviders: [EchoProvider()]

--- a/Tests/GRPCTests/ServerTLSErrorTests.swift
+++ b/Tests/GRPCTests/ServerTLSErrorTests.swift
@@ -53,13 +53,16 @@ class ServerTLSErrorTests: GRPCTestCase {
     tls: ClientConnection.Configuration.TLS,
     port: Int
   ) -> ClientConnection.Configuration {
-    return .init(
+    var configuration = ClientConnection.Configuration.default(
       target: .hostAndPort("localhost", port),
-      eventLoopGroup: self.clientEventLoopGroup,
-      tls: tls,
-      // No need to retry connecting.
-      connectionBackoff: nil
+      eventLoopGroup: self.clientEventLoopGroup
     )
+
+    configuration.tls = tls
+    // No need to retry connecting.
+    configuration.connectionBackoff = nil
+
+    return configuration
   }
 
   func makeClientConnectionExpectation() -> XCTestExpectation {


### PR DESCRIPTION
Motivation:

The `ClientConnection` and `Server` configuration objects are reasonably
large and contain many deafult initialized fields. Whenever we add a
field we need to add a new initializer and deprecate the old one in
order to not break API. Providing a static 'default' function which only
accepts the required properties allows us to add defaulted values without
doing the deprecate and replace.

Modifications:

- Add `default` methods to `ClientConnection.Configuration` and
  `Server.Configuration`
- Deprecate `init`s.

Result:

Easier to add new fields in the future.