### PR TITLE
Add connect which defaults port to 443 when using TLS

### DIFF
--- a/Sources/GRPC/GRPCChannel/GRPCChannelBuilder.swift
+++ b/Sources/GRPC/GRPCChannel/GRPCChannelBuilder.swift
@@ -150,6 +150,11 @@ extension ClientConnection.Builder {
       self.tls = tlsConfiguration
       super.init(group: group)
     }
+
+    /// Connect to `host` on port 443.
+    public func connect(host: String) -> ClientConnection {
+      return self.connect(host: host, port: 443)
+    }
   }
 }
 


### PR DESCRIPTION
Motivation:

Port 443 is commonly used for HTTPS. When we're using TLS we should
default to this unless otherwise specified.

Modifications:

- Add a `connect(host:)` to the TLS builder for `ClientConnection` which
  defaults to port 443.

Result:

- Resolves #981