### PR TITLE
Bump version number to 1.4.2

### DIFF
--- a/Sources/GRPC/Version.swift
+++ b/Sources/GRPC/Version.swift
@@ -22,7 +22,7 @@ internal enum Version {
   internal static let minor = 4
 
   /// The patch version.
-  internal static let patch = 1
+  internal static let patch = 2
 
   /// The version string.
   internal static let versionString = "\(major).\(minor).\(patch)"

--- a/dev/version-bump.commit.template
+++ b/dev/version-bump.commit.template
@@ -1,0 +1,14 @@
+Bump version number to VERSION
+
+Motivation:
+
+We plan on tagging a release soon.
+
+Modifications:
+
+- Bump the version to VERSION
+
+Result:
+
+The version in the default user-agent string will match the released
+version.


### PR DESCRIPTION
Motivation:

We plan on tagging a release soon.

Modifications:

- Bump the version to 1.4.2
- Add a commit template for version bumps, because the commit is always
  the same (unless I'm adding a commit template as well).

Result:

The version in the default user-agent string will match the released
version.