### PR TITLE
Upload linux release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  release:
+    types: [ created ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      
+      - name: Extract release version
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - name: Build the plugins
+        run: make plugins
+
+      - name: Zip the plugins
+        run: |
+          zip protoc-grpc-swift-plugins-linux-x86_64-${{ env.RELEASE_VERSION }}.zip protoc-gen-swift protoc-gen-grpc-swift
+      
+      - name: Upload artifacts
+        uses: softprops/action-gh-release@v1
+        with:
+          files: protoc-grpc-swift-plugins-linux-x86_64-${{ env.RELEASE_VERSION }}.zip


### PR DESCRIPTION
To make the consumption of the two protoc plugins a bit easier, I created a GH Action pipeline that is triggered when a release is created. This pipeline builds the artifacts, zips them, and then attaches them to the release.