### PR TITLE
Update README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Build Status](https://travis-ci.org/grpc/grpc-swift.svg?branch=main)](https://travis-ci.org/grpc/grpc-swift)
-[![sswg:sandbox|94x20](https://img.shields.io/badge/sswg-sandbox-lightgrey.svg)](https://github.com/swift-server/sswg/blob/master/process/incubation.md#sandbox-level)
+[![CI](https://img.shields.io/github/workflow/status/grpc/grpc-swift/CI?event=push)](https://github.com/grpc/grpc-swift/actions/workflows/ci.yaml)
 [![Latest Version](https://img.shields.io/github/v/release/grpc/grpc-swift?include_prereleases&sort=semver)](https://img.shields.io/github/v/release/grpc/grpc-swift?include_prereleases&sort=semver)
+[![sswg:graduated|104x20](https://img.shields.io/badge/sswg-graduated-green.svg)](https://github.com/swift-server/sswg/blob/main/process/incubation.md#graduated-level)
 
 # gRPC Swift
 


### PR DESCRIPTION
Motivation:

grpc-swift is now a graduated SSWG project; the badge in our README
should reflect that.

Modifications:

- Update SSWG badge to graduated
- Update CI badge which was still pointing to Travis

Result:

README is more up-to-date