### PR TITLE
[async-await] Code generation for "simple, but safe" wrapper client calls.

### DIFF
--- a/Sources/Examples/Echo/Model/echo.grpc.swift
+++ b/Sources/Examples/Echo/Model/echo.grpc.swift
@@ -282,6 +282,7 @@ extension Echo_EchoAsyncClientProtocol {
       callOptions: callOptions ?? self.defaultCallOptions
     )
   }
+
   public func collect<RequestStream>(
     _ requests: RequestStream,
     callOptions: CallOptions? = nil
@@ -303,6 +304,7 @@ extension Echo_EchoAsyncClientProtocol {
       callOptions: callOptions ?? self.defaultCallOptions
     )
   }
+
   public func update<RequestStream>(
     _ requests: RequestStream,
     callOptions: CallOptions? = nil

--- a/Sources/Examples/Echo/Model/echo.grpc.swift
+++ b/Sources/Examples/Echo/Model/echo.grpc.swift
@@ -254,69 +254,44 @@ extension Echo_EchoAsyncClientProtocol {
     _ request: Echo_EchoRequest,
     callOptions: CallOptions? = nil
   ) async throws -> Echo_EchoResponse {
-    return try await self.makeGetCall(
-      request,
-      callOptions: callOptions
-    ).response
+    return try await self.performAsyncUnaryCall(
+      path: "/echo.Echo/Get",
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions
+    )
   }
 
   public func expand(
     _ request: Echo_EchoRequest,
     callOptions: CallOptions? = nil
   ) -> GRPCAsyncResponseStream<Echo_EchoResponse> {
-    return self.makeExpandCall(
-      request,
-      callOptions: callOptions
-    ).responses
+    return self.performAsyncServerStreamingCall(
+      path: "/echo.Echo/Expand",
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions
+    )
   }
 
   public func collect<RequestStream>(
     requests: RequestStream,
     callOptions: CallOptions? = nil
   ) async throws -> Echo_EchoResponse where RequestStream: AsyncSequence, RequestStream.Element == Echo_EchoRequest {
-    let call = self.makeCollectCall(
-      callOptions: callOptions
+    return try await self.performAsyncClientStreamingCall(
+      path: "/echo.Echo/Collect",
+      requests: requests,
+      callOptions: callOptions ?? self.defaultCallOptions
     )
-    return try await withTaskCancellationHandler {
-      try Task.checkCancellation()
-      for try await request in requests {
-        try Task.checkCancellation()
-        try await call.sendMessage(request)
-      }
-      try Task.checkCancellation()
-      try await call.sendEnd()
-      try Task.checkCancellation()
-      return try await call.response
-    } onCancel: {
-      Task.detached {
-        try await call.cancel()
-      }
-    }
   }
 
   public func update<RequestStream>(
     requests: RequestStream,
     callOptions: CallOptions? = nil
   ) -> GRPCAsyncResponseStream<Echo_EchoResponse> where RequestStream: AsyncSequence, RequestStream.Element == Echo_EchoRequest {
-    let call = self.makeUpdateCall(
-      callOptions: callOptions
+    return self.performAsyncBidirectionalStreamingCall(
+      path: "/echo.Echo/Update",
+      requests: requests,
+      callOptions: callOptions ?? self.defaultCallOptions
     )
-    Task {
-      try await withTaskCancellationHandler {
-        try Task.checkCancellation()
-        for try await request in requests {
-          try Task.checkCancellation()
-          try await call.sendMessage(request)
-        }
-        try Task.checkCancellation()
-        try await call.sendEnd()
-      } onCancel: {
-        Task.detached {
-          try await call.cancel()
-        }
-      }
-    }
-    return call.responses
   }
 }
 

--- a/Sources/Examples/Echo/Model/echo.grpc.swift
+++ b/Sources/Examples/Echo/Model/echo.grpc.swift
@@ -275,6 +275,16 @@ extension Echo_EchoAsyncClientProtocol {
   public func collect<RequestStream>(
     requests: RequestStream,
     callOptions: CallOptions? = nil
+  ) async throws -> Echo_EchoResponse where RequestStream: Sequence, RequestStream.Element == Echo_EchoRequest {
+    return try await self.performAsyncClientStreamingCall(
+      path: "/echo.Echo/Collect",
+      requests: requests,
+      callOptions: callOptions ?? self.defaultCallOptions
+    )
+  }
+  public func collect<RequestStream>(
+    requests: RequestStream,
+    callOptions: CallOptions? = nil
   ) async throws -> Echo_EchoResponse where RequestStream: AsyncSequence, RequestStream.Element == Echo_EchoRequest {
     return try await self.performAsyncClientStreamingCall(
       path: "/echo.Echo/Collect",
@@ -283,6 +293,16 @@ extension Echo_EchoAsyncClientProtocol {
     )
   }
 
+  public func update<RequestStream>(
+    requests: RequestStream,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncResponseStream<Echo_EchoResponse> where RequestStream: Sequence, RequestStream.Element == Echo_EchoRequest {
+    return self.performAsyncBidirectionalStreamingCall(
+      path: "/echo.Echo/Update",
+      requests: requests,
+      callOptions: callOptions ?? self.defaultCallOptions
+    )
+  }
   public func update<RequestStream>(
     requests: RequestStream,
     callOptions: CallOptions? = nil

--- a/Sources/Examples/Echo/Model/echo.grpc.swift
+++ b/Sources/Examples/Echo/Model/echo.grpc.swift
@@ -273,7 +273,7 @@ extension Echo_EchoAsyncClientProtocol {
   }
 
   public func collect<RequestStream>(
-    requests: RequestStream,
+    _ requests: RequestStream,
     callOptions: CallOptions? = nil
   ) async throws -> Echo_EchoResponse where RequestStream: Sequence, RequestStream.Element == Echo_EchoRequest {
     return try await self.performAsyncClientStreamingCall(
@@ -283,7 +283,7 @@ extension Echo_EchoAsyncClientProtocol {
     )
   }
   public func collect<RequestStream>(
-    requests: RequestStream,
+    _ requests: RequestStream,
     callOptions: CallOptions? = nil
   ) async throws -> Echo_EchoResponse where RequestStream: AsyncSequence, RequestStream.Element == Echo_EchoRequest {
     return try await self.performAsyncClientStreamingCall(
@@ -294,7 +294,7 @@ extension Echo_EchoAsyncClientProtocol {
   }
 
   public func update<RequestStream>(
-    requests: RequestStream,
+    _ requests: RequestStream,
     callOptions: CallOptions? = nil
   ) -> GRPCAsyncResponseStream<Echo_EchoResponse> where RequestStream: Sequence, RequestStream.Element == Echo_EchoRequest {
     return self.performAsyncBidirectionalStreamingCall(
@@ -304,7 +304,7 @@ extension Echo_EchoAsyncClientProtocol {
     )
   }
   public func update<RequestStream>(
-    requests: RequestStream,
+    _ requests: RequestStream,
     callOptions: CallOptions? = nil
   ) -> GRPCAsyncResponseStream<Echo_EchoResponse> where RequestStream: AsyncSequence, RequestStream.Element == Echo_EchoRequest {
     return self.performAsyncBidirectionalStreamingCall(

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCChannel+AsyncAwaitSupport.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCChannel+AsyncAwaitSupport.swift
@@ -26,7 +26,7 @@ extension GRPCChannel {
   ///   - request: The request to send.
   ///   - callOptions: Options for the RPC.
   ///   - interceptors: A list of interceptors to intercept the request and response stream with.
-  public func makeAsyncUnaryCall<Request: Message, Response: Message>(
+  internal func makeAsyncUnaryCall<Request: Message, Response: Message>(
     path: String,
     request: Request,
     callOptions: CallOptions,
@@ -50,7 +50,7 @@ extension GRPCChannel {
   ///   - request: The request to send.
   ///   - callOptions: Options for the RPC.
   ///   - interceptors: A list of interceptors to intercept the request and response stream with.
-  public func makeAsyncUnaryCall<Request: GRPCPayload, Response: GRPCPayload>(
+  internal func makeAsyncUnaryCall<Request: GRPCPayload, Response: GRPCPayload>(
     path: String,
     request: Request,
     callOptions: CallOptions,
@@ -73,7 +73,7 @@ extension GRPCChannel {
   ///   - path: Path of the RPC, e.g. "/echo.Echo/Get"
   ///   - callOptions: Options for the RPC.
   ///   - interceptors: A list of interceptors to intercept the request and response stream with.
-  public func makeAsyncClientStreamingCall<Request: Message, Response: Message>(
+  internal func makeAsyncClientStreamingCall<Request: Message, Response: Message>(
     path: String,
     callOptions: CallOptions,
     interceptors: [ClientInterceptor<Request, Response>] = []
@@ -94,7 +94,7 @@ extension GRPCChannel {
   ///   - path: Path of the RPC, e.g. "/echo.Echo/Get"
   ///   - callOptions: Options for the RPC.
   ///   - interceptors: A list of interceptors to intercept the request and response stream with.
-  public func makeAsyncClientStreamingCall<Request: GRPCPayload, Response: GRPCPayload>(
+  internal func makeAsyncClientStreamingCall<Request: GRPCPayload, Response: GRPCPayload>(
     path: String,
     callOptions: CallOptions,
     interceptors: [ClientInterceptor<Request, Response>] = []
@@ -116,7 +116,7 @@ extension GRPCChannel {
   ///   - request: The request to send.
   ///   - callOptions: Options for the RPC.
   ///   - interceptors: A list of interceptors to intercept the request and response stream with.
-  public func makeAsyncServerStreamingCall<Request: Message, Response: Message>(
+  internal func makeAsyncServerStreamingCall<Request: Message, Response: Message>(
     path: String,
     request: Request,
     callOptions: CallOptions,
@@ -140,7 +140,7 @@ extension GRPCChannel {
   ///   - request: The request to send.
   ///   - callOptions: Options for the RPC.
   ///   - interceptors: A list of interceptors to intercept the request and response stream with.
-  public func makeAsyncServerStreamingCall<Request: GRPCPayload, Response: GRPCPayload>(
+  internal func makeAsyncServerStreamingCall<Request: GRPCPayload, Response: GRPCPayload>(
     path: String,
     request: Request,
     callOptions: CallOptions,
@@ -163,7 +163,7 @@ extension GRPCChannel {
   ///   - path: Path of the RPC, e.g. "/echo.Echo/Get"
   ///   - callOptions: Options for the RPC.
   ///   - interceptors: A list of interceptors to intercept the request and response stream with.
-  public func makeAsyncBidirectionalStreamingCall<Request: Message, Response: Message>(
+  internal func makeAsyncBidirectionalStreamingCall<Request: Message, Response: Message>(
     path: String,
     callOptions: CallOptions,
     interceptors: [ClientInterceptor<Request, Response>] = []
@@ -184,7 +184,7 @@ extension GRPCChannel {
   ///   - path: Path of the RPC, e.g. "/echo.Echo/Get"
   ///   - callOptions: Options for the RPC.
   ///   - interceptors: A list of interceptors to intercept the request and response stream with.
-  public func makeAsyncBidirectionalStreamingCall<Request: GRPCPayload, Response: GRPCPayload>(
+  internal func makeAsyncBidirectionalStreamingCall<Request: GRPCPayload, Response: GRPCPayload>(
     path: String,
     callOptions: CallOptions,
     interceptors: [ClientInterceptor<Request, Response>] = []

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCClient+AsyncAwaitSupport.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCClient+AsyncAwaitSupport.swift
@@ -233,7 +233,7 @@ extension GRPCClient {
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: interceptors
     )
-    return try await self.perform(call, requests)
+    return try await self.perform(call, with: requests)
   }
 
   public func performAsyncClientStreamingCall<
@@ -254,7 +254,7 @@ extension GRPCClient {
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: interceptors
     )
-    return try await self.perform(call, requests)
+    return try await self.perform(call, with: requests)
   }
 
   public func performAsyncClientStreamingCall<
@@ -275,7 +275,7 @@ extension GRPCClient {
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: interceptors
     )
-    return try await self.perform(call, AsyncStream(wrapping: requests))
+    return try await self.perform(call, with: AsyncStream(wrapping: requests))
   }
 
   public func performAsyncClientStreamingCall<
@@ -296,7 +296,7 @@ extension GRPCClient {
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: interceptors
     )
-    return try await self.perform(call, AsyncStream(wrapping: requests))
+    return try await self.perform(call, with: AsyncStream(wrapping: requests))
   }
 
   public func performAsyncBidirectionalStreamingCall<
@@ -317,7 +317,7 @@ extension GRPCClient {
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: interceptors
     )
-    return self.perform(call, requests)
+    return self.perform(call, with: requests)
   }
 
   public func performAsyncBidirectionalStreamingCall<
@@ -338,7 +338,7 @@ extension GRPCClient {
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: interceptors
     )
-    return self.perform(call, requests)
+    return self.perform(call, with: requests)
   }
 
   public func performAsyncBidirectionalStreamingCall<
@@ -359,7 +359,7 @@ extension GRPCClient {
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: interceptors
     )
-    return self.perform(call, AsyncStream(wrapping: requests))
+    return self.perform(call, with: AsyncStream(wrapping: requests))
   }
 
   public func performAsyncBidirectionalStreamingCall<
@@ -380,7 +380,7 @@ extension GRPCClient {
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: interceptors
     )
-    return self.perform(call, AsyncStream(wrapping: requests))
+    return self.perform(call, with: AsyncStream(wrapping: requests))
   }
 }
 
@@ -389,7 +389,7 @@ extension GRPCClient {
   @inlinable
   internal func perform<Request, Response, RequestStream>(
     _ call: GRPCAsyncClientStreamingCall<Request, Response>,
-    _ requests: RequestStream
+    with requests: RequestStream
   )
   async throws -> Response
     where RequestStream: AsyncSequence, RequestStream.Element == Request {
@@ -423,7 +423,7 @@ extension GRPCClient {
   @inlinable
   internal func perform<Request, Response, RequestStream>(
     _ call: GRPCAsyncBidirectionalStreamingCall<Request, Response>,
-    _ requests: RequestStream
+    with requests: RequestStream
   )
     -> GRPCAsyncResponseStream<Response>
     where RequestStream: AsyncSequence, RequestStream.Element == Request {

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCClient+AsyncAwaitSupport.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCClient+AsyncAwaitSupport.swift
@@ -219,7 +219,7 @@ extension GRPCClient {
     callOptions: CallOptions? = nil,
     interceptors: [ClientInterceptor<Request, Response>] = []
   ) async throws -> Response
-  where RequestStream: AsyncSequence, RequestStream.Element == Request {
+    where RequestStream: AsyncSequence, RequestStream.Element == Request {
     let call = self.channel.makeAsyncClientStreamingCall(
       path: path,
       callOptions: callOptions ?? self.defaultCallOptions,
@@ -238,7 +238,7 @@ extension GRPCClient {
     callOptions: CallOptions? = nil,
     interceptors: [ClientInterceptor<Request, Response>] = []
   ) async throws -> Response
-  where RequestStream: AsyncSequence, RequestStream.Element == Request {
+    where RequestStream: AsyncSequence, RequestStream.Element == Request {
     let call = self.channel.makeAsyncClientStreamingCall(
       path: path,
       callOptions: callOptions ?? self.defaultCallOptions,
@@ -257,11 +257,11 @@ extension GRPCClient {
     callOptions: CallOptions? = nil,
     interceptors: [ClientInterceptor<Request, Response>] = []
   ) -> GRPCAsyncResponseStream<Response>
-  where RequestStream.Element == Request {
+    where RequestStream.Element == Request {
     let call = self.channel.makeAsyncBidirectionalStreamingCall(
-        path: path,
-        callOptions: callOptions ?? self.defaultCallOptions,
-        interceptors: interceptors
+      path: path,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: interceptors
     )
     return self.perform(call, requests)
   }
@@ -276,11 +276,11 @@ extension GRPCClient {
     callOptions: CallOptions? = nil,
     interceptors: [ClientInterceptor<Request, Response>] = []
   ) -> GRPCAsyncResponseStream<Response>
-  where RequestStream.Element == Request {
+    where RequestStream.Element == Request {
     let call = self.channel.makeAsyncBidirectionalStreamingCall(
-        path: path,
-        callOptions: callOptions ?? self.defaultCallOptions,
-        interceptors: interceptors
+      path: path,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: interceptors
     )
     return self.perform(call, requests)
   }
@@ -290,11 +290,11 @@ extension GRPCClient {
 extension GRPCClient {
   @inlinable
   internal func perform<Request, Response, RequestStream>(
-    _ call:  GRPCAsyncClientStreamingCall<Request, Response>,
+    _ call: GRPCAsyncClientStreamingCall<Request, Response>,
     _ requests: RequestStream
   )
   async throws -> Response
-  where RequestStream: AsyncSequence, RequestStream.Element == Request {
+    where RequestStream: AsyncSequence, RequestStream.Element == Request {
     return try await withTaskCancellationHandler {
       try Task.checkCancellation()
       for try await request in requests {
@@ -314,11 +314,11 @@ extension GRPCClient {
 
   @inlinable
   internal func perform<Request, Response, RequestStream>(
-    _ call:  GRPCAsyncBidirectionalStreamingCall<Request, Response>,
+    _ call: GRPCAsyncBidirectionalStreamingCall<Request, Response>,
     _ requests: RequestStream
   )
-  -> GRPCAsyncResponseStream<Response>
-  where RequestStream: AsyncSequence, RequestStream.Element == Request {
+    -> GRPCAsyncResponseStream<Response>
+    where RequestStream: AsyncSequence, RequestStream.Element == Request {
     Task {
       try await withTaskCancellationHandler {
         try Task.checkCancellation()

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCClient+AsyncAwaitSupport.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCClient+AsyncAwaitSupport.swift
@@ -390,8 +390,7 @@ extension GRPCClient {
   internal func perform<Request, Response, RequestStream>(
     _ call: GRPCAsyncClientStreamingCall<Request, Response>,
     with requests: RequestStream
-  )
-  async throws -> Response
+  ) async throws -> Response
     where RequestStream: AsyncSequence, RequestStream.Element == Request {
     // We use a detached task because we use cancellation to signal early, but successful exit.
     let requestsTask = Task.detached {

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCClient+AsyncAwaitSupport.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCClient+AsyncAwaitSupport.swift
@@ -447,6 +447,10 @@ extension GRPCClient {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AsyncStream {
+  /// Create an `AsyncStream` from a regular (non-async) `Sequence`.
+  ///
+  /// - Note: This is just here to avoid duplicating the above two `perform(_:with:)` functions
+  ///         for `Sequence`.
   fileprivate init<T>(wrapping sequence: T) where T: Sequence, T.Element == Element {
     self.init { continuation in
       var iterator = sequence.makeIterator()

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCClient+AsyncAwaitSupport.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCClient+AsyncAwaitSupport.swift
@@ -397,10 +397,10 @@ extension GRPCClient {
       try Task.checkCancellation()
       for try await request in requests {
         try Task.checkCancellation()
-        try await call.sendMessage(request)
+        try await call.requestStream.send(request)
       }
       try Task.checkCancellation()
-      try await call.sendEnd()
+      try await call.requestStream.finish()
       try Task.checkCancellation()
     }
     return try await withTaskCancellationHandler {
@@ -431,10 +431,10 @@ extension GRPCClient {
         try Task.checkCancellation()
         for try await request in requests {
           try Task.checkCancellation()
-          try await call.sendMessage(request)
+          try await call.requestStream.send(request)
         }
         try Task.checkCancellation()
-        try await call.sendEnd()
+        try await call.requestStream.finish()
       } onCancel: {
         Task.detached {
           try await call.cancel()

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCClient+AsyncAwaitSupport.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCClient+AsyncAwaitSupport.swift
@@ -148,13 +148,16 @@ extension GRPCClient {
   }
 }
 
+// MARK: - "Simple, but safe" wrappers.
+
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension GRPCClient {
   public func performAsyncUnaryCall<Request: Message, Response: Message>(
     path: String,
     request: Request,
     callOptions: CallOptions? = nil,
-    interceptors: [ClientInterceptor<Request, Response>] = []
+    interceptors: [ClientInterceptor<Request, Response>] = [],
+    responseType: Response.Type = Response.self
   ) async throws -> Response {
     return try await self.channel.makeAsyncUnaryCall(
       path: path,
@@ -168,7 +171,8 @@ extension GRPCClient {
     path: String,
     request: Request,
     callOptions: CallOptions? = nil,
-    interceptors: [ClientInterceptor<Request, Response>] = []
+    interceptors: [ClientInterceptor<Request, Response>] = [],
+    responseType: Response.Type = Response.self
   ) async throws -> Response {
     return try await self.channel.makeAsyncUnaryCall(
       path: path,
@@ -185,7 +189,8 @@ extension GRPCClient {
     path: String,
     request: Request,
     callOptions: CallOptions? = nil,
-    interceptors: [ClientInterceptor<Request, Response>] = []
+    interceptors: [ClientInterceptor<Request, Response>] = [],
+    responseType: Response.Type = Response.self
   ) -> GRPCAsyncResponseStream<Response> {
     return self.channel.makeAsyncServerStreamingCall(
       path: path,
@@ -199,7 +204,8 @@ extension GRPCClient {
     path: String,
     request: Request,
     callOptions: CallOptions? = nil,
-    interceptors: [ClientInterceptor<Request, Response>] = []
+    interceptors: [ClientInterceptor<Request, Response>] = [],
+    responseType: Response.Type = Response.self
   ) -> GRPCAsyncResponseStream<Response> {
     return self.channel.makeAsyncServerStreamingCall(
       path: path,
@@ -217,7 +223,9 @@ extension GRPCClient {
     path: String,
     requests: RequestStream,
     callOptions: CallOptions? = nil,
-    interceptors: [ClientInterceptor<Request, Response>] = []
+    interceptors: [ClientInterceptor<Request, Response>] = [],
+    requestType: Request.Type = Request.self,
+    responseType: Response.Type = Response.self
   ) async throws -> Response
     where RequestStream: AsyncSequence, RequestStream.Element == Request {
     let call = self.channel.makeAsyncClientStreamingCall(
@@ -236,7 +244,9 @@ extension GRPCClient {
     path: String,
     requests: RequestStream,
     callOptions: CallOptions? = nil,
-    interceptors: [ClientInterceptor<Request, Response>] = []
+    interceptors: [ClientInterceptor<Request, Response>] = [],
+    requestType: Request.Type = Request.self,
+    responseType: Response.Type = Response.self
   ) async throws -> Response
     where RequestStream: AsyncSequence, RequestStream.Element == Request {
     let call = self.channel.makeAsyncClientStreamingCall(
@@ -255,7 +265,9 @@ extension GRPCClient {
     path: String,
     requests: RequestStream,
     callOptions: CallOptions? = nil,
-    interceptors: [ClientInterceptor<Request, Response>] = []
+    interceptors: [ClientInterceptor<Request, Response>] = [],
+    requestType: Request.Type = Request.self,
+    responseType: Response.Type = Response.self
   ) async throws -> Response
     where RequestStream: Sequence, RequestStream.Element == Request {
     let call = self.channel.makeAsyncClientStreamingCall(
@@ -274,7 +286,9 @@ extension GRPCClient {
     path: String,
     requests: RequestStream,
     callOptions: CallOptions? = nil,
-    interceptors: [ClientInterceptor<Request, Response>] = []
+    interceptors: [ClientInterceptor<Request, Response>] = [],
+    requestType: Request.Type = Request.self,
+    responseType: Response.Type = Response.self
   ) async throws -> Response
     where RequestStream: Sequence, RequestStream.Element == Request {
     let call = self.channel.makeAsyncClientStreamingCall(
@@ -293,7 +307,9 @@ extension GRPCClient {
     path: String,
     requests: RequestStream,
     callOptions: CallOptions? = nil,
-    interceptors: [ClientInterceptor<Request, Response>] = []
+    interceptors: [ClientInterceptor<Request, Response>] = [],
+    requestType: Request.Type = Request.self,
+    responseType: Response.Type = Response.self
   ) -> GRPCAsyncResponseStream<Response>
     where RequestStream.Element == Request {
     let call = self.channel.makeAsyncBidirectionalStreamingCall(
@@ -312,7 +328,9 @@ extension GRPCClient {
     path: String,
     requests: RequestStream,
     callOptions: CallOptions? = nil,
-    interceptors: [ClientInterceptor<Request, Response>] = []
+    interceptors: [ClientInterceptor<Request, Response>] = [],
+    requestType: Request.Type = Request.self,
+    responseType: Response.Type = Response.self
   ) -> GRPCAsyncResponseStream<Response>
     where RequestStream.Element == Request {
     let call = self.channel.makeAsyncBidirectionalStreamingCall(
@@ -331,7 +349,9 @@ extension GRPCClient {
     path: String,
     requests: RequestStream,
     callOptions: CallOptions? = nil,
-    interceptors: [ClientInterceptor<Request, Response>] = []
+    interceptors: [ClientInterceptor<Request, Response>] = [],
+    requestType: Request.Type = Request.self,
+    responseType: Response.Type = Response.self
   ) -> GRPCAsyncResponseStream<Response>
     where RequestStream.Element == Request {
     let call = self.channel.makeAsyncBidirectionalStreamingCall(
@@ -350,7 +370,9 @@ extension GRPCClient {
     path: String,
     requests: RequestStream,
     callOptions: CallOptions? = nil,
-    interceptors: [ClientInterceptor<Request, Response>] = []
+    interceptors: [ClientInterceptor<Request, Response>] = [],
+    requestType: Request.Type = Request.self,
+    responseType: Response.Type = Response.self
   ) -> GRPCAsyncResponseStream<Response>
     where RequestStream.Element == Request {
     let call = self.channel.makeAsyncBidirectionalStreamingCall(

--- a/Sources/protoc-gen-grpc-swift/Generator-Client+AsyncAwait.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator-Client+AsyncAwait.swift
@@ -136,7 +136,6 @@ extension Generator {
   internal func printAsyncClientProtocolSafeWrappersExtension() {
     self.printAvailabilityForAsyncAwait()
     self.withIndentation("extension \(self.asyncClientProtocolName)", braces: .curly) {
-
       // 'Safe' calls.
       for (i, method) in self.service.methods.enumerated() {
         if i > 0 {
@@ -160,7 +159,11 @@ extension Generator {
             async: true,
             throws: true
           ) {
-            self.withIndentation("return try await self.make\(self.method.name)Call", braces: .round, newline: false) {
+            self.withIndentation(
+              "return try await self.make\(self.method.name)Call",
+              braces: .round,
+              newline: false
+            ) {
               self.println("request,")
               self.println("callOptions: callOptions")
             }
@@ -176,7 +179,11 @@ extension Generator {
             returnType: "\(responseStreamType)<\(self.methodOutputName)>",
             access: self.access
           ) {
-            self.withIndentation("return self.make\(self.method.name)Call", braces: .round, newline: false) {
+            self.withIndentation(
+              "return self.make\(self.method.name)Call",
+              braces: .round,
+              newline: false
+            ) {
               self.println("request,")
               self.println("callOptions: callOptions")
             }

--- a/Sources/protoc-gen-grpc-swift/Generator-Client+AsyncAwait.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator-Client+AsyncAwait.swift
@@ -191,46 +191,50 @@ extension Generator {
           }
 
         case .clientStreaming:
-          self.printFunction(
-            name: "\(self.methodFunctionName)<RequestStream>",
-            arguments: [
-              "requests: RequestStream",
-              "callOptions: \(Types.clientCallOptions)? = nil",
-            ],
-            returnType: self.methodOutputName,
-            access: self.access,
-            async: true,
-            throws: true,
-            genericWhereClause: "where RequestStream: AsyncSequence, RequestStream.Element == \(self.methodInputName)"
-          ) {
-            self.withIndentation(
-              "return try await self.perform\(callTypeWithoutPrefix)",
-              braces: .round
+          for sequenceProtocol in ["Sequence", "AsyncSequence"] {
+            self.printFunction(
+              name: "\(self.methodFunctionName)<RequestStream>",
+              arguments: [
+                "requests: RequestStream",
+                "callOptions: \(Types.clientCallOptions)? = nil",
+              ],
+              returnType: self.methodOutputName,
+              access: self.access,
+              async: true,
+              throws: true,
+              genericWhereClause: "where RequestStream: \(sequenceProtocol), RequestStream.Element == \(self.methodInputName)"
             ) {
-              self.println("path: \(self.methodPath),")
-              self.println("requests: requests,")
-              self.println("callOptions: callOptions ?? self.defaultCallOptions")
+              self.withIndentation(
+                "return try await self.perform\(callTypeWithoutPrefix)",
+                braces: .round
+              ) {
+                self.println("path: \(self.methodPath),")
+                self.println("requests: requests,")
+                self.println("callOptions: callOptions ?? self.defaultCallOptions")
+              }
             }
           }
 
         case .bidirectionalStreaming:
-          self.printFunction(
-            name: "\(self.methodFunctionName)<RequestStream>",
-            arguments: [
-              "requests: RequestStream",
-              "callOptions: \(Types.clientCallOptions)? = nil",
-            ],
-            returnType: "\(responseStreamType)<\(self.methodOutputName)>",
-            access: self.access,
-            genericWhereClause: "where RequestStream: AsyncSequence, RequestStream.Element == \(self.methodInputName)"
-          ) {
-            self.withIndentation(
-              "return self.perform\(callTypeWithoutPrefix)",
-              braces: .round
+          for sequenceProtocol in ["Sequence", "AsyncSequence"] {
+            self.printFunction(
+              name: "\(self.methodFunctionName)<RequestStream>",
+              arguments: [
+                "requests: RequestStream",
+                "callOptions: \(Types.clientCallOptions)? = nil",
+              ],
+              returnType: "\(responseStreamType)<\(self.methodOutputName)>",
+              access: self.access,
+              genericWhereClause: "where RequestStream: \(sequenceProtocol), RequestStream.Element == \(self.methodInputName)"
             ) {
-              self.println("path: \(self.methodPath),")
-              self.println("requests: requests,")
-              self.println("callOptions: callOptions ?? self.defaultCallOptions")
+              self.withIndentation(
+                "return self.perform\(callTypeWithoutPrefix)",
+                braces: .round
+              ) {
+                self.println("path: \(self.methodPath),")
+                self.println("requests: requests,")
+                self.println("callOptions: callOptions ?? self.defaultCallOptions")
+              }
             }
           }
         }

--- a/Sources/protoc-gen-grpc-swift/Generator-Client+AsyncAwait.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator-Client+AsyncAwait.swift
@@ -145,7 +145,7 @@ extension Generator {
 
         let rpcType = streamingType(self.method)
         let callTypeWithoutPrefix = Types.call(for: rpcType, withGRPCPrefix: false)
-        let responseStreamType = "GRPCAsyncResponseStream"
+        let responseStreamType = Types.responseStream(of: self.methodOutputName)
 
         switch rpcType {
         case .unary:
@@ -177,7 +177,7 @@ extension Generator {
               "_ request: \(self.methodInputName)",
               "callOptions: \(Types.clientCallOptions)? = nil",
             ],
-            returnType: "\(responseStreamType)<\(self.methodOutputName)>",
+            returnType: "\(responseStreamType)",
             access: self.access
           ) {
             self.withIndentation(
@@ -223,7 +223,7 @@ extension Generator {
                 "requests: RequestStream",
                 "callOptions: \(Types.clientCallOptions)? = nil",
               ],
-              returnType: "\(responseStreamType)<\(self.methodOutputName)>",
+              returnType: "\(responseStreamType)",
               access: self.access,
               genericWhereClause: "where RequestStream: \(sequenceProtocol), RequestStream.Element == \(self.methodInputName)"
             ) {

--- a/Sources/protoc-gen-grpc-swift/Generator-Client+AsyncAwait.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator-Client+AsyncAwait.swift
@@ -137,9 +137,6 @@ extension Generator {
     self.printAvailabilityForAsyncAwait()
     self.withIndentation("extension \(self.asyncClientProtocolName)", braces: .curly) {
       for (i, method) in self.service.methods.enumerated() {
-        if i > 0 {
-          self.println()
-        }
         self.method = method
 
         let rpcType = streamingType(self.method)
@@ -150,7 +147,11 @@ extension Generator {
 
         let sequenceProtocols = streamsRequests ? ["Sequence", "AsyncSequence"] : [nil]
 
-        for sequenceProtocol in sequenceProtocols {
+        for (j, sequenceProtocol) in sequenceProtocols.enumerated() {
+          // Print a new line if this is not the first function in the extension.
+          if i > 0 || j > 0 {
+            self.println()
+          }
           let functionName = streamsRequests
             ? "\(self.methodFunctionName)<RequestStream>"
             : self.methodFunctionName

--- a/Sources/protoc-gen-grpc-swift/Generator-Client.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator-Client.swift
@@ -37,6 +37,8 @@ extension Generator {
       self.println()
       self.printAsyncClientProtocolExtension()
       self.println()
+      self.printAsyncClientProtocolSafeWrappersExtension()
+      self.println()
       self.printAsyncServiceClientImplementation()
       self.println()
       self.printEndCompilerGuardForAsyncAwait()

--- a/Sources/protoc-gen-grpc-swift/Generator.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator.swift
@@ -92,6 +92,7 @@ class Generator {
   internal func withIndentation(
     _ header: String,
     braces: Braces,
+    newline: Bool = true,
     _ body: () -> Void
   ) {
     let spaceBeforeOpeningBrace: Bool
@@ -104,7 +105,7 @@ class Generator {
 
     self.println(header + "\(spaceBeforeOpeningBrace ? " " : "")" + "\(braces.open)")
     self.withIndentation(body: body)
-    self.println(braces.close)
+    self.println(braces.close, newline: newline)
   }
 
   private func printMain() {

--- a/Sources/protoc-gen-grpc-swift/Generator.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator.swift
@@ -92,7 +92,6 @@ class Generator {
   internal func withIndentation(
     _ header: String,
     braces: Braces,
-    newline: Bool = true,
     _ body: () -> Void
   ) {
     let spaceBeforeOpeningBrace: Bool
@@ -105,7 +104,7 @@ class Generator {
 
     self.println(header + "\(spaceBeforeOpeningBrace ? " " : "")" + "\(braces.open)")
     self.withIndentation(body: body)
-    self.println(braces.close, newline: newline)
+    self.println(braces.close)
   }
 
   private func printMain() {


### PR DESCRIPTION
This PR adds codegen support for the "simple, but safe wrappers" that were part of the proposal for async/await support, added in #1231.

Codegen has also been re-run for the example Echo service.

