### PR TITLE
Raise the default HTTP/2 target window size

### DIFF
--- a/Sources/GRPC/ClientConnection.swift
+++ b/Sources/GRPC/ClientConnection.swift
@@ -341,9 +341,9 @@ extension ClientConnection {
     /// Defaults to `waitsForConnectivity`.
     public var callStartBehavior: CallStartBehavior = .waitsForConnectivity
 
-    /// The HTTP/2 flow control target window size. Defaults to 65535. Values are clamped between
+    /// The HTTP/2 flow control target window size. Defaults to 8MB. Values are clamped between
     /// 1 and 2^31-1 inclusive.
-    public var httpTargetWindowSize = 65535 {
+    public var httpTargetWindowSize = 8 * 1024 * 1024 {
       didSet {
         self.httpTargetWindowSize = self.httpTargetWindowSize.clamped(to: 1 ... Int(Int32.max))
       }
@@ -418,7 +418,7 @@ extension ClientConnection {
       connectionKeepalive: ClientConnectionKeepalive = ClientConnectionKeepalive(),
       connectionIdleTimeout: TimeAmount = .minutes(30),
       callStartBehavior: CallStartBehavior = .waitsForConnectivity,
-      httpTargetWindowSize: Int = 65535,
+      httpTargetWindowSize: Int = 8 * 1024 * 1024,
       backgroundActivityLogger: Logger = Logger(
         label: "io.grpc",
         factory: { _ in SwiftLogNoOpLogHandler() }

--- a/Sources/GRPC/GRPCChannel/GRPCChannelBuilder.swift
+++ b/Sources/GRPC/GRPCChannel/GRPCChannelBuilder.swift
@@ -387,7 +387,7 @@ extension ClientConnection.Builder.Secure {
 #endif
 
 extension ClientConnection.Builder {
-  /// Sets the HTTP/2 flow control target window size. Defaults to 65,535 if not explicitly set.
+  /// Sets the HTTP/2 flow control target window size. Defaults to 8MB if not explicitly set.
   /// Values are clamped between 1 and 2^31-1 inclusive.
   @discardableResult
   public func withHTTPTargetWindowSize(_ httpTargetWindowSize: Int) -> Self {

--- a/Sources/GRPC/Server.swift
+++ b/Sources/GRPC/Server.swift
@@ -322,9 +322,9 @@ extension Server {
       }
     }
 
-    /// The HTTP/2 flow control target window size. Defaults to 65535. Values are clamped between
+    /// The HTTP/2 flow control target window size. Defaults to 8MB. Values are clamped between
     /// 1 and 2^31-1 inclusive.
-    public var httpTargetWindowSize = 65535 {
+    public var httpTargetWindowSize = 8 * 1024 * 1024 {
       didSet {
         self.httpTargetWindowSize = self.httpTargetWindowSize.clamped(to: 1 ... Int(Int32.max))
       }
@@ -391,7 +391,7 @@ extension Server {
       connectionKeepalive: ServerConnectionKeepalive = ServerConnectionKeepalive(),
       connectionIdleTimeout: TimeAmount = .nanoseconds(.max),
       messageEncoding: ServerMessageEncoding = .disabled,
-      httpTargetWindowSize: Int = 65535,
+      httpTargetWindowSize: Int = 8 * 1024 * 1024,
       logger: Logger = Logger(label: "io.grpc", factory: { _ in SwiftLogNoOpLogHandler() }),
       debugChannelInitializer: ((Channel) -> EventLoopFuture<Void>)? = nil
     ) {

--- a/Sources/GRPC/ServerBuilder.swift
+++ b/Sources/GRPC/ServerBuilder.swift
@@ -152,7 +152,7 @@ extension Server.Builder.Secure {
 }
 
 extension Server.Builder {
-  /// Sets the HTTP/2 flow control target window size. Defaults to 65,535 if not explicitly set.
+  /// Sets the HTTP/2 flow control target window size. Defaults to 8MB if not explicitly set.
   /// Values are clamped between 1 and 2^31-1 inclusive.
   @discardableResult
   public func withHTTPTargetWindowSize(_ httpTargetWindowSize: Int) -> Self {


### PR DESCRIPTION
Motivation:

The default flow control window size is 64kb which is quite small. As a
result connections may spend longer than necessary waiting for
window updates.

Modifications:

Increase the target window size to 8MB.

Result:

HTTP target window size is 8MB by default.