### PR TITLE
Log connectivity changes at debug level

### DIFF
--- a/Sources/GRPC/ConnectivityState.swift
+++ b/Sources/GRPC/ConnectivityState.swift
@@ -119,7 +119,7 @@ public class ConnectivityStateMonitor {
     }
 
     if let (oldState, newState) = change {
-      logger.info("connectivity state change", metadata: [
+      logger.debug("connectivity state change", metadata: [
         "old_state": "\(oldState)",
         "new_state": "\(newState)",
       ])


### PR DESCRIPTION
Motivation:

gRPC should only log at debug/trace. This one was missed.

Modifications:

- Log connectivity changes at debug level

Result:

No more info level logs.