### PR TITLE
Prepare CI for async/await.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,12 +54,12 @@ jobs:
         include:
           - image: swiftlang/swift:nightly-5.5-focal
             env:
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 515000
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 227000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 503000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 215000
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 112000
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 67000
               MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 63000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 216000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 204000
           - image: swift:5.4-focal
             env:
               MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 503000

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, async-await]
 jobs:
   preflight:
     name: License Header and Formatting Checks
@@ -24,6 +24,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - image: swiftlang/swift:nightly-5.5-focal
+            swift-build-flags: "-Xswiftc -Xfrontend -Xswiftc -enable-experimental-concurrency"
+            swift-test-flags: "--enable-test-discovery -Xswiftc -Xfrontend -Xswiftc -enable-experimental-concurrency"
           - image: swift:5.4-focal
             swift-test-flags: "--enable-test-discovery --sanitize=thread"
           - image: swift:5.3-focal
@@ -49,6 +52,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - image: swiftlang/swift:nightly-5.5-focal
+            env:
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 515000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 227000
+              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 112000
+              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 67000
+              MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 63000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 216000
           - image: swift:5.4-focal
             env:
               MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 503000


### PR DESCRIPTION
Motivation: To test async/await, we actually need a Swift version in CI that supports it.