### PR TITLE
Allow gRPC to be built without NIOSSL

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,3 +89,27 @@ jobs:
       run: ./Performance/allocations/test-allocation-counts.sh
       env: ${{ matrix.env }}
       timeout-minutes: 20
+  integration-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: swift:5.4-focal
+          - image: swift:5.3-focal
+          - image: swift:5.2-bionic
+    name: Integration Tests on ${{ matrix.image }}
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.image }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build without NIOSSL
+      run: swift build
+      env:
+        GRPC_NO_NIO_SSL: 1
+      timeout-minutes: 20
+    - name: Test without NIOSSL
+      run: swift test --enable-test-discovery
+      env:
+        GRPC_NO_NIO_SSL: 1
+      timeout-minutes: 20

--- a/Package.swift
+++ b/Package.swift
@@ -15,298 +15,423 @@
  * limitations under the License.
  */
 import PackageDescription
+// swiftformat puts the next import before the tools version.
+// swiftformat:disable:next sortedImports
+import class Foundation.ProcessInfo
+
+let grpcPackageName = "grpc-swift"
+let grpcProductName = "GRPC"
+let cgrpcZlibProductName = "CGRPCZlib"
+let grpcTargetName = grpcProductName
+let cgrpcZlibTargetName = cgrpcZlibProductName
+
+let includeNIOSSL = ProcessInfo.processInfo.environment["GRPC_NO_NIO_SSL"] == nil
+
+// MARK: - Package Dependencies
+
+let packageDependencies: [Package.Dependency] = [
+  .package(
+    url: "https://github.com/apple/swift-nio.git",
+    from: "2.32.0"
+  ),
+  .package(
+    url: "https://github.com/apple/swift-nio-http2.git",
+    from: "1.18.2"
+  ),
+  .package(
+    url: "https://github.com/apple/swift-nio-transport-services.git",
+    from: "1.11.1"
+  ),
+  .package(
+    url: "https://github.com/apple/swift-nio-extras.git",
+    from: "1.4.0"
+  ),
+  .package(
+    name: "SwiftProtobuf",
+    url: "https://github.com/apple/swift-protobuf.git",
+    from: "1.9.0"
+  ),
+  .package(
+    url: "https://github.com/apple/swift-log.git",
+    from: "1.4.0"
+  ),
+  .package(
+    url: "https://github.com/apple/swift-argument-parser.git",
+    from: "1.0.0"
+  ),
+].appending(
+  .package(
+    url: "https://github.com/apple/swift-nio-ssl.git",
+    from: "2.14.0"
+  ),
+  if: includeNIOSSL
+)
+
+// MARK: - Target Dependencies
+
+extension Target.Dependency {
+  // Target dependencies; external
+  static let grpc: Self = .target(name: grpcTargetName)
+  static let cgrpcZlib: Self = .target(name: cgrpcZlibTargetName)
+  static let protocGenGRPCSwift: Self = .target(name: "protoc-gen-grpc-swift")
+
+  // Target dependencies; internal
+  static let grpcSampleData: Self = .target(name: "GRPCSampleData")
+  static let echoModel: Self = .target(name: "EchoModel")
+  static let echoImplementation: Self = .target(name: "EchoImplementation")
+  static let helloWorldModel: Self = .target(name: "HelloWorldModel")
+  static let routeGuideModel: Self = .target(name: "RouteGuideModel")
+  static let interopTestModels: Self = .target(name: "GRPCInteroperabilityTestModels")
+  static let interopTestImplementation: Self =
+    .target(name: "GRPCInteroperabilityTestsImplementation")
+
+  // Product dependencies
+  static let argumentParser: Self = .product(
+    name: "ArgumentParser",
+    package: "swift-argument-parser"
+  )
+  static let nio: Self = .product(name: "NIO", package: "swift-nio")
+  static let nioConcurrencyHelpers: Self = .product(
+    name: "NIOConcurrencyHelpers",
+    package: "swift-nio"
+  )
+  static let nioCore: Self = .product(name: "NIOCore", package: "swift-nio")
+  static let nioEmbedded: Self = .product(name: "NIOEmbedded", package: "swift-nio")
+  static let nioExtras: Self = .product(name: "NIOExtras", package: "swift-nio-extras")
+  static let nioFoundationCompat: Self = .product(name: "NIOFoundationCompat", package: "swift-nio")
+  static let nioHTTP1: Self = .product(name: "NIOHTTP1", package: "swift-nio")
+  static let nioHTTP2: Self = .product(name: "NIOHTTP2", package: "swift-nio-http2")
+  static let nioPosix: Self = .product(name: "NIOPosix", package: "swift-nio")
+  static let nioSSL: Self = .product(name: "NIOSSL", package: "swift-nio-ssl")
+  static let nioTLS: Self = .product(name: "NIOTLS", package: "swift-nio")
+  static let nioTransportServices: Self = .product(
+    name: "NIOTransportServices",
+    package: "swift-nio-transport-services"
+  )
+  static let logging: Self = .product(name: "Logging", package: "swift-log")
+  static let protobuf: Self = .product(name: "SwiftProtobuf", package: "SwiftProtobuf")
+  static let protobufPluginLibrary: Self = .product(
+    name: "SwiftProtobufPluginLibrary",
+    package: "SwiftProtobuf"
+  )
+}
+
+// MARK: - Targets
+
+extension Target {
+  static let grpc: Target = .target(
+    name: grpcTargetName,
+    dependencies: [
+      .cgrpcZlib,
+      .nio,
+      .nioCore,
+      .nioPosix,
+      .nioEmbedded,
+      .nioFoundationCompat,
+      .nioTLS,
+      .nioTransportServices,
+      .nioHTTP1,
+      .nioHTTP2,
+      .nioExtras,
+      .logging,
+      .protobuf,
+    ].appending(
+      .nioSSL, if: includeNIOSSL
+    ),
+    path: "Sources/GRPC"
+  )
+
+  static let cgrpcZlib: Target = .target(
+    name: cgrpcZlibTargetName,
+    path: "Sources/CGRPCZlib",
+    linkerSettings: [
+      .linkedLibrary("z"),
+    ]
+  )
+
+  static let protocGenGRPCSwift: Target = .target(
+    name: "protoc-gen-grpc-swift",
+    dependencies: [
+      .protobuf,
+      .protobufPluginLibrary,
+    ]
+  )
+
+  static let grpcTests: Target = .testTarget(
+    name: "GRPCTests",
+    dependencies: [
+      .grpc,
+      .echoModel,
+      .echoImplementation,
+      .helloWorldModel,
+      .interopTestModels,
+      .interopTestImplementation,
+      .grpcSampleData,
+      .nioCore,
+      .nioConcurrencyHelpers,
+      .nioPosix,
+      .nioTLS,
+      .nioHTTP1,
+      .nioHTTP2,
+      .nioEmbedded,
+      .nioTransportServices,
+      .logging,
+    ].appending(
+      .nioSSL, if: includeNIOSSL
+    )
+  )
+
+  static let interopTestModels: Target = .target(
+    name: "GRPCInteroperabilityTestModels",
+    dependencies: [
+      .grpc,
+      .nio,
+      .protobuf,
+    ]
+  )
+
+  static let interopTestImplementation: Target = .target(
+    name: "GRPCInteroperabilityTestsImplementation",
+    dependencies: [
+      .grpc,
+      .interopTestModels,
+      .nioCore,
+      .nioPosix,
+      .nioHTTP1,
+      .logging,
+    ].appending(
+      .nioSSL, if: includeNIOSSL
+    )
+  )
+
+  static let interopTests: Target = .target(
+    name: "GRPCInteroperabilityTests",
+    dependencies: [
+      .grpc,
+      .interopTestImplementation,
+      .nioCore,
+      .nioPosix,
+      .logging,
+      .argumentParser,
+    ]
+  )
+
+  static let backoffInteropTest: Target = .target(
+    name: "GRPCConnectionBackoffInteropTest",
+    dependencies: [
+      .grpc,
+      .interopTestModels,
+      .nioCore,
+      .nioPosix,
+      .logging,
+      .argumentParser,
+    ]
+  )
+
+  static let perfTests: Target = .target(
+    name: "GRPCPerformanceTests",
+    dependencies: [
+      .grpc,
+      .nioCore,
+      .nioEmbedded,
+      .nioPosix,
+      .nioHTTP2,
+      .argumentParser,
+    ]
+  )
+
+  static let grpcSampleData: Target = .target(
+    name: "GRPCSampleData",
+    dependencies: includeNIOSSL ? [.nioSSL] : []
+  )
+
+  static let echoModel: Target = .target(
+    name: "EchoModel",
+    dependencies: [
+      .grpc,
+      .nio,
+      .protobuf,
+    ],
+    path: "Sources/Examples/Echo/Model"
+  )
+
+  static let echoImplementation: Target = .target(
+    name: "EchoImplementation",
+    dependencies: [
+      .echoModel,
+      .grpc,
+      .nioCore,
+      .nioHTTP2,
+      .protobuf,
+    ],
+    path: "Sources/Examples/Echo/Implementation"
+  )
+
+  static let echo: Target = .target(
+    name: "Echo",
+    dependencies: [
+      .grpc,
+      .echoModel,
+      .echoImplementation,
+      .grpcSampleData,
+      .nioCore,
+      .nioPosix,
+      .logging,
+      .argumentParser,
+    ].appending(
+      .nioSSL, if: includeNIOSSL
+    ),
+    path: "Sources/Examples/Echo/Runtime"
+  )
+
+  static let helloWorldModel: Target = .target(
+    name: "HelloWorldModel",
+    dependencies: [
+      .grpc,
+      .nio,
+      .protobuf,
+    ],
+    path: "Sources/Examples/HelloWorld/Model"
+  )
+
+  static let helloWorldClient: Target = .target(
+    name: "HelloWorldClient",
+    dependencies: [
+      .grpc,
+      .helloWorldModel,
+      .nioCore,
+      .nioPosix,
+      .argumentParser,
+    ],
+    path: "Sources/Examples/HelloWorld/Client"
+  )
+
+  static let helloWorldServer: Target = .target(
+    name: "HelloWorldServer",
+    dependencies: [
+      .grpc,
+      .helloWorldModel,
+      .nioCore,
+      .nioPosix,
+      .argumentParser,
+    ],
+    path: "Sources/Examples/HelloWorld/Server"
+  )
+
+  static let routeGuideModel: Target = .target(
+    name: "RouteGuideModel",
+    dependencies: [
+      .grpc,
+      .nio,
+      .protobuf,
+    ],
+    path: "Sources/Examples/RouteGuide/Model"
+  )
+
+  static let routeGuideClient: Target = .target(
+    name: "RouteGuideClient",
+    dependencies: [
+      .grpc,
+      .routeGuideModel,
+      .nioCore,
+      .nioPosix,
+      .argumentParser,
+    ],
+    path: "Sources/Examples/RouteGuide/Client"
+  )
+
+  static let routeGuideServer: Target = .target(
+    name: "RouteGuideServer",
+    dependencies: [
+      .grpc,
+      .routeGuideModel,
+      .nioCore,
+      .nioConcurrencyHelpers,
+      .nioPosix,
+      .argumentParser,
+    ],
+    path: "Sources/Examples/RouteGuide/Server"
+  )
+
+  static let packetCapture: Target = .target(
+    name: "PacketCapture",
+    dependencies: [
+      .grpc,
+      .echoModel,
+      .nioCore,
+      .nioPosix,
+      .nioExtras,
+      .logging,
+      .argumentParser,
+    ],
+    path: "Sources/Examples/PacketCapture"
+  )
+}
+
+// MARK: - Products
+
+extension Product {
+  static let grpc: Product = .library(
+    name: grpcProductName,
+    targets: [grpcTargetName]
+  )
+
+  static let cgrpcZlib: Product = .library(
+    name: cgrpcZlibProductName,
+    targets: [cgrpcZlibTargetName]
+  )
+
+  static let protocGenGRPCSwift: Product = .executable(
+    name: "protoc-gen-grpc-swift",
+    targets: ["protoc-gen-grpc-swift"]
+  )
+}
+
+// MARK: - Package
 
 let package = Package(
-  name: "grpc-swift",
+  name: grpcPackageName,
   products: [
-    .library(name: "GRPC", targets: ["GRPC"]),
-    .library(name: "CGRPCZlib", targets: ["CGRPCZlib"]),
-    .executable(name: "protoc-gen-grpc-swift", targets: ["protoc-gen-grpc-swift"]),
+    .grpc,
+    .cgrpcZlib,
+    .protocGenGRPCSwift,
   ],
-  dependencies: [
-    // GRPC dependencies:
-    // Main SwiftNIO package
-    .package(url: "https://github.com/apple/swift-nio.git", from: "2.32.0"),
-    // HTTP2 via SwiftNIO
-    .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.18.2"),
-    // TLS via SwiftNIO
-    .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.14.0"),
-    // Support for Network.framework where possible.
-    .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.11.1"),
-    // Extra NIO stuff; quiescing helpers.
-    .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.4.0"),
-
-    // Official SwiftProtobuf library, for [de]serializing data to send on the wire.
-    .package(
-      name: "SwiftProtobuf",
-      url: "https://github.com/apple/swift-protobuf.git",
-      from: "1.9.0"
-    ),
-
-    // Logging API.
-    .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),
-
-    // Argument parsing: only for internal targets (i.e. examples).
-    .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.0.0"),
-  ],
+  dependencies: packageDependencies,
   targets: [
-    // The main GRPC module.
-    .target(
-      name: "GRPC",
-      dependencies: [
-        .product(name: "NIO", package: "swift-nio"),
-        .product(name: "NIOCore", package: "swift-nio"),
-        .product(name: "NIOPosix", package: "swift-nio"),
-        .product(name: "NIOEmbedded", package: "swift-nio"),
-        .product(name: "NIOFoundationCompat", package: "swift-nio"),
-        .product(name: "NIOTLS", package: "swift-nio"),
-        .product(name: "NIOTransportServices", package: "swift-nio-transport-services"),
-        .product(name: "NIOHTTP1", package: "swift-nio"),
-        .product(name: "NIOHTTP2", package: "swift-nio-http2"),
-        .product(name: "NIOExtras", package: "swift-nio-extras"),
-        .product(name: "NIOSSL", package: "swift-nio-ssl"),
-        .product(name: "SwiftProtobuf", package: "SwiftProtobuf"),
-        .product(name: "Logging", package: "swift-log"),
-        .target(name: "CGRPCZlib"),
-      ]
-    ), // and its tests.
-    .testTarget(
-      name: "GRPCTests",
-      dependencies: [
-        .target(name: "GRPC"),
-        .target(name: "EchoModel"),
-        .target(name: "EchoImplementation"),
-        .target(name: "GRPCSampleData"),
-        .target(name: "GRPCInteroperabilityTestsImplementation"),
-        .target(name: "HelloWorldModel"),
-        .product(name: "NIOCore", package: "swift-nio"),
-        .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
-        .product(name: "NIOPosix", package: "swift-nio"),
-        .product(name: "NIOTLS", package: "swift-nio"),
-        .product(name: "NIOHTTP1", package: "swift-nio"),
-        .product(name: "NIOHTTP2", package: "swift-nio-http2"),
-        .product(name: "NIOEmbedded", package: "swift-nio"),
-        .product(name: "NIOTransportServices", package: "swift-nio-transport-services"),
-        .product(name: "Logging", package: "swift-log"),
-      ]
-    ),
+    // Products
+    .grpc,
+    .cgrpcZlib,
+    .protocGenGRPCSwift,
 
-    .target(
-      name: "CGRPCZlib",
-      linkerSettings: [
-        .linkedLibrary("z"),
-      ]
-    ),
+    // Tests etc.
+    .grpcTests,
+    .interopTestModels,
+    .interopTestImplementation,
+    .interopTests,
+    .backoffInteropTest,
+    .perfTests,
+    .grpcSampleData,
 
-    // The `protoc` plugin.
-    .target(
-      name: "protoc-gen-grpc-swift",
-      dependencies: [
-        .product(name: "SwiftProtobuf", package: "SwiftProtobuf"),
-        .product(name: "SwiftProtobufPluginLibrary", package: "SwiftProtobuf"),
-      ]
-    ),
-
-    // Interoperability tests implementation.
-    .target(
-      name: "GRPCInteroperabilityTestsImplementation",
-      dependencies: [
-        .target(name: "GRPC"),
-        .target(name: "GRPCInteroperabilityTestModels"),
-        .product(name: "NIOCore", package: "swift-nio"),
-        .product(name: "NIOPosix", package: "swift-nio"),
-        .product(name: "NIOHTTP2", package: "swift-nio-http2"),
-        .product(name: "NIOSSL", package: "swift-nio-ssl"),
-        .product(name: "Logging", package: "swift-log"),
-      ]
-    ),
-
-    // Generated interoperability test models.
-    .target(
-      name: "GRPCInteroperabilityTestModels",
-      dependencies: [
-        .target(name: "GRPC"),
-        .product(name: "NIO", package: "swift-nio"),
-        .product(name: "SwiftProtobuf", package: "SwiftProtobuf"),
-      ]
-    ),
-
-    // The CLI for the interoperability tests.
-    .target(
-      name: "GRPCInteroperabilityTests",
-      dependencies: [
-        .target(name: "GRPC"),
-        .target(name: "GRPCInteroperabilityTestsImplementation"),
-        .product(name: "NIOCore", package: "swift-nio"),
-        .product(name: "NIOPosix", package: "swift-nio"),
-        .product(name: "Logging", package: "swift-log"),
-        .product(name: "ArgumentParser", package: "swift-argument-parser"),
-      ]
-    ),
-
-    // The connection backoff interoperability test.
-    .target(
-      name: "GRPCConnectionBackoffInteropTest",
-      dependencies: [
-        .target(name: "GRPC"),
-        .target(name: "GRPCInteroperabilityTestModels"),
-        .product(name: "NIOCore", package: "swift-nio"),
-        .product(name: "NIOPosix", package: "swift-nio"),
-        .product(name: "Logging", package: "swift-log"),
-        .product(name: "ArgumentParser", package: "swift-argument-parser"),
-      ]
-    ),
-
-    // Performance tests implementation and CLI.
-    .target(
-      name: "GRPCPerformanceTests",
-      dependencies: [
-        .target(name: "GRPC"),
-        .product(name: "NIOCore", package: "swift-nio"),
-        .product(name: "NIOEmbedded", package: "swift-nio"),
-        .product(name: "NIOPosix", package: "swift-nio"),
-        .product(name: "NIOHTTP2", package: "swift-nio-http2"),
-        .product(name: "ArgumentParser", package: "swift-argument-parser"),
-      ]
-    ),
-
-    // Sample data, used in examples and tests.
-    .target(
-      name: "GRPCSampleData",
-      dependencies: [
-        .product(name: "NIOSSL", package: "swift-nio-ssl"),
-      ]
-    ),
-
-    // Echo example CLI.
-    .target(
-      name: "Echo",
-      dependencies: [
-        .target(name: "EchoModel"),
-        .target(name: "EchoImplementation"),
-        .target(name: "GRPC"),
-        .target(name: "GRPCSampleData"),
-        .product(name: "NIOCore", package: "swift-nio"),
-        .product(name: "NIOPosix", package: "swift-nio"),
-        .product(name: "NIOSSL", package: "swift-nio-ssl"),
-        .product(name: "Logging", package: "swift-log"),
-        .product(name: "ArgumentParser", package: "swift-argument-parser"),
-      ],
-      path: "Sources/Examples/Echo/Runtime"
-    ),
-
-    // Echo example service implementation.
-    .target(
-      name: "EchoImplementation",
-      dependencies: [
-        .target(name: "EchoModel"),
-        .target(name: "GRPC"),
-        .product(name: "NIOCore", package: "swift-nio"),
-        .product(name: "NIOHTTP2", package: "swift-nio-http2"),
-        .product(name: "SwiftProtobuf", package: "SwiftProtobuf"),
-      ],
-      path: "Sources/Examples/Echo/Implementation"
-    ),
-
-    // Model for Echo example.
-    .target(
-      name: "EchoModel",
-      dependencies: [
-        .target(name: "GRPC"),
-        .product(name: "NIO", package: "swift-nio"),
-        .product(name: "SwiftProtobuf", package: "SwiftProtobuf"),
-      ],
-      path: "Sources/Examples/Echo/Model"
-    ),
-
-    // Model for the HelloWorld example
-    .target(
-      name: "HelloWorldModel",
-      dependencies: [
-        .target(name: "GRPC"),
-        .product(name: "NIO", package: "swift-nio"),
-        .product(name: "SwiftProtobuf", package: "SwiftProtobuf"),
-      ],
-      path: "Sources/Examples/HelloWorld/Model"
-    ),
-
-    // Client for the HelloWorld example
-    .target(
-      name: "HelloWorldClient",
-      dependencies: [
-        .target(name: "GRPC"),
-        .target(name: "HelloWorldModel"),
-        .product(name: "NIOCore", package: "swift-nio"),
-        .product(name: "NIOPosix", package: "swift-nio"),
-        .product(name: "ArgumentParser", package: "swift-argument-parser"),
-      ],
-      path: "Sources/Examples/HelloWorld/Client"
-    ),
-
-    // Server for the HelloWorld example
-    .target(
-      name: "HelloWorldServer",
-      dependencies: [
-        .target(name: "GRPC"),
-        .target(name: "HelloWorldModel"),
-        .product(name: "NIOCore", package: "swift-nio"),
-        .product(name: "NIOPosix", package: "swift-nio"),
-        .product(name: "ArgumentParser", package: "swift-argument-parser"),
-      ],
-      path: "Sources/Examples/HelloWorld/Server"
-    ),
-
-    // Model for the RouteGuide example
-    .target(
-      name: "RouteGuideModel",
-      dependencies: [
-        .target(name: "GRPC"),
-        .product(name: "NIO", package: "swift-nio"),
-        .product(name: "SwiftProtobuf", package: "SwiftProtobuf"),
-      ],
-      path: "Sources/Examples/RouteGuide/Model"
-    ),
-
-    // Client for the RouteGuide example
-    .target(
-      name: "RouteGuideClient",
-      dependencies: [
-        .target(name: "GRPC"),
-        .target(name: "RouteGuideModel"),
-        .product(name: "NIOCore", package: "swift-nio"),
-        .product(name: "NIOPosix", package: "swift-nio"),
-        .product(name: "ArgumentParser", package: "swift-argument-parser"),
-      ],
-      path: "Sources/Examples/RouteGuide/Client"
-    ),
-
-    // Server for the RouteGuide example
-    .target(
-      name: "RouteGuideServer",
-      dependencies: [
-        .target(name: "GRPC"),
-        .target(name: "RouteGuideModel"),
-        .product(name: "NIOCore", package: "swift-nio"),
-        .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
-        .product(name: "NIOPosix", package: "swift-nio"),
-        .product(name: "ArgumentParser", package: "swift-argument-parser"),
-      ],
-      path: "Sources/Examples/RouteGuide/Server"
-    ),
-
-    // Client for the PacketCapture example
-    .target(
-      name: "PacketCapture",
-      dependencies: [
-        .target(name: "GRPC"),
-        .target(name: "EchoModel"),
-        .product(name: "NIOCore", package: "swift-nio"),
-        .product(name: "NIOPosix", package: "swift-nio"),
-        .product(name: "NIOExtras", package: "swift-nio-extras"),
-        .product(name: "Logging", package: "swift-log"),
-        .product(name: "ArgumentParser", package: "swift-argument-parser"),
-      ],
-      path: "Sources/Examples/PacketCapture"
-    ),
+    // Examples
+    .echoModel,
+    .echoImplementation,
+    .echo,
+    .helloWorldModel,
+    .helloWorldClient,
+    .helloWorldServer,
+    .routeGuideModel,
+    .routeGuideClient,
+    .routeGuideServer,
+    .packetCapture,
   ]
 )
+
+extension Array {
+  func appending(_ element: Element, if condition: Bool) -> [Element] {
+    if condition {
+      return self + [element]
+    } else {
+      return self
+    }
+  }
+}

--- a/Sources/Examples/Echo/Runtime/main.swift
+++ b/Sources/Examples/Echo/Runtime/main.swift
@@ -21,7 +21,9 @@ import GRPCSampleData
 import Logging
 import NIOCore
 import NIOPosix
+#if canImport(NIOSSL)
 import NIOSSL
+#endif
 
 // MARK: - Argument parsing
 
@@ -114,6 +116,7 @@ func startEchoServer(group: EventLoopGroup, port: Int, useTLS: Bool) throws {
   let builder: Server.Builder
 
   if useTLS {
+    #if canImport(NIOSSL)
     // We're using some self-signed certs here: check they aren't expired.
     let caCert = SampleCertificate.ca
     let serverCert = SampleCertificate.server
@@ -129,6 +132,9 @@ func startEchoServer(group: EventLoopGroup, port: Int, useTLS: Bool) throws {
     )
     .withTLS(trustRoots: .certificates([caCert.certificate]))
     print("starting secure server")
+    #else
+    fatalError("'useTLS: true' passed to \(#function) but NIOSSL is not available")
+    #endif // canImport(NIOSSL)
   } else {
     print("starting insecure server")
     builder = Server.insecure(group: group)
@@ -154,6 +160,7 @@ func makeClient(
   let security: GRPCChannelPool.Configuration.TransportSecurity
 
   if useTLS {
+    #if canImport(NIOSSL)
     // We're using some self-signed certs here: check they aren't expired.
     let caCert = SampleCertificate.ca
     let clientCert = SampleCertificate.client
@@ -169,6 +176,9 @@ func makeClient(
     )
 
     security = .tls(tlsConfiguration)
+    #else
+    fatalError("'useTLS: true' passed to \(#function) but NIOSSL is not available")
+    #endif // canImport(NIOSSL)
   } else {
     security = .plaintext
   }

--- a/Sources/GRPC/ClientConnection.swift
+++ b/Sources/GRPC/ClientConnection.swift
@@ -18,7 +18,9 @@ import Logging
 import NIOCore
 import NIOHPACK
 import NIOHTTP2
+#if canImport(NIOSSL)
 import NIOSSL
+#endif
 import NIOTLS
 import NIOTransportServices
 import SwiftProtobuf
@@ -360,6 +362,7 @@ extension ClientConnection {
     /// provided but the queue is `nil` then one will be created by gRPC. Defaults to `nil`.
     public var connectivityStateDelegateQueue: DispatchQueue?
 
+    #if canImport(NIOSSL)
     /// TLS configuration for this connection. `nil` if TLS is not desired.
     ///
     /// - Important: `tls` is deprecated; use `tlsConfiguration` or one of
@@ -373,6 +376,7 @@ extension ClientConnection {
         self.tlsConfiguration = newValue.map { .init(transforming: $0) }
       }
     }
+    #endif // canImport(NIOSSL)
 
     /// TLS configuration for this connection. `nil` if TLS is not desired.
     public var tlsConfiguration: GRPCTLSConfiguration?
@@ -441,6 +445,7 @@ extension ClientConnection {
     /// - Warning: The initializer closure may be invoked *multiple times*.
     public var debugChannelInitializer: ((Channel) -> EventLoopFuture<Void>)?
 
+    #if canImport(NIOSSL)
     /// Create a `Configuration` with some pre-defined defaults. Prefer using
     /// `ClientConnection.secure(group:)` to build a connection secured with TLS or
     /// `ClientConnection.insecure(group:)` to build a plaintext connection.
@@ -496,6 +501,7 @@ extension ClientConnection {
       self.backgroundActivityLogger = backgroundActivityLogger
       self.debugChannelInitializer = debugChannelInitializer
     }
+    #endif // canImport(NIOSSL)
 
     private init(eventLoopGroup: EventLoopGroup, target: ConnectionTarget) {
       self.eventLoopGroup = eventLoopGroup
@@ -538,6 +544,7 @@ extension ClientBootstrapProtocol {
   }
 }
 
+#if canImport(NIOSSL)
 extension ChannelPipeline.SynchronousOperations {
   internal func configureNIOSSLForGRPCClient(
     sslContext: Result<NIOSSLContext, Error>,
@@ -564,7 +571,10 @@ extension ChannelPipeline.SynchronousOperations {
     try self.addHandler(sslClientHandler)
     try self.addHandler(TLSVerificationHandler(logger: logger))
   }
+}
+#endif // canImport(NIOSSL)
 
+extension ChannelPipeline.SynchronousOperations {
   internal func configureHTTP2AndGRPCHandlersForGRPCClient(
     channel: Channel,
     connectionManager: ConnectionManager,

--- a/Sources/GRPC/ClientConnectionConfiguration+NIOSSL.swift
+++ b/Sources/GRPC/ClientConnectionConfiguration+NIOSSL.swift
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#if canImport(NIOSSL)
 import NIOSSL
 
 extension ClientConnection.Configuration {
@@ -129,108 +130,4 @@ extension ClientConnection.Configuration {
   }
 }
 
-extension Server.Configuration {
-  /// TLS configuration for a `Server`.
-  ///
-  /// Note that this configuration is a subset of `NIOSSL.TLSConfiguration` where certain options
-  /// are removed from the users control to ensure the configuration complies with the gRPC
-  /// specification.
-  @available(*, deprecated, renamed: "GRPCTLSConfiguration")
-  public struct TLS {
-    public private(set) var configuration: TLSConfiguration
-
-    /// Whether ALPN is required. Disabling this option may be useful in cases where ALPN is not
-    /// supported.
-    public var requireALPN: Bool = true
-
-    /// The certificates to offer during negotiation. If not present, no certificates will be
-    /// offered.
-    public var certificateChain: [NIOSSLCertificateSource] {
-      get {
-        return self.configuration.certificateChain
-      }
-      set {
-        self.configuration.certificateChain = newValue
-      }
-    }
-
-    /// The private key associated with the leaf certificate.
-    public var privateKey: NIOSSLPrivateKeySource? {
-      get {
-        return self.configuration.privateKey
-      }
-      set {
-        self.configuration.privateKey = newValue
-      }
-    }
-
-    /// The trust roots to use to validate certificates. This only needs to be provided if you
-    /// intend to validate certificates.
-    public var trustRoots: NIOSSLTrustRoots? {
-      get {
-        return self.configuration.trustRoots
-      }
-      set {
-        self.configuration.trustRoots = newValue
-      }
-    }
-
-    /// Whether to verify remote certificates.
-    public var certificateVerification: CertificateVerification {
-      get {
-        return self.configuration.certificateVerification
-      }
-      set {
-        self.configuration.certificateVerification = newValue
-      }
-    }
-
-    /// TLS Configuration with suitable defaults for servers.
-    ///
-    /// This is a wrapper around `NIOSSL.TLSConfiguration` to restrict input to values which comply
-    /// with the gRPC protocol.
-    ///
-    /// - Parameter certificateChain: The certificate to offer during negotiation.
-    /// - Parameter privateKey: The private key associated with the leaf certificate.
-    /// - Parameter trustRoots: The trust roots to validate certificates, this defaults to using a
-    ///     root provided by the platform.
-    /// - Parameter certificateVerification: Whether to verify the remote certificate. Defaults to
-    ///     `.none`.
-    /// - Parameter requireALPN: Whether ALPN is required or not.
-    public init(
-      certificateChain: [NIOSSLCertificateSource],
-      privateKey: NIOSSLPrivateKeySource,
-      trustRoots: NIOSSLTrustRoots = .default,
-      certificateVerification: CertificateVerification = .none,
-      requireALPN: Bool = true
-    ) {
-      var configuration = TLSConfiguration.makeServerConfiguration(
-        certificateChain: certificateChain,
-        privateKey: privateKey
-      )
-      configuration.minimumTLSVersion = .tlsv12
-      configuration.certificateVerification = certificateVerification
-      configuration.trustRoots = trustRoots
-      configuration.applicationProtocols = GRPCApplicationProtocolIdentifier.server
-
-      self.configuration = configuration
-      self.requireALPN = requireALPN
-    }
-
-    /// Creates a TLS Configuration using the given `NIOSSL.TLSConfiguration`.
-    /// - Note: If no ALPN tokens are set in `configuration.applicationProtocols` then the tokens
-    ///  "grpc-exp", "h2" and "http/1.1" will be used.
-    /// - Parameters:
-    ///   - configuration: The `NIOSSL.TLSConfiguration` to base this configuration on.
-    ///   - requireALPN: Whether ALPN is required.
-    public init(configuration: TLSConfiguration, requireALPN: Bool = true) {
-      self.configuration = configuration
-      self.requireALPN = requireALPN
-
-      // Set the ALPN tokens if none were set.
-      if self.configuration.applicationProtocols.isEmpty {
-        self.configuration.applicationProtocols = GRPCApplicationProtocolIdentifier.server
-      }
-    }
-  }
-}
+#endif // canImport(NIOSSL)

--- a/Sources/GRPC/DelegatingErrorHandler.swift
+++ b/Sources/GRPC/DelegatingErrorHandler.swift
@@ -16,7 +16,6 @@
 import Foundation
 import Logging
 import NIOCore
-import NIOSSL
 
 /// A channel handler which allows caught errors to be passed to a `ClientErrorDelegate`. This
 /// handler is intended to be used in the client channel pipeline after the HTTP/2 stream
@@ -43,7 +42,7 @@ internal final class DelegatingErrorHandler: ChannelInboundHandler {
     //
     // Without this we would unnecessarily log when we're communicating with peers which don't
     // send `close_notify`.
-    if let sslError = error as? NIOSSLError, case .uncleanShutdown = sslError {
+    if error.isNIOSSLUncleanShutdown {
       return
     }
 

--- a/Sources/GRPC/Error+NIOSSL.swift
+++ b/Sources/GRPC/Error+NIOSSL.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, gRPC Authors All rights reserved.
+ * Copyright 2021, gRPC Authors All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 #if canImport(NIOSSL)
-import Foundation
-import GRPCSampleData
-import XCTest
+import NIOSSL
+#endif
 
-extension SampleCertificate {
-  func assertNotExpired(file: StaticString = #file, line: UInt = #line) {
-    XCTAssertFalse(
-      self.isExpired,
-      "Certificate expired at \(self.notAfter)",
-      // swiftformat:disable:next redundantParens
-      file: (file),
-      line: line
-    )
+extension Error {
+  internal var isNIOSSLUncleanShutdown: Bool {
+    #if canImport(NIOSSL)
+    if let sslError = self as? NIOSSLError {
+      return sslError == .uncleanShutdown
+    } else {
+      return false
+    }
+    #else
+    return false
+    #endif
   }
 }
-#endif // canImport(NIOSSL)

--- a/Sources/GRPC/EventLoopFuture+RecoverFromUncleanShutdown.swift
+++ b/Sources/GRPC/EventLoopFuture+RecoverFromUncleanShutdown.swift
@@ -14,24 +14,17 @@
  * limitations under the License.
  */
 import NIOCore
-#if canImport(NIOSSL)
-import NIOSSL
-#endif
 
 extension EventLoopFuture where Value == Void {
   internal func recoveringFromUncleanShutdown() -> EventLoopFuture<Void> {
-    #if canImport(NIOSSL)
     // We can ignore unclean shutdown since gRPC is self-terminated and therefore not prone to
     // truncation attacks.
     return self.flatMapErrorThrowing { error in
-      if let sslError = error as? NIOSSLError, sslError == .uncleanShutdown {
-        ()
+      if error.isNIOSSLUncleanShutdown {
+        return ()
       } else {
         throw error
       }
     }
-    #else
-    return self
-    #endif
   }
 }

--- a/Sources/GRPC/GRPCChannel/ClientConnection+NIOSSL.swift
+++ b/Sources/GRPC/GRPCChannel/ClientConnection+NIOSSL.swift
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2021, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#if canImport(NIOSSL)
+import NIOCore
+import NIOSSL
+
+extension ClientConnection {
+  /// Returns a `ClientConnection` builder configured with TLS.
+  @available(
+    *, deprecated,
+    message: "Use one of 'usingPlatformAppropriateTLS(for:)', 'usingTLSBackedByNIOSSL(on:)' or 'usingTLSBackedByNetworkFramework(on:)' or 'usingTLS(on:with:)'"
+  )
+  public static func secure(group: EventLoopGroup) -> ClientConnection.Builder.Secure {
+    return ClientConnection.usingTLSBackedByNIOSSL(on: group)
+  }
+
+  /// Returns a `ClientConnection` builder configured with the 'NIOSSL' TLS backend.
+  ///
+  /// This builder may use either a `MultiThreadedEventLoopGroup` or a `NIOTSEventLoopGroup` (or an
+  /// `EventLoop` from either group).
+  ///
+  /// - Parameter group: The `EventLoopGroup` use for the connection.
+  /// - Returns: A builder for a connection using the NIOSSL TLS backend.
+  public static func usingTLSBackedByNIOSSL(
+    on group: EventLoopGroup
+  ) -> ClientConnection.Builder.Secure {
+    return Builder.Secure(group: group, tlsConfiguration: .makeClientConfigurationBackedByNIOSSL())
+  }
+}
+
+// MARK: - NIOSSL TLS backend options
+
+extension ClientConnection.Builder.Secure {
+  /// Sets the sources of certificates to offer during negotiation. No certificates are offered
+  /// during negotiation by default.
+  ///
+  /// - Note: May only be used with the 'NIOSSL' TLS backend.
+  @discardableResult
+  public func withTLS(certificateChain: [NIOSSLCertificate]) -> Self {
+    self.tls.updateNIOCertificateChain(to: certificateChain)
+    return self
+  }
+
+  /// Sets the private key associated with the leaf certificate.
+  ///
+  /// - Note: May only be used with the 'NIOSSL' TLS backend.
+  @discardableResult
+  public func withTLS(privateKey: NIOSSLPrivateKey) -> Self {
+    self.tls.updateNIOPrivateKey(to: privateKey)
+    return self
+  }
+
+  /// Sets the trust roots to use to validate certificates. This only needs to be provided if you
+  /// intend to validate certificates. Defaults to the system provided trust store (`.default`) if
+  /// not set.
+  ///
+  /// - Note: May only be used with the 'NIOSSL' TLS backend.
+  @discardableResult
+  public func withTLS(trustRoots: NIOSSLTrustRoots) -> Self {
+    self.tls.updateNIOTrustRoots(to: trustRoots)
+    return self
+  }
+
+  /// Whether to verify remote certificates. Defaults to `.fullVerification` if not otherwise
+  /// configured.
+  ///
+  /// - Note: May only be used with the 'NIOSSL' TLS backend.
+  @discardableResult
+  public func withTLS(certificateVerification: CertificateVerification) -> Self {
+    self.tls.updateNIOCertificateVerification(to: certificateVerification)
+    return self
+  }
+
+  /// A custom verification callback that allows completely overriding the certificate verification logic.
+  ///
+  /// - Note: May only be used with the 'NIOSSL' TLS backend.
+  @discardableResult
+  public func withTLSCustomVerificationCallback(
+    _ callback: @escaping NIOSSLCustomVerificationCallback
+  ) -> Self {
+    self.tls.updateNIOCustomVerificationCallback(to: callback)
+    return self
+  }
+}
+
+#endif // canImport(NIOSSL)

--- a/Sources/GRPC/GRPCChannel/ClientConnection+NWTLS.swift
+++ b/Sources/GRPC/GRPCChannel/ClientConnection+NWTLS.swift
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#if canImport(Security)
+#if canImport(Network)
+import NIOCore
+import Security
+
+extension ClientConnection {
+  /// Returns a `ClientConnection` builder configured with the Network.framework TLS backend.
+  ///
+  /// This builder must use a `NIOTSEventLoopGroup` (or an `EventLoop` from a
+  /// `NIOTSEventLoopGroup`).
+  ///
+  /// - Parameter group: The `EventLoopGroup` use for the connection.
+  /// - Returns: A builder for a connection using the Network.framework TLS backend.
+  @available(macOS 10.14, iOS 12.0, watchOS 6.0, tvOS 12.0, *)
+  public static func usingTLSBackedByNetworkFramework(
+    on group: EventLoopGroup
+  ) -> ClientConnection.Builder.Secure {
+    precondition(
+      PlatformSupport.isTransportServicesEventLoopGroup(group),
+      "'\(#function)' requires 'group' to be a 'NIOTransportServices.NIOTSEventLoopGroup' or 'NIOTransportServices.QoSEventLoop' (but was '\(type(of: group))'"
+    )
+    return Builder.Secure(
+      group: group,
+      tlsConfiguration: .makeClientConfigurationBackedByNetworkFramework()
+    )
+  }
+}
+
+extension ClientConnection.Builder.Secure {
+  /// Update the local identity.
+  ///
+  /// - Note: May only be used with the 'Network.framework' TLS backend.
+  @discardableResult
+  @available(macOS 10.14, iOS 12.0, watchOS 6.0, tvOS 12.0, *)
+  public func withTLS(localIdentity: SecIdentity) -> Self {
+    self.tls.updateNetworkLocalIdentity(to: localIdentity)
+    return self
+  }
+
+  /// Update the callback used to verify a trust object during a TLS handshake.
+  ///
+  /// - Note: May only be used with the 'Network.framework' TLS backend.
+  @discardableResult
+  @available(macOS 10.14, iOS 12.0, watchOS 6.0, tvOS 12.0, *)
+  public func withTLSHandshakeVerificationCallback(
+    on queue: DispatchQueue,
+    verificationCallback callback: @escaping sec_protocol_verify_t
+  ) -> Self {
+    self.tls.updateNetworkVerifyCallbackWithQueue(callback: callback, queue: queue)
+    return self
+  }
+}
+
+#endif // canImport(Network)
+#endif // canImport(Security)

--- a/Sources/GRPC/GRPCTLSConfiguration.swift
+++ b/Sources/GRPC/GRPCTLSConfiguration.swift
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#if canImport(NIOSSL)
 import NIOSSL
+#endif
 
 #if canImport(Network)
 import Network
@@ -28,8 +30,10 @@ import Security
 /// the gRPC specification.
 public struct GRPCTLSConfiguration {
   fileprivate enum Backend {
+    #if canImport(NIOSSL)
     /// Configuration for NIOSSSL.
     case nio(NIOConfiguration)
+    #endif
     #if canImport(Network)
     /// Configuration for Network.framework.
     case network(NetworkConfiguration)
@@ -39,12 +43,21 @@ public struct GRPCTLSConfiguration {
   /// The TLS backend.
   private var backend: Backend
 
-  private init(backend: Backend) {
-    self.backend = backend
+  #if canImport(NIOSSL)
+  fileprivate init(nio: NIOConfiguration) {
+    self.backend = .nio(nio)
   }
+  #endif
+
+  #if canImport(Network)
+  fileprivate init(network: NetworkConfiguration) {
+    self.backend = .network(network)
+  }
+  #endif
 
   /// Return the configuration for NIOSSL or `nil` if Network.framework is being used as the
   /// TLS backend.
+  #if canImport(NIOSSL)
   internal var nioConfiguration: NIOConfiguration? {
     switch self.backend {
     case let .nio(configuration):
@@ -55,11 +68,14 @@ public struct GRPCTLSConfiguration {
     #endif
     }
   }
+  #endif // canImport(NIOSSL)
 
   internal var isNetworkFrameworkTLSBackend: Bool {
     switch self.backend {
+    #if canImport(NIOSSL)
     case .nio:
       return false
+    #endif
     #if canImport(Network)
     case .network:
       return true
@@ -75,8 +91,10 @@ public struct GRPCTLSConfiguration {
   internal var hostnameOverride: String? {
     get {
       switch self.backend {
+      #if canImport(NIOSSL)
       case let .nio(config):
         return config.hostnameOverride
+      #endif
 
       #if canImport(Network)
       case let .network(config):
@@ -87,9 +105,11 @@ public struct GRPCTLSConfiguration {
 
     set {
       switch self.backend {
+      #if canImport(NIOSSL)
       case var .nio(config):
         config.hostnameOverride = newValue
         self.backend = .nio(config)
+      #endif
 
       #if canImport(Network)
       case var .network(config):
@@ -118,8 +138,10 @@ public struct GRPCTLSConfiguration {
   internal var requireALPN: Bool {
     get {
       switch self.backend {
+      #if canImport(NIOSSL)
       case let .nio(config):
         return config.requireALPN
+      #endif
 
       #if canImport(Network)
       case .network:
@@ -129,9 +151,11 @@ public struct GRPCTLSConfiguration {
     }
     set {
       switch self.backend {
+      #if canImport(NIOSSL)
       case var .nio(config):
         config.requireALPN = newValue
         self.backend = .nio(config)
+      #endif
 
       #if canImport(Network)
       case .network:
@@ -141,6 +165,7 @@ public struct GRPCTLSConfiguration {
     }
   }
 
+  #if canImport(NIOSSL)
   // Marked to silence the deprecation warning
   @available(*, deprecated)
   internal init(transforming deprecated: ClientConnection.Configuration.TLS) {
@@ -183,10 +208,12 @@ public struct GRPCTLSConfiguration {
     }
     return nil
   }
+  #endif // canImport(NIOSSL)
 }
 
 // MARK: - NIO Backend
 
+#if canImport(NIOSSL)
 extension GRPCTLSConfiguration {
   internal struct NIOConfiguration {
     var configuration: TLSConfiguration
@@ -262,7 +289,7 @@ extension GRPCTLSConfiguration {
       requireALPN: false // We don't currently support this.
     )
 
-    return GRPCTLSConfiguration(backend: .nio(nioConfiguration))
+    return GRPCTLSConfiguration(nio: nioConfiguration)
   }
 
   /// TLS Configuration with suitable defaults for servers.
@@ -326,7 +353,7 @@ extension GRPCTLSConfiguration {
       requireALPN: requireALPN
     )
 
-    return GRPCTLSConfiguration(backend: .nio(nioConfiguration))
+    return GRPCTLSConfiguration(nio: nioConfiguration)
   }
 
   @usableFromInline
@@ -398,6 +425,7 @@ extension GRPCTLSConfiguration {
     }
   }
 }
+#endif // canImport(NIOSSL)
 
 // MARK: - Network Backend
 
@@ -496,7 +524,7 @@ extension GRPCTLSConfiguration {
     hostnameOverride: String? = nil
   ) -> GRPCTLSConfiguration {
     let network = NetworkConfiguration(options: options, hostnameOverride: hostnameOverride)
-    return GRPCTLSConfiguration(backend: .network(network))
+    return GRPCTLSConfiguration(network: network)
   }
 
   @available(macOS 10.14, iOS 12.0, watchOS 6.0, tvOS 12.0, *)
@@ -531,7 +559,7 @@ extension GRPCTLSConfiguration {
     options: NWProtocolTLS.Options
   ) -> GRPCTLSConfiguration {
     let network = NetworkConfiguration(options: options, hostnameOverride: nil)
-    return GRPCTLSConfiguration(backend: .network(network))
+    return GRPCTLSConfiguration(network: network)
   }
 
   @available(macOS 10.14, iOS 12.0, watchOS 6.0, tvOS 12.0, *)
@@ -565,8 +593,10 @@ extension GRPCTLSConfiguration {
     case var .network(_configuration):
       modify(&_configuration)
       self.backend = .network(_configuration)
+    #if canImport(NIOSSL)
     case .nio:
       preconditionFailure()
+    #endif // canImport(NIOSSL)
     }
   }
 }
@@ -582,10 +612,12 @@ extension GRPCTLSConfiguration {
     case let .network(_configuration):
       return bootstrap.tlsOptions(_configuration.options)
 
+    #if canImport(NIOSSL)
     case .nio:
       // We're using NIOSSL with Network.framework; that's okay and permitted for backwards
       // compatibility.
       return bootstrap
+    #endif // canImport(NIOSSL)
     }
   }
 
@@ -597,10 +629,12 @@ extension GRPCTLSConfiguration {
     case let .network(_configuration):
       return bootstrap.tlsOptions(_configuration.options)
 
+    #if canImport(NIOSSL)
     case .nio:
       // We're using NIOSSL with Network.framework; that's okay and permitted for backwards
       // compatibility.
       return bootstrap
+    #endif // canImport(NIOSSL)
     }
   }
 }

--- a/Sources/GRPC/PlatformSupport.swift
+++ b/Sources/GRPC/PlatformSupport.swift
@@ -16,7 +16,6 @@
 import Logging
 import NIOCore
 import NIOPosix
-import NIOSSL
 import NIOTransportServices
 
 /// How a network implementation should be chosen.
@@ -352,7 +351,11 @@ extension GRPCTLSConfiguration {
       #endif
 
     case .posix:
+      #if canImport(NIOSSL)
       return .makeClientConfigurationBackedByNIOSSL()
+      #else
+      fatalError("Default client TLS configuration for '.posix' requires NIOSSL")
+      #endif
     }
   }
 }

--- a/Sources/GRPC/Server+NIOSSL.swift
+++ b/Sources/GRPC/Server+NIOSSL.swift
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2019, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#if canImport(NIOSSL)
+import NIOSSL
+
+extension Server.Configuration {
+  /// TLS configuration for a `Server`.
+  ///
+  /// Note that this configuration is a subset of `NIOSSL.TLSConfiguration` where certain options
+  /// are removed from the users control to ensure the configuration complies with the gRPC
+  /// specification.
+  @available(*, deprecated, renamed: "GRPCTLSConfiguration")
+  public struct TLS {
+    public private(set) var configuration: TLSConfiguration
+
+    /// Whether ALPN is required. Disabling this option may be useful in cases where ALPN is not
+    /// supported.
+    public var requireALPN: Bool = true
+
+    /// The certificates to offer during negotiation. If not present, no certificates will be
+    /// offered.
+    public var certificateChain: [NIOSSLCertificateSource] {
+      get {
+        return self.configuration.certificateChain
+      }
+      set {
+        self.configuration.certificateChain = newValue
+      }
+    }
+
+    /// The private key associated with the leaf certificate.
+    public var privateKey: NIOSSLPrivateKeySource? {
+      get {
+        return self.configuration.privateKey
+      }
+      set {
+        self.configuration.privateKey = newValue
+      }
+    }
+
+    /// The trust roots to use to validate certificates. This only needs to be provided if you
+    /// intend to validate certificates.
+    public var trustRoots: NIOSSLTrustRoots? {
+      get {
+        return self.configuration.trustRoots
+      }
+      set {
+        self.configuration.trustRoots = newValue
+      }
+    }
+
+    /// Whether to verify remote certificates.
+    public var certificateVerification: CertificateVerification {
+      get {
+        return self.configuration.certificateVerification
+      }
+      set {
+        self.configuration.certificateVerification = newValue
+      }
+    }
+
+    /// TLS Configuration with suitable defaults for servers.
+    ///
+    /// This is a wrapper around `NIOSSL.TLSConfiguration` to restrict input to values which comply
+    /// with the gRPC protocol.
+    ///
+    /// - Parameter certificateChain: The certificate to offer during negotiation.
+    /// - Parameter privateKey: The private key associated with the leaf certificate.
+    /// - Parameter trustRoots: The trust roots to validate certificates, this defaults to using a
+    ///     root provided by the platform.
+    /// - Parameter certificateVerification: Whether to verify the remote certificate. Defaults to
+    ///     `.none`.
+    /// - Parameter requireALPN: Whether ALPN is required or not.
+    public init(
+      certificateChain: [NIOSSLCertificateSource],
+      privateKey: NIOSSLPrivateKeySource,
+      trustRoots: NIOSSLTrustRoots = .default,
+      certificateVerification: CertificateVerification = .none,
+      requireALPN: Bool = true
+    ) {
+      var configuration = TLSConfiguration.makeServerConfiguration(
+        certificateChain: certificateChain,
+        privateKey: privateKey
+      )
+      configuration.minimumTLSVersion = .tlsv12
+      configuration.certificateVerification = certificateVerification
+      configuration.trustRoots = trustRoots
+      configuration.applicationProtocols = GRPCApplicationProtocolIdentifier.server
+
+      self.configuration = configuration
+      self.requireALPN = requireALPN
+    }
+
+    /// Creates a TLS Configuration using the given `NIOSSL.TLSConfiguration`.
+    /// - Note: If no ALPN tokens are set in `configuration.applicationProtocols` then the tokens
+    ///  "grpc-exp", "h2" and "http/1.1" will be used.
+    /// - Parameters:
+    ///   - configuration: The `NIOSSL.TLSConfiguration` to base this configuration on.
+    ///   - requireALPN: Whether ALPN is required.
+    public init(configuration: TLSConfiguration, requireALPN: Bool = true) {
+      self.configuration = configuration
+      self.requireALPN = requireALPN
+
+      // Set the ALPN tokens if none were set.
+      if self.configuration.applicationProtocols.isEmpty {
+        self.configuration.applicationProtocols = GRPCApplicationProtocolIdentifier.server
+      }
+    }
+  }
+}
+
+#endif // canImport(NIOSSL)

--- a/Sources/GRPC/ServerBuilder+NIOSSL.swift
+++ b/Sources/GRPC/ServerBuilder+NIOSSL.swift
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2021, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#if canImport(NIOSSL)
+import NIOCore
+import NIOSSL
+
+extension Server {
+  /// Returns a `Server` builder configured with TLS.
+  @available(
+    *, deprecated,
+    message: "Use one of 'usingTLSBackedByNIOSSL(on:certificateChain:privateKey:)', 'usingTLSBackedByNetworkFramework(on:with:)' or 'usingTLS(with:on:)'"
+  )
+  public static func secure(
+    group: EventLoopGroup,
+    certificateChain: [NIOSSLCertificate],
+    privateKey: NIOSSLPrivateKey
+  ) -> Builder.Secure {
+    return Server.usingTLSBackedByNIOSSL(
+      on: group,
+      certificateChain: certificateChain,
+      privateKey: privateKey
+    )
+  }
+
+  /// Returns a `Server` builder configured with the 'NIOSSL' TLS backend.
+  ///
+  /// This builder may use either a `MultiThreadedEventLoopGroup` or a `NIOTSEventLoopGroup` (or an
+  /// `EventLoop` from either group).
+  public static func usingTLSBackedByNIOSSL(
+    on group: EventLoopGroup,
+    certificateChain: [NIOSSLCertificate],
+    privateKey: NIOSSLPrivateKey
+  ) -> Builder.Secure {
+    return Builder.Secure(
+      group: group,
+      tlsConfiguration: .makeServerConfigurationBackedByNIOSSL(
+        certificateChain: certificateChain.map { .certificate($0) },
+        privateKey: .privateKey(privateKey)
+      )
+    )
+  }
+}
+
+extension Server.Builder.Secure {
+  /// Sets the trust roots to use to validate certificates. This only needs to be provided if you
+  /// intend to validate certificates. Defaults to the system provided trust store (`.default`) if
+  /// not set.
+  ///
+  /// - Note: May only be used with the 'NIOSSL' TLS backend.
+  @discardableResult
+  public func withTLS(trustRoots: NIOSSLTrustRoots) -> Self {
+    self.tls.updateNIOTrustRoots(to: trustRoots)
+    return self
+  }
+
+  /// Sets whether certificates should be verified. Defaults to `.none` if not set.
+  ///
+  /// - Note: May only be used with the 'NIOSSL' TLS backend.
+  @discardableResult
+  public func withTLS(certificateVerification: CertificateVerification) -> Self {
+    self.tls.updateNIOCertificateVerification(to: certificateVerification)
+    return self
+  }
+}
+
+#endif // canImport(NIOSSL)

--- a/Sources/GRPCConnectionBackoffInteropTest/main.swift
+++ b/Sources/GRPCConnectionBackoffInteropTest/main.swift
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#if canImport(NIOSSL)
 import ArgumentParser
 import struct Foundation.Date
 import GRPC
@@ -118,3 +119,4 @@ struct ConnectionBackoffInteropTest: ParsableCommand {
 }
 
 ConnectionBackoffInteropTest.main()
+#endif // canImport(NIOSSL)

--- a/Sources/GRPCInteroperabilityTestsImplementation/InteroperabilityTestClientConnection.swift
+++ b/Sources/GRPCInteroperabilityTestsImplementation/InteroperabilityTestClientConnection.swift
@@ -15,7 +15,9 @@
  */
 import GRPC
 import NIOCore
+#if canImport(NIOSSL)
 import NIOSSL
+#endif
 
 public func makeInteroperabilityTestClientBuilder(
   group: EventLoopGroup,
@@ -24,11 +26,15 @@ public func makeInteroperabilityTestClientBuilder(
   let builder: ClientConnection.Builder
 
   if useTLS {
+    #if canImport(NIOSSL)
     // The CA certificate has a common name of "*.test.google.fr", use the following host override
     // so we can do full certificate verification.
     builder = ClientConnection.usingTLSBackedByNIOSSL(on: group)
       .withTLS(trustRoots: .certificates([InteroperabilityTestCredentials.caCertificate]))
       .withTLS(serverHostnameOverride: "foo.test.google.fr")
+    #else
+    fatalError("'useTLS: true' passed to \(#function) but NIOSSL is not available")
+    #endif // canImport(NIOSSL)
   } else {
     builder = ClientConnection.insecure(group: group)
   }

--- a/Sources/GRPCInteroperabilityTestsImplementation/InteroperabilityTestCredentials.swift
+++ b/Sources/GRPCInteroperabilityTestsImplementation/InteroperabilityTestCredentials.swift
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#if canImport(NIOSSL)
 import NIOSSL
 
 /// Contains credentials used for the gRPC interoperability tests.
@@ -105,3 +106,4 @@ public struct InteroperabilityTestCredentials {
   -----END PRIVATE KEY-----
   """
 }
+#endif // canImport(NIOSSL)

--- a/Sources/GRPCInteroperabilityTestsImplementation/InteroperabilityTestServer.swift
+++ b/Sources/GRPCInteroperabilityTestsImplementation/InteroperabilityTestServer.swift
@@ -16,7 +16,9 @@
 import GRPC
 import Logging
 import NIOCore
+#if canImport(NIOSSL)
 import NIOSSL
+#endif
 
 /// Makes a server for gRPC interoperability testing.
 ///
@@ -41,10 +43,7 @@ public func makeInteroperabilityTestServer(
   let builder: Server.Builder
 
   if useTLS {
-    print(
-      "Using the gRPC interop testing CA for TLS; clients should expect the host to be '*.test.google.fr'"
-    )
-
+    #if canImport(NIOSSL)
     let caCert = InteroperabilityTestCredentials.caCertificate
     let serverCert = InteroperabilityTestCredentials.server1Certificate
     let serverKey = InteroperabilityTestCredentials.server1Key
@@ -55,6 +54,9 @@ public func makeInteroperabilityTestServer(
       privateKey: serverKey
     )
     .withTLS(trustRoots: .certificates([caCert]))
+    #else
+    fatalError("'useTLS: true' passed to \(#function) but NIOSSL is not available")
+    #endif // canImport(NIOSSL)
   } else {
     builder = Server.insecure(group: eventLoopGroup)
   }

--- a/Sources/GRPCSampleData/GRPCSwiftCertificate.swift
+++ b/Sources/GRPCSampleData/GRPCSwiftCertificate.swift
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#if canImport(NIOSSL)
 import struct Foundation.Date
 import NIOSSL
 
@@ -367,3 +368,5 @@ YyVRAgEBoUQDQgAE+YMhPzGDLJuuMxB+ICQKWvPjbTEsRXgbq3Hmrds6x/1QY14e
 /xh4TqpAEW6M0R5xhqg7ZU7O8NHtuiCyxPzCog==
 -----END EC PRIVATE KEY-----
 """
+
+#endif // canImport(NIOSSL)

--- a/Tests/GRPCTests/ALPNConfigurationTests.swift
+++ b/Tests/GRPCTests/ALPNConfigurationTests.swift
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#if canImport(NIOSSL)
 @testable import GRPC
 import NIOSSL
 import XCTest
@@ -100,3 +101,4 @@ class ALPNConfigurationTests: GRPCTestCase {
     XCTAssertEqual(config.nioConfiguration!.configuration.applicationProtocols, ["foo"])
   }
 }
+#endif // canImport(NIOSSL)

--- a/Tests/GRPCTests/BasicEchoTestCase.swift
+++ b/Tests/GRPCTests/BasicEchoTestCase.swift
@@ -20,7 +20,9 @@ import Foundation
 import GRPC
 import GRPCSampleData
 import NIOCore
+#if canImport(NIOSSL)
 import NIOSSL
+#endif
 import XCTest
 
 extension Echo_EchoRequest {
@@ -71,14 +73,22 @@ class EchoTestCaseBase: GRPCTestCase {
       return ClientConnection.insecure(group: self.clientEventLoopGroup)
 
     case .anonymousClient:
+      #if canImport(NIOSSL)
       return ClientConnection.usingTLSBackedByNIOSSL(on: self.clientEventLoopGroup)
         .withTLS(trustRoots: .certificates([SampleCertificate.ca.certificate]))
+      #else
+      fatalError("NIOSSL must be imported to use TLS")
+      #endif
 
     case .mutualAuthentication:
+      #if canImport(NIOSSL)
       return ClientConnection.usingTLSBackedByNIOSSL(on: self.clientEventLoopGroup)
         .withTLS(trustRoots: .certificates([SampleCertificate.ca.certificate]))
         .withTLS(certificateChain: [SampleCertificate.client.certificate])
         .withTLS(privateKey: SamplePrivateKey.client)
+      #else
+      fatalError("NIOSSL must be imported to use TLS")
+      #endif
     }
   }
 
@@ -88,13 +98,18 @@ class EchoTestCaseBase: GRPCTestCase {
       return Server.insecure(group: self.serverEventLoopGroup)
 
     case .anonymousClient:
+      #if canImport(NIOSSL)
       return Server.usingTLSBackedByNIOSSL(
         on: self.serverEventLoopGroup,
         certificateChain: [SampleCertificate.server.certificate],
         privateKey: SamplePrivateKey.server
       ).withTLS(trustRoots: .certificates([SampleCertificate.ca.certificate]))
+      #else
+      fatalError("NIOSSL must be imported to use TLS")
+      #endif
 
     case .mutualAuthentication:
+      #if canImport(NIOSSL)
       return Server.usingTLSBackedByNIOSSL(
         on: self.serverEventLoopGroup,
         certificateChain: [SampleCertificate.server.certificate],
@@ -102,6 +117,9 @@ class EchoTestCaseBase: GRPCTestCase {
       )
       .withTLS(trustRoots: .certificates([SampleCertificate.ca.certificate]))
       .withTLS(certificateVerification: .noHostnameVerification)
+      #else
+      fatalError("NIOSSL must be imported to use TLS")
+      #endif
     }
   }
 

--- a/Tests/GRPCTests/ClientTLSFailureTests.swift
+++ b/Tests/GRPCTests/ClientTLSFailureTests.swift
@@ -13,41 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#if canImport(NIOSSL)
 import EchoImplementation
 import EchoModel
 @testable import GRPC
 import GRPCSampleData
-import Logging
-import NIOConcurrencyHelpers
 import NIOCore
 import NIOPosix
 import NIOSSL
 import XCTest
-
-class ErrorRecordingDelegate: ClientErrorDelegate {
-  private let lock: Lock
-  private var _errors: [Error] = []
-
-  internal var errors: [Error] {
-    return self.lock.withLock {
-      return self._errors
-    }
-  }
-
-  var expectation: XCTestExpectation
-
-  init(expectation: XCTestExpectation) {
-    self.expectation = expectation
-    self.lock = Lock()
-  }
-
-  func didCatchError(_ error: Error, logger: Logger, file: StaticString, line: Int) {
-    self.lock.withLockVoid {
-      self._errors.append(error)
-    }
-    self.expectation.fulfill()
-  }
-}
 
 class ClientTLSFailureTests: GRPCTestCase {
   let defaultServerTLSConfiguration = GRPCTLSConfiguration.makeServerConfigurationBackedByNIOSSL(
@@ -242,3 +216,5 @@ class ClientTLSFailureTests: GRPCTestCase {
     }
   }
 }
+
+#endif // canImport(NIOSSL)

--- a/Tests/GRPCTests/ClientTLSTests.swift
+++ b/Tests/GRPCTests/ClientTLSTests.swift
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#if canImport(NIOSSL)
 import EchoImplementation
 import EchoModel
 import Foundation
@@ -210,3 +211,5 @@ private class AuthorityCheckingEcho: Echo_EchoProvider {
     preconditionFailure("Not implemented")
   }
 }
+
+#endif // canImport(NIOSSL)

--- a/Tests/GRPCTests/ConnectionPool/GRPCChannelPoolTests.swift
+++ b/Tests/GRPCTests/ConnectionPool/GRPCChannelPoolTests.swift
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#if canImport(NIOSSL)
 import EchoImplementation
 import EchoModel
 import GRPC
@@ -435,3 +436,5 @@ final class GRPCChannelPoolTests: GRPCTestCase {
     }
   }
 }
+
+#endif // canImport(NIOSSL)

--- a/Tests/GRPCTests/DelegatingErrorHandlerTests.swift
+++ b/Tests/GRPCTests/DelegatingErrorHandlerTests.swift
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#if canImport(NIOSSL)
 import Foundation
 @testable import GRPC
 import Logging
@@ -43,3 +44,5 @@ class DelegatingErrorHandlerTests: GRPCTestCase {
     XCTAssertEqual(delegate.errors[0] as? NIOSSLError, .writeDuringTLSShutdown)
   }
 }
+
+#endif // canImport(NIOSSL)

--- a/Tests/GRPCTests/ErrorRecordingDelegate.swift
+++ b/Tests/GRPCTests/ErrorRecordingDelegate.swift
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import GRPC
+import Logging
+import NIOConcurrencyHelpers
+import XCTest
+
+class ErrorRecordingDelegate: ClientErrorDelegate {
+  private let lock: Lock
+  private var _errors: [Error] = []
+
+  internal var errors: [Error] {
+    return self.lock.withLock {
+      return self._errors
+    }
+  }
+
+  var expectation: XCTestExpectation
+
+  init(expectation: XCTestExpectation) {
+    self.expectation = expectation
+    self.lock = Lock()
+  }
+
+  func didCatchError(_ error: Error, logger: Logger, file: StaticString, line: Int) {
+    self.lock.withLockVoid {
+      self._errors.append(error)
+    }
+    self.expectation.fulfill()
+  }
+}
+
+class ServerErrorRecordingDelegate: ServerErrorDelegate {
+  var errors: [Error] = []
+  var expectation: XCTestExpectation
+
+  init(expectation: XCTestExpectation) {
+    self.expectation = expectation
+  }
+
+  func observeLibraryError(_ error: Error) {
+    self.errors.append(error)
+    self.expectation.fulfill()
+  }
+}

--- a/Tests/GRPCTests/FunctionalTests.swift
+++ b/Tests/GRPCTests/FunctionalTests.swift
@@ -254,6 +254,7 @@ class FunctionalTestsInsecureTransport: EchoTestCaseBase {
   }
 }
 
+#if canImport(NIOSSL)
 class FunctionalTestsAnonymousClient: FunctionalTestsInsecureTransport {
   override var transportSecurity: TransportSecurity {
     return .anonymousClient
@@ -265,6 +266,7 @@ class FunctionalTestsMutualAuthentication: FunctionalTestsInsecureTransport {
     return .mutualAuthentication
   }
 }
+#endif // canImport(NIOSSL)
 
 // MARK: - Variants using NIO TS and Network.framework
 
@@ -356,6 +358,7 @@ class FunctionalTestsInsecureTransportNIOTS: FunctionalTestsInsecureTransport {
   }
 }
 
+#if canImport(NIOSSL)
 @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
 class FunctionalTestsAnonymousClientNIOTS: FunctionalTestsInsecureTransportNIOTS {
   override var transportSecurity: TransportSecurity {
@@ -369,3 +372,4 @@ class FunctionalTestsMutualAuthenticationNIOTS: FunctionalTestsInsecureTransport
     return .mutualAuthentication
   }
 }
+#endif // canImport(NIOSSL)

--- a/Tests/GRPCTests/GRPCInteroperabilityTests.swift
+++ b/Tests/GRPCTests/GRPCInteroperabilityTests.swift
@@ -165,6 +165,8 @@ class GRPCInsecureInteroperabilityTests: GRPCTestCase {
   }
 }
 
+#if canImport(NIOSSL)
 class GRPCSecureInteroperabilityTests: GRPCInsecureInteroperabilityTests {
   override var useTLS: Bool { return true }
 }
+#endif // canImport(NIOSSL)

--- a/Tests/GRPCTests/GRPCNetworkFrameworkTests.swift
+++ b/Tests/GRPCTests/GRPCNetworkFrameworkTests.swift
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#if canImport(NIOSSL)
 #if canImport(Network)
 import Dispatch
 import EchoImplementation
@@ -202,3 +203,4 @@ final class GRPCNetworkFrameworkTests: GRPCTestCase {
 }
 
 #endif // canImport(Network)
+#endif // canImport(NIOSSL)

--- a/Tests/GRPCTests/MutualTLSTests.swift
+++ b/Tests/GRPCTests/MutualTLSTests.swift
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#if canImport(NIOSSL)
 import EchoImplementation
 import EchoModel
 @testable import GRPC
@@ -267,3 +268,5 @@ class MutualTLSTests: GRPCTestCase {
     )
   }
 }
+
+#endif // canImport(NIOSSL)

--- a/Tests/GRPCTests/PlatformSupportTests.swift
+++ b/Tests/GRPCTests/PlatformSupportTests.swift
@@ -207,6 +207,7 @@ class PlatformSupportTests: GRPCTestCase {
 
   func testIsTLSConfigruationCompatible() {
     #if canImport(Network)
+    #if canImport(NIOSSL)
     guard #available(macOS 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *) else { return }
 
     let nwConfiguration = GRPCTLSConfiguration.makeClientConfigurationBackedByNetworkFramework()
@@ -231,15 +232,17 @@ class PlatformSupportTests: GRPCTestCase {
     XCTAssertTrue(group.isCompatible(with: nioSSLConfiguration))
     XCTAssertFalse(group.next().isCompatible(with: nwConfiguration))
     XCTAssertTrue(group.next().isCompatible(with: nioSSLConfiguration))
-
+    #endif
     #endif
   }
 
   func testMakeCompatibleEventLoopGroupForNIOSSL() {
+    #if canImport(NIOSSL)
     let configuration = GRPCTLSConfiguration.makeClientConfigurationBackedByNIOSSL()
     let group = PlatformSupport.makeEventLoopGroup(compatibleWith: configuration, loopCount: 1)
     XCTAssertNoThrow(try group.syncShutdownGracefully())
     XCTAssert(group is MultiThreadedEventLoopGroup)
+    #endif
   }
 
   func testMakeCompatibleEventLoopGroupForNetworkFramework() {

--- a/Tests/GRPCTests/ServerTLSErrorTests.swift
+++ b/Tests/GRPCTests/ServerTLSErrorTests.swift
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#if canImport(NIOSSL)
 import EchoImplementation
 import EchoModel
 @testable import GRPC
@@ -22,20 +23,6 @@ import NIOCore
 import NIOPosix
 import NIOSSL
 import XCTest
-
-class ServerErrorRecordingDelegate: ServerErrorDelegate {
-  var errors: [Error] = []
-  var expectation: XCTestExpectation
-
-  init(expectation: XCTestExpectation) {
-    self.expectation = expectation
-  }
-
-  func observeLibraryError(_ error: Error) {
-    self.errors.append(error)
-    self.expectation.fulfill()
-  }
-}
 
 class ServerTLSErrorTests: GRPCTestCase {
   let defaultClientTLSConfiguration = GRPCTLSConfiguration.makeClientConfigurationBackedByNIOSSL(
@@ -138,3 +125,5 @@ class ServerTLSErrorTests: GRPCTestCase {
     }
   }
 }
+
+#endif // canImport(NIOSSL)

--- a/Tests/GRPCTests/ZeroLengthWriteTests.swift
+++ b/Tests/GRPCTests/ZeroLengthWriteTests.swift
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#if canImport(NIOSSL)
 import Dispatch
 import EchoImplementation
 import EchoModel
@@ -261,3 +262,5 @@ final class ZeroLengthWriteTests: GRPCTestCase {
     #endif
   }
 }
+
+#endif // canImport(NIOSSL)


### PR DESCRIPTION
Motivation:

In some situations NIOSSL isn't required when using gRPC. Since NIOSSL
brings a copy of BoringSSL with it it is quite a large depenency to
bring along.

Modifications:

- Wrap all code which uses NIOSSL in `#if canImport(NIOSSL)`
- This required shuffling around a few files, the code isn't
  meaningfully different otherwise

Result:

gRPC can be compiled without NIOSSL.