### PR TITLE
Update Cocoapods for 1.3.0

### DIFF
--- a/CGRPCZlib.podspec
+++ b/CGRPCZlib.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
     s.name = 'CGRPCZlib'
     s.module_name = 'CGRPCZlib'
-    s.version = '1.1.0'
+    s.version = '1.3.0'
     s.license = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.summary = 'Compression library that provides in-memory compression and decompression functions'
     s.homepage = 'https://www.grpc.io'

--- a/gRPC-Swift-Plugins.podspec
+++ b/gRPC-Swift-Plugins.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
     s.name = 'gRPC-Swift-Plugins'
-    s.version = '1.1.0'
+    s.version = '1.3.0'
     s.license = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.summary = 'Swift gRPC code generator plugin binaries'
     s.homepage = 'https://www.grpc.io'

--- a/gRPC-Swift.podspec
+++ b/gRPC-Swift.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
     s.name = 'gRPC-Swift'
     s.module_name = 'GRPC'
-    s.version = '1.1.0'
+    s.version = '1.3.0'
     s.license = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.summary = 'Swift gRPC code generator plugin and runtime library'
     s.homepage = 'https://www.grpc.io'
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
     s.dependency 'SwiftNIO', '>= 2.28.0', '< 3.0.0'
     s.dependency 'SwiftNIOExtras', '>= 1.4.0', '< 2.0.0'
     s.dependency 'SwiftNIOHTTP2', '>= 1.16.1', '< 2.0.0'
-    s.dependency 'SwiftNIOSSL', '>= 2.8.0', '< 3.0.0'
+    s.dependency 'SwiftNIOSSL', '>= 2.14.0', '< 3.0.0'
     s.dependency 'SwiftNIOTransportServices', '>= 1.6.0', '< 2.0.0'
     s.dependency 'SwiftProtobuf', '>= 1.9.0', '< 2.0.0'
 

--- a/scripts/build_podspecs.py
+++ b/scripts/build_podspecs.py
@@ -104,8 +104,21 @@ class PodManager:
     def publish(self, pod_name):
         subprocess.check_call(['pod', 'repo', 'update'])
         print('    Publishing %s.podspec' % (pod_name))
-        subprocess.check_call(['pod', 'trunk', 'push', '--synchronous',
-                               self.directory + '/' + pod_name + ".podspec"])
+
+        args = ['pod', 'trunk', 'push', '--synchronous']
+
+        # The gRPC-Swift pod emits warnings about redundant availability
+        # guards on watchOS. These are redundant for the Cocoapods where we set
+        # the deployment target for watchOS to watchOS 6. However they are
+        # required for SPM where the deployment target is lower (and we can't
+        # raise it without breaking all of our consumers). We'll allow warnings
+        # to work around this.
+        if pod_name == "gRPC-Swift":
+            args.append("--allow-warnings")
+
+        path_to_podspec = self.directory + '/' + pod_name + ".podspec"
+        args.append(path_to_podspec)
+        subprocess.check_call(args)
 
     def build_pods(self):
         cgrpczlib_pod = Pod(


### PR DESCRIPTION
Motivation:

We tagged 1.3.0, we need to update the podspecs as well.

Modifications:

- Update pods
- Update the build_podspec.py script to allow ignore warnings when
  publishing the 'gRPC-Swift' pod.

Result:

Pods are up-to-date.