### PR TITLE
Provide more context to failing RPCs from the connection pool

### DIFF
--- a/Sources/GRPC/ConnectionManager+Delegates.swift
+++ b/Sources/GRPC/ConnectionManager+Delegates.swift
@@ -23,8 +23,8 @@ internal protocol ConnectionManagerConnectivityDelegate {
   ///   - newState: The current `ConnectivityState`.
   func connectionStateDidChange(
     _ connectionManager: ConnectionManager,
-    from oldState: ConnectivityState,
-    to newState: ConnectivityState
+    from oldState: _ConnectivityState,
+    to newState: _ConnectivityState
   )
 
   /// The connection is quiescing.
@@ -50,4 +50,45 @@ internal protocol ConnectionManagerHTTP2Delegate {
     _ connectionManager: ConnectionManager,
     maxConcurrentStreams: Int
   )
+}
+
+// This mirrors `ConnectivityState` (which is public API) but adds `Error` as associated data
+// to a few cases.
+internal enum _ConnectivityState {
+  case idle(Error?)
+  case connecting
+  case ready
+  case transientFailure(Error)
+  case shutdown
+
+  /// Returns whether this state is the same as the other state (ignoring any associated data).
+  internal func isSameState(as other: _ConnectivityState) -> Bool {
+    switch (self, other) {
+    case (.idle, .idle),
+         (.connecting, .connecting),
+         (.ready, .ready),
+         (.transientFailure, .transientFailure),
+         (.shutdown, .shutdown):
+      return true
+    default:
+      return false
+    }
+  }
+}
+
+extension ConnectivityState {
+  internal init(_ state: _ConnectivityState) {
+    switch state {
+    case .idle:
+      self = .idle
+    case .connecting:
+      self = .connecting
+    case .ready:
+      self = .ready
+    case .transientFailure:
+      self = .transientFailure
+    case .shutdown:
+      self = .shutdown
+    }
+  }
 }

--- a/Sources/GRPC/ConnectivityState.swift
+++ b/Sources/GRPC/ConnectivityState.swift
@@ -144,10 +144,10 @@ public class ConnectivityStateMonitor {
 extension ConnectivityStateMonitor: ConnectionManagerConnectivityDelegate {
   internal func connectionStateDidChange(
     _ connectionManager: ConnectionManager,
-    from oldState: ConnectivityState,
-    to newState: ConnectivityState
+    from oldState: _ConnectivityState,
+    to newState: _ConnectivityState
   ) {
-    self.updateState(to: newState, logger: connectionManager.logger)
+    self.updateState(to: ConnectivityState(newState), logger: connectionManager.logger)
   }
 
   internal func connectionIsQuiescing(_ connectionManager: ConnectionManager) {

--- a/Tests/GRPCTests/ConnectionPool/GRPCChannelPoolTests.swift
+++ b/Tests/GRPCTests/ConnectionPool/GRPCChannelPoolTests.swift
@@ -19,6 +19,7 @@ import GRPC
 import GRPCSampleData
 import NIO
 import NIOConcurrencyHelpers
+import NIOSSL
 import XCTest
 
 final class GRPCChannelPoolTests: GRPCTestCase {
@@ -107,7 +108,7 @@ final class GRPCChannelPoolTests: GRPCTestCase {
     self.startChannel(withTLS: tls) {
       // We'll allow any number of waiters since we immediately fire off a bunch of RPCs and don't
       // want to bounce off the limit as we wait for a connection to come up.
-      $0.connectionPool.maxWaitersPerEventLoop = .max
+      $0.connectionPool.maxWaitersPerEventLoop = 1000
     }
   }
 
@@ -380,5 +381,56 @@ final class GRPCChannelPoolTests: GRPCTestCase {
     let timedOutOnOwnDeadline = self.echo.get(.with { $0.text = "" }, callOptions: options)
 
     XCTAssertEqual(try timedOutOnOwnDeadline.status.wait().code, .deadlineExceeded)
+  }
+
+  func testTLSFailuresAreClearerAtTheRPCLevel() throws {
+    // Mix and match TLS.
+    self.configureEventLoopGroup(threads: 1)
+    self.startServer(withTLS: false)
+    self.startChannel(withTLS: true) {
+      $0.connectionPool.maxWaitersPerEventLoop = 10
+    }
+
+    // We can't guarantee an error happens within a certain time limit, so if we don't see what we
+    // expect we'll loop until a given deadline passes.
+    let testDeadline = NIODeadline.now() + .seconds(5)
+    var seenError = false
+    while testDeadline > .now() {
+      let options = CallOptions(timeLimit: .deadline(.now() + .milliseconds(50)))
+      let get = self.echo.get(.with { $0.text = "foo" }, callOptions: options)
+
+      let status = try get.status.wait()
+      XCTAssertEqual(status.code, .deadlineExceeded)
+
+      if let cause = status.cause, cause is NIOSSLError {
+        // What we expect.
+        seenError = true
+        break
+      } else {
+        // Try again.
+        continue
+      }
+    }
+    XCTAssert(seenError)
+
+    // Now queue up a bunch of RPCs to fill up the waiter queue. We don't care about the outcome
+    // of these. (They'll fail when we tear down the pool at the end of the test.)
+    _ = (0 ..< 10).map { i -> UnaryCall<Echo_EchoRequest, Echo_EchoResponse> in
+      let options = CallOptions(timeLimit: .deadline(.distantFuture))
+      return self.echo.get(.with { $0.text = String(describing: i) }, callOptions: options)
+    }
+
+    // Queue up one more.
+    let options = CallOptions(timeLimit: .deadline(.distantFuture))
+    let tooManyWaiters = self.echo.get(.with { $0.text = "foo" }, callOptions: options)
+
+    let status = try tooManyWaiters.status.wait()
+    XCTAssertEqual(status.code, .resourceExhausted)
+
+    if let cause = status.cause {
+      XCTAssert(cause is NIOSSLError)
+    } else {
+      XCTFail("Status message did not contain a possible cause: '\(status.message ?? "nil")'")
+    }
   }
 }

--- a/Tests/GRPCTests/ConnectionPool/GRPCChannelPoolTests.swift
+++ b/Tests/GRPCTests/ConnectionPool/GRPCChannelPoolTests.swift
@@ -108,7 +108,7 @@ final class GRPCChannelPoolTests: GRPCTestCase {
     self.startChannel(withTLS: tls) {
       // We'll allow any number of waiters since we immediately fire off a bunch of RPCs and don't
       // want to bounce off the limit as we wait for a connection to come up.
-      $0.connectionPool.maxWaitersPerEventLoop = 1000
+      $0.connectionPool.maxWaitersPerEventLoop = .max
     }
   }
 

--- a/Tests/GRPCTests/GRPCStatusTests.swift
+++ b/Tests/GRPCTests/GRPCStatusTests.swift
@@ -77,7 +77,7 @@ class GRPCStatusTests: GRPCTestCase {
     // No message/cause, so uses the nil backing storage.
     XCTAssertEqual(status.testingOnly_storageObjectIdentifier, nilStorageID)
 
-    status.cause = ConnectionPoolError.tooManyWaiters
+    status.cause = ConnectionPoolError.tooManyWaiters(connectionError: nil)
     let storageID = status.testingOnly_storageObjectIdentifier
     XCTAssertNotEqual(storageID, nilStorageID)
     XCTAssert(status.cause is ConnectionPoolError)


### PR DESCRIPTION
Motivation:

When an RPC is started using the connection pool, it waits for a
connection to come up and a stream to be created. It may also time out
waiting for the connection to come up, this may be because the pool is
genuinely too busy to handle the RPC or there is an underlying problem
with the connection.

In the latter case it's not possible for the RPC to see the underlying
reason that it timed out. This makes issue diagnosis more difficult than
necessary when there root cause is at the connection level (e.g. due to TLS
configuration) as important but infrequent connection-level errors are
lost in the noise of RPC-level timeouts.

Modifications:

- Give connection pools a notion of a 'last known error', the most
  recent connection-level error to occur on a connection managed by the
  pool. The error is cleared as soon as any connection within the pool
  becomes available. This error is added to existing waiter errors to
  provide more context.
- Add a '_ConnectivityState' mirroring the public 'ConnectivityState'
  but which holds 'Error' as associated data in some cases.
- Wire this through the `ConnectionManager` to the `ConnectionPool`

Result:

Connection level errors are more obvious.