### PR TITLE
Add platforms requirements

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,12 @@ import PackageDescription
 
 let package = Package(
   name: "grpc-swift",
+  platforms: [
+    .iOS(.v12),
+    .macOS(.v10_14),
+    .tvOS(.v12),
+    .watchOS(.v6)
+  ],
   products: [
     .library(name: "GRPC", targets: ["GRPC"]),
     .library(name: "CGRPCZlib", targets: ["CGRPCZlib"]),


### PR DESCRIPTION
Add platform requirements to do release build in Apple platforms in Xcode 13.

In Xcode 13 beta, Swift libraries fail to build for iOS targets that use armv7. 
This will affect to release build in Apple platforms.
<img width="1018" alt="Screen Shot 2021-08-27 at 13 14 42" src="https://user-images.githubusercontent.com/20222809/131070815-0dc02d77-7532-4854-a520-4124c7fe3936.png">

We cannot reproduce this issue on gRPC-swift directly due to fail in swift-nio-transport-services, but after fixed that, gRPC-swift will fail in same issue.
I also try to fix in https://github.com/apple/swift-nio-transport-services/pull/128.

To be resolved, as described in Xcode release note, just add `platforms:` in Package.swift. 

> Swift libraries may fail to build for iOS targets that use armv7. (74120874)
Workaround: Increase the platform dependency of the package to v12 or later.
https://developer.apple.com/documentation/xcode-release-notes/xcode-13-beta-release-notes

This is caused by using Network.framework so platforms versions are depends on `Network.framework` availability.
The `platforms:` attribute will be ignored in Linux or Server Side Swift.