### PR TITLE
Update swift-argument-parser version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,8 +47,7 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),
 
     // Argument parsing: only for internal targets (i.e. examples).
-    // swift-argument-parser only provides source compatibility guarantees between minor version.
-    .package(url: "https://github.com/apple/swift-argument-parser", "0.3.0" ..< "0.5.0"),
+    .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.0.0"),
   ],
   targets: [
     // The main GRPC module.


### PR DESCRIPTION
Motivation:

Stable APIs are better than unstable APIs. swift-argument-parser has
released a 1.0.0 and now has a stable API.

Modifications:

Change swift-argument-parser version requirements to "from: 1.0.0"

Result:

Dependencies are more stable.