### PR TITLE
Update allocation limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Latest Version](https://img.shields.io/github/v/release/grpc/grpc-swift?include_prereleases&sort=semver)](https://img.shields.io/github/v/release/grpc/grpc-swift?include_prereleases&sort=semver)
 [![sswg:graduated|104x20](https://img.shields.io/badge/sswg-graduated-green.svg)](https://github.com/swift-server/sswg/blob/main/process/incubation.md#graduated-level)
 
+
 # gRPC Swift
 
 This repository contains a gRPC Swift API and code generator.


### PR DESCRIPTION
Motivation:

The latest version of swift-nio-http2 reduces allocations so our alloc
limits are now likely to be a bit off.

Modifications:

- Update allocation limits.

Result:

CI passes.