### PR TITLE
Use more accurate imports

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -80,8 +80,14 @@ let package = Package(
         .target(name: "GRPCInteroperabilityTestsImplementation"),
         .target(name: "HelloWorldModel"),
         .product(name: "NIOCore", package: "swift-nio"),
+        .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
         .product(name: "NIOPosix", package: "swift-nio"),
+        .product(name: "NIOTLS", package: "swift-nio"),
+        .product(name: "NIOHTTP1", package: "swift-nio"),
+        .product(name: "NIOHTTP2", package: "swift-nio-http2"),
         .product(name: "NIOEmbedded", package: "swift-nio"),
+        .product(name: "NIOTransportServices", package: "swift-nio-transport-services"),
+        .product(name: "Logging", package: "swift-log"),
       ]
     ),
 

--- a/Package.swift
+++ b/Package.swift
@@ -279,8 +279,10 @@ let package = Package(
       name: "RouteGuideServer",
       dependencies: [
         .target(name: "GRPC"),
-        .product(name: "NIO", package: "swift-nio"),
         .target(name: "RouteGuideModel"),
+        .product(name: "NIOCore", package: "swift-nio"),
+        .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
+        .product(name: "NIOPosix", package: "swift-nio"),
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
       ],
       path: "Sources/Examples/RouteGuide/Server"

--- a/Package.swift
+++ b/Package.swift
@@ -125,7 +125,11 @@ let package = Package(
     .target(
       name: "GRPCInteroperabilityTests",
       dependencies: [
+        .target(name: "GRPC"),
         .target(name: "GRPCInteroperabilityTestsImplementation"),
+        .product(name: "NIOCore", package: "swift-nio"),
+        .product(name: "NIOPosix", package: "swift-nio"),
+        .product(name: "Logging", package: "swift-log"),
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
       ]
     ),

--- a/Package.swift
+++ b/Package.swift
@@ -107,6 +107,11 @@ let package = Package(
       dependencies: [
         .target(name: "GRPC"),
         .target(name: "GRPCInteroperabilityTestModels"),
+        .product(name: "NIOCore", package: "swift-nio"),
+        .product(name: "NIOPosix", package: "swift-nio"),
+        .product(name: "NIOHTTP2", package: "swift-nio-http2"),
+        .product(name: "NIOSSL", package: "swift-nio-ssl"),
+        .product(name: "Logging", package: "swift-log"),
       ]
     ),
 

--- a/Package.swift
+++ b/Package.swift
@@ -294,8 +294,10 @@ let package = Package(
       dependencies: [
         .target(name: "GRPC"),
         .target(name: "EchoModel"),
-        .product(name: "NIO", package: "swift-nio"),
+        .product(name: "NIOCore", package: "swift-nio"),
+        .product(name: "NIOPosix", package: "swift-nio"),
         .product(name: "NIOExtras", package: "swift-nio-extras"),
+        .product(name: "Logging", package: "swift-log"),
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
       ],
       path: "Sources/Examples/PacketCapture"

--- a/Package.swift
+++ b/Package.swift
@@ -144,6 +144,8 @@ let package = Package(
       dependencies: [
         .target(name: "GRPC"),
         .target(name: "GRPCInteroperabilityTestModels"),
+        .product(name: "NIOCore", package: "swift-nio"),
+        .product(name: "NIOPosix", package: "swift-nio"),
         .product(name: "Logging", package: "swift-log"),
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
       ]

--- a/Package.swift
+++ b/Package.swift
@@ -230,6 +230,8 @@ let package = Package(
       dependencies: [
         .target(name: "GRPC"),
         .target(name: "HelloWorldModel"),
+        .product(name: "NIOCore", package: "swift-nio"),
+        .product(name: "NIOPosix", package: "swift-nio"),
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
       ],
       path: "Sources/Examples/HelloWorld/Client"

--- a/Package.swift
+++ b/Package.swift
@@ -121,7 +121,6 @@ let package = Package(
       dependencies: [
         .target(name: "GRPC"),
         .product(name: "NIO", package: "swift-nio"),
-        .product(name: "NIOHTTP1", package: "swift-nio"),
         .product(name: "SwiftProtobuf", package: "SwiftProtobuf"),
       ]
     ),

--- a/Package.swift
+++ b/Package.swift
@@ -180,7 +180,10 @@ let package = Package(
         .target(name: "EchoImplementation"),
         .target(name: "GRPC"),
         .target(name: "GRPCSampleData"),
-        .product(name: "SwiftProtobuf", package: "SwiftProtobuf"),
+        .product(name: "NIOCore", package: "swift-nio"),
+        .product(name: "NIOPosix", package: "swift-nio"),
+        .product(name: "NIOSSL", package: "swift-nio-ssl"),
+        .product(name: "Logging", package: "swift-log"),
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
       ],
       path: "Sources/Examples/Echo/Runtime"

--- a/Package.swift
+++ b/Package.swift
@@ -192,6 +192,8 @@ let package = Package(
       dependencies: [
         .target(name: "EchoModel"),
         .target(name: "GRPC"),
+        .product(name: "NIOCore", package: "swift-nio"),
+        .product(name: "NIOHTTP2", package: "swift-nio-http2"),
         .product(name: "SwiftProtobuf", package: "SwiftProtobuf"),
       ],
       path: "Sources/Examples/Echo/Implementation"

--- a/Package.swift
+++ b/Package.swift
@@ -242,8 +242,9 @@ let package = Package(
       name: "HelloWorldServer",
       dependencies: [
         .target(name: "GRPC"),
-        .product(name: "NIO", package: "swift-nio"),
         .target(name: "HelloWorldModel"),
+        .product(name: "NIOCore", package: "swift-nio"),
+        .product(name: "NIOPosix", package: "swift-nio"),
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
       ],
       path: "Sources/Examples/HelloWorld/Server"

--- a/Package.swift
+++ b/Package.swift
@@ -267,6 +267,8 @@ let package = Package(
       dependencies: [
         .target(name: "GRPC"),
         .target(name: "RouteGuideModel"),
+        .product(name: "NIOCore", package: "swift-nio"),
+        .product(name: "NIOPosix", package: "swift-nio"),
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
       ],
       path: "Sources/Examples/RouteGuide/Client"

--- a/Package.swift
+++ b/Package.swift
@@ -146,7 +146,10 @@ let package = Package(
       name: "GRPCPerformanceTests",
       dependencies: [
         .target(name: "GRPC"),
-        .product(name: "NIO", package: "swift-nio"),
+        .product(name: "NIOCore", package: "swift-nio"),
+        .product(name: "NIOEmbedded", package: "swift-nio"),
+        .product(name: "NIOPosix", package: "swift-nio"),
+        .product(name: "NIOHTTP2", package: "swift-nio-http2"),
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
       ]
     ),

--- a/Sources/Examples/Echo/Implementation/EchoProvider.swift
+++ b/Sources/Examples/Echo/Implementation/EchoProvider.swift
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 import EchoModel
-import Foundation
 import GRPC
-import NIO
+import NIOCore
 import SwiftProtobuf
 
 public class EchoProvider: Echo_EchoProvider {

--- a/Sources/Examples/Echo/Implementation/Interceptors.swift
+++ b/Sources/Examples/Echo/Implementation/Interceptors.swift
@@ -15,7 +15,7 @@
  */
 import EchoModel
 import GRPC
-import NIO
+import NIOCore
 
 // All client interceptors derive from the 'ClientInterceptor' base class. We know the request and
 // response types for all Echo RPCs are the same: so we'll use them concretely here, allowing us

--- a/Sources/Examples/Echo/Runtime/main.swift
+++ b/Sources/Examples/Echo/Runtime/main.swift
@@ -16,11 +16,11 @@
 import ArgumentParser
 import EchoImplementation
 import EchoModel
-import Foundation
 import GRPC
 import GRPCSampleData
 import Logging
-import NIO
+import NIOCore
+import NIOPosix
 import NIOSSL
 
 // MARK: - Argument parsing

--- a/Sources/Examples/HelloWorld/Client/main.swift
+++ b/Sources/Examples/HelloWorld/Client/main.swift
@@ -16,8 +16,8 @@
 import ArgumentParser
 import GRPC
 import HelloWorldModel
-import Logging
-import NIO
+import NIOCore
+import NIOPosix
 
 func greet(name: String?, client greeter: Helloworld_GreeterClient) {
   // Form the request with the name, if one was provided.

--- a/Sources/Examples/HelloWorld/Server/GreeterProvider.swift
+++ b/Sources/Examples/HelloWorld/Server/GreeterProvider.swift
@@ -15,7 +15,7 @@
  */
 import GRPC
 import HelloWorldModel
-import NIO
+import NIOCore
 
 class GreeterProvider: Helloworld_GreeterProvider {
   var interceptors: Helloworld_GreeterServerInterceptorFactoryProtocol?

--- a/Sources/Examples/HelloWorld/Server/main.swift
+++ b/Sources/Examples/HelloWorld/Server/main.swift
@@ -16,8 +16,8 @@
 import ArgumentParser
 import GRPC
 import HelloWorldModel
-import Logging
-import NIO
+import NIOCore
+import NIOPosix
 
 struct HelloWorld: ParsableCommand {
   @Option(help: "The port to listen on for new connections")

--- a/Sources/Examples/PacketCapture/main.swift
+++ b/Sources/Examples/PacketCapture/main.swift
@@ -18,8 +18,9 @@ import Dispatch
 import EchoModel
 import GRPC
 import Logging
-import NIO
+import NIOCore
 import NIOExtras
+import NIOPosix
 
 // Create a logger.
 let logger = Logger(label: "gRPC PCAP Demo")

--- a/Sources/Examples/RouteGuide/Client/main.swift
+++ b/Sources/Examples/RouteGuide/Client/main.swift
@@ -16,8 +16,8 @@
 import ArgumentParser
 import Foundation
 import GRPC
-import Logging
-import NIO
+import NIOCore
+import NIOPosix
 import RouteGuideModel
 
 /// Makes a `RouteGuide` client for a service hosted on "localhost" and listening on the given port.

--- a/Sources/Examples/RouteGuide/Server/RouteGuideProvider.swift
+++ b/Sources/Examples/RouteGuide/Server/RouteGuideProvider.swift
@@ -15,8 +15,8 @@
  */
 import Foundation
 import GRPC
-import NIO
 import NIOConcurrencyHelpers
+import NIOCore
 import RouteGuideModel
 
 class RouteGuideProvider: Routeguide_RouteGuideProvider {

--- a/Sources/Examples/RouteGuide/Server/main.swift
+++ b/Sources/Examples/RouteGuide/Server/main.swift
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 import ArgumentParser
-import Foundation
+import struct Foundation.Data
+import struct Foundation.URL
 import GRPC
-import Logging
-import NIO
+import NIOCore
+import NIOPosix
 import RouteGuideModel
-import SwiftProtobuf
 
 /// Loads the features from `route_guide_db.json`, assumed to be in the directory above this file.
 func loadFeatures() throws -> [Routeguide_Feature] {

--- a/Sources/GRPC/ConnectionPool/PooledChannel.swift
+++ b/Sources/GRPC/ConnectionPool/PooledChannel.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import Logging
-import NIO
+import NIOCore
 import NIOHTTP2
 import NIOSSL
 import SwiftProtobuf

--- a/Sources/GRPCConnectionBackoffInteropTest/main.swift
+++ b/Sources/GRPCConnectionBackoffInteropTest/main.swift
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 import ArgumentParser
-import Foundation
+import struct Foundation.Date
 import GRPC
 import GRPCInteroperabilityTestModels
 import Logging
-import NIO
+import NIOCore
+import NIOPosix
 
 // Notes from the test procedure are inline.
 // See: https://github.com/grpc/grpc/blob/master/doc/connection-backoff-interop-test-description.md

--- a/Sources/GRPCInteroperabilityTests/main.swift
+++ b/Sources/GRPCInteroperabilityTests/main.swift
@@ -18,8 +18,8 @@ import Foundation
 import GRPC
 import GRPCInteroperabilityTestsImplementation
 import Logging
-import NIO
-import NIOSSL
+import NIOCore
+import NIOPosix
 
 // Reduce stdout noise.
 LoggingSystem.bootstrap(StreamLogHandler.standardError)

--- a/Sources/GRPCInteroperabilityTestsImplementation/Assertions.swift
+++ b/Sources/GRPCInteroperabilityTestsImplementation/Assertions.swift
@@ -13,8 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Foundation
-import NIO
+import NIOCore
 
 /// Assertion error for interoperability testing.
 ///

--- a/Sources/GRPCInteroperabilityTestsImplementation/GRPCTestingConvenienceMethods.swift
+++ b/Sources/GRPCInteroperabilityTestsImplementation/GRPCTestingConvenienceMethods.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Foundation
+import struct Foundation.Data
 import GRPCInteroperabilityTestModels
 import NIOHPACK
 import SwiftProtobuf

--- a/Sources/GRPCInteroperabilityTestsImplementation/InteroperabilityTestCase.swift
+++ b/Sources/GRPCInteroperabilityTestsImplementation/InteroperabilityTestCase.swift
@@ -13,10 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Foundation
 import GRPC
-import NIO
-import NIOHTTP1
+import NIOCore
 
 public protocol InteroperabilityTest {
   /// Run a test case using the given connection.

--- a/Sources/GRPCInteroperabilityTestsImplementation/InteroperabilityTestCases.swift
+++ b/Sources/GRPCInteroperabilityTestsImplementation/InteroperabilityTestCases.swift
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Foundation
+import Dispatch
+import struct Foundation.Data
 import GRPC
 import GRPCInteroperabilityTestModels
 import NIOHPACK
-import NIOHTTP1
 
 /// This test verifies that implementations support zero-size messages. Ideally, client
 /// implementations would verify that the request and response were zero bytes serialized, but

--- a/Sources/GRPCInteroperabilityTestsImplementation/InteroperabilityTestClientConnection.swift
+++ b/Sources/GRPCInteroperabilityTestsImplementation/InteroperabilityTestClientConnection.swift
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Foundation
 import GRPC
-import NIO
+import NIOCore
 import NIOSSL
 
 public func makeInteroperabilityTestClientBuilder(

--- a/Sources/GRPCInteroperabilityTestsImplementation/InteroperabilityTestCredentials.swift
+++ b/Sources/GRPCInteroperabilityTestsImplementation/InteroperabilityTestCredentials.swift
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Foundation
 import NIOSSL
 
 /// Contains credentials used for the gRPC interoperability tests.

--- a/Sources/GRPCInteroperabilityTestsImplementation/InteroperabilityTestServer.swift
+++ b/Sources/GRPCInteroperabilityTestsImplementation/InteroperabilityTestServer.swift
@@ -13,10 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Foundation
 import GRPC
 import Logging
-import NIO
+import NIOCore
 import NIOSSL
 
 /// Makes a server for gRPC interoperability testing.

--- a/Sources/GRPCInteroperabilityTestsImplementation/ServerFeatures.swift
+++ b/Sources/GRPCInteroperabilityTestsImplementation/ServerFeatures.swift
@@ -13,10 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Foundation
-import GRPC
-import NIO
-import NIOHTTP1
 
 /// Server features which may be required for tests.
 ///

--- a/Sources/GRPCInteroperabilityTestsImplementation/TestServiceProvider.swift
+++ b/Sources/GRPCInteroperabilityTestsImplementation/TestServiceProvider.swift
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Foundation
+import struct Foundation.Data
 import GRPC
 import GRPCInteroperabilityTestModels
-import NIO
+import NIOCore
 
 /// A service provider for the gRPC interoperability test suite.
 ///

--- a/Sources/GRPCPerformanceTests/Benchmarks/EmbeddedClientThroughput.swift
+++ b/Sources/GRPCPerformanceTests/Benchmarks/EmbeddedClientThroughput.swift
@@ -16,7 +16,8 @@
 import struct Foundation.Data
 import GRPC
 import Logging
-import NIO
+import NIOCore
+import NIOEmbedded
 import NIOHPACK
 import NIOHTTP2
 

--- a/Sources/GRPCPerformanceTests/Benchmarks/EmbeddedServer.swift
+++ b/Sources/GRPCPerformanceTests/Benchmarks/EmbeddedServer.swift
@@ -15,7 +15,8 @@
  */
 import GRPC
 import Logging
-import NIO
+import NIOCore
+import NIOEmbedded
 import NIOHPACK
 import NIOHTTP2
 

--- a/Sources/GRPCPerformanceTests/Benchmarks/MinimalEchoProvider.swift
+++ b/Sources/GRPCPerformanceTests/Benchmarks/MinimalEchoProvider.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import GRPC
-import NIO
+import NIOCore
 
 /// The echo provider that comes with the example does some string processing, we'll avoid some of
 /// that here so we're looking at the right things.

--- a/Sources/GRPCPerformanceTests/Benchmarks/PercentEncoding.swift
+++ b/Sources/GRPCPerformanceTests/Benchmarks/PercentEncoding.swift
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Foundation
 import GRPC
-import NIO
+import NIOCore
 
 class PercentEncoding: Benchmark {
   let message: String

--- a/Sources/GRPCPerformanceTests/Benchmarks/ServerProvidingBenchmark.swift
+++ b/Sources/GRPCPerformanceTests/Benchmarks/ServerProvidingBenchmark.swift
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Foundation
 import GRPC
-import NIO
+import NIOCore
+import NIOPosix
 
 class ServerProvidingBenchmark: Benchmark {
   private let providers: [CallHandlerProvider]

--- a/Sources/GRPCPerformanceTests/Benchmarks/UnaryThroughput.swift
+++ b/Sources/GRPCPerformanceTests/Benchmarks/UnaryThroughput.swift
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Foundation
 import GRPC
-import NIO
+import NIOCore
+import NIOPosix
 
 /// Tests unary throughput by sending requests on a single connection.
 ///

--- a/Sources/GRPCPerformanceTests/main.swift
+++ b/Sources/GRPCPerformanceTests/main.swift
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 import ArgumentParser
-import Foundation
 import GRPC
 import Logging
-import NIO
-import NIOSSL
 
 let smallRequest = String(repeating: "x", count: 8)
 let largeRequest = String(repeating: "x", count: 1 << 16) // 65k

--- a/Sources/GRPCSampleData/GRPCSwiftCertificate.swift
+++ b/Sources/GRPCSampleData/GRPCSwiftCertificate.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Foundation
+import struct Foundation.Date
 import NIOSSL
 
 /// Wraps `NIOSSLCertificate` to provide the certificate common name and expiry date.

--- a/Tests/GRPCTests/ConnectionPool/GRPCChannelPoolTests.swift
+++ b/Tests/GRPCTests/ConnectionPool/GRPCChannelPoolTests.swift
@@ -17,8 +17,9 @@ import EchoImplementation
 import EchoModel
 import GRPC
 import GRPCSampleData
-import NIO
 import NIOConcurrencyHelpers
+import NIOCore
+import NIOPosix
 import NIOSSL
 import XCTest
 


### PR DESCRIPTION
Motivation:

Imports can quite easily get out of sync over time: a once
used import stops being used and sometimes new imports
are added but not declared in the target dependencies in the
package manifest.

Modifications:

- Remove unused imports where possible
- Replace NIO imports with NIOPosix and NIOCore where possible
- Add missing imports to Package.swift

Results:

Fewer unnecessary imports and a more accurate description
of our dependencies.