### PR TITLE
Make path available in ClientCalls

### DIFF
--- a/Sources/GRPC/ClientCalls/BidirectionalStreamingCall.swift
+++ b/Sources/GRPC/ClientCalls/BidirectionalStreamingCall.swift
@@ -37,6 +37,11 @@ public struct BidirectionalStreamingCall<
     return self.call.options
   }
 
+  /// The path used to make the RPC.
+  public var path: String {
+    return self.call.path
+  }
+
   /// The `Channel` used to transport messages for this RPC.
   public var subchannel: EventLoopFuture<Channel> {
     return self.call.channel

--- a/Sources/GRPC/ClientCalls/ClientCall.swift
+++ b/Sources/GRPC/ClientCalls/ClientCall.swift
@@ -33,6 +33,9 @@ public protocol ClientCall {
   /// The options used to make the RPC.
   var options: CallOptions { get }
 
+  /// The path used to make the RPC.
+  var path: String { get }
+
   /// HTTP/2 stream that requests and responses are sent and received on.
   var subchannel: EventLoopFuture<Channel> { get }
 

--- a/Sources/GRPC/ClientCalls/ClientStreamingCall.swift
+++ b/Sources/GRPC/ClientCalls/ClientStreamingCall.swift
@@ -35,6 +35,11 @@ public struct ClientStreamingCall<RequestPayload, ResponsePayload>: StreamingReq
     return self.call.options
   }
 
+  /// The path used to make the RPC.
+  public var path: String {
+    return self.call.path
+  }
+
   /// The `Channel` used to transport messages for this RPC.
   public var subchannel: EventLoopFuture<Channel> {
     return self.call.channel

--- a/Sources/GRPC/ClientCalls/ServerStreamingCall.swift
+++ b/Sources/GRPC/ClientCalls/ServerStreamingCall.swift
@@ -32,6 +32,11 @@ public struct ServerStreamingCall<RequestPayload, ResponsePayload>: ClientCall {
     return self.call.options
   }
 
+  /// The path used to make the RPC.
+  public var path: String {
+    return self.call.path
+  }
+
   /// The `Channel` used to transport messages for this RPC.
   public var subchannel: EventLoopFuture<Channel> {
     return self.call.channel

--- a/Sources/GRPC/ClientCalls/UnaryCall.swift
+++ b/Sources/GRPC/ClientCalls/UnaryCall.swift
@@ -34,6 +34,11 @@ public struct UnaryCall<RequestPayload, ResponsePayload>: UnaryResponseClientCal
     return self.call.options
   }
 
+  /// The path used to make the RPC.
+  public var path: String {
+    return self.call.path
+  }
+
   /// The `Channel` used to transport messages for this RPC.
   public var subchannel: EventLoopFuture<Channel> {
     return self.call.channel


### PR DESCRIPTION
This PR's purpose is making `path` variable available in `ClientCall`s.

Related Issue: #1236 