### PR TITLE
[async-await] Support for sending response headers via context

### DIFF
--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncBidirectionalStreamingCall.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncBidirectionalStreamingCall.swift
@@ -40,6 +40,10 @@ public struct GRPCAsyncBidirectionalStreamingCall<Request, Response> {
   // MARK: - Response Parts
 
   /// The initial metadata returned from the server.
+  ///
+  /// - Important: The initial metadata will only be available when the first response has been
+  /// received. However, it is not necessary for the response to have been consumed before reading
+  /// this property.
   public var initialMetadata: HPACKHeaders {
     // swiftformat:disable:next redundantGet
     get async throws {

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncClientStreamingCall.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncClientStreamingCall.swift
@@ -36,6 +36,8 @@ public struct GRPCAsyncClientStreamingCall<Request, Response> {
   // MARK: - Response Parts
 
   /// The initial metadata returned from the server.
+  ///
+  /// - Important: The initial metadata will only be available when the response has been received.
   public var initialMetadata: HPACKHeaders {
     // swiftformat:disable:next redundantGet
     get async throws {

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncServerCallContext.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncServerCallContext.swift
@@ -34,8 +34,8 @@ import NIOHPACK
 public final class GRPCAsyncServerCallContext {
   private let lock = Lock()
 
-  /// Request headers for this request.
-  public let requestHeaders: HPACKHeaders
+  /// Metadata for this request.
+  public let requestMetadata: HPACKHeaders
 
   /// The logger used for this call.
   public var logger: Logger {
@@ -85,32 +85,32 @@ public final class GRPCAsyncServerCallContext {
 
   /// Metadata to return at the start of the RPC.
   ///
-  /// If this is required it should be updated before the first response is sent via the response
-  /// stream writer.
-  public var responseHeaders: HPACKHeaders {
+  /// - Important: If this is required it should be updated _before_ the first response is sent via
+  /// the response stream writer. Any updates made after the first response will be ignored.
+  public var initialResponseMetadata: HPACKHeaders {
     get { self.lock.withLock {
-      return self._responseHeaders
+      return self._initialResponseMetadata
     } }
     set { self.lock.withLock {
-      self._responseHeaders = newValue
+      self._initialResponseMetadata = newValue
     } }
   }
 
-  private var _responseHeaders: HPACKHeaders = [:]
+  private var _initialResponseMetadata: HPACKHeaders = [:]
 
   /// Metadata to return at the end of the RPC.
   ///
   /// If this is required it should be updated before returning from the handler.
-  public var responseTrailers: HPACKHeaders {
+  public var trailingResponseMetadata: HPACKHeaders {
     get { self.lock.withLock {
-      return self._responseTrailers
+      return self._trailingResponseMetadata
     } }
     set { self.lock.withLock {
-      self._responseTrailers = newValue
+      self._trailingResponseMetadata = newValue
     } }
   }
 
-  private var _responseTrailers: HPACKHeaders = [:]
+  private var _trailingResponseMetadata: HPACKHeaders = [:]
 
   @inlinable
   internal init(
@@ -118,7 +118,7 @@ public final class GRPCAsyncServerCallContext {
     logger: Logger,
     userInfoRef: Ref<UserInfo>
   ) {
-    self.requestHeaders = headers
+    self.requestMetadata = headers
     self.userInfoRef = userInfoRef
     self._logger = logger
   }

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncServerHandler.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncServerHandler.swift
@@ -519,7 +519,7 @@ internal final class AsyncServerHandler<
         activeState.haveSentResponseHeaders = true
         self.state = .active(activeState)
         // Send response headers back via the interceptors.
-        self.interceptors.send(.metadata(activeState.context.responseHeaders), promise: nil)
+        self.interceptors.send(.metadata(activeState.context.initialResponseMetadata), promise: nil)
       }
       // Send the response back via the interceptors.
       self.interceptors.send(.message(response, metadata), promise: nil)
@@ -576,7 +576,7 @@ internal final class AsyncServerHandler<
     case let .active(activeState):
       // Now we have drained the response stream writer from the user handler we can send end.
       self.state = .completed
-      self.interceptors.send(.end(status, activeState.context.responseTrailers), promise: nil)
+      self.interceptors.send(.end(status, activeState.context.trailingResponseMetadata), promise: nil)
 
     case .completed:
       ()
@@ -619,8 +619,8 @@ internal final class AsyncServerHandler<
       if isHandlerError {
         (status, trailers) = ServerErrorProcessor.processObserverError(
           error,
-          headers: activeState.context.requestHeaders,
-          trailers: activeState.context.responseTrailers,
+          headers: activeState.context.requestMetadata,
+          trailers: activeState.context.trailingResponseMetadata,
           delegate: self.context.errorDelegate
         )
       } else {

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncServerHandler.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncServerHandler.swift
@@ -576,7 +576,10 @@ internal final class AsyncServerHandler<
     case let .active(activeState):
       // Now we have drained the response stream writer from the user handler we can send end.
       self.state = .completed
-      self.interceptors.send(.end(status, activeState.context.trailingResponseMetadata), promise: nil)
+      self.interceptors.send(
+        .end(status, activeState.context.trailingResponseMetadata),
+        promise: nil
+      )
 
     case .completed:
       ()

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncServerStreamingCall.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncServerStreamingCall.swift
@@ -39,6 +39,10 @@ public struct GRPCAsyncServerStreamingCall<Request, Response> {
   // MARK: - Response Parts
 
   /// The initial metadata returned from the server.
+  ///
+  /// - Important: The initial metadata will only be available when the first response has been
+  /// received. However, it is not necessary for the response to have been consumed before reading
+  /// this property.
   public var initialMetadata: HPACKHeaders {
     // swiftformat:disable:next redundantGet
     get async throws {

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncUnaryCall.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncUnaryCall.swift
@@ -39,6 +39,8 @@ public struct GRPCAsyncUnaryCall<Request, Response> {
   // MARK: - Response Parts
 
   /// The initial metadata returned from the server.
+  ///
+  /// - Important: The initial metadata will only be available when the response has been received.
   public var initialMetadata: HPACKHeaders {
     // swiftformat:disable:next redundantGet
     get async throws {

--- a/Tests/GRPCTests/GRPCAsyncServerHandlerTests.swift
+++ b/Tests/GRPCTests/GRPCAsyncServerHandlerTests.swift
@@ -146,9 +146,9 @@ class AsyncServerHandlerTests: ServerHandlerTestCaseBase {
 
   func testResponseHeadersAndTrailersSentFromContext() { XCTAsyncTest {
     let handler = self.makeHandler { _, responseStreamWriter, context in
-      context.responseHeaders = ["pontiac": "bandit"]
+      context.initialResponseMetadata = ["pontiac": "bandit"]
       try await responseStreamWriter.send("1")
-      context.responseTrailers = ["disco": "strangler"]
+      context.trailingResponseMetadata = ["disco": "strangler"]
     }
     handler.receiveMetadata([:])
     handler.receiveEnd()
@@ -163,8 +163,8 @@ class AsyncServerHandlerTests: ServerHandlerTestCaseBase {
   func testResponseHeadersDroppedIfSetAfterFirstResponse() { XCTAsyncTest {
     let handler = self.makeHandler { _, responseStreamWriter, context in
       try await responseStreamWriter.send("1")
-      context.responseHeaders = ["pontiac": "bandit"]
-      context.responseTrailers = ["disco": "strangler"]
+      context.initialResponseMetadata = ["pontiac": "bandit"]
+      context.trailingResponseMetadata = ["disco": "strangler"]
     }
     handler.receiveMetadata([:])
     handler.receiveEnd()

--- a/Tests/GRPCTests/GRPCAsyncServerHandlerTests.swift
+++ b/Tests/GRPCTests/GRPCAsyncServerHandlerTests.swift
@@ -328,14 +328,14 @@ class AsyncServerHandlerTests: ServerHandlerTestCaseBase {
 
     // Send two requests and end, pausing the writer in the middle.
     switch handler.state {
-    case let .activeAwaitingFirstResponse(_, _, responseStreamWriter, promise):
+    case let .active(activeState):
       handler.receiveMessage(ByteBuffer(string: "diaz"))
-      await responseStreamWriter.asyncWriter.toggleWritability()
+      await activeState.responseStreamWriter.asyncWriter.toggleWritability()
       handler.receiveMessage(ByteBuffer(string: "santiago"))
       handler.receiveEnd()
-      await responseStreamWriter.asyncWriter.toggleWritability()
+      await activeState.responseStreamWriter.asyncWriter.toggleWritability()
       await handler.userHandlerTask?.value
-      _ = try await promise.futureResult.get()
+      _ = try await activeState._userHandlerPromise.futureResult.get()
     default:
       XCTFail("Unexpected handler state: \(handler.state)")
     }

--- a/Tests/GRPCTests/GRPCAsyncServerHandlerTests.swift
+++ b/Tests/GRPCTests/GRPCAsyncServerHandlerTests.swift
@@ -241,7 +241,6 @@ class AsyncServerHandlerTests: ServerHandlerTestCaseBase {
     await assertThat(self.recorder.status, .notNil(.hasCode(.internalError)))
   } }
 
-  // TODO: Running this 1000 times shows up a segfault in NIO event loop group.
   func testReceiveMultipleHeaders() { XCTAsyncTest {
     let handler = self
       .makeHandler(observer: self.neverReceivesMessage(requests:responseStreamWriter:context:))
@@ -317,8 +316,6 @@ class AsyncServerHandlerTests: ServerHandlerTestCaseBase {
     // Check the status is `.unknown`.
     await assertThat(self.recorder.status, .notNil(.hasCode(.unknown)))
   } }
-
-  // TODO: We should be consistent about where we put the tasks... maybe even use a task group to simplify cancellation (unless they both go in the enum state which might be better).
 
   func testResponseStreamDrain() { XCTAsyncTest {
     // Set up echo handler.


### PR DESCRIPTION
The adopter may wish to set the response headers (aka "initial metadata") from their user handler. Until now this was not possible, even in the existing non–async-await API, and it was only possible for an adopter to set the trailers.

This introduces a new mutable property to the context passed to the user handler that allows them to set the headers that should be sent back to the client before the first response message.

* `let GRPCAsyncServerCallContext.headers` has been renamed to `requestHeaders` to disambiguate from newly introduced property.
* `var GRPCAsyncServerCallContext.trailers` has been renamed to `responseTrailers` to better align with newly introduced property.
* `var GRPCAsyncServerCallContext.responseHeaders` has been introduced.