### PR TITLE
Remove client didSet state transition check

### DIFF
--- a/Sources/GRPC/GRPCClientStateMachine.swift
+++ b/Sources/GRPC/GRPCClientStateMachine.swift
@@ -131,41 +131,7 @@ struct GRPCClientStateMachine {
   }
 
   /// The current state of the state machine.
-  internal private(set) var state: State {
-    didSet {
-      switch (oldValue, self.state) {
-      // Any modifying transitions are fine.
-      case (.modifying, _),
-           (_, .modifying):
-        break
-
-      // All valid transitions:
-      case (.clientIdleServerIdle, .clientActiveServerIdle),
-           (.clientIdleServerIdle, .clientClosedServerClosed),
-           (.clientActiveServerIdle, .clientActiveServerActive),
-           (.clientActiveServerIdle, .clientClosedServerIdle),
-           (.clientActiveServerIdle, .clientClosedServerClosed),
-           (.clientClosedServerIdle, .clientClosedServerActive),
-           (.clientClosedServerIdle, .clientClosedServerClosed),
-           (.clientActiveServerActive, .clientClosedServerActive),
-           (.clientActiveServerActive, .clientClosedServerClosed),
-           (.clientClosedServerActive, .clientClosedServerClosed):
-        break
-
-      // Self transitions, also valid:
-      case (.clientIdleServerIdle, .clientIdleServerIdle),
-           (.clientActiveServerIdle, .clientActiveServerIdle),
-           (.clientClosedServerIdle, .clientClosedServerIdle),
-           (.clientActiveServerActive, .clientActiveServerActive),
-           (.clientClosedServerActive, .clientClosedServerActive),
-           (.clientClosedServerClosed, .clientClosedServerClosed):
-        break
-
-      default:
-        preconditionFailure("invalid state transition from '\(oldValue)' to '\(self.state)'")
-      }
-    }
-  }
+  internal private(set) var state: State
 
   /// The default user-agent string.
   private static let userAgent = "grpc-swift-nio/\(Version.versionString)"


### PR DESCRIPTION
Motivation:

`GRPCClientStateMachine.state` has a `didSet` to validate state
transitions. The presence of this block seems to trip up libbacktrace
when running with the scudo sanitizer. Moreover, the check is not
particularly helpful since we should always be transition to and from
the modifying state. This appears to have been leftover from when the
modifying state was introduced.

This is related to https://bugs.swift.org/browse/SR-15478.

Modifications:

Remove the didSet block for state in GRPCClientStateMachine.

Result:

We don't trip over in libbacktrace when running with scudo.