### PR TITLE
Update examples to use channel pool

### DIFF
--- a/Sources/Examples/HelloWorld/Client/main.swift
+++ b/Sources/Examples/HelloWorld/Client/main.swift
@@ -56,8 +56,11 @@ struct HelloWorld: ParsableCommand {
     }
 
     // Configure the channel, we're not using TLS so the connection is `insecure`.
-    let channel = ClientConnection.insecure(group: group)
-      .connect(host: "localhost", port: self.port)
+    let channel = try GRPCChannelPool.with(
+      target: .host("localhost", port: self.port),
+      transportSecurity: .plaintext,
+      eventLoopGroup: group
+    )
 
     // Close the connection when we're done with it.
     defer {

--- a/docs/basic-tutorial.md
+++ b/docs/basic-tutorial.md
@@ -469,8 +469,8 @@ To call service methods, we first need to create a *stub*. All generated Swift
 stubs are *non-blocking/asynchronous*.
 
 First we need to create a gRPC channel for our stub, we're not using TLS so we
-use the `insecure` builder and specify the server address and port we want to
-connect to:
+use the `.plaintext` security transport and specify the server address and port
+we want to connect to:
 
 ```swift
 let group = PlatformSupport.makeEventLoopGroup(loopCount: 1)
@@ -478,8 +478,11 @@ defer {
   try? group.syncShutdownGracefully()
 }
 
-let channel = ClientConnection.insecure(group: group)
-  .connect(host: "localhost", port: port)
+let channel = try GRPCChannelPool.with(
+  target: .host("localhost", port: port),
+  transportSecurity: .plaintext,
+  eventLoopGroup: group
+)
 
 let client = Routeguide_RouteGuideClient(channel: channel)
 ```

--- a/docs/client-without-codegen.md
+++ b/docs/client-without-codegen.md
@@ -8,8 +8,8 @@ can use `AnyServiceClient`. For example, to call the "SayHello" RPC on the
 [Greeter][helloworld-source] service you can do the following:
 
 ```swift
-let connection = ... // get a ClientConnection
-let anyService = AnyServiceClient(connection: connection)
+let channel = ... // get a GRPCChannel
+let anyService = AnyServiceClient(channel: channel)
 
 let sayHello = anyService.makeUnaryCall(
   path: "/helloworld.Greeter/SayHello",

--- a/docs/keepalive.md
+++ b/docs/keepalive.md
@@ -2,11 +2,11 @@
 
 gRPC sends HTTP2 pings on the transport to detect if the connection is down.
 If the ping is not acknowledged by the other side within a certain period, the connection
-will be closed. Note that pings are only necessary when there is no activity on the connection. 
+will be closed. Note that pings are only necessary when there is no activity on the connection.
 
 ## What should I set?
 
-It should be sufficient for most users to only change `interval` and `timeout` properties, but the 
+It should be sufficient for most users to only change `interval` and `timeout` properties, but the
 following properties can also be useful in certain use cases.
 
 Property | Client | Server | Description
@@ -19,7 +19,7 @@ minimumSentPingIntervalWithoutData|.minutes(5)|.minutes(5)|If there are no data/
 minimumReceivedPingIntervalWithoutData|N/A|.minutes(5)|If there are no data/header frames being sent: the minimum amount of time expected between receiving successive pings. If the time between successive pings is less than this value, then the ping will be considered a bad ping from the peer. Such a ping counts as a "ping strike".
 maximumPingStrikes|N/A|2|Maximum number of bad pings that the server will tolerate before sending an HTTP2 GOAWAY frame and closing the connection. Setting it to `0` allows the server to accept any number of bad pings.
 
-### Client 
+### Client
 
 ```swift
 let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
@@ -29,13 +29,14 @@ let keepalive = ClientConnectionKeepalive(
   timeout: .seconds(10)
 )
 
-let configuration = ClientConnection.Configuration(
-  target: .hostAndPort("localhost", 443),
-  eventLoopGroup: group,
-  connectionKeepalive: keepalive
-)
-
-let client = ClientConnection(configuration: configuration)
+let channel = try GRPCChannelPool.with(
+  target: .host("localhost"),
+  transportSecurity: .tls(...),
+  eventLoopGroup: group
+) {
+  // Configure keepalive.
+  $0.keepalive = keepalive
+}
 ```
 
 ### Server


### PR DESCRIPTION
Motivation:

Examples are still using `ClientConnection`. They should use
`GRPCChannelPool` instead.

Modifications:

- Update echo, helloworld, and routeguide
- Update tutorials

Result:

Examples and tutorials are more up-to-date