### PR TITLE
[async-await] Added generation of interceptors

### DIFF
--- a/Sources/Examples/Echo/Model/echo.grpc.swift
+++ b/Sources/Examples/Echo/Model/echo.grpc.swift
@@ -214,7 +214,8 @@ extension Echo_EchoAsyncClientProtocol {
     return self.makeAsyncUnaryCall(
       path: "/echo.Echo/Get",
       request: request,
-      callOptions: callOptions ?? self.defaultCallOptions
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeGetInterceptors() ?? []
     )
   }
 
@@ -225,7 +226,8 @@ extension Echo_EchoAsyncClientProtocol {
     return self.makeAsyncServerStreamingCall(
       path: "/echo.Echo/Expand",
       request: request,
-      callOptions: callOptions ?? self.defaultCallOptions
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeExpandInterceptors() ?? []
     )
   }
 
@@ -234,7 +236,8 @@ extension Echo_EchoAsyncClientProtocol {
   ) -> GRPCAsyncClientStreamingCall<Echo_EchoRequest, Echo_EchoResponse> {
     return self.makeAsyncClientStreamingCall(
       path: "/echo.Echo/Collect",
-      callOptions: callOptions ?? self.defaultCallOptions
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeCollectInterceptors() ?? []
     )
   }
 
@@ -243,7 +246,8 @@ extension Echo_EchoAsyncClientProtocol {
   ) -> GRPCAsyncBidirectionalStreamingCall<Echo_EchoRequest, Echo_EchoResponse> {
     return self.makeAsyncBidirectionalStreamingCall(
       path: "/echo.Echo/Update",
-      callOptions: callOptions ?? self.defaultCallOptions
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeUpdateInterceptors() ?? []
     )
   }
 }
@@ -257,7 +261,8 @@ extension Echo_EchoAsyncClientProtocol {
     return try await self.performAsyncUnaryCall(
       path: "/echo.Echo/Get",
       request: request,
-      callOptions: callOptions ?? self.defaultCallOptions
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeGetInterceptors() ?? []
     )
   }
 
@@ -268,7 +273,8 @@ extension Echo_EchoAsyncClientProtocol {
     return self.performAsyncServerStreamingCall(
       path: "/echo.Echo/Expand",
       request: request,
-      callOptions: callOptions ?? self.defaultCallOptions
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeExpandInterceptors() ?? []
     )
   }
 
@@ -279,7 +285,8 @@ extension Echo_EchoAsyncClientProtocol {
     return try await self.performAsyncClientStreamingCall(
       path: "/echo.Echo/Collect",
       requests: requests,
-      callOptions: callOptions ?? self.defaultCallOptions
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeCollectInterceptors() ?? []
     )
   }
 
@@ -290,7 +297,8 @@ extension Echo_EchoAsyncClientProtocol {
     return try await self.performAsyncClientStreamingCall(
       path: "/echo.Echo/Collect",
       requests: requests,
-      callOptions: callOptions ?? self.defaultCallOptions
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeCollectInterceptors() ?? []
     )
   }
 
@@ -301,7 +309,8 @@ extension Echo_EchoAsyncClientProtocol {
     return self.performAsyncBidirectionalStreamingCall(
       path: "/echo.Echo/Update",
       requests: requests,
-      callOptions: callOptions ?? self.defaultCallOptions
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeUpdateInterceptors() ?? []
     )
   }
 
@@ -312,7 +321,8 @@ extension Echo_EchoAsyncClientProtocol {
     return self.performAsyncBidirectionalStreamingCall(
       path: "/echo.Echo/Update",
       requests: requests,
-      callOptions: callOptions ?? self.defaultCallOptions
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeUpdateInterceptors() ?? []
     )
   }
 }

--- a/Sources/Examples/HelloWorld/Model/helloworld.grpc.swift
+++ b/Sources/Examples/HelloWorld/Model/helloworld.grpc.swift
@@ -131,3 +131,4 @@ public protocol Helloworld_GreeterServerInterceptorFactoryProtocol {
   ///   Defaults to calling `self.makeInterceptors()`.
   func makeSayHelloInterceptors() -> [ServerInterceptor<Helloworld_HelloRequest, Helloworld_HelloReply>]
 }
+

--- a/Sources/Examples/RouteGuide/Model/route_guide.grpc.swift
+++ b/Sources/Examples/RouteGuide/Model/route_guide.grpc.swift
@@ -295,3 +295,4 @@ public protocol Routeguide_RouteGuideServerInterceptorFactoryProtocol {
   ///   Defaults to calling `self.makeInterceptors()`.
   func makeRouteChatInterceptors() -> [ServerInterceptor<Routeguide_RouteNote, Routeguide_RouteNote>]
 }
+

--- a/Sources/protoc-gen-grpc-swift/Generator-Client+AsyncAwait.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator-Client+AsyncAwait.swift
@@ -108,7 +108,10 @@ extension Generator {
             self.withIndentation("return self.make\(callTypeWithoutPrefix)", braces: .round) {
               self.println("path: \(self.methodPath),")
               self.println("request: request,")
-              self.println("callOptions: callOptions ?? self.defaultCallOptions")
+              self.println("callOptions: callOptions ?? self.defaultCallOptions,")
+              self.println(
+                "interceptors: self.interceptors?.\(self.methodInterceptorFactoryName)() ?? []"
+              )
             }
           }
 
@@ -121,7 +124,10 @@ extension Generator {
           ) {
             self.withIndentation("return self.make\(callTypeWithoutPrefix)", braces: .round) {
               self.println("path: \(self.methodPath),")
-              self.println("callOptions: callOptions ?? self.defaultCallOptions")
+              self.println("callOptions: callOptions ?? self.defaultCallOptions,")
+              self.println(
+                "interceptors: self.interceptors?.\(self.methodInterceptorFactoryName)() ?? []"
+              )
             }
           }
         }
@@ -181,7 +187,10 @@ extension Generator {
             ) {
               self.println("path: \(self.methodPath),")
               self.println("\(requestParamName): \(requestParamName),")
-              self.println("callOptions: callOptions ?? self.defaultCallOptions")
+              self.println("callOptions: callOptions ?? self.defaultCallOptions,")
+              self.println(
+                "interceptors: self.interceptors?.\(self.methodInterceptorFactoryName)() ?? []"
+              )
             }
           }
         }

--- a/Tests/GRPCTests/AsyncAwaitSupport/InterceptorsAsyncTests.swift
+++ b/Tests/GRPCTests/AsyncAwaitSupport/InterceptorsAsyncTests.swift
@@ -49,7 +49,7 @@ class InterceptorsAsyncTests: GRPCTestCase {
       .connect(host: "127.0.0.1", port: server.channel.localAddress!.port!)
 
     self.connection = connection
-    
+
     self.echo = Echo_EchoAsyncClient(
       channel: connection,
       defaultCallOptions: CallOptions(logger: self.clientLogger),
@@ -70,26 +70,26 @@ class InterceptorsAsyncTests: GRPCTestCase {
 
     super.tearDown()
   }
-  
+
   func testUnaryCall() { XCTAsyncTest {
     let get = try await self.echo.get(.with { $0.text = "hello" })
     await assertThat(get, .is(.with { $0.text = "hello :teg ohce tfiwS" }))
   } }
-  
+
   func testMakingUnaryCall() { XCTAsyncTest {
     let call = self.echo.makeGetCall(.with { $0.text = "hello" })
     await assertThat(try await call.response, .is(.with { $0.text = "hello :teg ohce tfiwS" }))
   } }
-  
+
   func testClientStreamingSequence() { XCTAsyncTest {
     let requests = ["1 2", "3 4"].map { item in
       Echo_EchoRequest.with { $0.text = item }
     }
     let response = try await self.echo.collect(requests, callOptions: .init())
-    
+
     await assertThat(response, .is(.with { $0.text = "3 4 1 2 :tcelloc ohce tfiwS" }))
   } }
-  
+
   func testClientStreamingAsyncSequence() { XCTAsyncTest {
     let stream = AsyncStream<Echo_EchoRequest> { continuation in
       continuation.yield(.with { $0.text = "1 2" })
@@ -97,17 +97,20 @@ class InterceptorsAsyncTests: GRPCTestCase {
       continuation.finish()
     }
     let response = try await self.echo.collect(stream, callOptions: .init())
-    
+
     await assertThat(response, .is(.with { $0.text = "3 4 1 2 :tcelloc ohce tfiwS" }))
   } }
-  
+
   func testMakingCallClientStreaming() { XCTAsyncTest {
     let call = self.echo.makeCollectCall(callOptions: .init())
     try await call.requestStream.send(.with { $0.text = "1 2" })
     try await call.requestStream.send(.with { $0.text = "3 4" })
     try await call.requestStream.finish()
-    
-    await assertThat(try await call.response, .is(.with { $0.text = "3 4 1 2 :tcelloc ohce tfiwS" }))
+
+    await assertThat(
+      try await call.response,
+      .is(.with { $0.text = "3 4 1 2 :tcelloc ohce tfiwS" })
+    )
   } }
 
   func testServerStreaming() { XCTAsyncTest {
@@ -117,7 +120,7 @@ class InterceptorsAsyncTests: GRPCTestCase {
       await assertThat(response, .is(.with { $0.text = "hello :)0( dnapxe ohce tfiwS" }))
     }
   } }
-  
+
   func testMakingCallServerStreaming() { XCTAsyncTest {
     let call = self.echo.makeExpandCall(.with { $0.text = "hello" }, callOptions: .init())
     for try await response in call.responses {
@@ -125,13 +128,13 @@ class InterceptorsAsyncTests: GRPCTestCase {
       await assertThat(response, .is(.with { $0.text = "hello :)0( dnapxe ohce tfiwS" }))
     }
   } }
-  
+
   func testBidirectionalStreaming() { XCTAsyncTest {
     let requests = ["1 2", "3 4"].map { item in
       Echo_EchoRequest.with { $0.text = item }
     }
     let responses = self.echo.update(requests, callOptions: .init())
-    
+
     var count = 0
     for try await response in responses {
       switch count {
@@ -145,13 +148,13 @@ class InterceptorsAsyncTests: GRPCTestCase {
       count += 1
     }
   } }
-  
+
   func testMakingCallBidirectionalStreaming() { XCTAsyncTest {
     let call = self.echo.makeUpdateCall(callOptions: .init())
     try await call.requestStream.send(.with { $0.text = "1 2" })
     try await call.requestStream.send(.with { $0.text = "3 4" })
     try await call.requestStream.finish()
-    
+
     var count = 0
     for try await response in call.responses {
       switch count {
@@ -165,7 +168,6 @@ class InterceptorsAsyncTests: GRPCTestCase {
       count += 1
     }
   } }
-  
 }
 
 #endif

--- a/Tests/GRPCTests/AsyncAwaitSupport/InterceptorsAsyncTests.swift
+++ b/Tests/GRPCTests/AsyncAwaitSupport/InterceptorsAsyncTests.swift
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#if compiler(>=5.5)
 import EchoImplementation
 import EchoModel
 import GRPC
@@ -22,9 +23,6 @@ import NIOHPACK
 import NIOPosix
 import SwiftProtobuf
 import XCTest
-
-
-#if compiler(>=5.5)
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 class InterceptorsAsyncTests: GRPCTestCase {

--- a/Tests/GRPCTests/Codegen/Normalization/normalization.grpc.swift
+++ b/Tests/GRPCTests/Codegen/Normalization/normalization.grpc.swift
@@ -425,3 +425,4 @@ internal protocol Normalization_NormalizationServerInterceptorFactoryProtocol {
   ///   Defaults to calling `self.makeInterceptors()`.
   func makebidirectionalStreamingInterceptors() -> [ServerInterceptor<SwiftProtobuf.Google_Protobuf_Empty, Normalization_FunctionName>]
 }
+

--- a/Tests/GRPCTests/InterceptorsAsyncTests.swift
+++ b/Tests/GRPCTests/InterceptorsAsyncTests.swift
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2021, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import EchoImplementation
+import EchoModel
+import GRPC
+import HelloWorldModel
+import NIOCore
+import NIOHPACK
+import NIOPosix
+import SwiftProtobuf
+import XCTest
+
+
+#if compiler(>=5.5)
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+class InterceptorsAsyncTests: GRPCTestCase {
+  private var group: EventLoopGroup!
+  private var server: Server!
+  private var connection: ClientConnection!
+  private var echo: Echo_EchoAsyncClient!
+
+  override func setUp() {
+    super.setUp()
+    let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    self.group = group
+
+    let server = try! Server.insecure(group: group)
+      .withServiceProviders([EchoProvider()])
+      .withLogger(self.serverLogger)
+      .bind(host: "127.0.0.1", port: 0)
+      .wait()
+
+    self.server = server
+
+    let connection = ClientConnection.insecure(group: group)
+      .withBackgroundActivityLogger(self.clientLogger)
+      .connect(host: "127.0.0.1", port: server.channel.localAddress!.port!)
+
+    self.connection = connection
+    
+    self.echo = Echo_EchoAsyncClient(
+      channel: connection,
+      defaultCallOptions: CallOptions(logger: self.clientLogger),
+      interceptors: ReversingInterceptors()
+    )
+  }
+
+  override func tearDown() {
+    if let connection = self.connection {
+      XCTAssertNoThrow(try connection.close().wait())
+    }
+    if let server = self.server {
+      XCTAssertNoThrow(try server.close().wait())
+    }
+    if let group = self.group {
+      XCTAssertNoThrow(try group.syncShutdownGracefully())
+    }
+
+    super.tearDown()
+  }
+  
+  func testUnaryCall() { XCTAsyncTest {
+    let get = try await self.echo.get(.with { $0.text = "hello" })
+    await assertThat(get, .is(.with { $0.text = "hello :teg ohce tfiwS" }))
+  } }
+  
+  func testMakingUnaryCall() { XCTAsyncTest {
+    let call = self.echo.makeGetCall(.with { $0.text = "hello" })
+    await assertThat(try await call.response, .is(.with { $0.text = "hello :teg ohce tfiwS" }))
+    await assertThat(await call.status, .hasCode(.ok))
+  } }
+  
+  func testClientStreamingSequence() { XCTAsyncTest {
+    let requests = ["1 2", "3 4"].map { item in
+      Echo_EchoRequest.with { $0.text = item }
+    }
+    let response = try await self.echo.collect(requests, callOptions: .init())
+    
+    await assertThat(response, .is(.with { $0.text = "3 4 1 2 :tcelloc ohce tfiwS" }))
+  } }
+  
+  func testClientStreamingAsyncSequence() { XCTAsyncTest {
+    let stream = AsyncStream<Echo_EchoRequest> { continuation in
+      continuation.yield(.with { $0.text = "1 2" })
+      continuation.yield(.with { $0.text = "3 4" })
+      continuation.finish()
+    }
+    let response = try await self.echo.collect(stream, callOptions: .init())
+    
+    await assertThat(response, .is(.with { $0.text = "3 4 1 2 :tcelloc ohce tfiwS" }))
+  } }
+  
+  func testMakingCallClientStreaming() { XCTAsyncTest {
+    let call = self.echo.makeCollectCall(callOptions: .init())
+    try await call.requestStream.send(.with { $0.text = "1 2" })
+    try await call.requestStream.send(.with { $0.text = "3 4" })
+    try await call.requestStream.finish()
+    
+    await assertThat(try await call.response, .is(.with { $0.text = "3 4 1 2 :tcelloc ohce tfiwS" }))
+  } }
+
+  func testServerStreaming() { XCTAsyncTest {
+    let responses = self.echo.expand(.with { $0.text = "hello" }, callOptions: .init())
+    for try await response in responses {
+      // Expand splits on spaces, so we only expect one response.
+      await assertThat(response, .is(.with { $0.text = "hello :)0( dnapxe ohce tfiwS" }))
+    }
+  } }
+  
+  func testMakingCallServerStreaming() { XCTAsyncTest {
+    let call = self.echo.makeExpandCall(.with { $0.text = "hello" }, callOptions: .init())
+    for try await response in call.responses {
+      // Expand splits on spaces, so we only expect one response.
+      await assertThat(response, .is(.with { $0.text = "hello :)0( dnapxe ohce tfiwS" }))
+    }
+  } }
+  
+  func testBidirectionalStreaming() { XCTAsyncTest {
+    let requests = ["1 2", "3 4"].map { item in
+      Echo_EchoRequest.with { $0.text = item }
+    }
+    let responses = self.echo.update(requests, callOptions: .init())
+    
+    var count = 0
+    for try await response in responses {
+      switch count {
+      case 0:
+        await assertThat(response, .is(.with { $0.text = "1 2 :)0( etadpu ohce tfiwS" }))
+      case 1:
+        await assertThat(response, .is(.with { $0.text = "3 4 :)1( etadpu ohce tfiwS" }))
+      default:
+        XCTFail("Got more than 2 responses")
+      }
+      count += 1
+    }
+  } }
+  
+  func testMakingCallBidirectionalStreaming() { XCTAsyncTest {
+    let call = self.echo.makeUpdateCall(callOptions: .init())
+    try await call.requestStream.send(.with { $0.text = "1 2" })
+    try await call.requestStream.send(.with { $0.text = "3 4" })
+    try await call.requestStream.finish()
+    
+    var count = 0
+    for try await response in call.responses {
+      switch count {
+      case 0:
+        await assertThat(response, .is(.with { $0.text = "1 2 :)0( etadpu ohce tfiwS" }))
+      case 1:
+        await assertThat(response, .is(.with { $0.text = "3 4 :)1( etadpu ohce tfiwS" }))
+      default:
+        XCTFail("Got more than 2 responses")
+      }
+      count += 1
+    }
+  } }
+  
+}
+
+#endif

--- a/Tests/GRPCTests/InterceptorsAsyncTests.swift
+++ b/Tests/GRPCTests/InterceptorsAsyncTests.swift
@@ -81,7 +81,6 @@ class InterceptorsAsyncTests: GRPCTestCase {
   func testMakingUnaryCall() { XCTAsyncTest {
     let call = self.echo.makeGetCall(.with { $0.text = "hello" })
     await assertThat(try await call.response, .is(.with { $0.text = "hello :teg ohce tfiwS" }))
-    await assertThat(await call.status, .hasCode(.ok))
   } }
   
   func testClientStreamingSequence() { XCTAsyncTest {

--- a/Tests/GRPCTests/InterceptorsTests.swift
+++ b/Tests/GRPCTests/InterceptorsTests.swift
@@ -335,7 +335,7 @@ class EchoReverseInterceptor: ClientInterceptor<Echo_EchoRequest, Echo_EchoRespo
   }
 }
 
-private class ReversingInterceptors: Echo_EchoClientInterceptorFactoryProtocol {
+class ReversingInterceptors: Echo_EchoClientInterceptorFactoryProtocol {
   // This interceptor is stateless, let's just share it.
   private let interceptors = [EchoReverseInterceptor()]
 


### PR DESCRIPTION
Currently interceptors does not propagated to calls. Seems like it was forgotten to be implemented in this alpha implementation.