### PR TITLE
Wire up connection backoff of channel pool

### DIFF
--- a/Sources/GRPC/ConnectionPool/ConnectionPool.swift
+++ b/Sources/GRPC/ConnectionPool/ConnectionPool.swift
@@ -70,6 +70,10 @@ internal final class ConnectionPool {
   @usableFromInline
   internal let maxWaiters: Int
 
+  /// Configuration for backoff between subsequence connection attempts.
+  @usableFromInline
+  internal let connectionBackoff: ConnectionBackoff
+
   /// Provides a channel factory to the `ConnectionManager`.
   @usableFromInline
   internal let channelProvider: ConnectionManagerChannelProvider
@@ -125,6 +129,7 @@ internal final class ConnectionPool {
     maxWaiters: Int,
     reservationLoadThreshold: Double,
     assumedMaxConcurrentStreams: Int,
+    connectionBackoff: ConnectionBackoff,
     channelProvider: ConnectionManagerChannelProvider,
     streamLender: StreamLender,
     logger: GRPCLogger,
@@ -142,6 +147,7 @@ internal final class ConnectionPool {
     self.waiters = CircularBuffer(initialCapacity: 16)
 
     self.eventLoop = eventLoop
+    self.connectionBackoff = connectionBackoff
     self.channelProvider = channelProvider
     self.streamLender = streamLender
     self.logger = logger
@@ -165,7 +171,7 @@ internal final class ConnectionPool {
       eventLoop: self.eventLoop,
       channelProvider: self.channelProvider,
       callStartBehavior: .waitsForConnectivity,
-      connectionBackoff: ConnectionBackoff(),
+      connectionBackoff: self.connectionBackoff,
       connectivityDelegate: self,
       http2Delegate: self,
       logger: self.logger.unwrapped

--- a/Sources/GRPC/ConnectionPool/PoolManager.swift
+++ b/Sources/GRPC/ConnectionPool/PoolManager.swift
@@ -45,6 +45,9 @@ internal final class PoolManager {
       return self.maxConnections * self.assumedMaxConcurrentStreams
     }
 
+    @usableFromInline
+    var connectionBackoff: ConnectionBackoff
+
     /// A `Channel` provider.
     @usableFromInline
     var channelProvider: DefaultChannelProvider
@@ -55,12 +58,14 @@ internal final class PoolManager {
       maxWaiters: Int,
       loadThreshold: Double,
       assumedMaxConcurrentStreams: Int = 100,
+      connectionBackoff: ConnectionBackoff,
       channelProvider: DefaultChannelProvider
     ) {
       self.maxConnections = maxConnections
       self.maxWaiters = maxWaiters
       self.loadThreshold = loadThreshold
       self.assumedMaxConcurrentStreams = assumedMaxConcurrentStreams
+      self.connectionBackoff = connectionBackoff
       self.channelProvider = channelProvider
     }
   }
@@ -211,6 +216,7 @@ internal final class PoolManager {
         maxWaiters: configuration.maxWaiters,
         reservationLoadThreshold: configuration.loadThreshold,
         assumedMaxConcurrentStreams: configuration.assumedMaxConcurrentStreams,
+        connectionBackoff: configuration.connectionBackoff,
         channelProvider: configuration.channelProvider,
         streamLender: self,
         logger: logger

--- a/Sources/GRPC/ConnectionPool/PooledChannel.swift
+++ b/Sources/GRPC/ConnectionPool/PooledChannel.swift
@@ -72,6 +72,7 @@ internal final class PooledChannel: GRPCChannel {
         maxWaiters: configuration.connectionPool.maxWaitersPerEventLoop,
         loadThreshold: configuration.connectionPool.reservationLoadThreshold,
         assumedMaxConcurrentStreams: 100,
+        connectionBackoff: configuration.connectionBackoff,
         channelProvider: provider
       ),
       logger: configuration.backgroundActivityLogger.wrapped

--- a/Tests/GRPCTests/ConnectionPool/PoolManagerStateMachineTests.swift
+++ b/Tests/GRPCTests/ConnectionPool/PoolManagerStateMachineTests.swift
@@ -25,6 +25,7 @@ class PoolManagerStateMachineTests: GRPCTestCase {
     maxWaiters: Int = 100,
     maxConcurrentStreams: Int = 100,
     loadThreshold: Double = 0.9,
+    connectionBackoff: ConnectionBackoff = ConnectionBackoff(),
     makeChannel: @escaping (ConnectionManager, EventLoop) -> EventLoopFuture<Channel>
   ) -> ConnectionPool {
     return ConnectionPool(
@@ -32,6 +33,7 @@ class PoolManagerStateMachineTests: GRPCTestCase {
       maxWaiters: maxWaiters,
       reservationLoadThreshold: loadThreshold,
       assumedMaxConcurrentStreams: maxConcurrentStreams,
+      connectionBackoff: connectionBackoff,
       channelProvider: HookedChannelProvider(makeChannel),
       streamLender: HookedStreamLender(
         onReturnStreams: { _ in },


### PR DESCRIPTION
Motivation:

`GRPCChannelPool.Configuration` has an entry controlling connection
backoff configuration. However this was never wired up to the underlying
connection pool and connections which just use the defaults.

Modifications:

- Propagate connection backoff through the API
- Add a test

Result:

Connection backoff is wired up as expected for `GRPCChannelPool`.