### PR TITLE
Deflake zero length write tests

### DIFF
--- a/Tests/GRPCTests/ZeroLengthWriteTests.swift
+++ b/Tests/GRPCTests/ZeroLengthWriteTests.swift
@@ -67,7 +67,7 @@ final class ZeroLengthWriteTests: GRPCTestCase {
     return try self.serverBuilder(group: group, secure: secure, debugInitializer: debugInitializer)
       .withServiceProviders([self.makeEchoProvider()])
       .withLogger(self.serverLogger)
-      .bind(host: "localhost", port: 0)
+      .bind(host: "127.0.0.1", port: 0)
       .wait()
   }
 
@@ -79,7 +79,8 @@ final class ZeroLengthWriteTests: GRPCTestCase {
   ) throws -> ClientConnection {
     return self.clientBuilder(group: group, secure: secure, debugInitializer: debugInitializer)
       .withBackgroundActivityLogger(self.clientLogger)
-      .connect(host: "localhost", port: port)
+      .withConnectionReestablishment(enabled: false)
+      .connect(host: "127.0.0.1", port: port)
   }
 
   func makeEchoProvider() -> Echo_EchoProvider { return EchoProvider() }


### PR DESCRIPTION
Motivation:

The zero-length write tests fail every so often because the XCTest
expectations are over fulfilled.

They can be overfulfilled when the client makes multiple attempts to
connect to the test server. This can happen because of happy eyeballs or
because the client is re-attempting to connect to the server.

Modifications:

- Use "127.0.0.1" instead of "localhost" to avoid using happy eyeballs
- Disable client connection re-establishment

Result:

Less flakey test.