### PR TITLE
Use more specific NIO imports (#1239)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,13 +26,13 @@ let package = Package(
   dependencies: [
     // GRPC dependencies:
     // Main SwiftNIO package
-    .package(url: "https://github.com/apple/swift-nio.git", from: "2.28.0"),
+    .package(url: "https://github.com/apple/swift-nio.git", from: "2.32.0"),
     // HTTP2 via SwiftNIO
-    .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.17.0"),
+    .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.18.2"),
     // TLS via SwiftNIO
     .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.14.0"),
     // Support for Network.framework where possible.
-    .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.6.0"),
+    .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.11.1"),
     // Extra NIO stuff; quiescing helpers.
     .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.4.0"),
 
@@ -46,8 +46,8 @@ let package = Package(
     // Logging API.
     .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),
 
-    // Argument parsering: only for internal targets (i.e. examples).
-    // swift-argument-parser only provides source compatability guarantees between minor version.
+    // Argument parsing: only for internal targets (i.e. examples).
+    // swift-argument-parser only provides source compatibility guarantees between minor version.
     .package(url: "https://github.com/apple/swift-argument-parser", "0.3.0" ..< "0.5.0"),
   ],
   targets: [
@@ -56,6 +56,9 @@ let package = Package(
       name: "GRPC",
       dependencies: [
         .product(name: "NIO", package: "swift-nio"),
+        .product(name: "NIOCore", package: "swift-nio"),
+        .product(name: "NIOPosix", package: "swift-nio"),
+        .product(name: "NIOEmbedded", package: "swift-nio"),
         .product(name: "NIOFoundationCompat", package: "swift-nio"),
         .product(name: "NIOTransportServices", package: "swift-nio-transport-services"),
         .product(name: "NIOHTTP1", package: "swift-nio"),
@@ -76,6 +79,9 @@ let package = Package(
         .target(name: "GRPCSampleData"),
         .target(name: "GRPCInteroperabilityTestsImplementation"),
         .target(name: "HelloWorldModel"),
+        .product(name: "NIOCore", package: "swift-nio"),
+        .product(name: "NIOPosix", package: "swift-nio"),
+        .product(name: "NIOEmbedded", package: "swift-nio"),
       ]
     ),
 

--- a/Sources/GRPC/CallHandlers/BidirectionalStreamingServerHandler.swift
+++ b/Sources/GRPC/CallHandlers/BidirectionalStreamingServerHandler.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import NIO
+import NIOCore
 import NIOHPACK
 
 public final class BidirectionalStreamingServerHandler<

--- a/Sources/GRPC/CallHandlers/ClientStreamingServerHandler.swift
+++ b/Sources/GRPC/CallHandlers/ClientStreamingServerHandler.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import NIO
+import NIOCore
 import NIOHPACK
 
 public final class ClientStreamingServerHandler<

--- a/Sources/GRPC/CallHandlers/ServerHandlerProtocol.swift
+++ b/Sources/GRPC/CallHandlers/ServerHandlerProtocol.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import NIO
+import NIOCore
 import NIOHPACK
 
 /// This protocol lays out the inbound interface between the gRPC module and generated server code.

--- a/Sources/GRPC/CallHandlers/ServerStreamingServerHandler.swift
+++ b/Sources/GRPC/CallHandlers/ServerStreamingServerHandler.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import NIO
+import NIOCore
 import NIOHPACK
 
 public final class ServerStreamingServerHandler<

--- a/Sources/GRPC/CallHandlers/UnaryServerHandler.swift
+++ b/Sources/GRPC/CallHandlers/UnaryServerHandler.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import NIO
+import NIOCore
 import NIOHPACK
 
 public final class UnaryServerHandler<

--- a/Sources/GRPC/CallOptions.swift
+++ b/Sources/GRPC/CallOptions.swift
@@ -15,7 +15,7 @@
  */
 import struct Foundation.UUID
 import Logging
-import NIO
+import NIOCore
 import NIOHPACK
 import NIOHTTP1
 import NIOHTTP2

--- a/Sources/GRPC/ClientCalls/BidirectionalStreamingCall.swift
+++ b/Sources/GRPC/ClientCalls/BidirectionalStreamingCall.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import Logging
-import NIO
+import NIOCore
 import NIOHPACK
 import NIOHTTP2
 

--- a/Sources/GRPC/ClientCalls/Call.swift
+++ b/Sources/GRPC/ClientCalls/Call.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import Logging
-import NIO
+import NIOCore
 import NIOHPACK
 import NIOHTTP2
 import protocol SwiftProtobuf.Message

--- a/Sources/GRPC/ClientCalls/ClientCall.swift
+++ b/Sources/GRPC/ClientCalls/ClientCall.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import Foundation
-import NIO
+import NIOCore
 import NIOHPACK
 import NIOHTTP1
 import NIOHTTP2

--- a/Sources/GRPC/ClientCalls/ClientStreamingCall.swift
+++ b/Sources/GRPC/ClientCalls/ClientStreamingCall.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import Logging
-import NIO
+import NIOCore
 import NIOHPACK
 import NIOHTTP2
 

--- a/Sources/GRPC/ClientCalls/LazyEventLoopPromise.swift
+++ b/Sources/GRPC/ClientCalls/LazyEventLoopPromise.swift
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import NIO
 import NIOConcurrencyHelpers
+import NIOCore
 
 extension EventLoop {
   internal func makeLazyPromise<Value>(of: Value.Type = Value.self) -> LazyEventLoopPromise<Value> {

--- a/Sources/GRPC/ClientCalls/ResponseContainers.swift
+++ b/Sources/GRPC/ClientCalls/ResponseContainers.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import NIO
+import NIOCore
 import NIOHPACK
 
 /// A bucket of promises for a unary-response RPC.

--- a/Sources/GRPC/ClientCalls/ResponsePartContainer.swift
+++ b/Sources/GRPC/ClientCalls/ResponsePartContainer.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import NIO
+import NIOCore
 import NIOHPACK
 
 /// A container for RPC response parts.

--- a/Sources/GRPC/ClientCalls/ServerStreamingCall.swift
+++ b/Sources/GRPC/ClientCalls/ServerStreamingCall.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import Logging
-import NIO
+import NIOCore
 import NIOHPACK
 import NIOHTTP2
 

--- a/Sources/GRPC/ClientCalls/UnaryCall.swift
+++ b/Sources/GRPC/ClientCalls/UnaryCall.swift
@@ -15,7 +15,7 @@
  */
 import Foundation
 import Logging
-import NIO
+import NIOCore
 import NIOHPACK
 import NIOHTTP1
 import NIOHTTP2

--- a/Sources/GRPC/ClientConnection.swift
+++ b/Sources/GRPC/ClientConnection.swift
@@ -15,7 +15,7 @@
  */
 import Foundation
 import Logging
-import NIO
+import NIOCore
 import NIOHTTP2
 import NIOSSL
 import NIOTLS

--- a/Sources/GRPC/Compression/Zlib.swift
+++ b/Sources/GRPC/Compression/Zlib.swift
@@ -15,7 +15,7 @@
  */
 import CGRPCZlib
 import struct Foundation.Data
-import NIO
+import NIOCore
 
 /// Provides minimally configurable wrappers around zlib's compression and decompression
 /// functionality.

--- a/Sources/GRPC/ConnectionKeepalive.swift
+++ b/Sources/GRPC/ConnectionKeepalive.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import NIO
+import NIOCore
 
 /// Provides keepalive pings.
 ///

--- a/Sources/GRPC/ConnectionManager.swift
+++ b/Sources/GRPC/ConnectionManager.swift
@@ -15,8 +15,8 @@
  */
 import Foundation
 import Logging
-import NIO
 import NIOConcurrencyHelpers
+import NIOCore
 import NIOHTTP2
 
 internal final class ConnectionManager {

--- a/Sources/GRPC/ConnectionManagerChannelProvider.swift
+++ b/Sources/GRPC/ConnectionManagerChannelProvider.swift
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 import Logging
-import NIO
+import NIOCore
+import NIOPosix
 import NIOSSL
 import NIOTransportServices
 

--- a/Sources/GRPC/ConnectionPool/ConnectionPool+Waiter.swift
+++ b/Sources/GRPC/ConnectionPool/ConnectionPool+Waiter.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import NIO
+import NIOCore
 import NIOHTTP2
 
 extension ConnectionPool {

--- a/Sources/GRPC/ConnectionPool/ConnectionPool.swift
+++ b/Sources/GRPC/ConnectionPool/ConnectionPool.swift
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 import Logging
-import NIO
 import NIOConcurrencyHelpers
+import NIOCore
 import NIOHTTP2
 
 internal final class ConnectionPool {

--- a/Sources/GRPC/ConnectionPool/PoolManager.swift
+++ b/Sources/GRPC/ConnectionPool/PoolManager.swift
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 import Logging
-import NIO
 import NIOConcurrencyHelpers
+import NIOCore
 
 internal final class PoolManager {
   /// Configuration used for each connection pool.

--- a/Sources/GRPC/ConnectionPool/PoolManagerStateMachine+PerPoolState.swift
+++ b/Sources/GRPC/ConnectionPool/PoolManagerStateMachine+PerPoolState.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import NIO
+import NIOCore
 
 extension PoolManagerStateMachine.ActiveState {
   internal struct PerPoolState {

--- a/Sources/GRPC/ConnectionPool/PoolManagerStateMachine.swift
+++ b/Sources/GRPC/ConnectionPool/PoolManagerStateMachine.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import NIO
+import NIOCore
 
 internal struct PoolManagerStateMachine {
   /// The current state.

--- a/Sources/GRPC/ConnectivityState.swift
+++ b/Sources/GRPC/ConnectivityState.swift
@@ -15,8 +15,8 @@
  */
 import Foundation
 import Logging
-import NIO
 import NIOConcurrencyHelpers
+import NIOCore
 
 /// The connectivity state of a client connection. Note that this is heavily lifted from the gRPC
 /// documentation: https://github.com/grpc/grpc/blob/master/doc/connectivity-semantics-and-api.md.

--- a/Sources/GRPC/DelegatingErrorHandler.swift
+++ b/Sources/GRPC/DelegatingErrorHandler.swift
@@ -15,7 +15,7 @@
  */
 import Foundation
 import Logging
-import NIO
+import NIOCore
 import NIOSSL
 
 /// A channel handler which allows caught errors to be passed to a `ClientErrorDelegate`. This

--- a/Sources/GRPC/FakeChannel.swift
+++ b/Sources/GRPC/FakeChannel.swift
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 import Logging
-import NIO
+import NIOCore
+import NIOEmbedded
 import SwiftProtobuf
 
 /// A fake channel for use with generated test clients.

--- a/Sources/GRPC/GRPCChannel/EmbeddedGRPCChannel.swift
+++ b/Sources/GRPC/GRPCChannel/EmbeddedGRPCChannel.swift
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 import Logging
-import NIO
+import NIOCore
+import NIOEmbedded
 import NIOHTTP2
 import SwiftProtobuf
 

--- a/Sources/GRPC/GRPCChannel/GRPCChannel.swift
+++ b/Sources/GRPC/GRPCChannel/GRPCChannel.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import NIO
+import NIOCore
 import NIOHTTP2
 import NIOSSL
 import SwiftProtobuf

--- a/Sources/GRPC/GRPCChannel/GRPCChannelBuilder.swift
+++ b/Sources/GRPC/GRPCChannel/GRPCChannelBuilder.swift
@@ -15,7 +15,7 @@
  */
 import Dispatch
 import Logging
-import NIO
+import NIOCore
 import NIOSSL
 
 #if canImport(Security)

--- a/Sources/GRPC/GRPCClient.swift
+++ b/Sources/GRPC/GRPCClient.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import NIO
+import NIOCore
 import NIOHTTP2
 import SwiftProtobuf
 

--- a/Sources/GRPC/GRPCClientChannelHandler.swift
+++ b/Sources/GRPC/GRPCClientChannelHandler.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import Logging
-import NIO
+import NIOCore
 import NIOHPACK
 import NIOHTTP1
 import NIOHTTP2

--- a/Sources/GRPC/GRPCClientStateMachine.swift
+++ b/Sources/GRPC/GRPCClientStateMachine.swift
@@ -15,7 +15,7 @@
  */
 import Foundation
 import Logging
-import NIO
+import NIOCore
 import NIOHPACK
 import NIOHTTP1
 import SwiftProtobuf

--- a/Sources/GRPC/GRPCIdleHandler.swift
+++ b/Sources/GRPC/GRPCIdleHandler.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import Logging
-import NIO
+import NIOCore
 import NIOHTTP2
 
 internal final class GRPCIdleHandler: ChannelInboundHandler {

--- a/Sources/GRPC/GRPCIdleHandlerStateMachine.swift
+++ b/Sources/GRPC/GRPCIdleHandlerStateMachine.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import Logging
-import NIO
+import NIOCore
 import NIOHTTP2
 
 /// Holds state for the 'GRPCIdleHandler', this isn't really just the idleness of the connection,

--- a/Sources/GRPC/GRPCKeepaliveHandlers.swift
+++ b/Sources/GRPC/GRPCKeepaliveHandlers.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import NIO
+import NIOCore
 import NIOHTTP2
 
 struct PingHandler {

--- a/Sources/GRPC/GRPCLogger.swift
+++ b/Sources/GRPC/GRPCLogger.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import Logging
-import NIO
+import NIOCore
 
 /// Wraps `Logger` to always provide the source as "GRPC".
 ///

--- a/Sources/GRPC/GRPCPayload.swift
+++ b/Sources/GRPC/GRPCPayload.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import NIO
+import NIOCore
 
 /// A data type which may be serialized into and out from a `ByteBuffer` in order to be sent between
 /// gRPC peers.

--- a/Sources/GRPC/GRPCServerPipelineConfigurator.swift
+++ b/Sources/GRPC/GRPCServerPipelineConfigurator.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import Logging
-import NIO
+import NIOCore
 import NIOHPACK
 import NIOHTTP1
 import NIOHTTP2

--- a/Sources/GRPC/GRPCServerRequestRoutingHandler.swift
+++ b/Sources/GRPC/GRPCServerRequestRoutingHandler.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import Logging
-import NIO
+import NIOCore
 import NIOHPACK
 import NIOHTTP1
 import NIOHTTP2

--- a/Sources/GRPC/GRPCStatus.swift
+++ b/Sources/GRPC/GRPCStatus.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import Foundation
-import NIO
+import NIOCore
 import NIOHTTP1
 import NIOHTTP2
 

--- a/Sources/GRPC/GRPCTimeout.swift
+++ b/Sources/GRPC/GRPCTimeout.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import Dispatch
-import NIO
+import NIOCore
 
 /// A timeout for a gRPC call.
 ///

--- a/Sources/GRPC/GRPCWebToHTTP2ServerCodec.swift
+++ b/Sources/GRPC/GRPCWebToHTTP2ServerCodec.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import struct Foundation.Data
-import NIO
+import NIOCore
 import NIOHPACK
 import NIOHTTP1
 import NIOHTTP2

--- a/Sources/GRPC/HTTP2ToRawGRPCServerCodec.swift
+++ b/Sources/GRPC/HTTP2ToRawGRPCServerCodec.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import Logging
-import NIO
+import NIOCore
 import NIOHPACK
 import NIOHTTP2
 

--- a/Sources/GRPC/HTTP2ToRawGRPCStateMachine.swift
+++ b/Sources/GRPC/HTTP2ToRawGRPCStateMachine.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import Logging
-import NIO
+import NIOCore
 import NIOHPACK
 import NIOHTTP2
 

--- a/Sources/GRPC/Interceptor/ClientInterceptorContext.swift
+++ b/Sources/GRPC/Interceptor/ClientInterceptorContext.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import Logging
-import NIO
+import NIOCore
 
 public struct ClientInterceptorContext<Request, Response> {
   /// The interceptor this context is for.

--- a/Sources/GRPC/Interceptor/ClientInterceptorPipeline.swift
+++ b/Sources/GRPC/Interceptor/ClientInterceptorPipeline.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import Logging
-import NIO
+import NIOCore
 import NIOHPACK
 import NIOHTTP2
 

--- a/Sources/GRPC/Interceptor/ClientInterceptorProtocol.swift
+++ b/Sources/GRPC/Interceptor/ClientInterceptorProtocol.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import NIO
+import NIOCore
 
 internal protocol ClientInterceptorProtocol {
   associatedtype Request

--- a/Sources/GRPC/Interceptor/ClientInterceptors.swift
+++ b/Sources/GRPC/Interceptor/ClientInterceptors.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import NIO
+import NIOCore
 
 /// A base class for client interceptors.
 ///

--- a/Sources/GRPC/Interceptor/ClientTransport.swift
+++ b/Sources/GRPC/Interceptor/ClientTransport.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import Logging
-import NIO
+import NIOCore
 import NIOHPACK
 import NIOHTTP2
 

--- a/Sources/GRPC/Interceptor/ClientTransportFactory.swift
+++ b/Sources/GRPC/Interceptor/ClientTransportFactory.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import NIO
+import NIOCore
 import NIOHTTP2
 import protocol SwiftProtobuf.Message
 

--- a/Sources/GRPC/Interceptor/ServerInterceptorContext.swift
+++ b/Sources/GRPC/Interceptor/ServerInterceptorContext.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import Logging
-import NIO
+import NIOCore
 
 public struct ServerInterceptorContext<Request, Response> {
   /// The interceptor this context is for.

--- a/Sources/GRPC/Interceptor/ServerInterceptorPipeline.swift
+++ b/Sources/GRPC/Interceptor/ServerInterceptorPipeline.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import Logging
-import NIO
+import NIOCore
 
 @usableFromInline
 internal final class ServerInterceptorPipeline<Request, Response> {

--- a/Sources/GRPC/Interceptor/ServerInterceptors.swift
+++ b/Sources/GRPC/Interceptor/ServerInterceptors.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import NIO
+import NIOCore
 
 /// A base class for server interceptors.
 ///

--- a/Sources/GRPC/LengthPrefixedMessageReader.swift
+++ b/Sources/GRPC/LengthPrefixedMessageReader.swift
@@ -15,7 +15,7 @@
  */
 import Foundation
 import Logging
-import NIO
+import NIOCore
 import NIOHTTP1
 
 /// This class reads and decodes length-prefixed gRPC messages.

--- a/Sources/GRPC/LengthPrefixedMessageWriter.swift
+++ b/Sources/GRPC/LengthPrefixedMessageWriter.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import Foundation
-import NIO
+import NIOCore
 
 internal struct LengthPrefixedMessageWriter {
   static let metadataLength = 5

--- a/Sources/GRPC/Logger.swift
+++ b/Sources/GRPC/Logger.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import Logging
-import NIO
+import NIOCore
 
 /// Keys for `Logger` metadata.
 enum MetadataKey {

--- a/Sources/GRPC/PlatformSupport.swift
+++ b/Sources/GRPC/PlatformSupport.swift
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 import Logging
-import NIO
+import NIOCore
+import NIOPosix
 import NIOSSL
 import NIOTransportServices
 

--- a/Sources/GRPC/ReadWriteStates.swift
+++ b/Sources/GRPC/ReadWriteStates.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import NIO
+import NIOCore
 import SwiftProtobuf
 
 /// Number of messages expected on a stream.

--- a/Sources/GRPC/Serialization.swift
+++ b/Sources/GRPC/Serialization.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import NIO
+import NIOCore
 import NIOFoundationCompat
 import SwiftProtobuf
 

--- a/Sources/GRPC/Server.swift
+++ b/Sources/GRPC/Server.swift
@@ -15,10 +15,11 @@
  */
 import Foundation
 import Logging
-import NIO
+import NIOCore
 import NIOExtras
 import NIOHTTP1
 import NIOHTTP2
+import NIOPosix
 import NIOSSL
 import NIOTransportServices
 #if canImport(Network)

--- a/Sources/GRPC/ServerBuilder.swift
+++ b/Sources/GRPC/ServerBuilder.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import Logging
-import NIO
+import NIOCore
 import NIOSSL
 
 #if canImport(Network)

--- a/Sources/GRPC/ServerCallContexts/ServerCallContext.swift
+++ b/Sources/GRPC/ServerCallContexts/ServerCallContext.swift
@@ -15,7 +15,7 @@
  */
 import Foundation
 import Logging
-import NIO
+import NIOCore
 import NIOHPACK
 import NIOHTTP1
 import SwiftProtobuf

--- a/Sources/GRPC/ServerCallContexts/StreamingResponseCallContext.swift
+++ b/Sources/GRPC/ServerCallContexts/StreamingResponseCallContext.swift
@@ -15,7 +15,7 @@
  */
 import Foundation
 import Logging
-import NIO
+import NIOCore
 import NIOHPACK
 import NIOHTTP1
 import SwiftProtobuf

--- a/Sources/GRPC/ServerCallContexts/UnaryResponseCallContext.swift
+++ b/Sources/GRPC/ServerCallContexts/UnaryResponseCallContext.swift
@@ -15,7 +15,7 @@
  */
 import Foundation
 import Logging
-import NIO
+import NIOCore
 import NIOHPACK
 import NIOHTTP1
 import SwiftProtobuf

--- a/Sources/GRPC/ServerChannelErrorHandler.swift
+++ b/Sources/GRPC/ServerChannelErrorHandler.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import NIO
+import NIOCore
 
 /// A handler that passes errors thrown into the server channel to the server error delegate.
 ///

--- a/Sources/GRPC/ServerErrorDelegate.swift
+++ b/Sources/GRPC/ServerErrorDelegate.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import Foundation
-import NIO
+import NIOCore
 import NIOHPACK
 import NIOHTTP1
 

--- a/Sources/GRPC/TLSVerificationHandler.swift
+++ b/Sources/GRPC/TLSVerificationHandler.swift
@@ -15,7 +15,7 @@
  */
 import Foundation
 import Logging
-import NIO
+import NIOCore
 import NIOSSL
 import NIOTLS
 

--- a/Sources/GRPC/TimeLimit.swift
+++ b/Sources/GRPC/TimeLimit.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import Dispatch
-import NIO
+import NIOCore
 
 /// A time limit for an RPC.
 ///

--- a/Sources/GRPC/WebCORSHandler.swift
+++ b/Sources/GRPC/WebCORSHandler.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import NIO
+import NIOCore
 import NIOHTTP1
 
 /// Handler that manages the CORS protocol for requests incoming from the browser.

--- a/Sources/GRPC/WriteCapturingHandler.swift
+++ b/Sources/GRPC/WriteCapturingHandler.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import NIO
+import NIOCore
 
 /// A handler which redirects all writes into a callback until the `.end` part is seen, after which
 /// all writes will be failed.

--- a/Sources/GRPC/_EmbeddedThroughput.swift
+++ b/Sources/GRPC/_EmbeddedThroughput.swift
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 import Logging
-import NIO
+import NIOCore
+import NIOEmbedded
 import SwiftProtobuf
 
 extension EmbeddedChannel {

--- a/Sources/GRPC/_FakeResponseStream.swift
+++ b/Sources/GRPC/_FakeResponseStream.swift
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import NIO
+import NIOCore
+import NIOEmbedded
 import NIOHPACK
 
 public enum FakeRequestPart<Request> {

--- a/Sources/GRPC/_GRPCClientCodecHandler.swift
+++ b/Sources/GRPC/_GRPCClientCodecHandler.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import NIO
+import NIOCore
 
 internal class GRPCClientCodecHandler<
   Serializer: MessageSerializer,

--- a/Tests/GRPCTests/BasicEchoTestCase.swift
+++ b/Tests/GRPCTests/BasicEchoTestCase.swift
@@ -19,7 +19,7 @@ import EchoModel
 import Foundation
 import GRPC
 import GRPCSampleData
-import NIO
+import NIOCore
 import NIOSSL
 import XCTest
 

--- a/Tests/GRPCTests/CallStartBehaviorTests.swift
+++ b/Tests/GRPCTests/CallStartBehaviorTests.swift
@@ -15,7 +15,8 @@
  */
 import EchoModel
 import GRPC
-import NIO
+import NIOCore
+import NIOPosix
 import XCTest
 
 class CallStartBehaviorTests: GRPCTestCase {

--- a/Tests/GRPCTests/ClientCallTests.swift
+++ b/Tests/GRPCTests/ClientCallTests.swift
@@ -16,7 +16,8 @@
 import EchoImplementation
 import EchoModel
 @testable import GRPC
-import NIO
+import NIOCore
+import NIOPosix
 import XCTest
 
 class ClientCallTests: GRPCTestCase {

--- a/Tests/GRPCTests/ClientClosedChannelTests.swift
+++ b/Tests/GRPCTests/ClientClosedChannelTests.swift
@@ -16,7 +16,7 @@
 import EchoModel
 import Foundation
 import GRPC
-import NIO
+import NIOCore
 import XCTest
 
 class ClientClosedChannelTests: EchoTestCaseBase {

--- a/Tests/GRPCTests/ClientConnectionBackoffTests.swift
+++ b/Tests/GRPCTests/ClientConnectionBackoffTests.swift
@@ -17,8 +17,9 @@ import EchoImplementation
 import EchoModel
 import Foundation
 import GRPC
-import NIO
 import NIOConcurrencyHelpers
+import NIOCore
+import NIOPosix
 import XCTest
 
 class ClientConnectionBackoffTests: GRPCTestCase {

--- a/Tests/GRPCTests/ClientEventLoopPreferenceTests.swift
+++ b/Tests/GRPCTests/ClientEventLoopPreferenceTests.swift
@@ -16,7 +16,8 @@
 import EchoImplementation
 import EchoModel
 import GRPC
-import NIO
+import NIOCore
+import NIOPosix
 import XCTest
 
 final class ClientEventLoopPreferenceTests: GRPCTestCase {

--- a/Tests/GRPCTests/ClientInterceptorPipelineTests.swift
+++ b/Tests/GRPCTests/ClientInterceptorPipelineTests.swift
@@ -15,7 +15,8 @@
  */
 @testable import GRPC
 import Logging
-import NIO
+import NIOCore
+import NIOEmbedded
 import NIOHPACK
 import XCTest
 

--- a/Tests/GRPCTests/ClientTLSFailureTests.swift
+++ b/Tests/GRPCTests/ClientTLSFailureTests.swift
@@ -18,8 +18,9 @@ import EchoModel
 @testable import GRPC
 import GRPCSampleData
 import Logging
-import NIO
 import NIOConcurrencyHelpers
+import NIOCore
+import NIOPosix
 import NIOSSL
 import XCTest
 

--- a/Tests/GRPCTests/ClientTLSTests.swift
+++ b/Tests/GRPCTests/ClientTLSTests.swift
@@ -18,7 +18,8 @@ import EchoModel
 import Foundation
 import GRPC
 import GRPCSampleData
-import NIO
+import NIOCore
+import NIOPosix
 import NIOSSL
 import XCTest
 

--- a/Tests/GRPCTests/ClientTimeoutTests.swift
+++ b/Tests/GRPCTests/ClientTimeoutTests.swift
@@ -16,7 +16,8 @@
 import EchoModel
 import Foundation
 @testable import GRPC
-import NIO
+import NIOCore
+import NIOEmbedded
 import XCTest
 
 class ClientTimeoutTests: GRPCTestCase {

--- a/Tests/GRPCTests/ClientTransportTests.swift
+++ b/Tests/GRPCTests/ClientTransportTests.swift
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 @testable import GRPC
-import NIO
+import NIOCore
+import NIOEmbedded
 import XCTest
 
 class ClientTransportTests: GRPCTestCase {

--- a/Tests/GRPCTests/Codegen/Normalization/NormalizationProvider.swift
+++ b/Tests/GRPCTests/Codegen/Normalization/NormalizationProvider.swift
@@ -15,7 +15,7 @@
  */
 
 import GRPC
-import NIO
+import NIOCore
 import SwiftProtobuf
 
 final class NormalizationProvider: Normalization_NormalizationProvider {

--- a/Tests/GRPCTests/Codegen/Normalization/NormalizationTests.swift
+++ b/Tests/GRPCTests/Codegen/Normalization/NormalizationTests.swift
@@ -15,7 +15,8 @@
  */
 
 import GRPC
-import NIO
+import NIOCore
+import NIOPosix
 import XCTest
 
 /// These tests validate that:

--- a/Tests/GRPCTests/CompressionTests.swift
+++ b/Tests/GRPCTests/CompressionTests.swift
@@ -16,8 +16,9 @@
 import EchoImplementation
 import EchoModel
 import GRPC
-import NIO
+import NIOCore
 import NIOHPACK
+import NIOPosix
 import XCTest
 
 class MessageCompressionTests: GRPCTestCase {

--- a/Tests/GRPCTests/ConnectionFailingTests.swift
+++ b/Tests/GRPCTests/ConnectionFailingTests.swift
@@ -15,7 +15,8 @@
  */
 import EchoModel
 import GRPC
-import NIO
+import NIOCore
+import NIOPosix
 import XCTest
 
 class ConnectionFailingTests: GRPCTestCase {

--- a/Tests/GRPCTests/ConnectionManagerTests.swift
+++ b/Tests/GRPCTests/ConnectionManagerTests.swift
@@ -16,7 +16,8 @@
 import EchoModel
 @testable import GRPC
 import Logging
-import NIO
+import NIOCore
+import NIOEmbedded
 import NIOHTTP2
 import XCTest
 

--- a/Tests/GRPCTests/ConnectionPool/ConnectionPoolTests.swift
+++ b/Tests/GRPCTests/ConnectionPool/ConnectionPoolTests.swift
@@ -15,7 +15,8 @@
  */
 @testable import GRPC
 import Logging
-import NIO
+import NIOCore
+import NIOEmbedded
 import NIOHTTP2
 import XCTest
 

--- a/Tests/GRPCTests/ConnectionPool/PoolManagerStateMachineTests.swift
+++ b/Tests/GRPCTests/ConnectionPool/PoolManagerStateMachineTests.swift
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 @testable import GRPC
-import NIO
 import NIOConcurrencyHelpers
+import NIOCore
+import NIOEmbedded
 import XCTest
 
 class PoolManagerStateMachineTests: GRPCTestCase {

--- a/Tests/GRPCTests/DebugChannelInitializerTests.swift
+++ b/Tests/GRPCTests/DebugChannelInitializerTests.swift
@@ -16,8 +16,9 @@
 import EchoImplementation
 import EchoModel
 import GRPC
-import NIO
 import NIOConcurrencyHelpers
+import NIOCore
+import NIOPosix
 import XCTest
 
 class DebugChannelInitializerTests: GRPCTestCase {

--- a/Tests/GRPCTests/DelegatingErrorHandlerTests.swift
+++ b/Tests/GRPCTests/DelegatingErrorHandlerTests.swift
@@ -16,7 +16,8 @@
 import Foundation
 @testable import GRPC
 import Logging
-import NIO
+import NIOCore
+import NIOEmbedded
 import NIOSSL
 import XCTest
 

--- a/Tests/GRPCTests/EchoHelpers/Interceptors/DelegatingClientInterceptor.swift
+++ b/Tests/GRPCTests/EchoHelpers/Interceptors/DelegatingClientInterceptor.swift
@@ -15,7 +15,7 @@
  */
 import EchoModel
 import GRPC
-import NIO
+import NIOCore
 import SwiftProtobuf
 
 /// A client interceptor which delegates the implementation of `send` and `receive` to callbacks.

--- a/Tests/GRPCTests/EchoHelpers/Providers/DelegatingOnCloseEchoProvider.swift
+++ b/Tests/GRPCTests/EchoHelpers/Providers/DelegatingOnCloseEchoProvider.swift
@@ -15,7 +15,7 @@
  */
 import EchoModel
 import GRPC
-import NIO
+import NIOCore
 
 /// An `Echo_EchoProvider` which sets `onClose` for each RPC and then calls a delegate to provide
 /// the RPC implementation.

--- a/Tests/GRPCTests/EchoHelpers/Providers/FailingEchoProvider.swift
+++ b/Tests/GRPCTests/EchoHelpers/Providers/FailingEchoProvider.swift
@@ -15,7 +15,7 @@
  */
 import EchoModel
 import GRPC
-import NIO
+import NIOCore
 
 /// An `Echo_EchoProvider` which always returns failed future for each RPC.
 class FailingEchoProvider: Echo_EchoProvider {

--- a/Tests/GRPCTests/EchoHelpers/Providers/NeverResolvingEchoProvider.swift
+++ b/Tests/GRPCTests/EchoHelpers/Providers/NeverResolvingEchoProvider.swift
@@ -15,7 +15,7 @@
  */
 import EchoModel
 import GRPC
-import NIO
+import NIOCore
 
 /// An `Echo_EchoProvider` which returns a failed future for each RPC which resolves in the distant
 /// future.

--- a/Tests/GRPCTests/EchoTestClientTests.swift
+++ b/Tests/GRPCTests/EchoTestClientTests.swift
@@ -16,7 +16,8 @@
 import EchoImplementation
 import EchoModel
 import GRPC
-import NIO
+import NIOCore
+import NIOPosix
 import XCTest
 
 /// An example model using a generated client for the 'Echo' service.

--- a/Tests/GRPCTests/EventLoopFuture+Assertions.swift
+++ b/Tests/GRPCTests/EventLoopFuture+Assertions.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import Foundation
-import NIO
+import NIOCore
 import XCTest
 
 extension EventLoopFuture where Value: Equatable {

--- a/Tests/GRPCTests/FakeChannelTests.swift
+++ b/Tests/GRPCTests/FakeChannelTests.swift
@@ -15,7 +15,7 @@
  */
 import EchoModel
 import GRPC
-import NIO
+import NIOCore
 import XCTest
 
 class FakeChannelTests: GRPCTestCase {

--- a/Tests/GRPCTests/FakeResponseStreamTests.swift
+++ b/Tests/GRPCTests/FakeResponseStreamTests.swift
@@ -15,7 +15,8 @@
  */
 import EchoModel
 @testable import GRPC
-import NIO
+import NIOCore
+import NIOEmbedded
 import NIOHPACK
 import XCTest
 

--- a/Tests/GRPCTests/FunctionalTests.swift
+++ b/Tests/GRPCTests/FunctionalTests.swift
@@ -17,7 +17,7 @@ import Dispatch
 import EchoModel
 import Foundation
 @testable import GRPC
-import NIO
+import NIOCore
 import NIOHTTP1
 import NIOHTTP2
 import XCTest

--- a/Tests/GRPCTests/GRPCClientChannelHandlerTests.swift
+++ b/Tests/GRPCTests/GRPCClientChannelHandlerTests.swift
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 @testable import GRPC
-import NIO
+import NIOCore
+import NIOEmbedded
 import NIOHPACK
 import NIOHTTP2
 import XCTest

--- a/Tests/GRPCTests/GRPCClientStateMachineTests.swift
+++ b/Tests/GRPCTests/GRPCClientStateMachineTests.swift
@@ -17,7 +17,7 @@ import EchoModel
 import Foundation
 @testable import GRPC
 import Logging
-import NIO
+import NIOCore
 import NIOHPACK
 import NIOHTTP1
 import SwiftProtobuf

--- a/Tests/GRPCTests/GRPCCustomPayloadTests.swift
+++ b/Tests/GRPCTests/GRPCCustomPayloadTests.swift
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 import GRPC
-import NIO
+import NIOCore
+import NIOPosix
 import XCTest
 
 // These tests demonstrate how to use gRPC to create a service provider using your own payload type,

--- a/Tests/GRPCTests/GRPCIdleHandlerStateMachineTests.swift
+++ b/Tests/GRPCTests/GRPCIdleHandlerStateMachineTests.swift
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 @testable import GRPC
-import NIO
+import NIOCore
+import NIOEmbedded
 import NIOHTTP2
 import XCTest
 

--- a/Tests/GRPCTests/GRPCIdleTests.swift
+++ b/Tests/GRPCTests/GRPCIdleTests.swift
@@ -16,7 +16,8 @@
 import EchoImplementation
 import EchoModel
 @testable import GRPC
-import NIO
+import NIOCore
+import NIOPosix
 import XCTest
 
 class GRPCIdleTests: GRPCTestCase {

--- a/Tests/GRPCTests/GRPCInteroperabilityTests.swift
+++ b/Tests/GRPCTests/GRPCInteroperabilityTests.swift
@@ -16,7 +16,8 @@
 import Foundation
 import GRPC
 import GRPCInteroperabilityTestsImplementation
-import NIO
+import NIOCore
+import NIOPosix
 import XCTest
 
 /// These are the gRPC interoperability tests running on the NIO client and server.

--- a/Tests/GRPCTests/GRPCKeepaliveTests.swift
+++ b/Tests/GRPCTests/GRPCKeepaliveTests.swift
@@ -16,7 +16,8 @@
 import EchoImplementation
 import EchoModel
 @testable import GRPC
-import NIO
+import NIOCore
+import NIOPosix
 import XCTest
 
 class GRPCClientKeepaliveTests: GRPCTestCase {

--- a/Tests/GRPCTests/GRPCMessageLengthLimitTests.swift
+++ b/Tests/GRPCTests/GRPCMessageLengthLimitTests.swift
@@ -16,7 +16,8 @@
 import EchoImplementation
 import EchoModel
 import GRPC
-import NIO
+import NIOCore
+import NIOPosix
 import XCTest
 
 final class GRPCMessageLengthLimitTests: GRPCTestCase {

--- a/Tests/GRPCTests/GRPCNetworkFrameworkTests.swift
+++ b/Tests/GRPCTests/GRPCNetworkFrameworkTests.swift
@@ -19,7 +19,8 @@ import EchoImplementation
 import EchoModel
 import GRPC
 import Network
-import NIO
+import NIOCore
+import NIOPosix
 import NIOSSL
 import NIOTransportServices
 import Security

--- a/Tests/GRPCTests/GRPCPingHandlerTests.swift
+++ b/Tests/GRPCTests/GRPCPingHandlerTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 @testable import GRPC
-import NIO
+import NIOCore
 import NIOHTTP2
 import XCTest
 

--- a/Tests/GRPCTests/GRPCServerPipelineConfiguratorTests.swift
+++ b/Tests/GRPCTests/GRPCServerPipelineConfiguratorTests.swift
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 @testable import GRPC
-import NIO
+import NIOCore
+import NIOEmbedded
 import NIOHTTP2
 import NIOTLS
 import XCTest

--- a/Tests/GRPCTests/GRPCStatusCodeTests.swift
+++ b/Tests/GRPCTests/GRPCStatusCodeTests.swift
@@ -17,7 +17,8 @@ import EchoModel
 import Foundation
 @testable import GRPC
 import Logging
-import NIO
+import NIOCore
+import NIOEmbedded
 import NIOHPACK
 import NIOHTTP1
 import NIOHTTP2

--- a/Tests/GRPCTests/GRPCTimeoutTests.swift
+++ b/Tests/GRPCTests/GRPCTimeoutTests.swift
@@ -16,7 +16,7 @@
 import Dispatch
 import Foundation
 @testable import GRPC
-import NIO
+import NIOCore
 import XCTest
 
 class GRPCTimeoutTests: GRPCTestCase {

--- a/Tests/GRPCTests/GRPCWebToHTTP2ServerCodecTests.swift
+++ b/Tests/GRPCTests/GRPCWebToHTTP2ServerCodecTests.swift
@@ -15,7 +15,8 @@
  */
 import struct Foundation.Data
 @testable import GRPC
-import NIO
+import NIOCore
+import NIOEmbedded
 import NIOHPACK
 import NIOHTTP1
 import NIOHTTP2

--- a/Tests/GRPCTests/GRPCWebToHTTP2StateMachineTests.swift
+++ b/Tests/GRPCTests/GRPCWebToHTTP2StateMachineTests.swift
@@ -15,7 +15,7 @@
  */
 
 @testable import GRPC
-import NIO
+import NIOCore
 import NIOHPACK
 import NIOHTTP1
 import NIOHTTP2

--- a/Tests/GRPCTests/HTTP2MaxConcurrentStreamsTests.swift
+++ b/Tests/GRPCTests/HTTP2MaxConcurrentStreamsTests.swift
@@ -16,8 +16,9 @@
 import EchoImplementation
 import EchoModel
 @testable import GRPC
-import NIO
+import NIOCore
 import NIOHTTP2
+import NIOPosix
 import XCTest
 
 class HTTP2MaxConcurrentStreamsTests: GRPCTestCase {

--- a/Tests/GRPCTests/HTTP2ToRawGRPCStateMachineTests.swift
+++ b/Tests/GRPCTests/HTTP2ToRawGRPCStateMachineTests.swift
@@ -15,9 +15,11 @@
  */
 import EchoImplementation
 @testable import GRPC
-import NIO
+import NIOCore
+import NIOEmbedded
 import NIOHPACK
 import NIOHTTP2
+import NIOPosix
 import XCTest
 
 class HTTP2ToRawGRPCStateMachineTests: GRPCTestCase {

--- a/Tests/GRPCTests/HTTPVersionParserTests.swift
+++ b/Tests/GRPCTests/HTTPVersionParserTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 @testable import GRPC
-import NIO
+import NIOCore
 import XCTest
 
 class HTTPVersionParserTests: GRPCTestCase {

--- a/Tests/GRPCTests/HeaderNormalizationTests.swift
+++ b/Tests/GRPCTests/HeaderNormalizationTests.swift
@@ -16,9 +16,10 @@
 import EchoImplementation
 import EchoModel
 @testable import GRPC
-import NIO
+import NIOCore
 import NIOHPACK
 import NIOHTTP1
+import NIOPosix
 import XCTest
 
 class EchoMetadataValidator: Echo_EchoProvider {

--- a/Tests/GRPCTests/ImmediateServerFailureTests.swift
+++ b/Tests/GRPCTests/ImmediateServerFailureTests.swift
@@ -16,7 +16,7 @@
 import EchoModel
 import Foundation
 import GRPC
-import NIO
+import NIOCore
 import XCTest
 
 class ImmediatelyFailingEchoProvider: Echo_EchoProvider {

--- a/Tests/GRPCTests/InterceptorsTests.swift
+++ b/Tests/GRPCTests/InterceptorsTests.swift
@@ -17,8 +17,9 @@ import EchoImplementation
 import EchoModel
 import GRPC
 import HelloWorldModel
-import NIO
+import NIOCore
 import NIOHPACK
+import NIOPosix
 import SwiftProtobuf
 import XCTest
 

--- a/Tests/GRPCTests/LazyEventLoopPromiseTests.swift
+++ b/Tests/GRPCTests/LazyEventLoopPromiseTests.swift
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 @testable import GRPC
-import NIO
+import NIOCore
+import NIOEmbedded
 import XCTest
 
 class LazyEventLoopPromiseTests: GRPCTestCase {

--- a/Tests/GRPCTests/LengthPrefixedMessageReaderTests.swift
+++ b/Tests/GRPCTests/LengthPrefixedMessageReaderTests.swift
@@ -15,7 +15,7 @@
  */
 @testable import GRPC
 import Logging
-import NIO
+import NIOCore
 import XCTest
 
 class LengthPrefixedMessageReaderTests: GRPCTestCase {

--- a/Tests/GRPCTests/LengthPrefixedMessageWriterTests.swift
+++ b/Tests/GRPCTests/LengthPrefixedMessageWriterTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 @testable import GRPC
-import NIO
+import NIOCore
 import XCTest
 
 class LengthPrefixedMessageWriterTests: GRPCTestCase {

--- a/Tests/GRPCTests/PlatformSupportTests.swift
+++ b/Tests/GRPCTests/PlatformSupportTests.swift
@@ -15,7 +15,8 @@
  */
 import Foundation
 @testable import GRPC
-import NIO
+import NIOCore
+import NIOPosix
 import NIOTransportServices
 import XCTest
 

--- a/Tests/GRPCTests/ServerErrorDelegateTests.swift
+++ b/Tests/GRPCTests/ServerErrorDelegateTests.swift
@@ -18,7 +18,8 @@ import EchoModel
 import Foundation
 @testable import GRPC
 import Logging
-import NIO
+import NIOCore
+import NIOEmbedded
 import NIOHPACK
 import NIOHTTP2
 import XCTest

--- a/Tests/GRPCTests/ServerFuzzingRegressionTests.swift
+++ b/Tests/GRPCTests/ServerFuzzingRegressionTests.swift
@@ -17,7 +17,8 @@ import EchoImplementation
 import struct Foundation.Data
 import struct Foundation.URL
 import GRPC
-import NIO
+import NIOCore
+import NIOEmbedded
 import XCTest
 
 final class ServerFuzzingRegressionTests: GRPCTestCase {

--- a/Tests/GRPCTests/ServerInterceptorPipelineTests.swift
+++ b/Tests/GRPCTests/ServerInterceptorPipelineTests.swift
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 @testable import GRPC
-import NIO
+import NIOCore
+import NIOEmbedded
 import NIOHPACK
 import XCTest
 

--- a/Tests/GRPCTests/ServerInterceptorTests.swift
+++ b/Tests/GRPCTests/ServerInterceptorTests.swift
@@ -17,7 +17,8 @@ import EchoImplementation
 import EchoModel
 @testable import GRPC
 import HelloWorldModel
-import NIO
+import NIOCore
+import NIOEmbedded
 import NIOHTTP1
 import SwiftProtobuf
 import XCTest

--- a/Tests/GRPCTests/ServerOnCloseTests.swift
+++ b/Tests/GRPCTests/ServerOnCloseTests.swift
@@ -16,8 +16,9 @@
 import EchoImplementation
 import EchoModel
 import GRPC
-import NIO
 import NIOConcurrencyHelpers
+import NIOCore
+import NIOPosix
 import XCTest
 
 final class ServerOnCloseTests: GRPCTestCase {

--- a/Tests/GRPCTests/ServerQuiescingTests.swift
+++ b/Tests/GRPCTests/ServerQuiescingTests.swift
@@ -16,7 +16,8 @@
 import EchoImplementation
 import EchoModel
 import GRPC
-import NIO
+import NIOCore
+import NIOPosix
 import XCTest
 
 class ServerQuiescingTests: GRPCTestCase {

--- a/Tests/GRPCTests/ServerTLSErrorTests.swift
+++ b/Tests/GRPCTests/ServerTLSErrorTests.swift
@@ -18,7 +18,8 @@ import EchoModel
 @testable import GRPC
 import GRPCSampleData
 import Logging
-import NIO
+import NIOCore
+import NIOPosix
 import NIOSSL
 import XCTest
 

--- a/Tests/GRPCTests/ServerThrowingTests.swift
+++ b/Tests/GRPCTests/ServerThrowingTests.swift
@@ -17,7 +17,7 @@ import Dispatch
 import EchoModel
 import Foundation
 @testable import GRPC
-import NIO
+import NIOCore
 import NIOHPACK
 import NIOHTTP1
 import NIOHTTP2

--- a/Tests/GRPCTests/ServerWebTests.swift
+++ b/Tests/GRPCTests/ServerWebTests.swift
@@ -19,7 +19,7 @@ import FoundationNetworking
 #endif
 import EchoModel
 @testable import GRPC
-import NIO
+import NIOCore
 import XCTest
 
 // Only test Unary and ServerStreaming, as ClientStreaming is not

--- a/Tests/GRPCTests/TestClientExample.swift
+++ b/Tests/GRPCTests/TestClientExample.swift
@@ -16,7 +16,7 @@
 import EchoImplementation
 import EchoModel
 import GRPC
-import NIO
+import NIOCore
 import XCTest
 
 class FakeResponseStreamExampleTests: GRPCTestCase {

--- a/Tests/GRPCTests/TimeLimitTests.swift
+++ b/Tests/GRPCTests/TimeLimitTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 @testable import GRPC
-import NIO
+import NIOCore
 import XCTest
 
 class TimeLimitTests: GRPCTestCase {

--- a/Tests/GRPCTests/UnaryServerHandlerTests.swift
+++ b/Tests/GRPCTests/UnaryServerHandlerTests.swift
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 @testable import GRPC
-import NIO
+import NIOCore
+import NIOEmbedded
 import NIOHPACK
 import XCTest
 

--- a/Tests/GRPCTests/XCTestHelpers.swift
+++ b/Tests/GRPCTests/XCTestHelpers.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 @testable import GRPC
-import NIO
+import NIOCore
 import NIOHPACK
 import NIOHTTP1
 import NIOHTTP2

--- a/Tests/GRPCTests/ZeroLengthWriteTests.swift
+++ b/Tests/GRPCTests/ZeroLengthWriteTests.swift
@@ -19,7 +19,7 @@ import EchoModel
 import Foundation
 import GRPC
 import GRPCSampleData
-import NIO
+import NIOCore
 import NIOSSL
 import NIOTransportServices
 import XCTest

--- a/Tests/GRPCTests/ZlibTests.swift
+++ b/Tests/GRPCTests/ZlibTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 @testable import GRPC
-import NIO
+import NIOCore
 import XCTest
 
 class ZlibTests: GRPCTestCase {


### PR DESCRIPTION
Motivation:

The `NIO` module is now a 'shell' module which re-exports `NIOCore`,
`NIOPosix` and `NIOEmbeeded`.

Modifications:

For the GRPC and GRPCTests modules:
- Replace "import NIO" with "import NIOCore"
- Add imports for NIOEmbeeded and NIOPosix as necessary

Result:

Imports are closer to what we actually use.

(cherry picked from commit c88f038cdee150543ffcbb44a987db58abaf4d9c)