### PR TITLE
Bump version number to 1.4.1-async-await.3

### DIFF
--- a/Sources/GRPC/Version.swift
+++ b/Sources/GRPC/Version.swift
@@ -25,5 +25,5 @@ internal enum Version {
   internal static let patch = 1
 
   /// The version string.
-  internal static let versionString = "\(major).\(minor).\(patch)-async-await.2"
+  internal static let versionString = "\(major).\(minor).\(patch)-async-await.3"
 }


### PR DESCRIPTION
Motivation:

We plan on tagging a release soon.

Modifications:

- Bump the version to 1.4.1-async-await.3

Result:

The version in the default user-agent string will match the released
version.