### PR TITLE
Add a 'cause' to 'GRPCStatus'

### DIFF
--- a/Sources/GRPC/GRPCStatus.swift
+++ b/Sources/GRPC/GRPCStatus.swift
@@ -20,11 +20,68 @@ import NIOHTTP2
 
 /// Encapsulates the result of a gRPC call.
 public struct GRPCStatus: Error {
-  /// The status message of the RPC.
-  public var message: String?
+  /// Storage for message/cause. In the happy case ('ok') there will not be a message or cause
+  /// and this will reference a static storage containing nil values. Making it optional makes the
+  /// setters for message and cause a little messy.
+  private var storage: Storage = .makeStorage(message: nil, cause: nil)
 
   /// The status code of the RPC.
   public var code: Code
+
+  /// The status message of the RPC.
+  public var message: String? {
+    get {
+      return self.storage.message
+    }
+    set {
+      if isKnownUniquelyReferenced(&self.storage) {
+        self.storage.message = newValue
+      } else {
+        self.storage = .makeStorage(message: newValue, cause: self.storage.cause)
+      }
+    }
+  }
+
+  /// The cause of an error (not 'ok') status. This value is never transmitted over the wire and is
+  /// **not** included in equality checks.
+  public var cause: Error? {
+    get {
+      return self.storage.cause
+    }
+    set {
+      if isKnownUniquelyReferenced(&self.storage) {
+        self.storage.cause = newValue
+      } else {
+        self.storage = .makeStorage(message: self.storage.message, cause: newValue)
+      }
+    }
+  }
+
+  // Backing storage for 'message' and 'cause'.
+  private final class Storage {
+    // On many happy paths there will be no message or cause, so we'll use this shared reference
+    // instead of allocating a new storage each time.
+    //
+    // Alternatively: `GRPCStatus` could hold a storage optionally however doing so made the code
+    // quite unreadable.
+    private static let none = Storage(message: nil, cause: nil)
+
+    private init(message: String?, cause: Error?) {
+      self.message = message
+      self.cause = cause
+    }
+
+    fileprivate var message: Optional<String>
+    fileprivate var cause: Optional<Error>
+
+    fileprivate static func makeStorage(message: String?, cause: Error?) -> Storage {
+      if message == nil, cause == nil {
+        return Storage.none
+      } else {
+        return Storage(message: message, cause: cause)
+      }
+    }
+  }
 
   /// Whether the status is '.ok'.
   public var isOk: Bool {
@@ -32,8 +89,12 @@ public struct GRPCStatus: Error {
   }
 
   public init(code: Code, message: String?) {
+    self.init(code: code, message: message, cause: nil)
+  }
+
+  public init(code: Code, message: String? = nil, cause: Error? = nil) {
     self.code = code
-    self.message = message
+    self.storage = .makeStorage(message: message, cause: cause)
   }
 
   // Frequently used "default" statuses.
@@ -63,6 +124,12 @@ extension GRPCStatus: CustomStringConvertible {
     } else {
       return "\(self.code)"
     }
+  }
+}
+
+extension GRPCStatus {
+  internal var testingOnly_storageObjectIdentifier: ObjectIdentifier {
+    return ObjectIdentifier(self.storage)
   }
 }
 
@@ -257,13 +324,13 @@ extension GRPCStatus: GRPCStatusTransformable {
 
 extension NIOHTTP2Errors.StreamClosed: GRPCStatusTransformable {
   public func makeGRPCStatus() -> GRPCStatus {
-    return .init(code: .unavailable, message: self.localizedDescription)
+    return .init(code: .unavailable, message: self.localizedDescription, cause: self)
   }
 }
 
 extension NIOHTTP2Errors.IOOnClosedConnection: GRPCStatusTransformable {
   public func makeGRPCStatus() -> GRPCStatus {
-    return .init(code: .unavailable, message: "The connection is closed")
+    return .init(code: .unavailable, message: "The connection is closed", cause: self)
   }
 }
 
@@ -271,10 +338,12 @@ extension ChannelError: GRPCStatusTransformable {
   public func makeGRPCStatus() -> GRPCStatus {
     switch self {
     case .inputClosed, .outputClosed, .ioOnClosedChannel:
-      return .init(code: .unavailable, message: "The connection is closed")
+      return .init(code: .unavailable, message: "The connection is closed", cause: self)
 
     default:
-      return .processingError
+      var processingError = GRPCStatus.processingError
+      processingError.cause = self
+      return processingError
     }
   }
 }

--- a/Sources/GRPC/GRPCStatus.swift
+++ b/Sources/GRPC/GRPCStatus.swift
@@ -23,7 +23,7 @@ public struct GRPCStatus: Error {
   /// Storage for message/cause. In the happy case ('ok') there will not be a message or cause
   /// and this will reference a static storage containing nil values. Making it optional makes the
   /// setters for message and cause a little messy.
-  private var storage: Storage = .makeStorage(message: nil, cause: nil)
+  private var storage: Storage
 
   /// The status code of the RPC.
   public var code: Code


### PR DESCRIPTION
Motivation:

In some causes it's useful to know the underlying error which caused an
RPC to complete with a particular status. The current way of achieving
this is by embeddeding it in the status message. While the information
may be relevant to some callers it is noise to others. Moreover, to
those that want the information, they have to know how to search for it
(some strings may embed errors in different ways and so on). This also
precludes them from being able to switch on a particular error type, for
example.

Modifications:

- Add an optional 'cause' field to 'GRPCStatus', an error associated
  with the status.
- Adding cause directly into 'GRPCStatus' made it a little too wide so a
  backing storage was added for the storage and message. This is a bit
  of a shame since we now unconditionally allocate for messages but the
  happy path ('ok') should be without message or cause and so should not
  allocate.

Result:

- Causal errors can be attached to 'GRPCStatus'