### PR TITLE
Remove unused imports

### DIFF
--- a/Sources/GRPC/GRPCChannel/GRPCChannel.swift
+++ b/Sources/GRPC/GRPCChannel/GRPCChannel.swift
@@ -15,7 +15,6 @@
  */
 import NIOCore
 import NIOHTTP2
-import NIOSSL
 import SwiftProtobuf
 
 public protocol GRPCChannel {

--- a/Sources/GRPC/TLSVerificationHandler.swift
+++ b/Sources/GRPC/TLSVerificationHandler.swift
@@ -13,10 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Foundation
 import Logging
 import NIOCore
-import NIOSSL
 import NIOTLS
 
 /// Application protocol identifiers for ALPN.


### PR DESCRIPTION
Motivation:

We import NIOSSL unnecessarily in a few places.

Modifications:

Remove unused imports.

Result:

Fewer unnecessarily imports.