### PR TITLE
Use new NIOSSL API for making 'TLSConfiguration'

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
     // HTTP2 via SwiftNIO
     .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.16.1"),
     // TLS via SwiftNIO
-    .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.8.0"),
+    .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.14.0"),
     // Support for Network.framework where possible.
     .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.6.0"),
     // Extra NIO stuff; quiescing helpers.

--- a/Sources/GRPC/TLSConfiguration.swift
+++ b/Sources/GRPC/TLSConfiguration.swift
@@ -96,14 +96,15 @@ extension ClientConnection.Configuration {
       hostnameOverride: String? = nil,
       customVerificationCallback: NIOSSLCustomVerificationCallback? = nil
     ) {
-      self.configuration = .forClient(
-        minimumTLSVersion: .tlsv12,
-        certificateVerification: certificateVerification,
-        trustRoots: trustRoots,
-        certificateChain: certificateChain,
-        privateKey: privateKey,
-        applicationProtocols: GRPCApplicationProtocolIdentifier.client
-      )
+      var configuration = TLSConfiguration.makeClientConfiguration()
+      configuration.minimumTLSVersion = .tlsv12
+      configuration.certificateVerification = certificateVerification
+      configuration.trustRoots = trustRoots
+      configuration.certificateChain = certificateChain
+      configuration.privateKey = privateKey
+      configuration.applicationProtocols = GRPCApplicationProtocolIdentifier.client
+
+      self.configuration = configuration
       self.hostnameOverride = hostnameOverride
       self.customVerificationCallback = customVerificationCallback
     }
@@ -201,14 +202,16 @@ extension Server.Configuration {
       certificateVerification: CertificateVerification = .none,
       requireALPN: Bool = true
     ) {
-      self.configuration = .forServer(
+      var configuration = TLSConfiguration.makeServerConfiguration(
         certificateChain: certificateChain,
-        privateKey: privateKey,
-        minimumTLSVersion: .tlsv12,
-        certificateVerification: certificateVerification,
-        trustRoots: trustRoots,
-        applicationProtocols: GRPCApplicationProtocolIdentifier.server
+        privateKey: privateKey
       )
+      configuration.minimumTLSVersion = .tlsv12
+      configuration.certificateVerification = certificateVerification
+      configuration.trustRoots = trustRoots
+      configuration.applicationProtocols = GRPCApplicationProtocolIdentifier.server
+
+      self.configuration = configuration
       self.requireALPN = requireALPN
     }
 

--- a/Tests/GRPCTests/ALPNConfigurationTests.swift
+++ b/Tests/GRPCTests/ALPNConfigurationTests.swift
@@ -32,7 +32,7 @@ class ALPNConfigurationTests: GRPCTestCase {
   }
 
   func testClientAddsTokensFromEmptyNIOSSLConfig() {
-    let tlsConfig = TLSConfiguration.forClient()
+    let tlsConfig = TLSConfiguration.makeClientConfiguration()
     XCTAssertTrue(tlsConfig.applicationProtocols.isEmpty)
 
     let config = ClientConnection.Configuration.TLS(configuration: tlsConfig)
@@ -41,7 +41,8 @@ class ALPNConfigurationTests: GRPCTestCase {
   }
 
   func testClientDoesNotOverrideNonEmptyNIOSSLConfig() {
-    let tlsConfig = TLSConfiguration.forClient(applicationProtocols: ["foo"])
+    var tlsConfig = TLSConfiguration.makeClientConfiguration()
+    tlsConfig.applicationProtocols = ["foo"]
 
     let config = ClientConnection.Configuration.TLS(configuration: tlsConfig)
     // Should not be overridden.
@@ -54,7 +55,10 @@ class ALPNConfigurationTests: GRPCTestCase {
   }
 
   func testServerAddsTokensFromEmptyNIOSSLConfig() {
-    let tlsConfig = TLSConfiguration.forServer(certificateChain: [], privateKey: .file(""))
+    let tlsConfig = TLSConfiguration.makeServerConfiguration(
+      certificateChain: [],
+      privateKey: .file("")
+    )
     XCTAssertTrue(tlsConfig.applicationProtocols.isEmpty)
 
     let config = Server.Configuration.TLS(configuration: tlsConfig)
@@ -63,11 +67,11 @@ class ALPNConfigurationTests: GRPCTestCase {
   }
 
   func testServerDoesNotOverrideNonEmptyNIOSSLConfig() {
-    let tlsConfig = TLSConfiguration.forServer(
+    var tlsConfig = TLSConfiguration.makeServerConfiguration(
       certificateChain: [],
-      privateKey: .file(""),
-      applicationProtocols: ["foo"]
+      privateKey: .file("")
     )
+    tlsConfig.applicationProtocols = ["foo"]
 
     let config = ClientConnection.Configuration.TLS(configuration: tlsConfig)
     // Should not be overridden.


### PR DESCRIPTION
Motivation:

NIOSSL deprecteated its 'forClient' and 'forServer' methods for creating
'TLSConfiguration' objects.

Modifications:

- Bump the version requirements for NIOSSL
- Replace occurrences of `TLSConfiguration.forClient` and
  `TLSConfiguration.forServer` with the new API

Result:

No deprecteation warnings.