### PR TITLE
Add note to README about async/await support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,24 @@ Version | Implementation | Branch                 | `protoc` Plugin         | Co
 
 The remainder of this README refers to the 1.x version of gRPC Swift.
 
+## Experimental `async`/`await` Support
+
+Swift 5.5 introduces new language features for concurrency. One such feature is
+[`async`/`await`][SE-0296].
+
+gRPC Swift includes **experimental** support for async/await. While support is
+**experimental**, async/await releases of gRPC Swift *do not guarantees a stable
+API*. Features and APIs may change between async/await releases.
+
+To ensure the 1.x release series does maintain a stable API, async/await releases
+will be branched from stable releases and tagged in the following format:
+`X.Y.Z-async-await.N`. Where `X.Y.Z` indicates the tag of the stable release
+from which the branch was created and `N` indicates a release number on that
+branch.
+
+The `protoc-gen-grpc-swift` options for generating async/await style clients and
+servers are described in [`docs/plugin.md`][docs-plugin].
+
 ## Supported Platforms
 
 gRPC Swift's platform support is identical to the [platform support of Swift
@@ -180,3 +198,4 @@ Please get involved! See our [guidelines for contributing](CONTRIBUTING.md).
 [branch-old]: https://github.com/grpc/grpc-swift/tree/cgrpc
 [examples-out-of-source]: https://github.com/grpc/grpc-swift/tree/main/Examples
 [examples-in-source]: https://github.com/grpc/grpc-swift/tree/main/Sources/Examples
+[SE-0296]: https://github.com/apple/swift-evolution/blob/main/proposals/0296-async-await.md

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -48,6 +48,22 @@ protocol.
 - **Possible values:** true, false
 - **Default value:** true
 
+### ExperimentalAsyncServer
+
+The **ExperimentalAsyncServer** option determines whether async/await style
+server code is generated. See also [README.md](../README.md).
+
+- **Possible values:** true, false
+- **Default value:** false
+
+### ExperimentalAsyncClient
+
+The **ExperimentalAsyncClient** option determines whether async/await style
+client code is generated. See also [README.md](../README.md).
+
+- **Possible values:** true, false
+- **Default value:** false
+
 ### TestClient
 
 The **TestClient** option determines whether test client code is generated.
@@ -102,11 +118,11 @@ the gRPC core C library whose module name is also "GRPC".*
 
 ### SwiftProtobufModuleName
 
- The **SwiftProtobufModuleName** option allows the name of the SwiftProtobuf 
- runtime module to be specified. The value, if not specified, defaults to 
+ The **SwiftProtobufModuleName** option allows the name of the SwiftProtobuf
+ runtime module to be specified. The value, if not specified, defaults to
  "SwiftProtobuf".
 
- *Note: most users will not need to use this option. Introduced to match 
+ *Note: most users will not need to use this option. Introduced to match
  the option that exists in [SwiftProtobuf][swift-protobuf-module-name].
 
 ## Specifying Options


### PR DESCRIPTION
Motivation:

The `async-await` branch has enough code in place that we can tag an
experimental async/await version. We should, however, make a few things
clear:

- that it is experimental API and subject to change
- which versions contain async/await code
- how to generate async/await code

Modifications:

- Add an async/await section to README.md
- Update docs/plugin.md to include the async/await codegen options

Result:

We're clearer about async/await support