### PR TITLE
Fix watchOS availability guard for Network.framework TLS

### DIFF
--- a/Sources/GRPC/GRPCChannel/GRPCChannelBuilder.swift
+++ b/Sources/GRPC/GRPCChannel/GRPCChannelBuilder.swift
@@ -42,7 +42,7 @@ extension ClientConnection {
   ///
   /// gRPC Swift offers two TLS 'backends'. The 'NIOSSL' backend is available on Darwin and Linux
   /// platforms and delegates to SwiftNIO SSL. On recent Darwin platforms (macOS 10.14+, iOS 12+,
-  /// tvOS 12+, and watchOS 5+) the 'Network.framework' backend is available. The two backends have
+  /// tvOS 12+, and watchOS 6+) the 'Network.framework' backend is available. The two backends have
   /// a number of incompatible configuration options and users are responsible for selecting the
   /// appropriate APIs. The TLS configuration options on the builder document which backends they
   /// support.
@@ -85,7 +85,7 @@ extension ClientConnection {
   ///
   /// - Parameter group: The `EventLoopGroup` use for the connection.
   /// - Returns: A builder for a connection using the Network.framework TLS backend.
-  @available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *)
+  @available(macOS 10.14, iOS 12.0, watchOS 6.0, tvOS 12.0, *)
   public static func usingTLSBackedByNetworkFramework(
     on group: EventLoopGroup
   ) -> ClientConnection.Builder.Secure {
@@ -365,7 +365,7 @@ extension ClientConnection.Builder.Secure {
   ///
   /// - Note: May only be used with the 'Network.framework' TLS backend.
   @discardableResult
-  @available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *)
+  @available(macOS 10.14, iOS 12.0, watchOS 6.0, tvOS 12.0, *)
   public func withTLS(localIdentity: SecIdentity) -> Self {
     self.tls.updateNetworkLocalIdentity(to: localIdentity)
     return self
@@ -375,7 +375,7 @@ extension ClientConnection.Builder.Secure {
   ///
   /// - Note: May only be used with the 'Network.framework' TLS backend.
   @discardableResult
-  @available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *)
+  @available(macOS 10.14, iOS 12.0, watchOS 6.0, tvOS 12.0, *)
   public func withTLSHandshakeVerificationCallback(
     on queue: DispatchQueue,
     verificationCallback callback: @escaping sec_protocol_verify_t

--- a/Sources/GRPC/GRPCTLSConfiguration.swift
+++ b/Sources/GRPC/GRPCTLSConfiguration.swift
@@ -93,7 +93,7 @@ public struct GRPCTLSConfiguration {
 
       #if canImport(Network)
       case var .network(config):
-        if #available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *) {
+        if #available(macOS 10.14, iOS 12.0, watchOS 6.0, tvOS 12.0, *) {
           if let hostnameOverride = newValue {
             config.updateHostnameOverride(to: hostnameOverride)
           } else {
@@ -403,7 +403,7 @@ extension GRPCTLSConfiguration {
 #if canImport(Network)
 extension GRPCTLSConfiguration {
   internal struct NetworkConfiguration {
-    @available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *)
+    @available(macOS 10.14, iOS 12.0, watchOS 6.0, tvOS 12.0, *)
     internal var options: NWProtocolTLS.Options {
       get {
         return self._options as! NWProtocolTLS.Options
@@ -424,13 +424,13 @@ extension GRPCTLSConfiguration {
     // guards to update the value in the underlying `sec_protocol_options`.
     internal private(set) var hostnameOverride: String?
 
-    @available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *)
+    @available(macOS 10.14, iOS 12.0, watchOS 6.0, tvOS 12.0, *)
     init(options: NWProtocolTLS.Options, hostnameOverride: String?) {
       self._options = options
       self.hostnameOverride = hostnameOverride
     }
 
-    @available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *)
+    @available(macOS 10.14, iOS 12.0, watchOS 6.0, tvOS 12.0, *)
     internal mutating func updateHostnameOverride(to hostnameOverride: String) {
       self.hostnameOverride = hostnameOverride
       sec_protocol_options_set_tls_server_name(
@@ -440,7 +440,7 @@ extension GRPCTLSConfiguration {
     }
   }
 
-  @available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *)
+  @available(macOS 10.14, iOS 12.0, watchOS 6.0, tvOS 12.0, *)
   public static func makeClientConfigurationBackedByNetworkFramework(
     identity: SecIdentity? = nil,
     hostnameOverride: String? = nil,
@@ -489,7 +489,7 @@ extension GRPCTLSConfiguration {
     )
   }
 
-  @available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *)
+  @available(macOS 10.14, iOS 12.0, watchOS 6.0, tvOS 12.0, *)
   public static func makeClientConfigurationBackedByNetworkFramework(
     options: NWProtocolTLS.Options,
     hostnameOverride: String? = nil
@@ -498,7 +498,7 @@ extension GRPCTLSConfiguration {
     return GRPCTLSConfiguration(backend: .network(network))
   }
 
-  @available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *)
+  @available(macOS 10.14, iOS 12.0, watchOS 6.0, tvOS 12.0, *)
   public static func makeServerConfigurationBackedByNetworkFramework(
     identity: SecIdentity
   ) -> GRPCTLSConfiguration {
@@ -525,7 +525,7 @@ extension GRPCTLSConfiguration {
     return GRPCTLSConfiguration.makeServerConfigurationBackedByNetworkFramework(options: options)
   }
 
-  @available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *)
+  @available(macOS 10.14, iOS 12.0, watchOS 6.0, tvOS 12.0, *)
   public static func makeServerConfigurationBackedByNetworkFramework(
     options: NWProtocolTLS.Options
   ) -> GRPCTLSConfiguration {
@@ -533,7 +533,7 @@ extension GRPCTLSConfiguration {
     return GRPCTLSConfiguration(backend: .network(network))
   }
 
-  @available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *)
+  @available(macOS 10.14, iOS 12.0, watchOS 6.0, tvOS 12.0, *)
   internal mutating func updateNetworkLocalIdentity(to identity: SecIdentity) {
     self.modifyingNetworkConfiguration {
       sec_protocol_options_set_local_identity(
@@ -543,7 +543,7 @@ extension GRPCTLSConfiguration {
     }
   }
 
-  @available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *)
+  @available(macOS 10.14, iOS 12.0, watchOS 6.0, tvOS 12.0, *)
   internal mutating func updateNetworkVerifyCallbackWithQueue(
     callback: @escaping sec_protocol_verify_t,
     queue: DispatchQueue
@@ -573,7 +573,7 @@ extension GRPCTLSConfiguration {
 
 #if canImport(Network)
 extension GRPCTLSConfiguration {
-  @available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *)
+  @available(macOS 10.14, iOS 12.0, watchOS 6.0, tvOS 12.0, *)
   internal func applyNetworkTLSOptions(
     to bootstrap: NIOTSConnectionBootstrap
   ) -> NIOTSConnectionBootstrap {
@@ -588,7 +588,7 @@ extension GRPCTLSConfiguration {
     }
   }
 
-  @available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *)
+  @available(macOS 10.14, iOS 12.0, watchOS 6.0, tvOS 12.0, *)
   internal func applyNetworkTLSOptions(
     to bootstrap: NIOTSListenerBootstrap
   ) -> NIOTSListenerBootstrap {
@@ -604,7 +604,7 @@ extension GRPCTLSConfiguration {
   }
 }
 
-@available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *)
+@available(macOS 10.14, iOS 12.0, watchOS 6.0, tvOS 12.0, *)
 extension NIOTSConnectionBootstrap {
   internal func tlsOptions(
     from configuration: GRPCTLSConfiguration
@@ -613,7 +613,7 @@ extension NIOTSConnectionBootstrap {
   }
 }
 
-@available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *)
+@available(macOS 10.14, iOS 12.0, watchOS 6.0, tvOS 12.0, *)
 extension NIOTSListenerBootstrap {
   internal func tlsOptions(
     from configuration: GRPCTLSConfiguration

--- a/Sources/GRPC/ServerBuilder.swift
+++ b/Sources/GRPC/ServerBuilder.swift
@@ -240,7 +240,7 @@ extension Server {
   /// Returns a `Server` builder configured with the 'Network.framework' TLS backend.
   ///
   /// This builder must use a `NIOTSEventLoopGroup`.
-  @available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *)
+  @available(macOS 10.14, iOS 12.0, watchOS 6.0, tvOS 12.0, *)
   public static func usingTLSBackedByNetworkFramework(
     on group: EventLoopGroup,
     with identity: SecIdentity

--- a/Tests/GRPCTests/GRPCNetworkFrameworkTests.swift
+++ b/Tests/GRPCTests/GRPCNetworkFrameworkTests.swift
@@ -25,7 +25,7 @@ import NIOTransportServices
 import Security
 import XCTest
 
-@available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *)
+@available(macOS 10.14, iOS 12.0, watchOS 6.0, tvOS 12.0, *)
 final class GRPCNetworkFrameworkTests: GRPCTestCase {
   private var server: Server!
   private var client: ClientConnection!

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -4,13 +4,13 @@ gRPC Swift offers two TLS 'backends'. A 'NIOSSL' backend and a 'Network.framewor
 
 The NIOSSL backend is available on Darwin and Linux and delegates to SwiftNIO SSL. The
 Network.framework backend is available on recent Darwin platforms (macOS 10.14+, iOS 12+, tvOS 12+,
-and watchOS 5+) and uses the TLS implementation provided by Network.framework. Moreover, the
+and watchOS 6+) and uses the TLS implementation provided by Network.framework. Moreover, the
 Network.framework backend is only compatible with clients and servers using the `EventLoopGroup`
 provided by SwiftNIO Transport Services, `NIOTSEventLoopGroup`.
 
 |                             | NIOSSL backend                                       | Network.framework backend                   |
 |-----------------------------|------------------------------------------------------|---------------------------------------------|
-| Platform Availability       | Darwin and Linux                                     | macOS 10.14+, iOS 12+, tvOS 12+, watchOS 5+ |
+| Platform Availability       | Darwin and Linux                                     | macOS 10.14+, iOS 12+, tvOS 12+, watchOS 6+ |
 | Compatible `EventLoopGroup` | `MultiThreadedEventLoopGroup`, `NIOTSEventLoopGroup` | `NIOTSEventLoopGroup`                       |
 
 Note that on supported Darwin platforms users should the prefer using `NIOTSEventLoopGroup` and the


### PR DESCRIPTION
Motivation:

In #1221 we added Network.framework as a provider for TLS. However in a
few places we incorrectly set the availability for watchOS as 5.0. It
should be 6.0 (as required by NIOTS).

If the watchOS deployment target was set to 5.0 then the build would
result in a number of errors (as the availability requirements for using
various NIOTS types would not be sufficient).

Modifications:

- Raise the availability version for various APIs which use Network.framework

Result:

No build errors for types which aren't availabile on watchOS 5.0.

Credit to @cpriebe for spotting this.