### PR TITLE
Implement `_preconditionSafeToSyncShutdown` extension point

### DIFF
--- a/Tests/GRPCTests/ConnectionPool/PoolManagerStateMachineTests.swift
+++ b/Tests/GRPCTests/ConnectionPool/PoolManagerStateMachineTests.swift
@@ -347,6 +347,12 @@ private final class EmbeddedEventLoopGroup: EventLoopGroup {
     return EventLoopIterator(self.loops)
   }
 
+  internal func _preconditionSafeToSyncShutdown(file: StaticString, line: UInt) {
+    // It's fine to sync shutdown on an `EmbeddedEventLoop`, so it's fine to sync shutdown on
+    // a group of them.
+    return
+  }
+
   internal func shutdownGracefully(queue: DispatchQueue, _ callback: @escaping (Error?) -> Void) {
     var shutdownError: Error?
 


### PR DESCRIPTION
Motivation:

NIO recently added a `_preconditionSafeToSyncShutdown` extension point
to `EventLoopGroup`. In our tests we have a custom `EventLoopGroup`
called `EmbeddedEventLoopGroup`. When testing against the `main` branch of
swift-nio we hit this precondition (because the default implementation
preconditions that we aren't on any of the event loops in the group, but
we are always on an `EmbeddedEventLoop`).

Modifications:

- Implement `_preconditionSafeToSyncShutdown` for `EmbeddedEventLoopGroup`

Result:

Tests shouldn't crash against NIOs `main` branch.