### PR TITLE
Check Swift reserved names when generating function names

### DIFF
--- a/Sources/protoc-gen-grpc-swift/Generator-Names.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator-Names.swift
@@ -69,8 +69,7 @@ extension Generator {
     return nameForPackageServiceMethod(file, service, method) + "Call"
   }
 
-  internal let quotableFieldNames: Set<String> = {
-    () -> Set<String> in
+  internal let quotableFieldNames: Set<String> = { () -> Set<String> in
     var names: Set<String> = []
 
     names = names.union(swiftKeywordsUsedInDeclarations)
@@ -97,14 +96,13 @@ extension Generator {
     "Self", "throw", "throws", "true", "try"
   ]
 
-  internal let quotableFieldNames: Set<String> = {
-    () -> Set<String> in
+  internal let quotableFieldNames: Set<String> = { () -> Set<String> in
     var names: Set<String> = []
 
     names = names.union(swiftKeywordsUsedInDeclarations)
     names = names.union(swiftKeywordsUsedInStatements)
     names = names.union(swiftKeywordsUsedInExpressionsAndTypes)
-      return names
+    return names
   }()
 
   internal var methodFunctionName: String {

--- a/Sources/protoc-gen-grpc-swift/Generator-Names.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator-Names.swift
@@ -32,6 +32,35 @@ internal func nameForPackageServiceMethod(_ file: FileDescriptor,
   return nameForPackageService(file, service) + method.name
 }
 
+fileprivate let swiftKeywordsUsedInDeclarations: Set<String> = [
+  "associatedtype", "class", "deinit", "enum", "extension",
+  "fileprivate", "func", "import", "init", "inout", "internal",
+  "let", "open", "operator", "private", "protocol", "public",
+  "static", "struct", "subscript", "typealias", "var"
+]
+
+fileprivate let swiftKeywordsUsedInStatements: Set<String> = [
+  "break", "case",
+  "continue", "default", "defer", "do", "else", "fallthrough",
+  "for", "guard", "if", "in", "repeat", "return", "switch", "where",
+  "while"
+]
+
+fileprivate let swiftKeywordsUsedInExpressionsAndTypes: Set<String> = [ 
+  "as",
+  "Any", "catch", "false", "is", "nil", "rethrows", "super", "self",
+  "Self", "throw", "throws", "true", "try"
+]
+
+fileprivate let quotableFieldNames: Set<String> = { () -> Set<String> in
+  var names: Set<String> = []
+
+  names = names.union(swiftKeywordsUsedInDeclarations)
+  names = names.union(swiftKeywordsUsedInStatements)
+  names = names.union(swiftKeywordsUsedInExpressionsAndTypes)
+  return names
+}()
+
 extension Generator {
   internal var access: String {
     return options.visibility.sourceSnippet
@@ -68,42 +97,6 @@ extension Generator {
   internal var callName: String {
     return nameForPackageServiceMethod(file, service, method) + "Call"
   }
-
-  internal let quotableFieldNames: Set<String> = { () -> Set<String> in
-    var names: Set<String> = []
-
-    names = names.union(swiftKeywordsUsedInDeclarations)
-    names = names.union(swiftKeywordsUsedInStatements)
-    names = names.union(swiftKeywordsUsedInExpressionsAndTypes)
-    return names
-  }()
-
-  internal let swiftKeywordsUsedInDeclarations: Set<String> = [
-    "associatedtype", "class", "deinit", "enum", "extension",
-    "fileprivate", "func", "import", "init", "inout", "internal",
-    "let", "open", "operator", "private", "protocol", "public",
-    "static", "struct", "subscript", "typealias", "var"
-  ]
-
-  internal let swiftKeywordsUsedInStatements: Set<String> = [ "break", "case",
-    "continue", "default", "defer", "do", "else", "fallthrough",
-    "for", "guard", "if", "in", "repeat", "return", "switch", "where",
-    "while"
-  ]
-
-  internal let swiftKeywordsUsedInExpressionsAndTypes: Set<String> = [ "as",
-    "Any", "catch", "false", "is", "nil", "rethrows", "super", "self",
-    "Self", "throw", "throws", "true", "try"
-  ]
-
-  internal let quotableFieldNames: Set<String> = { () -> Set<String> in
-    var names: Set<String> = []
-
-    names = names.union(swiftKeywordsUsedInDeclarations)
-    names = names.union(swiftKeywordsUsedInStatements)
-    names = names.union(swiftKeywordsUsedInExpressionsAndTypes)
-    return names
-  }()
 
   internal var methodFunctionName: String {
     var name = method.name

--- a/Sources/protoc-gen-grpc-swift/Generator-Names.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator-Names.swift
@@ -32,27 +32,27 @@ internal func nameForPackageServiceMethod(_ file: FileDescriptor,
   return nameForPackageService(file, service) + method.name
 }
 
-fileprivate let swiftKeywordsUsedInDeclarations: Set<String> = [
+private let swiftKeywordsUsedInDeclarations: Set<String> = [
   "associatedtype", "class", "deinit", "enum", "extension",
   "fileprivate", "func", "import", "init", "inout", "internal",
   "let", "open", "operator", "private", "protocol", "public",
-  "static", "struct", "subscript", "typealias", "var"
+  "static", "struct", "subscript", "typealias", "var",
 ]
 
-fileprivate let swiftKeywordsUsedInStatements: Set<String> = [
+private let swiftKeywordsUsedInStatements: Set<String> = [
   "break", "case",
   "continue", "default", "defer", "do", "else", "fallthrough",
   "for", "guard", "if", "in", "repeat", "return", "switch", "where",
-  "while"
+  "while",
 ]
 
-fileprivate let swiftKeywordsUsedInExpressionsAndTypes: Set<String> = [ 
+private let swiftKeywordsUsedInExpressionsAndTypes: Set<String> = [
   "as",
   "Any", "catch", "false", "is", "nil", "rethrows", "super", "self",
-  "Self", "throw", "throws", "true", "try"
+  "Self", "throw", "throws", "true", "try",
 ]
 
-fileprivate let quotableFieldNames: Set<String> = { () -> Set<String> in
+private let quotableFieldNames: Set<String> = { () -> Set<String> in
   var names: Set<String> = []
 
   names = names.union(swiftKeywordsUsedInDeclarations)
@@ -104,7 +104,7 @@ extension Generator {
       name = name.prefix(1).lowercased() + name.dropFirst()
     }
 
-    return sanitize(fieldName: name)
+    return self.sanitize(fieldName: name)
   }
 
   internal func sanitize(fieldName string: String) -> String {

--- a/Sources/protoc-gen-grpc-swift/Generator-Names.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator-Names.swift
@@ -69,13 +69,58 @@ extension Generator {
     return nameForPackageServiceMethod(file, service, method) + "Call"
   }
 
+  internal let quotableFieldNames: Set<String> = {
+    () -> Set<String> in
+    var names: Set<String> = []
+
+    names = names.union(swiftKeywordsUsedInDeclarations)
+    names = names.union(swiftKeywordsUsedInStatements)
+    names = names.union(swiftKeywordsUsedInExpressionsAndTypes)
+    return names
+  }()
+
+  internal let swiftKeywordsUsedInDeclarations: Set<String> = [
+    "associatedtype", "class", "deinit", "enum", "extension",
+    "fileprivate", "func", "import", "init", "inout", "internal",
+    "let", "open", "operator", "private", "protocol", "public",
+    "static", "struct", "subscript", "typealias", "var"
+  ]
+
+  internal let swiftKeywordsUsedInStatements: Set<String> = [ "break", "case",
+    "continue", "default", "defer", "do", "else", "fallthrough",
+    "for", "guard", "if", "in", "repeat", "return", "switch", "where",
+    "while"
+  ]
+
+  internal let swiftKeywordsUsedInExpressionsAndTypes: Set<String> = [ "as",
+    "Any", "catch", "false", "is", "nil", "rethrows", "super", "self",
+    "Self", "throw", "throws", "true", "try"
+  ]
+
+  internal let quotableFieldNames: Set<String> = {
+    () -> Set<String> in
+    var names: Set<String> = []
+
+    names = names.union(swiftKeywordsUsedInDeclarations)
+    names = names.union(swiftKeywordsUsedInStatements)
+    names = names.union(swiftKeywordsUsedInExpressionsAndTypes)
+      return names
+  }()
+
   internal var methodFunctionName: String {
-    let name = method.name
-    if self.options.keepMethodCasing {
-      return name
-    } else {
-      return name.prefix(1).lowercased() + name.dropFirst()
+    var name = method.name
+    if !self.options.keepMethodCasing {
+      name = name.prefix(1).lowercased() + name.dropFirst()
     }
+
+    return sanitize(fieldName: name)
+  }
+
+  internal func sanitize(fieldName string: String) -> String {
+    if quotableFieldNames.contains(string) {
+      return "`\(string)`"
+    }
+    return string
   }
 
   internal var methodInputName: String {


### PR DESCRIPTION
This PR fixes a bug that causes the Generator not to consider Swift reserved names such as the `do` keyword.

For example, assume we have an RPC like below:

```
service JsonRpc {
    rpc Do(Request) returns (Response) {}
}
```

If we don't consider Swift's `do` keyword, we will be going to have a compile error.

With these changes, the generated code should be like below:
```
public protocol JsonRpc_JsonRpcClientProtocol: GRPCClient {
  var serviceName: String { get }
  var interceptors: JsonRpc_JsonRpcClientInterceptorFactoryProtocol? { get }

  func `do`(
    _ request: JsonRpc_Request,
    callOptions: CallOptions?
  ) -> UnaryCall<JsonRpc_Request, JsonRpc_Response>
}
```

> The changes idea is the [same](https://github.com/apple/swift-protobuf/blob/4b11fbc4f2fea757d15fb6d392c7155f1e598bdd/Sources/SwiftProtobufPluginLibrary/NamingUtils.swift) as SwiftProtobuf library