### PR TITLE
Generate static service metadata

### DIFF
--- a/Sources/Examples/Echo/Model/echo.grpc.swift
+++ b/Sources/Examples/Echo/Model/echo.grpc.swift
@@ -67,7 +67,7 @@ extension Echo_EchoClientProtocol {
     callOptions: CallOptions? = nil
   ) -> UnaryCall<Echo_EchoRequest, Echo_EchoResponse> {
     return self.makeUnaryCall(
-      path: "/echo.Echo/Get",
+      path: Echo_EchoClientMetadata.Methods.get.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeGetInterceptors() ?? []
@@ -87,7 +87,7 @@ extension Echo_EchoClientProtocol {
     handler: @escaping (Echo_EchoResponse) -> Void
   ) -> ServerStreamingCall<Echo_EchoRequest, Echo_EchoResponse> {
     return self.makeServerStreamingCall(
-      path: "/echo.Echo/Expand",
+      path: Echo_EchoClientMetadata.Methods.expand.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeExpandInterceptors() ?? [],
@@ -107,7 +107,7 @@ extension Echo_EchoClientProtocol {
     callOptions: CallOptions? = nil
   ) -> ClientStreamingCall<Echo_EchoRequest, Echo_EchoResponse> {
     return self.makeClientStreamingCall(
-      path: "/echo.Echo/Collect",
+      path: Echo_EchoClientMetadata.Methods.collect.path,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeCollectInterceptors() ?? []
     )
@@ -127,27 +127,12 @@ extension Echo_EchoClientProtocol {
     handler: @escaping (Echo_EchoResponse) -> Void
   ) -> BidirectionalStreamingCall<Echo_EchoRequest, Echo_EchoResponse> {
     return self.makeBidirectionalStreamingCall(
-      path: "/echo.Echo/Update",
+      path: Echo_EchoClientMetadata.Methods.update.path,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeUpdateInterceptors() ?? [],
       handler: handler
     )
   }
-}
-
-public protocol Echo_EchoClientInterceptorFactoryProtocol {
-
-  /// - Returns: Interceptors to use when invoking 'get'.
-  func makeGetInterceptors() -> [ClientInterceptor<Echo_EchoRequest, Echo_EchoResponse>]
-
-  /// - Returns: Interceptors to use when invoking 'expand'.
-  func makeExpandInterceptors() -> [ClientInterceptor<Echo_EchoRequest, Echo_EchoResponse>]
-
-  /// - Returns: Interceptors to use when invoking 'collect'.
-  func makeCollectInterceptors() -> [ClientInterceptor<Echo_EchoRequest, Echo_EchoResponse>]
-
-  /// - Returns: Interceptors to use when invoking 'update'.
-  func makeUpdateInterceptors() -> [ClientInterceptor<Echo_EchoRequest, Echo_EchoResponse>]
 }
 
 public final class Echo_EchoClient: Echo_EchoClientProtocol {
@@ -175,7 +160,7 @@ public final class Echo_EchoClient: Echo_EchoClientProtocol {
 #if compiler(>=5.5) && canImport(_Concurrency)
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public protocol Echo_EchoAsyncClientProtocol: GRPCClient {
-  var serviceName: String { get }
+  static var serviceDescriptor: GRPCServiceDescriptor { get }
   var interceptors: Echo_EchoClientInterceptorFactoryProtocol? { get }
 
   func makeGetCall(
@@ -199,8 +184,8 @@ public protocol Echo_EchoAsyncClientProtocol: GRPCClient {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension Echo_EchoAsyncClientProtocol {
-  public var serviceName: String {
-    return "echo.Echo"
+  public static var serviceDescriptor: GRPCServiceDescriptor {
+    return Echo_EchoClientMetadata.serviceDescriptor
   }
 
   public var interceptors: Echo_EchoClientInterceptorFactoryProtocol? {
@@ -212,7 +197,7 @@ extension Echo_EchoAsyncClientProtocol {
     callOptions: CallOptions? = nil
   ) -> GRPCAsyncUnaryCall<Echo_EchoRequest, Echo_EchoResponse> {
     return self.makeAsyncUnaryCall(
-      path: "/echo.Echo/Get",
+      path: Echo_EchoClientMetadata.Methods.get.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeGetInterceptors() ?? []
@@ -224,7 +209,7 @@ extension Echo_EchoAsyncClientProtocol {
     callOptions: CallOptions? = nil
   ) -> GRPCAsyncServerStreamingCall<Echo_EchoRequest, Echo_EchoResponse> {
     return self.makeAsyncServerStreamingCall(
-      path: "/echo.Echo/Expand",
+      path: Echo_EchoClientMetadata.Methods.expand.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeExpandInterceptors() ?? []
@@ -235,7 +220,7 @@ extension Echo_EchoAsyncClientProtocol {
     callOptions: CallOptions? = nil
   ) -> GRPCAsyncClientStreamingCall<Echo_EchoRequest, Echo_EchoResponse> {
     return self.makeAsyncClientStreamingCall(
-      path: "/echo.Echo/Collect",
+      path: Echo_EchoClientMetadata.Methods.collect.path,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeCollectInterceptors() ?? []
     )
@@ -245,7 +230,7 @@ extension Echo_EchoAsyncClientProtocol {
     callOptions: CallOptions? = nil
   ) -> GRPCAsyncBidirectionalStreamingCall<Echo_EchoRequest, Echo_EchoResponse> {
     return self.makeAsyncBidirectionalStreamingCall(
-      path: "/echo.Echo/Update",
+      path: Echo_EchoClientMetadata.Methods.update.path,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeUpdateInterceptors() ?? []
     )
@@ -259,7 +244,7 @@ extension Echo_EchoAsyncClientProtocol {
     callOptions: CallOptions? = nil
   ) async throws -> Echo_EchoResponse {
     return try await self.performAsyncUnaryCall(
-      path: "/echo.Echo/Get",
+      path: Echo_EchoClientMetadata.Methods.get.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeGetInterceptors() ?? []
@@ -271,7 +256,7 @@ extension Echo_EchoAsyncClientProtocol {
     callOptions: CallOptions? = nil
   ) -> GRPCAsyncResponseStream<Echo_EchoResponse> {
     return self.performAsyncServerStreamingCall(
-      path: "/echo.Echo/Expand",
+      path: Echo_EchoClientMetadata.Methods.expand.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeExpandInterceptors() ?? []
@@ -283,7 +268,7 @@ extension Echo_EchoAsyncClientProtocol {
     callOptions: CallOptions? = nil
   ) async throws -> Echo_EchoResponse where RequestStream: Sequence, RequestStream.Element == Echo_EchoRequest {
     return try await self.performAsyncClientStreamingCall(
-      path: "/echo.Echo/Collect",
+      path: Echo_EchoClientMetadata.Methods.collect.path,
       requests: requests,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeCollectInterceptors() ?? []
@@ -295,7 +280,7 @@ extension Echo_EchoAsyncClientProtocol {
     callOptions: CallOptions? = nil
   ) async throws -> Echo_EchoResponse where RequestStream: AsyncSequence, RequestStream.Element == Echo_EchoRequest {
     return try await self.performAsyncClientStreamingCall(
-      path: "/echo.Echo/Collect",
+      path: Echo_EchoClientMetadata.Methods.collect.path,
       requests: requests,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeCollectInterceptors() ?? []
@@ -307,7 +292,7 @@ extension Echo_EchoAsyncClientProtocol {
     callOptions: CallOptions? = nil
   ) -> GRPCAsyncResponseStream<Echo_EchoResponse> where RequestStream: Sequence, RequestStream.Element == Echo_EchoRequest {
     return self.performAsyncBidirectionalStreamingCall(
-      path: "/echo.Echo/Update",
+      path: Echo_EchoClientMetadata.Methods.update.path,
       requests: requests,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeUpdateInterceptors() ?? []
@@ -319,7 +304,7 @@ extension Echo_EchoAsyncClientProtocol {
     callOptions: CallOptions? = nil
   ) -> GRPCAsyncResponseStream<Echo_EchoResponse> where RequestStream: AsyncSequence, RequestStream.Element == Echo_EchoRequest {
     return self.performAsyncBidirectionalStreamingCall(
-      path: "/echo.Echo/Update",
+      path: Echo_EchoClientMetadata.Methods.update.path,
       requests: requests,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeUpdateInterceptors() ?? []
@@ -345,6 +330,60 @@ public struct Echo_EchoAsyncClient: Echo_EchoAsyncClientProtocol {
 }
 
 #endif // compiler(>=5.5) && canImport(_Concurrency)
+
+public protocol Echo_EchoClientInterceptorFactoryProtocol {
+
+  /// - Returns: Interceptors to use when invoking 'get'.
+  func makeGetInterceptors() -> [ClientInterceptor<Echo_EchoRequest, Echo_EchoResponse>]
+
+  /// - Returns: Interceptors to use when invoking 'expand'.
+  func makeExpandInterceptors() -> [ClientInterceptor<Echo_EchoRequest, Echo_EchoResponse>]
+
+  /// - Returns: Interceptors to use when invoking 'collect'.
+  func makeCollectInterceptors() -> [ClientInterceptor<Echo_EchoRequest, Echo_EchoResponse>]
+
+  /// - Returns: Interceptors to use when invoking 'update'.
+  func makeUpdateInterceptors() -> [ClientInterceptor<Echo_EchoRequest, Echo_EchoResponse>]
+}
+
+public enum Echo_EchoClientMetadata {
+  public static let serviceDescriptor = GRPCServiceDescriptor(
+    name: "Echo",
+    fullName: "echo.Echo",
+    methods: [
+      Echo_EchoClientMetadata.Methods.get,
+      Echo_EchoClientMetadata.Methods.expand,
+      Echo_EchoClientMetadata.Methods.collect,
+      Echo_EchoClientMetadata.Methods.update,
+    ]
+  )
+
+  public enum Methods {
+    public static let get = GRPCMethodDescriptor(
+      name: "Get",
+      path: "/echo.Echo/Get",
+      type: GRPCCallType.unary
+    )
+
+    public static let expand = GRPCMethodDescriptor(
+      name: "Expand",
+      path: "/echo.Echo/Expand",
+      type: GRPCCallType.serverStreaming
+    )
+
+    public static let collect = GRPCMethodDescriptor(
+      name: "Collect",
+      path: "/echo.Echo/Collect",
+      type: GRPCCallType.clientStreaming
+    )
+
+    public static let update = GRPCMethodDescriptor(
+      name: "Update",
+      path: "/echo.Echo/Update",
+      type: GRPCCallType.bidirectionalStreaming
+    )
+  }
+}
 
 public final class Echo_EchoTestClient: Echo_EchoClientProtocol {
   private let fakeChannel: FakeChannel
@@ -372,7 +411,7 @@ public final class Echo_EchoTestClient: Echo_EchoClientProtocol {
   public func makeGetResponseStream(
     _ requestHandler: @escaping (FakeRequestPart<Echo_EchoRequest>) -> () = { _ in }
   ) -> FakeUnaryResponse<Echo_EchoRequest, Echo_EchoResponse> {
-    return self.fakeChannel.makeFakeUnaryResponse(path: "/echo.Echo/Get", requestHandler: requestHandler)
+    return self.fakeChannel.makeFakeUnaryResponse(path: Echo_EchoClientMetadata.Methods.get.path, requestHandler: requestHandler)
   }
 
   public func enqueueGetResponse(
@@ -386,7 +425,7 @@ public final class Echo_EchoTestClient: Echo_EchoClientProtocol {
 
   /// Returns true if there are response streams enqueued for 'Get'
   public var hasGetResponsesRemaining: Bool {
-    return self.fakeChannel.hasFakeResponseEnqueued(forPath: "/echo.Echo/Get")
+    return self.fakeChannel.hasFakeResponseEnqueued(forPath: Echo_EchoClientMetadata.Methods.get.path)
   }
 
   /// Make a streaming response for the Expand RPC. This must be called
@@ -396,7 +435,7 @@ public final class Echo_EchoTestClient: Echo_EchoClientProtocol {
   public func makeExpandResponseStream(
     _ requestHandler: @escaping (FakeRequestPart<Echo_EchoRequest>) -> () = { _ in }
   ) -> FakeStreamingResponse<Echo_EchoRequest, Echo_EchoResponse> {
-    return self.fakeChannel.makeFakeStreamingResponse(path: "/echo.Echo/Expand", requestHandler: requestHandler)
+    return self.fakeChannel.makeFakeStreamingResponse(path: Echo_EchoClientMetadata.Methods.expand.path, requestHandler: requestHandler)
   }
 
   public func enqueueExpandResponses(
@@ -411,7 +450,7 @@ public final class Echo_EchoTestClient: Echo_EchoClientProtocol {
 
   /// Returns true if there are response streams enqueued for 'Expand'
   public var hasExpandResponsesRemaining: Bool {
-    return self.fakeChannel.hasFakeResponseEnqueued(forPath: "/echo.Echo/Expand")
+    return self.fakeChannel.hasFakeResponseEnqueued(forPath: Echo_EchoClientMetadata.Methods.expand.path)
   }
 
   /// Make a unary response for the Collect RPC. This must be called
@@ -421,7 +460,7 @@ public final class Echo_EchoTestClient: Echo_EchoClientProtocol {
   public func makeCollectResponseStream(
     _ requestHandler: @escaping (FakeRequestPart<Echo_EchoRequest>) -> () = { _ in }
   ) -> FakeUnaryResponse<Echo_EchoRequest, Echo_EchoResponse> {
-    return self.fakeChannel.makeFakeUnaryResponse(path: "/echo.Echo/Collect", requestHandler: requestHandler)
+    return self.fakeChannel.makeFakeUnaryResponse(path: Echo_EchoClientMetadata.Methods.collect.path, requestHandler: requestHandler)
   }
 
   public func enqueueCollectResponse(
@@ -435,7 +474,7 @@ public final class Echo_EchoTestClient: Echo_EchoClientProtocol {
 
   /// Returns true if there are response streams enqueued for 'Collect'
   public var hasCollectResponsesRemaining: Bool {
-    return self.fakeChannel.hasFakeResponseEnqueued(forPath: "/echo.Echo/Collect")
+    return self.fakeChannel.hasFakeResponseEnqueued(forPath: Echo_EchoClientMetadata.Methods.collect.path)
   }
 
   /// Make a streaming response for the Update RPC. This must be called
@@ -445,7 +484,7 @@ public final class Echo_EchoTestClient: Echo_EchoClientProtocol {
   public func makeUpdateResponseStream(
     _ requestHandler: @escaping (FakeRequestPart<Echo_EchoRequest>) -> () = { _ in }
   ) -> FakeStreamingResponse<Echo_EchoRequest, Echo_EchoResponse> {
-    return self.fakeChannel.makeFakeStreamingResponse(path: "/echo.Echo/Update", requestHandler: requestHandler)
+    return self.fakeChannel.makeFakeStreamingResponse(path: Echo_EchoClientMetadata.Methods.update.path, requestHandler: requestHandler)
   }
 
   public func enqueueUpdateResponses(
@@ -460,7 +499,7 @@ public final class Echo_EchoTestClient: Echo_EchoClientProtocol {
 
   /// Returns true if there are response streams enqueued for 'Update'
   public var hasUpdateResponsesRemaining: Bool {
-    return self.fakeChannel.hasFakeResponseEnqueued(forPath: "/echo.Echo/Update")
+    return self.fakeChannel.hasFakeResponseEnqueued(forPath: Echo_EchoClientMetadata.Methods.update.path)
   }
 }
 
@@ -482,7 +521,9 @@ public protocol Echo_EchoProvider: CallHandlerProvider {
 }
 
 extension Echo_EchoProvider {
-  public var serviceName: Substring { return "echo.Echo" }
+  public var serviceName: Substring {
+    return Echo_EchoServerMetadata.serviceDescriptor.fullName[...]
+  }
 
   /// Determines, calls and returns the appropriate request handler, depending on the request's method.
   /// Returns nil for methods not handled by this service.
@@ -532,31 +573,12 @@ extension Echo_EchoProvider {
     }
   }
 }
-
-public protocol Echo_EchoServerInterceptorFactoryProtocol {
-
-  /// - Returns: Interceptors to use when handling 'get'.
-  ///   Defaults to calling `self.makeInterceptors()`.
-  func makeGetInterceptors() -> [ServerInterceptor<Echo_EchoRequest, Echo_EchoResponse>]
-
-  /// - Returns: Interceptors to use when handling 'expand'.
-  ///   Defaults to calling `self.makeInterceptors()`.
-  func makeExpandInterceptors() -> [ServerInterceptor<Echo_EchoRequest, Echo_EchoResponse>]
-
-  /// - Returns: Interceptors to use when handling 'collect'.
-  ///   Defaults to calling `self.makeInterceptors()`.
-  func makeCollectInterceptors() -> [ServerInterceptor<Echo_EchoRequest, Echo_EchoResponse>]
-
-  /// - Returns: Interceptors to use when handling 'update'.
-  ///   Defaults to calling `self.makeInterceptors()`.
-  func makeUpdateInterceptors() -> [ServerInterceptor<Echo_EchoRequest, Echo_EchoResponse>]
-}
-
 #if compiler(>=5.5) && canImport(_Concurrency)
 
 /// To implement a server, implement an object which conforms to this protocol.
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public protocol Echo_EchoAsyncProvider: CallHandlerProvider {
+  static var serviceDescriptor: GRPCServiceDescriptor { get }
   var interceptors: Echo_EchoServerInterceptorFactoryProtocol? { get }
 
   /// Immediately returns an echo of a request.
@@ -588,8 +610,12 @@ public protocol Echo_EchoAsyncProvider: CallHandlerProvider {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension Echo_EchoAsyncProvider {
+  public static var serviceDescriptor: GRPCServiceDescriptor {
+    return Echo_EchoServerMetadata.serviceDescriptor
+  }
+
   public var serviceName: Substring {
-    return "echo.Echo"
+    return Echo_EchoServerMetadata.serviceDescriptor.fullName[...]
   }
 
   public var interceptors: Echo_EchoServerInterceptorFactoryProtocol? {
@@ -645,3 +671,60 @@ extension Echo_EchoAsyncProvider {
 
 #endif // compiler(>=5.5) && canImport(_Concurrency)
 
+public protocol Echo_EchoServerInterceptorFactoryProtocol {
+
+  /// - Returns: Interceptors to use when handling 'get'.
+  ///   Defaults to calling `self.makeInterceptors()`.
+  func makeGetInterceptors() -> [ServerInterceptor<Echo_EchoRequest, Echo_EchoResponse>]
+
+  /// - Returns: Interceptors to use when handling 'expand'.
+  ///   Defaults to calling `self.makeInterceptors()`.
+  func makeExpandInterceptors() -> [ServerInterceptor<Echo_EchoRequest, Echo_EchoResponse>]
+
+  /// - Returns: Interceptors to use when handling 'collect'.
+  ///   Defaults to calling `self.makeInterceptors()`.
+  func makeCollectInterceptors() -> [ServerInterceptor<Echo_EchoRequest, Echo_EchoResponse>]
+
+  /// - Returns: Interceptors to use when handling 'update'.
+  ///   Defaults to calling `self.makeInterceptors()`.
+  func makeUpdateInterceptors() -> [ServerInterceptor<Echo_EchoRequest, Echo_EchoResponse>]
+}
+
+public enum Echo_EchoServerMetadata {
+  public static let serviceDescriptor = GRPCServiceDescriptor(
+    name: "Echo",
+    fullName: "echo.Echo",
+    methods: [
+      Echo_EchoServerMetadata.Methods.get,
+      Echo_EchoServerMetadata.Methods.expand,
+      Echo_EchoServerMetadata.Methods.collect,
+      Echo_EchoServerMetadata.Methods.update,
+    ]
+  )
+
+  public enum Methods {
+    public static let get = GRPCMethodDescriptor(
+      name: "Get",
+      path: "/echo.Echo/Get",
+      type: GRPCCallType.unary
+    )
+
+    public static let expand = GRPCMethodDescriptor(
+      name: "Expand",
+      path: "/echo.Echo/Expand",
+      type: GRPCCallType.serverStreaming
+    )
+
+    public static let collect = GRPCMethodDescriptor(
+      name: "Collect",
+      path: "/echo.Echo/Collect",
+      type: GRPCCallType.clientStreaming
+    )
+
+    public static let update = GRPCMethodDescriptor(
+      name: "Update",
+      path: "/echo.Echo/Update",
+      type: GRPCCallType.bidirectionalStreaming
+    )
+  }
+}

--- a/Sources/Examples/HelloWorld/Model/helloworld.grpc.swift
+++ b/Sources/Examples/HelloWorld/Model/helloworld.grpc.swift
@@ -54,18 +54,12 @@ extension Helloworld_GreeterClientProtocol {
     callOptions: CallOptions? = nil
   ) -> UnaryCall<Helloworld_HelloRequest, Helloworld_HelloReply> {
     return self.makeUnaryCall(
-      path: "/helloworld.Greeter/SayHello",
+      path: Helloworld_GreeterClientMetadata.Methods.sayHello.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeSayHelloInterceptors() ?? []
     )
   }
-}
-
-public protocol Helloworld_GreeterClientInterceptorFactoryProtocol {
-
-  /// - Returns: Interceptors to use when invoking 'sayHello'.
-  func makeSayHelloInterceptors() -> [ClientInterceptor<Helloworld_HelloRequest, Helloworld_HelloReply>]
 }
 
 public final class Helloworld_GreeterClient: Helloworld_GreeterClientProtocol {
@@ -90,6 +84,30 @@ public final class Helloworld_GreeterClient: Helloworld_GreeterClientProtocol {
   }
 }
 
+public protocol Helloworld_GreeterClientInterceptorFactoryProtocol {
+
+  /// - Returns: Interceptors to use when invoking 'sayHello'.
+  func makeSayHelloInterceptors() -> [ClientInterceptor<Helloworld_HelloRequest, Helloworld_HelloReply>]
+}
+
+public enum Helloworld_GreeterClientMetadata {
+  public static let serviceDescriptor = GRPCServiceDescriptor(
+    name: "Greeter",
+    fullName: "helloworld.Greeter",
+    methods: [
+      Helloworld_GreeterClientMetadata.Methods.sayHello,
+    ]
+  )
+
+  public enum Methods {
+    public static let sayHello = GRPCMethodDescriptor(
+      name: "SayHello",
+      path: "/helloworld.Greeter/SayHello",
+      type: GRPCCallType.unary
+    )
+  }
+}
+
 /// The greeting service definition.
 ///
 /// To build a server, implement a class that conforms to this protocol.
@@ -101,7 +119,9 @@ public protocol Helloworld_GreeterProvider: CallHandlerProvider {
 }
 
 extension Helloworld_GreeterProvider {
-  public var serviceName: Substring { return "helloworld.Greeter" }
+  public var serviceName: Substring {
+    return Helloworld_GreeterServerMetadata.serviceDescriptor.fullName[...]
+  }
 
   /// Determines, calls and returns the appropriate request handler, depending on the request's method.
   /// Returns nil for methods not handled by this service.
@@ -132,3 +152,20 @@ public protocol Helloworld_GreeterServerInterceptorFactoryProtocol {
   func makeSayHelloInterceptors() -> [ServerInterceptor<Helloworld_HelloRequest, Helloworld_HelloReply>]
 }
 
+public enum Helloworld_GreeterServerMetadata {
+  public static let serviceDescriptor = GRPCServiceDescriptor(
+    name: "Greeter",
+    fullName: "helloworld.Greeter",
+    methods: [
+      Helloworld_GreeterServerMetadata.Methods.sayHello,
+    ]
+  )
+
+  public enum Methods {
+    public static let sayHello = GRPCMethodDescriptor(
+      name: "SayHello",
+      path: "/helloworld.Greeter/SayHello",
+      type: GRPCCallType.unary
+    )
+  }
+}

--- a/Sources/Examples/RouteGuide/Model/route_guide.grpc.swift
+++ b/Sources/Examples/RouteGuide/Model/route_guide.grpc.swift
@@ -74,7 +74,7 @@ extension Routeguide_RouteGuideClientProtocol {
     callOptions: CallOptions? = nil
   ) -> UnaryCall<Routeguide_Point, Routeguide_Feature> {
     return self.makeUnaryCall(
-      path: "/routeguide.RouteGuide/GetFeature",
+      path: Routeguide_RouteGuideClientMetadata.Methods.getFeature.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeGetFeatureInterceptors() ?? []
@@ -99,7 +99,7 @@ extension Routeguide_RouteGuideClientProtocol {
     handler: @escaping (Routeguide_Feature) -> Void
   ) -> ServerStreamingCall<Routeguide_Rectangle, Routeguide_Feature> {
     return self.makeServerStreamingCall(
-      path: "/routeguide.RouteGuide/ListFeatures",
+      path: Routeguide_RouteGuideClientMetadata.Methods.listFeatures.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeListFeaturesInterceptors() ?? [],
@@ -122,7 +122,7 @@ extension Routeguide_RouteGuideClientProtocol {
     callOptions: CallOptions? = nil
   ) -> ClientStreamingCall<Routeguide_Point, Routeguide_RouteSummary> {
     return self.makeClientStreamingCall(
-      path: "/routeguide.RouteGuide/RecordRoute",
+      path: Routeguide_RouteGuideClientMetadata.Methods.recordRoute.path,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeRecordRouteInterceptors() ?? []
     )
@@ -145,27 +145,12 @@ extension Routeguide_RouteGuideClientProtocol {
     handler: @escaping (Routeguide_RouteNote) -> Void
   ) -> BidirectionalStreamingCall<Routeguide_RouteNote, Routeguide_RouteNote> {
     return self.makeBidirectionalStreamingCall(
-      path: "/routeguide.RouteGuide/RouteChat",
+      path: Routeguide_RouteGuideClientMetadata.Methods.routeChat.path,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeRouteChatInterceptors() ?? [],
       handler: handler
     )
   }
-}
-
-public protocol Routeguide_RouteGuideClientInterceptorFactoryProtocol {
-
-  /// - Returns: Interceptors to use when invoking 'getFeature'.
-  func makeGetFeatureInterceptors() -> [ClientInterceptor<Routeguide_Point, Routeguide_Feature>]
-
-  /// - Returns: Interceptors to use when invoking 'listFeatures'.
-  func makeListFeaturesInterceptors() -> [ClientInterceptor<Routeguide_Rectangle, Routeguide_Feature>]
-
-  /// - Returns: Interceptors to use when invoking 'recordRoute'.
-  func makeRecordRouteInterceptors() -> [ClientInterceptor<Routeguide_Point, Routeguide_RouteSummary>]
-
-  /// - Returns: Interceptors to use when invoking 'routeChat'.
-  func makeRouteChatInterceptors() -> [ClientInterceptor<Routeguide_RouteNote, Routeguide_RouteNote>]
 }
 
 public final class Routeguide_RouteGuideClient: Routeguide_RouteGuideClientProtocol {
@@ -187,6 +172,60 @@ public final class Routeguide_RouteGuideClient: Routeguide_RouteGuideClientProto
     self.channel = channel
     self.defaultCallOptions = defaultCallOptions
     self.interceptors = interceptors
+  }
+}
+
+public protocol Routeguide_RouteGuideClientInterceptorFactoryProtocol {
+
+  /// - Returns: Interceptors to use when invoking 'getFeature'.
+  func makeGetFeatureInterceptors() -> [ClientInterceptor<Routeguide_Point, Routeguide_Feature>]
+
+  /// - Returns: Interceptors to use when invoking 'listFeatures'.
+  func makeListFeaturesInterceptors() -> [ClientInterceptor<Routeguide_Rectangle, Routeguide_Feature>]
+
+  /// - Returns: Interceptors to use when invoking 'recordRoute'.
+  func makeRecordRouteInterceptors() -> [ClientInterceptor<Routeguide_Point, Routeguide_RouteSummary>]
+
+  /// - Returns: Interceptors to use when invoking 'routeChat'.
+  func makeRouteChatInterceptors() -> [ClientInterceptor<Routeguide_RouteNote, Routeguide_RouteNote>]
+}
+
+public enum Routeguide_RouteGuideClientMetadata {
+  public static let serviceDescriptor = GRPCServiceDescriptor(
+    name: "RouteGuide",
+    fullName: "routeguide.RouteGuide",
+    methods: [
+      Routeguide_RouteGuideClientMetadata.Methods.getFeature,
+      Routeguide_RouteGuideClientMetadata.Methods.listFeatures,
+      Routeguide_RouteGuideClientMetadata.Methods.recordRoute,
+      Routeguide_RouteGuideClientMetadata.Methods.routeChat,
+    ]
+  )
+
+  public enum Methods {
+    public static let getFeature = GRPCMethodDescriptor(
+      name: "GetFeature",
+      path: "/routeguide.RouteGuide/GetFeature",
+      type: GRPCCallType.unary
+    )
+
+    public static let listFeatures = GRPCMethodDescriptor(
+      name: "ListFeatures",
+      path: "/routeguide.RouteGuide/ListFeatures",
+      type: GRPCCallType.serverStreaming
+    )
+
+    public static let recordRoute = GRPCMethodDescriptor(
+      name: "RecordRoute",
+      path: "/routeguide.RouteGuide/RecordRoute",
+      type: GRPCCallType.clientStreaming
+    )
+
+    public static let routeChat = GRPCMethodDescriptor(
+      name: "RouteChat",
+      path: "/routeguide.RouteGuide/RouteChat",
+      type: GRPCCallType.bidirectionalStreaming
+    )
   }
 }
 
@@ -226,7 +265,9 @@ public protocol Routeguide_RouteGuideProvider: CallHandlerProvider {
 }
 
 extension Routeguide_RouteGuideProvider {
-  public var serviceName: Substring { return "routeguide.RouteGuide" }
+  public var serviceName: Substring {
+    return Routeguide_RouteGuideServerMetadata.serviceDescriptor.fullName[...]
+  }
 
   /// Determines, calls and returns the appropriate request handler, depending on the request's method.
   /// Returns nil for methods not handled by this service.
@@ -296,3 +337,41 @@ public protocol Routeguide_RouteGuideServerInterceptorFactoryProtocol {
   func makeRouteChatInterceptors() -> [ServerInterceptor<Routeguide_RouteNote, Routeguide_RouteNote>]
 }
 
+public enum Routeguide_RouteGuideServerMetadata {
+  public static let serviceDescriptor = GRPCServiceDescriptor(
+    name: "RouteGuide",
+    fullName: "routeguide.RouteGuide",
+    methods: [
+      Routeguide_RouteGuideServerMetadata.Methods.getFeature,
+      Routeguide_RouteGuideServerMetadata.Methods.listFeatures,
+      Routeguide_RouteGuideServerMetadata.Methods.recordRoute,
+      Routeguide_RouteGuideServerMetadata.Methods.routeChat,
+    ]
+  )
+
+  public enum Methods {
+    public static let getFeature = GRPCMethodDescriptor(
+      name: "GetFeature",
+      path: "/routeguide.RouteGuide/GetFeature",
+      type: GRPCCallType.unary
+    )
+
+    public static let listFeatures = GRPCMethodDescriptor(
+      name: "ListFeatures",
+      path: "/routeguide.RouteGuide/ListFeatures",
+      type: GRPCCallType.serverStreaming
+    )
+
+    public static let recordRoute = GRPCMethodDescriptor(
+      name: "RecordRoute",
+      path: "/routeguide.RouteGuide/RecordRoute",
+      type: GRPCCallType.clientStreaming
+    )
+
+    public static let routeChat = GRPCMethodDescriptor(
+      name: "RouteChat",
+      path: "/routeguide.RouteGuide/RouteChat",
+      type: GRPCCallType.bidirectionalStreaming
+    )
+  }
+}

--- a/Sources/Examples/RouteGuide/Model/route_guide.pb.swift
+++ b/Sources/Examples/RouteGuide/Model/route_guide.pb.swift
@@ -231,12 +231,16 @@ extension Routeguide_Rectangle: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._lo {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._lo {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
-    if let v = self._hi {
+    } }()
+    try { if let v = self._hi {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -269,12 +273,16 @@ extension Routeguide_Feature: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if !self.name.isEmpty {
       try visitor.visitSingularStringField(value: self.name, fieldNumber: 1)
     }
-    if let v = self._location {
+    try { if let v = self._location {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -307,9 +315,13 @@ extension Routeguide_RouteNote: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._location {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._location {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
+    } }()
     if !self.message.isEmpty {
       try visitor.visitSingularStringField(value: self.message, fieldNumber: 2)
     }

--- a/Sources/GRPC/GRPCClientChannelHandler.swift
+++ b/Sources/GRPC/GRPCClientChannelHandler.swift
@@ -226,7 +226,7 @@ extension _GRPCRequestHead {
 }
 
 /// The type of gRPC call.
-public enum GRPCCallType {
+public enum GRPCCallType: Hashable {
   /// Unary: a single request and a single response.
   case unary
 

--- a/Sources/GRPC/GRPCServiceDescription.swift
+++ b/Sources/GRPC/GRPCServiceDescription.swift
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+public struct GRPCServiceDescriptor: Hashable {
+  /// The name of the service excluding the package, e.g. 'Echo'.
+  public var name: String
+
+  /// The full name of the service including the package, e.g. 'echo.Echo'
+  public var fullName: String
+
+  /// Methods defined on the service.
+  public var methods: [GRPCMethodDescriptor]
+
+  public init(name: String, fullName: String, methods: [GRPCMethodDescriptor]) {
+    self.name = name
+    self.fullName = fullName
+    self.methods = methods
+  }
+}
+
+public struct GRPCMethodDescriptor: Hashable {
+  /// The name of the method, e.g. 'Get'.
+  public var name: String
+
+  /// The full name of the method include the fully qualified name of the service in the
+  /// format 'package.Service/Method', for example 'echo.Echo/Get'.
+  ///
+  /// This differs from the ``path`` only in that the leading '/' is removed.
+  public var fullName: String {
+    assert(self.path.utf8.first == UInt8(ascii: "/"))
+    return String(self.path.dropFirst())
+  }
+
+  /// The path of the method in the format '/package.Service/method', for example '/echo.Echo/Get'.
+  public var path: String
+
+  /// The type of call.
+  public var type: GRPCCallType
+
+  public init(name: String, path: String, type: GRPCCallType) {
+    self.name = name
+    self.path = path
+    self.type = type
+  }
+}

--- a/Sources/GRPCInteroperabilityTestModels/Generated/messages.pb.swift
+++ b/Sources/GRPCInteroperabilityTestModels/Generated/messages.pb.swift
@@ -558,30 +558,34 @@ extension Grpc_Testing_SimpleRequest: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if self.responseType != .compressable {
       try visitor.visitSingularEnumField(value: self.responseType, fieldNumber: 1)
     }
     if self.responseSize != 0 {
       try visitor.visitSingularInt32Field(value: self.responseSize, fieldNumber: 2)
     }
-    if let v = self._payload {
+    try { if let v = self._payload {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-    }
+    } }()
     if self.fillUsername != false {
       try visitor.visitSingularBoolField(value: self.fillUsername, fieldNumber: 4)
     }
     if self.fillOauthScope != false {
       try visitor.visitSingularBoolField(value: self.fillOauthScope, fieldNumber: 5)
     }
-    if let v = self._responseCompressed {
+    try { if let v = self._responseCompressed {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
-    }
-    if let v = self._responseStatus {
+    } }()
+    try { if let v = self._responseStatus {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
-    }
-    if let v = self._expectCompressed {
+    } }()
+    try { if let v = self._expectCompressed {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -622,9 +626,13 @@ extension Grpc_Testing_SimpleResponse: SwiftProtobuf.Message, SwiftProtobuf._Mes
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._payload {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._payload {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
+    } }()
     if !self.username.isEmpty {
       try visitor.visitSingularStringField(value: self.username, fieldNumber: 2)
     }
@@ -664,12 +672,16 @@ extension Grpc_Testing_StreamingInputCallRequest: SwiftProtobuf.Message, SwiftPr
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._payload {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._payload {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
-    if let v = self._expectCompressed {
+    } }()
+    try { if let v = self._expectCompressed {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -736,15 +748,19 @@ extension Grpc_Testing_ResponseParameters: SwiftProtobuf.Message, SwiftProtobuf.
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if self.size != 0 {
       try visitor.visitSingularInt32Field(value: self.size, fieldNumber: 1)
     }
     if self.intervalUs != 0 {
       try visitor.visitSingularInt32Field(value: self.intervalUs, fieldNumber: 2)
     }
-    if let v = self._compressed {
+    try { if let v = self._compressed {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -782,18 +798,22 @@ extension Grpc_Testing_StreamingOutputCallRequest: SwiftProtobuf.Message, SwiftP
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if self.responseType != .compressable {
       try visitor.visitSingularEnumField(value: self.responseType, fieldNumber: 1)
     }
     if !self.responseParameters.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.responseParameters, fieldNumber: 2)
     }
-    if let v = self._payload {
+    try { if let v = self._payload {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-    }
-    if let v = self._responseStatus {
+    } }()
+    try { if let v = self._responseStatus {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -826,9 +846,13 @@ extension Grpc_Testing_StreamingOutputCallResponse: SwiftProtobuf.Message, Swift
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._payload {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._payload {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 

--- a/Sources/GRPCInteroperabilityTestModels/Generated/test.grpc.swift
+++ b/Sources/GRPCInteroperabilityTestModels/Generated/test.grpc.swift
@@ -90,7 +90,7 @@ extension Grpc_Testing_TestServiceClientProtocol {
     callOptions: CallOptions? = nil
   ) -> UnaryCall<Grpc_Testing_Empty, Grpc_Testing_Empty> {
     return self.makeUnaryCall(
-      path: "/grpc.testing.TestService/EmptyCall",
+      path: Grpc_Testing_TestServiceClientMetadata.Methods.emptyCall.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeEmptyCallInterceptors() ?? []
@@ -108,7 +108,7 @@ extension Grpc_Testing_TestServiceClientProtocol {
     callOptions: CallOptions? = nil
   ) -> UnaryCall<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse> {
     return self.makeUnaryCall(
-      path: "/grpc.testing.TestService/UnaryCall",
+      path: Grpc_Testing_TestServiceClientMetadata.Methods.unaryCall.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeUnaryCallInterceptors() ?? []
@@ -128,7 +128,7 @@ extension Grpc_Testing_TestServiceClientProtocol {
     callOptions: CallOptions? = nil
   ) -> UnaryCall<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse> {
     return self.makeUnaryCall(
-      path: "/grpc.testing.TestService/CacheableUnaryCall",
+      path: Grpc_Testing_TestServiceClientMetadata.Methods.cacheableUnaryCall.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeCacheableUnaryCallInterceptors() ?? []
@@ -149,7 +149,7 @@ extension Grpc_Testing_TestServiceClientProtocol {
     handler: @escaping (Grpc_Testing_StreamingOutputCallResponse) -> Void
   ) -> ServerStreamingCall<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse> {
     return self.makeServerStreamingCall(
-      path: "/grpc.testing.TestService/StreamingOutputCall",
+      path: Grpc_Testing_TestServiceClientMetadata.Methods.streamingOutputCall.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeStreamingOutputCallInterceptors() ?? [],
@@ -170,7 +170,7 @@ extension Grpc_Testing_TestServiceClientProtocol {
     callOptions: CallOptions? = nil
   ) -> ClientStreamingCall<Grpc_Testing_StreamingInputCallRequest, Grpc_Testing_StreamingInputCallResponse> {
     return self.makeClientStreamingCall(
-      path: "/grpc.testing.TestService/StreamingInputCall",
+      path: Grpc_Testing_TestServiceClientMetadata.Methods.streamingInputCall.path,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeStreamingInputCallInterceptors() ?? []
     )
@@ -192,7 +192,7 @@ extension Grpc_Testing_TestServiceClientProtocol {
     handler: @escaping (Grpc_Testing_StreamingOutputCallResponse) -> Void
   ) -> BidirectionalStreamingCall<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse> {
     return self.makeBidirectionalStreamingCall(
-      path: "/grpc.testing.TestService/FullDuplexCall",
+      path: Grpc_Testing_TestServiceClientMetadata.Methods.fullDuplexCall.path,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeFullDuplexCallInterceptors() ?? [],
       handler: handler
@@ -216,7 +216,7 @@ extension Grpc_Testing_TestServiceClientProtocol {
     handler: @escaping (Grpc_Testing_StreamingOutputCallResponse) -> Void
   ) -> BidirectionalStreamingCall<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse> {
     return self.makeBidirectionalStreamingCall(
-      path: "/grpc.testing.TestService/HalfDuplexCall",
+      path: Grpc_Testing_TestServiceClientMetadata.Methods.halfDuplexCall.path,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeHalfDuplexCallInterceptors() ?? [],
       handler: handler
@@ -235,39 +235,12 @@ extension Grpc_Testing_TestServiceClientProtocol {
     callOptions: CallOptions? = nil
   ) -> UnaryCall<Grpc_Testing_Empty, Grpc_Testing_Empty> {
     return self.makeUnaryCall(
-      path: "/grpc.testing.TestService/UnimplementedCall",
+      path: Grpc_Testing_TestServiceClientMetadata.Methods.unimplementedCall.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeUnimplementedCallInterceptors() ?? []
     )
   }
-}
-
-public protocol Grpc_Testing_TestServiceClientInterceptorFactoryProtocol {
-
-  /// - Returns: Interceptors to use when invoking 'emptyCall'.
-  func makeEmptyCallInterceptors() -> [ClientInterceptor<Grpc_Testing_Empty, Grpc_Testing_Empty>]
-
-  /// - Returns: Interceptors to use when invoking 'unaryCall'.
-  func makeUnaryCallInterceptors() -> [ClientInterceptor<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse>]
-
-  /// - Returns: Interceptors to use when invoking 'cacheableUnaryCall'.
-  func makeCacheableUnaryCallInterceptors() -> [ClientInterceptor<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse>]
-
-  /// - Returns: Interceptors to use when invoking 'streamingOutputCall'.
-  func makeStreamingOutputCallInterceptors() -> [ClientInterceptor<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>]
-
-  /// - Returns: Interceptors to use when invoking 'streamingInputCall'.
-  func makeStreamingInputCallInterceptors() -> [ClientInterceptor<Grpc_Testing_StreamingInputCallRequest, Grpc_Testing_StreamingInputCallResponse>]
-
-  /// - Returns: Interceptors to use when invoking 'fullDuplexCall'.
-  func makeFullDuplexCallInterceptors() -> [ClientInterceptor<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>]
-
-  /// - Returns: Interceptors to use when invoking 'halfDuplexCall'.
-  func makeHalfDuplexCallInterceptors() -> [ClientInterceptor<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>]
-
-  /// - Returns: Interceptors to use when invoking 'unimplementedCall'.
-  func makeUnimplementedCallInterceptors() -> [ClientInterceptor<Grpc_Testing_Empty, Grpc_Testing_Empty>]
 }
 
 public final class Grpc_Testing_TestServiceClient: Grpc_Testing_TestServiceClientProtocol {
@@ -297,7 +270,7 @@ public final class Grpc_Testing_TestServiceClient: Grpc_Testing_TestServiceClien
 /// performance with various types of payload.
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public protocol Grpc_Testing_TestServiceAsyncClientProtocol: GRPCClient {
-  var serviceName: String { get }
+  static var serviceDescriptor: GRPCServiceDescriptor { get }
   var interceptors: Grpc_Testing_TestServiceClientInterceptorFactoryProtocol? { get }
 
   func makeEmptyCallCall(
@@ -340,8 +313,8 @@ public protocol Grpc_Testing_TestServiceAsyncClientProtocol: GRPCClient {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension Grpc_Testing_TestServiceAsyncClientProtocol {
-  public var serviceName: String {
-    return "grpc.testing.TestService"
+  public static var serviceDescriptor: GRPCServiceDescriptor {
+    return Grpc_Testing_TestServiceClientMetadata.serviceDescriptor
   }
 
   public var interceptors: Grpc_Testing_TestServiceClientInterceptorFactoryProtocol? {
@@ -353,7 +326,7 @@ extension Grpc_Testing_TestServiceAsyncClientProtocol {
     callOptions: CallOptions? = nil
   ) -> GRPCAsyncUnaryCall<Grpc_Testing_Empty, Grpc_Testing_Empty> {
     return self.makeAsyncUnaryCall(
-      path: "/grpc.testing.TestService/EmptyCall",
+      path: Grpc_Testing_TestServiceClientMetadata.Methods.emptyCall.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeEmptyCallInterceptors() ?? []
@@ -365,7 +338,7 @@ extension Grpc_Testing_TestServiceAsyncClientProtocol {
     callOptions: CallOptions? = nil
   ) -> GRPCAsyncUnaryCall<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse> {
     return self.makeAsyncUnaryCall(
-      path: "/grpc.testing.TestService/UnaryCall",
+      path: Grpc_Testing_TestServiceClientMetadata.Methods.unaryCall.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeUnaryCallInterceptors() ?? []
@@ -377,7 +350,7 @@ extension Grpc_Testing_TestServiceAsyncClientProtocol {
     callOptions: CallOptions? = nil
   ) -> GRPCAsyncUnaryCall<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse> {
     return self.makeAsyncUnaryCall(
-      path: "/grpc.testing.TestService/CacheableUnaryCall",
+      path: Grpc_Testing_TestServiceClientMetadata.Methods.cacheableUnaryCall.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeCacheableUnaryCallInterceptors() ?? []
@@ -389,7 +362,7 @@ extension Grpc_Testing_TestServiceAsyncClientProtocol {
     callOptions: CallOptions? = nil
   ) -> GRPCAsyncServerStreamingCall<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse> {
     return self.makeAsyncServerStreamingCall(
-      path: "/grpc.testing.TestService/StreamingOutputCall",
+      path: Grpc_Testing_TestServiceClientMetadata.Methods.streamingOutputCall.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeStreamingOutputCallInterceptors() ?? []
@@ -400,7 +373,7 @@ extension Grpc_Testing_TestServiceAsyncClientProtocol {
     callOptions: CallOptions? = nil
   ) -> GRPCAsyncClientStreamingCall<Grpc_Testing_StreamingInputCallRequest, Grpc_Testing_StreamingInputCallResponse> {
     return self.makeAsyncClientStreamingCall(
-      path: "/grpc.testing.TestService/StreamingInputCall",
+      path: Grpc_Testing_TestServiceClientMetadata.Methods.streamingInputCall.path,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeStreamingInputCallInterceptors() ?? []
     )
@@ -410,7 +383,7 @@ extension Grpc_Testing_TestServiceAsyncClientProtocol {
     callOptions: CallOptions? = nil
   ) -> GRPCAsyncBidirectionalStreamingCall<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse> {
     return self.makeAsyncBidirectionalStreamingCall(
-      path: "/grpc.testing.TestService/FullDuplexCall",
+      path: Grpc_Testing_TestServiceClientMetadata.Methods.fullDuplexCall.path,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeFullDuplexCallInterceptors() ?? []
     )
@@ -420,7 +393,7 @@ extension Grpc_Testing_TestServiceAsyncClientProtocol {
     callOptions: CallOptions? = nil
   ) -> GRPCAsyncBidirectionalStreamingCall<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse> {
     return self.makeAsyncBidirectionalStreamingCall(
-      path: "/grpc.testing.TestService/HalfDuplexCall",
+      path: Grpc_Testing_TestServiceClientMetadata.Methods.halfDuplexCall.path,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeHalfDuplexCallInterceptors() ?? []
     )
@@ -431,7 +404,7 @@ extension Grpc_Testing_TestServiceAsyncClientProtocol {
     callOptions: CallOptions? = nil
   ) -> GRPCAsyncUnaryCall<Grpc_Testing_Empty, Grpc_Testing_Empty> {
     return self.makeAsyncUnaryCall(
-      path: "/grpc.testing.TestService/UnimplementedCall",
+      path: Grpc_Testing_TestServiceClientMetadata.Methods.unimplementedCall.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeUnimplementedCallInterceptors() ?? []
@@ -446,7 +419,7 @@ extension Grpc_Testing_TestServiceAsyncClientProtocol {
     callOptions: CallOptions? = nil
   ) async throws -> Grpc_Testing_Empty {
     return try await self.performAsyncUnaryCall(
-      path: "/grpc.testing.TestService/EmptyCall",
+      path: Grpc_Testing_TestServiceClientMetadata.Methods.emptyCall.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeEmptyCallInterceptors() ?? []
@@ -458,7 +431,7 @@ extension Grpc_Testing_TestServiceAsyncClientProtocol {
     callOptions: CallOptions? = nil
   ) async throws -> Grpc_Testing_SimpleResponse {
     return try await self.performAsyncUnaryCall(
-      path: "/grpc.testing.TestService/UnaryCall",
+      path: Grpc_Testing_TestServiceClientMetadata.Methods.unaryCall.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeUnaryCallInterceptors() ?? []
@@ -470,7 +443,7 @@ extension Grpc_Testing_TestServiceAsyncClientProtocol {
     callOptions: CallOptions? = nil
   ) async throws -> Grpc_Testing_SimpleResponse {
     return try await self.performAsyncUnaryCall(
-      path: "/grpc.testing.TestService/CacheableUnaryCall",
+      path: Grpc_Testing_TestServiceClientMetadata.Methods.cacheableUnaryCall.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeCacheableUnaryCallInterceptors() ?? []
@@ -482,7 +455,7 @@ extension Grpc_Testing_TestServiceAsyncClientProtocol {
     callOptions: CallOptions? = nil
   ) -> GRPCAsyncResponseStream<Grpc_Testing_StreamingOutputCallResponse> {
     return self.performAsyncServerStreamingCall(
-      path: "/grpc.testing.TestService/StreamingOutputCall",
+      path: Grpc_Testing_TestServiceClientMetadata.Methods.streamingOutputCall.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeStreamingOutputCallInterceptors() ?? []
@@ -494,7 +467,7 @@ extension Grpc_Testing_TestServiceAsyncClientProtocol {
     callOptions: CallOptions? = nil
   ) async throws -> Grpc_Testing_StreamingInputCallResponse where RequestStream: Sequence, RequestStream.Element == Grpc_Testing_StreamingInputCallRequest {
     return try await self.performAsyncClientStreamingCall(
-      path: "/grpc.testing.TestService/StreamingInputCall",
+      path: Grpc_Testing_TestServiceClientMetadata.Methods.streamingInputCall.path,
       requests: requests,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeStreamingInputCallInterceptors() ?? []
@@ -506,7 +479,7 @@ extension Grpc_Testing_TestServiceAsyncClientProtocol {
     callOptions: CallOptions? = nil
   ) async throws -> Grpc_Testing_StreamingInputCallResponse where RequestStream: AsyncSequence, RequestStream.Element == Grpc_Testing_StreamingInputCallRequest {
     return try await self.performAsyncClientStreamingCall(
-      path: "/grpc.testing.TestService/StreamingInputCall",
+      path: Grpc_Testing_TestServiceClientMetadata.Methods.streamingInputCall.path,
       requests: requests,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeStreamingInputCallInterceptors() ?? []
@@ -518,7 +491,7 @@ extension Grpc_Testing_TestServiceAsyncClientProtocol {
     callOptions: CallOptions? = nil
   ) -> GRPCAsyncResponseStream<Grpc_Testing_StreamingOutputCallResponse> where RequestStream: Sequence, RequestStream.Element == Grpc_Testing_StreamingOutputCallRequest {
     return self.performAsyncBidirectionalStreamingCall(
-      path: "/grpc.testing.TestService/FullDuplexCall",
+      path: Grpc_Testing_TestServiceClientMetadata.Methods.fullDuplexCall.path,
       requests: requests,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeFullDuplexCallInterceptors() ?? []
@@ -530,7 +503,7 @@ extension Grpc_Testing_TestServiceAsyncClientProtocol {
     callOptions: CallOptions? = nil
   ) -> GRPCAsyncResponseStream<Grpc_Testing_StreamingOutputCallResponse> where RequestStream: AsyncSequence, RequestStream.Element == Grpc_Testing_StreamingOutputCallRequest {
     return self.performAsyncBidirectionalStreamingCall(
-      path: "/grpc.testing.TestService/FullDuplexCall",
+      path: Grpc_Testing_TestServiceClientMetadata.Methods.fullDuplexCall.path,
       requests: requests,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeFullDuplexCallInterceptors() ?? []
@@ -542,7 +515,7 @@ extension Grpc_Testing_TestServiceAsyncClientProtocol {
     callOptions: CallOptions? = nil
   ) -> GRPCAsyncResponseStream<Grpc_Testing_StreamingOutputCallResponse> where RequestStream: Sequence, RequestStream.Element == Grpc_Testing_StreamingOutputCallRequest {
     return self.performAsyncBidirectionalStreamingCall(
-      path: "/grpc.testing.TestService/HalfDuplexCall",
+      path: Grpc_Testing_TestServiceClientMetadata.Methods.halfDuplexCall.path,
       requests: requests,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeHalfDuplexCallInterceptors() ?? []
@@ -554,7 +527,7 @@ extension Grpc_Testing_TestServiceAsyncClientProtocol {
     callOptions: CallOptions? = nil
   ) -> GRPCAsyncResponseStream<Grpc_Testing_StreamingOutputCallResponse> where RequestStream: AsyncSequence, RequestStream.Element == Grpc_Testing_StreamingOutputCallRequest {
     return self.performAsyncBidirectionalStreamingCall(
-      path: "/grpc.testing.TestService/HalfDuplexCall",
+      path: Grpc_Testing_TestServiceClientMetadata.Methods.halfDuplexCall.path,
       requests: requests,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeHalfDuplexCallInterceptors() ?? []
@@ -566,7 +539,7 @@ extension Grpc_Testing_TestServiceAsyncClientProtocol {
     callOptions: CallOptions? = nil
   ) async throws -> Grpc_Testing_Empty {
     return try await self.performAsyncUnaryCall(
-      path: "/grpc.testing.TestService/UnimplementedCall",
+      path: Grpc_Testing_TestServiceClientMetadata.Methods.unimplementedCall.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeUnimplementedCallInterceptors() ?? []
@@ -592,6 +565,100 @@ public struct Grpc_Testing_TestServiceAsyncClient: Grpc_Testing_TestServiceAsync
 }
 
 #endif // compiler(>=5.5) && canImport(_Concurrency)
+
+public protocol Grpc_Testing_TestServiceClientInterceptorFactoryProtocol {
+
+  /// - Returns: Interceptors to use when invoking 'emptyCall'.
+  func makeEmptyCallInterceptors() -> [ClientInterceptor<Grpc_Testing_Empty, Grpc_Testing_Empty>]
+
+  /// - Returns: Interceptors to use when invoking 'unaryCall'.
+  func makeUnaryCallInterceptors() -> [ClientInterceptor<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse>]
+
+  /// - Returns: Interceptors to use when invoking 'cacheableUnaryCall'.
+  func makeCacheableUnaryCallInterceptors() -> [ClientInterceptor<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse>]
+
+  /// - Returns: Interceptors to use when invoking 'streamingOutputCall'.
+  func makeStreamingOutputCallInterceptors() -> [ClientInterceptor<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>]
+
+  /// - Returns: Interceptors to use when invoking 'streamingInputCall'.
+  func makeStreamingInputCallInterceptors() -> [ClientInterceptor<Grpc_Testing_StreamingInputCallRequest, Grpc_Testing_StreamingInputCallResponse>]
+
+  /// - Returns: Interceptors to use when invoking 'fullDuplexCall'.
+  func makeFullDuplexCallInterceptors() -> [ClientInterceptor<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>]
+
+  /// - Returns: Interceptors to use when invoking 'halfDuplexCall'.
+  func makeHalfDuplexCallInterceptors() -> [ClientInterceptor<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>]
+
+  /// - Returns: Interceptors to use when invoking 'unimplementedCall'.
+  func makeUnimplementedCallInterceptors() -> [ClientInterceptor<Grpc_Testing_Empty, Grpc_Testing_Empty>]
+}
+
+public enum Grpc_Testing_TestServiceClientMetadata {
+  public static let serviceDescriptor = GRPCServiceDescriptor(
+    name: "TestService",
+    fullName: "grpc.testing.TestService",
+    methods: [
+      Grpc_Testing_TestServiceClientMetadata.Methods.emptyCall,
+      Grpc_Testing_TestServiceClientMetadata.Methods.unaryCall,
+      Grpc_Testing_TestServiceClientMetadata.Methods.cacheableUnaryCall,
+      Grpc_Testing_TestServiceClientMetadata.Methods.streamingOutputCall,
+      Grpc_Testing_TestServiceClientMetadata.Methods.streamingInputCall,
+      Grpc_Testing_TestServiceClientMetadata.Methods.fullDuplexCall,
+      Grpc_Testing_TestServiceClientMetadata.Methods.halfDuplexCall,
+      Grpc_Testing_TestServiceClientMetadata.Methods.unimplementedCall,
+    ]
+  )
+
+  public enum Methods {
+    public static let emptyCall = GRPCMethodDescriptor(
+      name: "EmptyCall",
+      path: "/grpc.testing.TestService/EmptyCall",
+      type: GRPCCallType.unary
+    )
+
+    public static let unaryCall = GRPCMethodDescriptor(
+      name: "UnaryCall",
+      path: "/grpc.testing.TestService/UnaryCall",
+      type: GRPCCallType.unary
+    )
+
+    public static let cacheableUnaryCall = GRPCMethodDescriptor(
+      name: "CacheableUnaryCall",
+      path: "/grpc.testing.TestService/CacheableUnaryCall",
+      type: GRPCCallType.unary
+    )
+
+    public static let streamingOutputCall = GRPCMethodDescriptor(
+      name: "StreamingOutputCall",
+      path: "/grpc.testing.TestService/StreamingOutputCall",
+      type: GRPCCallType.serverStreaming
+    )
+
+    public static let streamingInputCall = GRPCMethodDescriptor(
+      name: "StreamingInputCall",
+      path: "/grpc.testing.TestService/StreamingInputCall",
+      type: GRPCCallType.clientStreaming
+    )
+
+    public static let fullDuplexCall = GRPCMethodDescriptor(
+      name: "FullDuplexCall",
+      path: "/grpc.testing.TestService/FullDuplexCall",
+      type: GRPCCallType.bidirectionalStreaming
+    )
+
+    public static let halfDuplexCall = GRPCMethodDescriptor(
+      name: "HalfDuplexCall",
+      path: "/grpc.testing.TestService/HalfDuplexCall",
+      type: GRPCCallType.bidirectionalStreaming
+    )
+
+    public static let unimplementedCall = GRPCMethodDescriptor(
+      name: "UnimplementedCall",
+      path: "/grpc.testing.TestService/UnimplementedCall",
+      type: GRPCCallType.unary
+    )
+  }
+}
 
 /// A simple service NOT implemented at servers so clients can test for
 /// that case.
@@ -623,18 +690,12 @@ extension Grpc_Testing_UnimplementedServiceClientProtocol {
     callOptions: CallOptions? = nil
   ) -> UnaryCall<Grpc_Testing_Empty, Grpc_Testing_Empty> {
     return self.makeUnaryCall(
-      path: "/grpc.testing.UnimplementedService/UnimplementedCall",
+      path: Grpc_Testing_UnimplementedServiceClientMetadata.Methods.unimplementedCall.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeUnimplementedCallInterceptors() ?? []
     )
   }
-}
-
-public protocol Grpc_Testing_UnimplementedServiceClientInterceptorFactoryProtocol {
-
-  /// - Returns: Interceptors to use when invoking 'unimplementedCall'.
-  func makeUnimplementedCallInterceptors() -> [ClientInterceptor<Grpc_Testing_Empty, Grpc_Testing_Empty>]
 }
 
 public final class Grpc_Testing_UnimplementedServiceClient: Grpc_Testing_UnimplementedServiceClientProtocol {
@@ -664,7 +725,7 @@ public final class Grpc_Testing_UnimplementedServiceClient: Grpc_Testing_Unimple
 /// that case.
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public protocol Grpc_Testing_UnimplementedServiceAsyncClientProtocol: GRPCClient {
-  var serviceName: String { get }
+  static var serviceDescriptor: GRPCServiceDescriptor { get }
   var interceptors: Grpc_Testing_UnimplementedServiceClientInterceptorFactoryProtocol? { get }
 
   func makeUnimplementedCallCall(
@@ -675,8 +736,8 @@ public protocol Grpc_Testing_UnimplementedServiceAsyncClientProtocol: GRPCClient
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension Grpc_Testing_UnimplementedServiceAsyncClientProtocol {
-  public var serviceName: String {
-    return "grpc.testing.UnimplementedService"
+  public static var serviceDescriptor: GRPCServiceDescriptor {
+    return Grpc_Testing_UnimplementedServiceClientMetadata.serviceDescriptor
   }
 
   public var interceptors: Grpc_Testing_UnimplementedServiceClientInterceptorFactoryProtocol? {
@@ -688,7 +749,7 @@ extension Grpc_Testing_UnimplementedServiceAsyncClientProtocol {
     callOptions: CallOptions? = nil
   ) -> GRPCAsyncUnaryCall<Grpc_Testing_Empty, Grpc_Testing_Empty> {
     return self.makeAsyncUnaryCall(
-      path: "/grpc.testing.UnimplementedService/UnimplementedCall",
+      path: Grpc_Testing_UnimplementedServiceClientMetadata.Methods.unimplementedCall.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeUnimplementedCallInterceptors() ?? []
@@ -703,7 +764,7 @@ extension Grpc_Testing_UnimplementedServiceAsyncClientProtocol {
     callOptions: CallOptions? = nil
   ) async throws -> Grpc_Testing_Empty {
     return try await self.performAsyncUnaryCall(
-      path: "/grpc.testing.UnimplementedService/UnimplementedCall",
+      path: Grpc_Testing_UnimplementedServiceClientMetadata.Methods.unimplementedCall.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeUnimplementedCallInterceptors() ?? []
@@ -729,6 +790,30 @@ public struct Grpc_Testing_UnimplementedServiceAsyncClient: Grpc_Testing_Unimple
 }
 
 #endif // compiler(>=5.5) && canImport(_Concurrency)
+
+public protocol Grpc_Testing_UnimplementedServiceClientInterceptorFactoryProtocol {
+
+  /// - Returns: Interceptors to use when invoking 'unimplementedCall'.
+  func makeUnimplementedCallInterceptors() -> [ClientInterceptor<Grpc_Testing_Empty, Grpc_Testing_Empty>]
+}
+
+public enum Grpc_Testing_UnimplementedServiceClientMetadata {
+  public static let serviceDescriptor = GRPCServiceDescriptor(
+    name: "UnimplementedService",
+    fullName: "grpc.testing.UnimplementedService",
+    methods: [
+      Grpc_Testing_UnimplementedServiceClientMetadata.Methods.unimplementedCall,
+    ]
+  )
+
+  public enum Methods {
+    public static let unimplementedCall = GRPCMethodDescriptor(
+      name: "UnimplementedCall",
+      path: "/grpc.testing.UnimplementedService/UnimplementedCall",
+      type: GRPCCallType.unary
+    )
+  }
+}
 
 /// A service used to control reconnect server.
 ///
@@ -764,7 +849,7 @@ extension Grpc_Testing_ReconnectServiceClientProtocol {
     callOptions: CallOptions? = nil
   ) -> UnaryCall<Grpc_Testing_ReconnectParams, Grpc_Testing_Empty> {
     return self.makeUnaryCall(
-      path: "/grpc.testing.ReconnectService/Start",
+      path: Grpc_Testing_ReconnectServiceClientMetadata.Methods.start.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeStartInterceptors() ?? []
@@ -782,21 +867,12 @@ extension Grpc_Testing_ReconnectServiceClientProtocol {
     callOptions: CallOptions? = nil
   ) -> UnaryCall<Grpc_Testing_Empty, Grpc_Testing_ReconnectInfo> {
     return self.makeUnaryCall(
-      path: "/grpc.testing.ReconnectService/Stop",
+      path: Grpc_Testing_ReconnectServiceClientMetadata.Methods.stop.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeStopInterceptors() ?? []
     )
   }
-}
-
-public protocol Grpc_Testing_ReconnectServiceClientInterceptorFactoryProtocol {
-
-  /// - Returns: Interceptors to use when invoking 'start'.
-  func makeStartInterceptors() -> [ClientInterceptor<Grpc_Testing_ReconnectParams, Grpc_Testing_Empty>]
-
-  /// - Returns: Interceptors to use when invoking 'stop'.
-  func makeStopInterceptors() -> [ClientInterceptor<Grpc_Testing_Empty, Grpc_Testing_ReconnectInfo>]
 }
 
 public final class Grpc_Testing_ReconnectServiceClient: Grpc_Testing_ReconnectServiceClientProtocol {
@@ -825,7 +901,7 @@ public final class Grpc_Testing_ReconnectServiceClient: Grpc_Testing_ReconnectSe
 /// A service used to control reconnect server.
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public protocol Grpc_Testing_ReconnectServiceAsyncClientProtocol: GRPCClient {
-  var serviceName: String { get }
+  static var serviceDescriptor: GRPCServiceDescriptor { get }
   var interceptors: Grpc_Testing_ReconnectServiceClientInterceptorFactoryProtocol? { get }
 
   func makeStartCall(
@@ -841,8 +917,8 @@ public protocol Grpc_Testing_ReconnectServiceAsyncClientProtocol: GRPCClient {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension Grpc_Testing_ReconnectServiceAsyncClientProtocol {
-  public var serviceName: String {
-    return "grpc.testing.ReconnectService"
+  public static var serviceDescriptor: GRPCServiceDescriptor {
+    return Grpc_Testing_ReconnectServiceClientMetadata.serviceDescriptor
   }
 
   public var interceptors: Grpc_Testing_ReconnectServiceClientInterceptorFactoryProtocol? {
@@ -854,7 +930,7 @@ extension Grpc_Testing_ReconnectServiceAsyncClientProtocol {
     callOptions: CallOptions? = nil
   ) -> GRPCAsyncUnaryCall<Grpc_Testing_ReconnectParams, Grpc_Testing_Empty> {
     return self.makeAsyncUnaryCall(
-      path: "/grpc.testing.ReconnectService/Start",
+      path: Grpc_Testing_ReconnectServiceClientMetadata.Methods.start.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeStartInterceptors() ?? []
@@ -866,7 +942,7 @@ extension Grpc_Testing_ReconnectServiceAsyncClientProtocol {
     callOptions: CallOptions? = nil
   ) -> GRPCAsyncUnaryCall<Grpc_Testing_Empty, Grpc_Testing_ReconnectInfo> {
     return self.makeAsyncUnaryCall(
-      path: "/grpc.testing.ReconnectService/Stop",
+      path: Grpc_Testing_ReconnectServiceClientMetadata.Methods.stop.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeStopInterceptors() ?? []
@@ -881,7 +957,7 @@ extension Grpc_Testing_ReconnectServiceAsyncClientProtocol {
     callOptions: CallOptions? = nil
   ) async throws -> Grpc_Testing_Empty {
     return try await self.performAsyncUnaryCall(
-      path: "/grpc.testing.ReconnectService/Start",
+      path: Grpc_Testing_ReconnectServiceClientMetadata.Methods.start.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeStartInterceptors() ?? []
@@ -893,7 +969,7 @@ extension Grpc_Testing_ReconnectServiceAsyncClientProtocol {
     callOptions: CallOptions? = nil
   ) async throws -> Grpc_Testing_ReconnectInfo {
     return try await self.performAsyncUnaryCall(
-      path: "/grpc.testing.ReconnectService/Stop",
+      path: Grpc_Testing_ReconnectServiceClientMetadata.Methods.stop.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeStopInterceptors() ?? []
@@ -919,6 +995,40 @@ public struct Grpc_Testing_ReconnectServiceAsyncClient: Grpc_Testing_ReconnectSe
 }
 
 #endif // compiler(>=5.5) && canImport(_Concurrency)
+
+public protocol Grpc_Testing_ReconnectServiceClientInterceptorFactoryProtocol {
+
+  /// - Returns: Interceptors to use when invoking 'start'.
+  func makeStartInterceptors() -> [ClientInterceptor<Grpc_Testing_ReconnectParams, Grpc_Testing_Empty>]
+
+  /// - Returns: Interceptors to use when invoking 'stop'.
+  func makeStopInterceptors() -> [ClientInterceptor<Grpc_Testing_Empty, Grpc_Testing_ReconnectInfo>]
+}
+
+public enum Grpc_Testing_ReconnectServiceClientMetadata {
+  public static let serviceDescriptor = GRPCServiceDescriptor(
+    name: "ReconnectService",
+    fullName: "grpc.testing.ReconnectService",
+    methods: [
+      Grpc_Testing_ReconnectServiceClientMetadata.Methods.start,
+      Grpc_Testing_ReconnectServiceClientMetadata.Methods.stop,
+    ]
+  )
+
+  public enum Methods {
+    public static let start = GRPCMethodDescriptor(
+      name: "Start",
+      path: "/grpc.testing.ReconnectService/Start",
+      type: GRPCCallType.unary
+    )
+
+    public static let stop = GRPCMethodDescriptor(
+      name: "Stop",
+      path: "/grpc.testing.ReconnectService/Stop",
+      type: GRPCCallType.unary
+    )
+  }
+}
 
 /// A simple service to test the various types of RPCs and experiment with
 /// performance with various types of payload.
@@ -959,7 +1069,9 @@ public protocol Grpc_Testing_TestServiceProvider: CallHandlerProvider {
 }
 
 extension Grpc_Testing_TestServiceProvider {
-  public var serviceName: Substring { return "grpc.testing.TestService" }
+  public var serviceName: Substring {
+    return Grpc_Testing_TestServiceServerMetadata.serviceDescriptor.fullName[...]
+  }
 
   /// Determines, calls and returns the appropriate request handler, depending on the request's method.
   /// Returns nil for methods not handled by this service.
@@ -1036,42 +1148,6 @@ extension Grpc_Testing_TestServiceProvider {
     }
   }
 }
-
-public protocol Grpc_Testing_TestServiceServerInterceptorFactoryProtocol {
-
-  /// - Returns: Interceptors to use when handling 'emptyCall'.
-  ///   Defaults to calling `self.makeInterceptors()`.
-  func makeEmptyCallInterceptors() -> [ServerInterceptor<Grpc_Testing_Empty, Grpc_Testing_Empty>]
-
-  /// - Returns: Interceptors to use when handling 'unaryCall'.
-  ///   Defaults to calling `self.makeInterceptors()`.
-  func makeUnaryCallInterceptors() -> [ServerInterceptor<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse>]
-
-  /// - Returns: Interceptors to use when handling 'cacheableUnaryCall'.
-  ///   Defaults to calling `self.makeInterceptors()`.
-  func makeCacheableUnaryCallInterceptors() -> [ServerInterceptor<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse>]
-
-  /// - Returns: Interceptors to use when handling 'streamingOutputCall'.
-  ///   Defaults to calling `self.makeInterceptors()`.
-  func makeStreamingOutputCallInterceptors() -> [ServerInterceptor<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>]
-
-  /// - Returns: Interceptors to use when handling 'streamingInputCall'.
-  ///   Defaults to calling `self.makeInterceptors()`.
-  func makeStreamingInputCallInterceptors() -> [ServerInterceptor<Grpc_Testing_StreamingInputCallRequest, Grpc_Testing_StreamingInputCallResponse>]
-
-  /// - Returns: Interceptors to use when handling 'fullDuplexCall'.
-  ///   Defaults to calling `self.makeInterceptors()`.
-  func makeFullDuplexCallInterceptors() -> [ServerInterceptor<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>]
-
-  /// - Returns: Interceptors to use when handling 'halfDuplexCall'.
-  ///   Defaults to calling `self.makeInterceptors()`.
-  func makeHalfDuplexCallInterceptors() -> [ServerInterceptor<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>]
-
-  /// - Returns: Interceptors to use when handling 'unimplementedCall'.
-  ///   Defaults to calling `self.makeInterceptors()`.
-  func makeUnimplementedCallInterceptors() -> [ServerInterceptor<Grpc_Testing_Empty, Grpc_Testing_Empty>]
-}
-
 #if compiler(>=5.5) && canImport(_Concurrency)
 
 /// A simple service to test the various types of RPCs and experiment with
@@ -1080,6 +1156,7 @@ public protocol Grpc_Testing_TestServiceServerInterceptorFactoryProtocol {
 /// To implement a server, implement an object which conforms to this protocol.
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public protocol Grpc_Testing_TestServiceAsyncProvider: CallHandlerProvider {
+  static var serviceDescriptor: GRPCServiceDescriptor { get }
   var interceptors: Grpc_Testing_TestServiceServerInterceptorFactoryProtocol? { get }
 
   /// One empty request followed by one empty response.
@@ -1139,8 +1216,12 @@ public protocol Grpc_Testing_TestServiceAsyncProvider: CallHandlerProvider {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension Grpc_Testing_TestServiceAsyncProvider {
+  public static var serviceDescriptor: GRPCServiceDescriptor {
+    return Grpc_Testing_TestServiceServerMetadata.serviceDescriptor
+  }
+
   public var serviceName: Substring {
-    return "grpc.testing.TestService"
+    return Grpc_Testing_TestServiceServerMetadata.serviceDescriptor.fullName[...]
   }
 
   public var interceptors: Grpc_Testing_TestServiceServerInterceptorFactoryProtocol? {
@@ -1223,6 +1304,107 @@ extension Grpc_Testing_TestServiceAsyncProvider {
 
 #endif // compiler(>=5.5) && canImport(_Concurrency)
 
+public protocol Grpc_Testing_TestServiceServerInterceptorFactoryProtocol {
+
+  /// - Returns: Interceptors to use when handling 'emptyCall'.
+  ///   Defaults to calling `self.makeInterceptors()`.
+  func makeEmptyCallInterceptors() -> [ServerInterceptor<Grpc_Testing_Empty, Grpc_Testing_Empty>]
+
+  /// - Returns: Interceptors to use when handling 'unaryCall'.
+  ///   Defaults to calling `self.makeInterceptors()`.
+  func makeUnaryCallInterceptors() -> [ServerInterceptor<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse>]
+
+  /// - Returns: Interceptors to use when handling 'cacheableUnaryCall'.
+  ///   Defaults to calling `self.makeInterceptors()`.
+  func makeCacheableUnaryCallInterceptors() -> [ServerInterceptor<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse>]
+
+  /// - Returns: Interceptors to use when handling 'streamingOutputCall'.
+  ///   Defaults to calling `self.makeInterceptors()`.
+  func makeStreamingOutputCallInterceptors() -> [ServerInterceptor<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>]
+
+  /// - Returns: Interceptors to use when handling 'streamingInputCall'.
+  ///   Defaults to calling `self.makeInterceptors()`.
+  func makeStreamingInputCallInterceptors() -> [ServerInterceptor<Grpc_Testing_StreamingInputCallRequest, Grpc_Testing_StreamingInputCallResponse>]
+
+  /// - Returns: Interceptors to use when handling 'fullDuplexCall'.
+  ///   Defaults to calling `self.makeInterceptors()`.
+  func makeFullDuplexCallInterceptors() -> [ServerInterceptor<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>]
+
+  /// - Returns: Interceptors to use when handling 'halfDuplexCall'.
+  ///   Defaults to calling `self.makeInterceptors()`.
+  func makeHalfDuplexCallInterceptors() -> [ServerInterceptor<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>]
+
+  /// - Returns: Interceptors to use when handling 'unimplementedCall'.
+  ///   Defaults to calling `self.makeInterceptors()`.
+  func makeUnimplementedCallInterceptors() -> [ServerInterceptor<Grpc_Testing_Empty, Grpc_Testing_Empty>]
+}
+
+public enum Grpc_Testing_TestServiceServerMetadata {
+  public static let serviceDescriptor = GRPCServiceDescriptor(
+    name: "TestService",
+    fullName: "grpc.testing.TestService",
+    methods: [
+      Grpc_Testing_TestServiceServerMetadata.Methods.emptyCall,
+      Grpc_Testing_TestServiceServerMetadata.Methods.unaryCall,
+      Grpc_Testing_TestServiceServerMetadata.Methods.cacheableUnaryCall,
+      Grpc_Testing_TestServiceServerMetadata.Methods.streamingOutputCall,
+      Grpc_Testing_TestServiceServerMetadata.Methods.streamingInputCall,
+      Grpc_Testing_TestServiceServerMetadata.Methods.fullDuplexCall,
+      Grpc_Testing_TestServiceServerMetadata.Methods.halfDuplexCall,
+      Grpc_Testing_TestServiceServerMetadata.Methods.unimplementedCall,
+    ]
+  )
+
+  public enum Methods {
+    public static let emptyCall = GRPCMethodDescriptor(
+      name: "EmptyCall",
+      path: "/grpc.testing.TestService/EmptyCall",
+      type: GRPCCallType.unary
+    )
+
+    public static let unaryCall = GRPCMethodDescriptor(
+      name: "UnaryCall",
+      path: "/grpc.testing.TestService/UnaryCall",
+      type: GRPCCallType.unary
+    )
+
+    public static let cacheableUnaryCall = GRPCMethodDescriptor(
+      name: "CacheableUnaryCall",
+      path: "/grpc.testing.TestService/CacheableUnaryCall",
+      type: GRPCCallType.unary
+    )
+
+    public static let streamingOutputCall = GRPCMethodDescriptor(
+      name: "StreamingOutputCall",
+      path: "/grpc.testing.TestService/StreamingOutputCall",
+      type: GRPCCallType.serverStreaming
+    )
+
+    public static let streamingInputCall = GRPCMethodDescriptor(
+      name: "StreamingInputCall",
+      path: "/grpc.testing.TestService/StreamingInputCall",
+      type: GRPCCallType.clientStreaming
+    )
+
+    public static let fullDuplexCall = GRPCMethodDescriptor(
+      name: "FullDuplexCall",
+      path: "/grpc.testing.TestService/FullDuplexCall",
+      type: GRPCCallType.bidirectionalStreaming
+    )
+
+    public static let halfDuplexCall = GRPCMethodDescriptor(
+      name: "HalfDuplexCall",
+      path: "/grpc.testing.TestService/HalfDuplexCall",
+      type: GRPCCallType.bidirectionalStreaming
+    )
+
+    public static let unimplementedCall = GRPCMethodDescriptor(
+      name: "UnimplementedCall",
+      path: "/grpc.testing.TestService/UnimplementedCall",
+      type: GRPCCallType.unary
+    )
+  }
+}
 /// A simple service NOT implemented at servers so clients can test for
 /// that case.
 ///
@@ -1235,7 +1417,9 @@ public protocol Grpc_Testing_UnimplementedServiceProvider: CallHandlerProvider {
 }
 
 extension Grpc_Testing_UnimplementedServiceProvider {
-  public var serviceName: Substring { return "grpc.testing.UnimplementedService" }
+  public var serviceName: Substring {
+    return Grpc_Testing_UnimplementedServiceServerMetadata.serviceDescriptor.fullName[...]
+  }
 
   /// Determines, calls and returns the appropriate request handler, depending on the request's method.
   /// Returns nil for methods not handled by this service.
@@ -1258,14 +1442,6 @@ extension Grpc_Testing_UnimplementedServiceProvider {
     }
   }
 }
-
-public protocol Grpc_Testing_UnimplementedServiceServerInterceptorFactoryProtocol {
-
-  /// - Returns: Interceptors to use when handling 'unimplementedCall'.
-  ///   Defaults to calling `self.makeInterceptors()`.
-  func makeUnimplementedCallInterceptors() -> [ServerInterceptor<Grpc_Testing_Empty, Grpc_Testing_Empty>]
-}
-
 #if compiler(>=5.5) && canImport(_Concurrency)
 
 /// A simple service NOT implemented at servers so clients can test for
@@ -1274,6 +1450,7 @@ public protocol Grpc_Testing_UnimplementedServiceServerInterceptorFactoryProtoco
 /// To implement a server, implement an object which conforms to this protocol.
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public protocol Grpc_Testing_UnimplementedServiceAsyncProvider: CallHandlerProvider {
+  static var serviceDescriptor: GRPCServiceDescriptor { get }
   var interceptors: Grpc_Testing_UnimplementedServiceServerInterceptorFactoryProtocol? { get }
 
   /// A call that no server should implement
@@ -1285,8 +1462,12 @@ public protocol Grpc_Testing_UnimplementedServiceAsyncProvider: CallHandlerProvi
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension Grpc_Testing_UnimplementedServiceAsyncProvider {
+  public static var serviceDescriptor: GRPCServiceDescriptor {
+    return Grpc_Testing_UnimplementedServiceServerMetadata.serviceDescriptor
+  }
+
   public var serviceName: Substring {
-    return "grpc.testing.UnimplementedService"
+    return Grpc_Testing_UnimplementedServiceServerMetadata.serviceDescriptor.fullName[...]
   }
 
   public var interceptors: Grpc_Testing_UnimplementedServiceServerInterceptorFactoryProtocol? {
@@ -1315,6 +1496,30 @@ extension Grpc_Testing_UnimplementedServiceAsyncProvider {
 
 #endif // compiler(>=5.5) && canImport(_Concurrency)
 
+public protocol Grpc_Testing_UnimplementedServiceServerInterceptorFactoryProtocol {
+
+  /// - Returns: Interceptors to use when handling 'unimplementedCall'.
+  ///   Defaults to calling `self.makeInterceptors()`.
+  func makeUnimplementedCallInterceptors() -> [ServerInterceptor<Grpc_Testing_Empty, Grpc_Testing_Empty>]
+}
+
+public enum Grpc_Testing_UnimplementedServiceServerMetadata {
+  public static let serviceDescriptor = GRPCServiceDescriptor(
+    name: "UnimplementedService",
+    fullName: "grpc.testing.UnimplementedService",
+    methods: [
+      Grpc_Testing_UnimplementedServiceServerMetadata.Methods.unimplementedCall,
+    ]
+  )
+
+  public enum Methods {
+    public static let unimplementedCall = GRPCMethodDescriptor(
+      name: "UnimplementedCall",
+      path: "/grpc.testing.UnimplementedService/UnimplementedCall",
+      type: GRPCCallType.unary
+    )
+  }
+}
 /// A service used to control reconnect server.
 ///
 /// To build a server, implement a class that conforms to this protocol.
@@ -1327,7 +1532,9 @@ public protocol Grpc_Testing_ReconnectServiceProvider: CallHandlerProvider {
 }
 
 extension Grpc_Testing_ReconnectServiceProvider {
-  public var serviceName: Substring { return "grpc.testing.ReconnectService" }
+  public var serviceName: Substring {
+    return Grpc_Testing_ReconnectServiceServerMetadata.serviceDescriptor.fullName[...]
+  }
 
   /// Determines, calls and returns the appropriate request handler, depending on the request's method.
   /// Returns nil for methods not handled by this service.
@@ -1359,18 +1566,6 @@ extension Grpc_Testing_ReconnectServiceProvider {
     }
   }
 }
-
-public protocol Grpc_Testing_ReconnectServiceServerInterceptorFactoryProtocol {
-
-  /// - Returns: Interceptors to use when handling 'start'.
-  ///   Defaults to calling `self.makeInterceptors()`.
-  func makeStartInterceptors() -> [ServerInterceptor<Grpc_Testing_ReconnectParams, Grpc_Testing_Empty>]
-
-  /// - Returns: Interceptors to use when handling 'stop'.
-  ///   Defaults to calling `self.makeInterceptors()`.
-  func makeStopInterceptors() -> [ServerInterceptor<Grpc_Testing_Empty, Grpc_Testing_ReconnectInfo>]
-}
-
 #if compiler(>=5.5) && canImport(_Concurrency)
 
 /// A service used to control reconnect server.
@@ -1378,6 +1573,7 @@ public protocol Grpc_Testing_ReconnectServiceServerInterceptorFactoryProtocol {
 /// To implement a server, implement an object which conforms to this protocol.
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 public protocol Grpc_Testing_ReconnectServiceAsyncProvider: CallHandlerProvider {
+  static var serviceDescriptor: GRPCServiceDescriptor { get }
   var interceptors: Grpc_Testing_ReconnectServiceServerInterceptorFactoryProtocol? { get }
 
   @Sendable func start(
@@ -1393,8 +1589,12 @@ public protocol Grpc_Testing_ReconnectServiceAsyncProvider: CallHandlerProvider 
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension Grpc_Testing_ReconnectServiceAsyncProvider {
+  public static var serviceDescriptor: GRPCServiceDescriptor {
+    return Grpc_Testing_ReconnectServiceServerMetadata.serviceDescriptor
+  }
+
   public var serviceName: Substring {
-    return "grpc.testing.ReconnectService"
+    return Grpc_Testing_ReconnectServiceServerMetadata.serviceDescriptor.fullName[...]
   }
 
   public var interceptors: Grpc_Testing_ReconnectServiceServerInterceptorFactoryProtocol? {
@@ -1432,3 +1632,38 @@ extension Grpc_Testing_ReconnectServiceAsyncProvider {
 
 #endif // compiler(>=5.5) && canImport(_Concurrency)
 
+public protocol Grpc_Testing_ReconnectServiceServerInterceptorFactoryProtocol {
+
+  /// - Returns: Interceptors to use when handling 'start'.
+  ///   Defaults to calling `self.makeInterceptors()`.
+  func makeStartInterceptors() -> [ServerInterceptor<Grpc_Testing_ReconnectParams, Grpc_Testing_Empty>]
+
+  /// - Returns: Interceptors to use when handling 'stop'.
+  ///   Defaults to calling `self.makeInterceptors()`.
+  func makeStopInterceptors() -> [ServerInterceptor<Grpc_Testing_Empty, Grpc_Testing_ReconnectInfo>]
+}
+
+public enum Grpc_Testing_ReconnectServiceServerMetadata {
+  public static let serviceDescriptor = GRPCServiceDescriptor(
+    name: "ReconnectService",
+    fullName: "grpc.testing.ReconnectService",
+    methods: [
+      Grpc_Testing_ReconnectServiceServerMetadata.Methods.start,
+      Grpc_Testing_ReconnectServiceServerMetadata.Methods.stop,
+    ]
+  )
+
+  public enum Methods {
+    public static let start = GRPCMethodDescriptor(
+      name: "Start",
+      path: "/grpc.testing.ReconnectService/Start",
+      type: GRPCCallType.unary
+    )
+
+    public static let stop = GRPCMethodDescriptor(
+      name: "Stop",
+      path: "/grpc.testing.ReconnectService/Stop",
+      type: GRPCCallType.unary
+    )
+  }
+}

--- a/Sources/protoc-gen-grpc-swift/Generator-Metadata.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator-Metadata.swift
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2021, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import SwiftProtobuf
+import SwiftProtobufPluginLibrary
+
+extension Generator {
+  internal func printServerMetadata() {
+    self.printMetadata(server: true)
+  }
+
+  internal func printClientMetadata() {
+    self.printMetadata(server: false)
+  }
+
+  private func printMetadata(server: Bool) {
+    let enumName = server ? self.serviceServerMetadata : self.serviceClientMetadata
+
+    self.withIndentation("\(self.access) enum \(enumName)", braces: .curly) {
+      self.println("\(self.access) static let serviceDescriptor = GRPCServiceDescriptor(")
+      self.withIndentation {
+        self.println("name: \(quoted(self.service.name)),")
+        self.println("fullName: \(quoted(self.servicePath)),")
+        self.println("methods: [")
+        for method in self.service.methods {
+          self.method = method
+          self.withIndentation {
+            self.println("\(enumName).Methods.\(self.methodFunctionName),")
+          }
+        }
+        self.println("]")
+      }
+      self.println(")")
+      self.println()
+
+      self.withIndentation("\(self.access) enum Methods", braces: .curly) {
+        for (offset, method) in self.service.methods.enumerated() {
+          self.method = method
+          self.println(
+            "\(self.access) static let \(self.methodFunctionName) = GRPCMethodDescriptor("
+          )
+          self.withIndentation {
+            self.println("name: \(quoted(self.method.name)),")
+            self.println("path: \(quoted(self.methodPath)),")
+            self.println("type: \(streamingType(self.method).asGRPCCallTypeCase)")
+          }
+          self.println(")")
+
+          if (offset + 1) < self.service.methods.count {
+            self.println()
+          }
+        }
+      }
+    }
+  }
+}
+
+extension Generator {
+  internal var serviceServerMetadata: String {
+    return nameForPackageService(self.file, self.service) + "ServerMetadata"
+  }
+
+  internal var serviceClientMetadata: String {
+    return nameForPackageService(self.file, self.service) + "ClientMetadata"
+  }
+
+  internal var methodPathUsingClientMetadata: String {
+    return "\(self.serviceClientMetadata).Methods.\(self.methodFunctionName).path"
+  }
+}

--- a/Sources/protoc-gen-grpc-swift/Generator-Names.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator-Names.swift
@@ -147,6 +147,14 @@ extension Generator {
   }
 
   internal var methodPath: String {
-    return "\"/" + self.servicePath + "/" + method.name + "\""
+    return "/" + self.fullMethodName
   }
+
+  internal var fullMethodName: String {
+    return self.servicePath + "/" + self.method.name
+  }
+}
+
+internal func quoted(_ str: String) -> String {
+  return "\"" + str + "\""
 }

--- a/Sources/protoc-gen-grpc-swift/Generator-Server+AsyncAwait.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator-Server+AsyncAwait.swift
@@ -32,6 +32,7 @@ extension Generator {
       "\(self.access) protocol \(self.asyncProviderName): CallHandlerProvider",
       braces: .curly
     ) {
+      self.println("static var serviceDescriptor: GRPCServiceDescriptor { get }")
       self.println("var interceptors: \(self.serverInterceptorProtocolName)? { get }")
 
       for method in service.methods {
@@ -100,8 +101,19 @@ extension Generator {
     // Default extension to provide the service name and routing for methods.
     self.printAvailabilityForAsyncAwait()
     self.withIndentation("extension \(self.asyncProviderName)", braces: .curly) {
+      self.withIndentation(
+        "\(self.access) static var serviceDescriptor: GRPCServiceDescriptor",
+        braces: .curly
+      ) {
+        self.println("return \(self.serviceServerMetadata).serviceDescriptor")
+      }
+
+      self.println()
+
+      // This fulfils a requirement from 'CallHandlerProvider'
       self.withIndentation("\(self.access) var serviceName: Substring", braces: .curly) {
-        self.println("return \"\(self.servicePath)\"")
+        /// This API returns a Substring (hence the '[...]')
+        self.println("return \(self.serviceServerMetadata).serviceDescriptor.fullName[...]")
       }
 
       self.println()

--- a/Sources/protoc-gen-grpc-swift/Generator-Server.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator-Server.swift
@@ -23,9 +23,6 @@ extension Generator {
       self.printServerProtocol()
       self.println()
       self.printServerProtocolExtension()
-      self.println()
-      self.printServerInterceptorFactoryProtocol()
-      self.println()
     }
 
     if self.options.generateAsyncServer {
@@ -36,13 +33,14 @@ extension Generator {
       self.printServerProtocolExtensionAsyncAwait()
       self.println()
       self.printEndCompilerGuardForAsyncAwait()
-      self.println()
     }
 
-    // If we generate only the async server we need to print the interceptor factory protocol (as
-    // it is used by both).
-    if self.options.generateAsyncServer, !self.options.generateServer {
+    // Both implementations share definitions for interceptors and metadata.
+    if self.options.generateServer || self.options.generateAsyncServer {
+      self.println()
       self.printServerInterceptorFactoryProtocol()
+      self.println()
+      self.printServerMetadata()
     }
   }
 
@@ -91,7 +89,10 @@ extension Generator {
   private func printServerProtocolExtension() {
     self.println("extension \(self.providerName) {")
     self.withIndentation {
-      self.println("\(self.access) var serviceName: Substring { return \"\(self.servicePath)\" }")
+      self.withIndentation("\(self.access) var serviceName: Substring", braces: .curly) {
+        /// This API returns a Substring (hence the '[...]')
+        self.println("return \(self.serviceServerMetadata).serviceDescriptor.fullName[...]")
+      }
       self.println()
       self.println(
         "/// Determines, calls and returns the appropriate request handler, depending on the request's method."

--- a/Sources/protoc-gen-grpc-swift/StreamingType.swift
+++ b/Sources/protoc-gen-grpc-swift/StreamingType.swift
@@ -22,6 +22,21 @@ internal enum StreamingType {
   case bidirectionalStreaming
 }
 
+extension StreamingType {
+  internal var asGRPCCallTypeCase: String {
+    switch self {
+    case .unary:
+      return "GRPCCallType.unary"
+    case .clientStreaming:
+      return "GRPCCallType.clientStreaming"
+    case .serverStreaming:
+      return "GRPCCallType.serverStreaming"
+    case .bidirectionalStreaming:
+      return "GRPCCallType.bidirectionalStreaming"
+    }
+  }
+}
+
 internal func streamingType(_ method: MethodDescriptor) -> StreamingType {
   if method.proto.clientStreaming {
     if method.proto.serverStreaming {

--- a/Tests/GRPCTests/Codegen/Normalization/normalization.grpc.swift
+++ b/Tests/GRPCTests/Codegen/Normalization/normalization.grpc.swift
@@ -87,7 +87,7 @@ extension Normalization_NormalizationClientProtocol {
     callOptions: CallOptions? = nil
   ) -> UnaryCall<SwiftProtobuf.Google_Protobuf_Empty, Normalization_FunctionName> {
     return self.makeUnaryCall(
-      path: "/normalization.Normalization/Unary",
+      path: Normalization_NormalizationClientMetadata.Methods.Unary.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeUnaryInterceptors() ?? []
@@ -105,7 +105,7 @@ extension Normalization_NormalizationClientProtocol {
     callOptions: CallOptions? = nil
   ) -> UnaryCall<SwiftProtobuf.Google_Protobuf_Empty, Normalization_FunctionName> {
     return self.makeUnaryCall(
-      path: "/normalization.Normalization/unary",
+      path: Normalization_NormalizationClientMetadata.Methods.unary.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeunaryInterceptors() ?? []
@@ -125,7 +125,7 @@ extension Normalization_NormalizationClientProtocol {
     handler: @escaping (Normalization_FunctionName) -> Void
   ) -> ServerStreamingCall<SwiftProtobuf.Google_Protobuf_Empty, Normalization_FunctionName> {
     return self.makeServerStreamingCall(
-      path: "/normalization.Normalization/ServerStreaming",
+      path: Normalization_NormalizationClientMetadata.Methods.ServerStreaming.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeServerStreamingInterceptors() ?? [],
@@ -146,7 +146,7 @@ extension Normalization_NormalizationClientProtocol {
     handler: @escaping (Normalization_FunctionName) -> Void
   ) -> ServerStreamingCall<SwiftProtobuf.Google_Protobuf_Empty, Normalization_FunctionName> {
     return self.makeServerStreamingCall(
-      path: "/normalization.Normalization/serverStreaming",
+      path: Normalization_NormalizationClientMetadata.Methods.serverStreaming.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeserverStreamingInterceptors() ?? [],
@@ -166,7 +166,7 @@ extension Normalization_NormalizationClientProtocol {
     callOptions: CallOptions? = nil
   ) -> ClientStreamingCall<SwiftProtobuf.Google_Protobuf_Empty, Normalization_FunctionName> {
     return self.makeClientStreamingCall(
-      path: "/normalization.Normalization/ClientStreaming",
+      path: Normalization_NormalizationClientMetadata.Methods.ClientStreaming.path,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeClientStreamingInterceptors() ?? []
     )
@@ -184,7 +184,7 @@ extension Normalization_NormalizationClientProtocol {
     callOptions: CallOptions? = nil
   ) -> ClientStreamingCall<SwiftProtobuf.Google_Protobuf_Empty, Normalization_FunctionName> {
     return self.makeClientStreamingCall(
-      path: "/normalization.Normalization/clientStreaming",
+      path: Normalization_NormalizationClientMetadata.Methods.clientStreaming.path,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeclientStreamingInterceptors() ?? []
     )
@@ -204,7 +204,7 @@ extension Normalization_NormalizationClientProtocol {
     handler: @escaping (Normalization_FunctionName) -> Void
   ) -> BidirectionalStreamingCall<SwiftProtobuf.Google_Protobuf_Empty, Normalization_FunctionName> {
     return self.makeBidirectionalStreamingCall(
-      path: "/normalization.Normalization/BidirectionalStreaming",
+      path: Normalization_NormalizationClientMetadata.Methods.BidirectionalStreaming.path,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeBidirectionalStreamingInterceptors() ?? [],
       handler: handler
@@ -225,11 +225,33 @@ extension Normalization_NormalizationClientProtocol {
     handler: @escaping (Normalization_FunctionName) -> Void
   ) -> BidirectionalStreamingCall<SwiftProtobuf.Google_Protobuf_Empty, Normalization_FunctionName> {
     return self.makeBidirectionalStreamingCall(
-      path: "/normalization.Normalization/bidirectionalStreaming",
+      path: Normalization_NormalizationClientMetadata.Methods.bidirectionalStreaming.path,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makebidirectionalStreamingInterceptors() ?? [],
       handler: handler
     )
+  }
+}
+
+internal final class Normalization_NormalizationClient: Normalization_NormalizationClientProtocol {
+  internal let channel: GRPCChannel
+  internal var defaultCallOptions: CallOptions
+  internal var interceptors: Normalization_NormalizationClientInterceptorFactoryProtocol?
+
+  /// Creates a client for the normalization.Normalization service.
+  ///
+  /// - Parameters:
+  ///   - channel: `GRPCChannel` to the service host.
+  ///   - defaultCallOptions: Options to use for each service call if the user doesn't provide them.
+  ///   - interceptors: A factory providing interceptors for each RPC.
+  internal init(
+    channel: GRPCChannel,
+    defaultCallOptions: CallOptions = CallOptions(),
+    interceptors: Normalization_NormalizationClientInterceptorFactoryProtocol? = nil
+  ) {
+    self.channel = channel
+    self.defaultCallOptions = defaultCallOptions
+    self.interceptors = interceptors
   }
 }
 
@@ -260,25 +282,70 @@ internal protocol Normalization_NormalizationClientInterceptorFactoryProtocol {
   func makebidirectionalStreamingInterceptors() -> [ClientInterceptor<SwiftProtobuf.Google_Protobuf_Empty, Normalization_FunctionName>]
 }
 
-internal final class Normalization_NormalizationClient: Normalization_NormalizationClientProtocol {
-  internal let channel: GRPCChannel
-  internal var defaultCallOptions: CallOptions
-  internal var interceptors: Normalization_NormalizationClientInterceptorFactoryProtocol?
+internal enum Normalization_NormalizationClientMetadata {
+  internal static let serviceDescriptor = GRPCServiceDescriptor(
+    name: "Normalization",
+    fullName: "normalization.Normalization",
+    methods: [
+      Normalization_NormalizationClientMetadata.Methods.Unary,
+      Normalization_NormalizationClientMetadata.Methods.unary,
+      Normalization_NormalizationClientMetadata.Methods.ServerStreaming,
+      Normalization_NormalizationClientMetadata.Methods.serverStreaming,
+      Normalization_NormalizationClientMetadata.Methods.ClientStreaming,
+      Normalization_NormalizationClientMetadata.Methods.clientStreaming,
+      Normalization_NormalizationClientMetadata.Methods.BidirectionalStreaming,
+      Normalization_NormalizationClientMetadata.Methods.bidirectionalStreaming,
+    ]
+  )
 
-  /// Creates a client for the normalization.Normalization service.
-  ///
-  /// - Parameters:
-  ///   - channel: `GRPCChannel` to the service host.
-  ///   - defaultCallOptions: Options to use for each service call if the user doesn't provide them.
-  ///   - interceptors: A factory providing interceptors for each RPC.
-  internal init(
-    channel: GRPCChannel,
-    defaultCallOptions: CallOptions = CallOptions(),
-    interceptors: Normalization_NormalizationClientInterceptorFactoryProtocol? = nil
-  ) {
-    self.channel = channel
-    self.defaultCallOptions = defaultCallOptions
-    self.interceptors = interceptors
+  internal enum Methods {
+    internal static let Unary = GRPCMethodDescriptor(
+      name: "Unary",
+      path: "/normalization.Normalization/Unary",
+      type: GRPCCallType.unary
+    )
+
+    internal static let unary = GRPCMethodDescriptor(
+      name: "unary",
+      path: "/normalization.Normalization/unary",
+      type: GRPCCallType.unary
+    )
+
+    internal static let ServerStreaming = GRPCMethodDescriptor(
+      name: "ServerStreaming",
+      path: "/normalization.Normalization/ServerStreaming",
+      type: GRPCCallType.serverStreaming
+    )
+
+    internal static let serverStreaming = GRPCMethodDescriptor(
+      name: "serverStreaming",
+      path: "/normalization.Normalization/serverStreaming",
+      type: GRPCCallType.serverStreaming
+    )
+
+    internal static let ClientStreaming = GRPCMethodDescriptor(
+      name: "ClientStreaming",
+      path: "/normalization.Normalization/ClientStreaming",
+      type: GRPCCallType.clientStreaming
+    )
+
+    internal static let clientStreaming = GRPCMethodDescriptor(
+      name: "clientStreaming",
+      path: "/normalization.Normalization/clientStreaming",
+      type: GRPCCallType.clientStreaming
+    )
+
+    internal static let BidirectionalStreaming = GRPCMethodDescriptor(
+      name: "BidirectionalStreaming",
+      path: "/normalization.Normalization/BidirectionalStreaming",
+      type: GRPCCallType.bidirectionalStreaming
+    )
+
+    internal static let bidirectionalStreaming = GRPCMethodDescriptor(
+      name: "bidirectionalStreaming",
+      path: "/normalization.Normalization/bidirectionalStreaming",
+      type: GRPCCallType.bidirectionalStreaming
+    )
   }
 }
 
@@ -304,7 +371,9 @@ internal protocol Normalization_NormalizationProvider: CallHandlerProvider {
 }
 
 extension Normalization_NormalizationProvider {
-  internal var serviceName: Substring { return "normalization.Normalization" }
+  internal var serviceName: Substring {
+    return Normalization_NormalizationServerMetadata.serviceDescriptor.fullName[...]
+  }
 
   /// Determines, calls and returns the appropriate request handler, depending on the request's method.
   /// Returns nil for methods not handled by this service.
@@ -426,3 +495,69 @@ internal protocol Normalization_NormalizationServerInterceptorFactoryProtocol {
   func makebidirectionalStreamingInterceptors() -> [ServerInterceptor<SwiftProtobuf.Google_Protobuf_Empty, Normalization_FunctionName>]
 }
 
+internal enum Normalization_NormalizationServerMetadata {
+  internal static let serviceDescriptor = GRPCServiceDescriptor(
+    name: "Normalization",
+    fullName: "normalization.Normalization",
+    methods: [
+      Normalization_NormalizationServerMetadata.Methods.Unary,
+      Normalization_NormalizationServerMetadata.Methods.unary,
+      Normalization_NormalizationServerMetadata.Methods.ServerStreaming,
+      Normalization_NormalizationServerMetadata.Methods.serverStreaming,
+      Normalization_NormalizationServerMetadata.Methods.ClientStreaming,
+      Normalization_NormalizationServerMetadata.Methods.clientStreaming,
+      Normalization_NormalizationServerMetadata.Methods.BidirectionalStreaming,
+      Normalization_NormalizationServerMetadata.Methods.bidirectionalStreaming,
+    ]
+  )
+
+  internal enum Methods {
+    internal static let Unary = GRPCMethodDescriptor(
+      name: "Unary",
+      path: "/normalization.Normalization/Unary",
+      type: GRPCCallType.unary
+    )
+
+    internal static let unary = GRPCMethodDescriptor(
+      name: "unary",
+      path: "/normalization.Normalization/unary",
+      type: GRPCCallType.unary
+    )
+
+    internal static let ServerStreaming = GRPCMethodDescriptor(
+      name: "ServerStreaming",
+      path: "/normalization.Normalization/ServerStreaming",
+      type: GRPCCallType.serverStreaming
+    )
+
+    internal static let serverStreaming = GRPCMethodDescriptor(
+      name: "serverStreaming",
+      path: "/normalization.Normalization/serverStreaming",
+      type: GRPCCallType.serverStreaming
+    )
+
+    internal static let ClientStreaming = GRPCMethodDescriptor(
+      name: "ClientStreaming",
+      path: "/normalization.Normalization/ClientStreaming",
+      type: GRPCCallType.clientStreaming
+    )
+
+    internal static let clientStreaming = GRPCMethodDescriptor(
+      name: "clientStreaming",
+      path: "/normalization.Normalization/clientStreaming",
+      type: GRPCCallType.clientStreaming
+    )
+
+    internal static let BidirectionalStreaming = GRPCMethodDescriptor(
+      name: "BidirectionalStreaming",
+      path: "/normalization.Normalization/BidirectionalStreaming",
+      type: GRPCCallType.bidirectionalStreaming
+    )
+
+    internal static let bidirectionalStreaming = GRPCMethodDescriptor(
+      name: "bidirectionalStreaming",
+      path: "/normalization.Normalization/bidirectionalStreaming",
+      type: GRPCCallType.bidirectionalStreaming
+    )
+  }
+}

--- a/Tests/GRPCTests/EchoMetadataTests.swift
+++ b/Tests/GRPCTests/EchoMetadataTests.swift
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2021, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import EchoModel
+import GRPC
+import XCTest
+
+internal final class EchoMetadataTests: GRPCTestCase {
+  private func testServiceDescriptor(_ description: GRPCServiceDescriptor) {
+    XCTAssertEqual(description.name, "Echo")
+    XCTAssertEqual(description.fullName, "echo.Echo")
+
+    XCTAssertEqual(description.methods.count, 4)
+
+    if let get = description.methods.first(where: { $0.name == "Get" }) {
+      self._testGet(get)
+    } else {
+      XCTFail("No 'Get' method found")
+    }
+
+    if let collect = description.methods.first(where: { $0.name == "Collect" }) {
+      self._testCollect(collect)
+    } else {
+      XCTFail("No 'Collect' method found")
+    }
+
+    if let expand = description.methods.first(where: { $0.name == "Expand" }) {
+      self._testExpand(expand)
+    } else {
+      XCTFail("No 'Expand' method found")
+    }
+
+    if let update = description.methods.first(where: { $0.name == "Update" }) {
+      self._testUpdate(update)
+    } else {
+      XCTFail("No 'Update' method found")
+    }
+  }
+
+  private func _testGet(_ description: GRPCMethodDescriptor) {
+    XCTAssertEqual(description.name, "Get")
+    XCTAssertEqual(description.fullName, "echo.Echo/Get")
+    XCTAssertEqual(description.path, "/echo.Echo/Get")
+    XCTAssertEqual(description.type, .unary)
+  }
+
+  private func _testCollect(_ description: GRPCMethodDescriptor) {
+    XCTAssertEqual(description.name, "Collect")
+    XCTAssertEqual(description.fullName, "echo.Echo/Collect")
+    XCTAssertEqual(description.path, "/echo.Echo/Collect")
+    XCTAssertEqual(description.type, .clientStreaming)
+  }
+
+  private func _testExpand(_ description: GRPCMethodDescriptor) {
+    XCTAssertEqual(description.name, "Expand")
+    XCTAssertEqual(description.fullName, "echo.Echo/Expand")
+    XCTAssertEqual(description.path, "/echo.Echo/Expand")
+    XCTAssertEqual(description.type, .serverStreaming)
+  }
+
+  private func _testUpdate(_ description: GRPCMethodDescriptor) {
+    XCTAssertEqual(description.name, "Update")
+    XCTAssertEqual(description.fullName, "echo.Echo/Update")
+    XCTAssertEqual(description.path, "/echo.Echo/Update")
+    XCTAssertEqual(description.type, .bidirectionalStreaming)
+  }
+
+  func testServiceDescriptor() {
+    self.testServiceDescriptor(Echo_EchoClientMetadata.serviceDescriptor)
+    self.testServiceDescriptor(Echo_EchoServerMetadata.serviceDescriptor)
+
+    #if swift(>=5.5)
+    if #available(macOS 12, *) {
+      self.testServiceDescriptor(Echo_EchoAsyncClient.serviceDescriptor)
+    }
+    #endif
+  }
+
+  func testGet() {
+    self._testGet(Echo_EchoClientMetadata.Methods.get)
+    self._testGet(Echo_EchoServerMetadata.Methods.get)
+  }
+
+  func testCollect() {
+    self._testCollect(Echo_EchoClientMetadata.Methods.collect)
+    self._testCollect(Echo_EchoServerMetadata.Methods.collect)
+  }
+
+  func testExpand() {
+    self._testExpand(Echo_EchoClientMetadata.Methods.expand)
+    self._testExpand(Echo_EchoServerMetadata.Methods.expand)
+  }
+
+  func testUpdate() {
+    self._testUpdate(Echo_EchoClientMetadata.Methods.update)
+    self._testUpdate(Echo_EchoServerMetadata.Methods.update)
+  }
+}


### PR DESCRIPTION
Motivation:

Sometimes it's useful to know information about a service, including its
name, methods it offers and so on. An example where this is useful is
service discovery (#1183). However, we currently only provide the
service name and this isn't available statically. For service discovery
this is problematic as it requires users to create a client in order to
get the service name so that a server can be dialled.

For the async/await code, since it is not yet final, we can add
requirements to generated protocols to provide the service metadata
statically.

Modifications:

- Add service and method descriptors to `GRPC`
- Generate service descriptors for client and server separately (it's feasible
  that a user may generate client code into one module and server code
  into separate modules)
- Update the generated code for async/await and NIO based APIs to use
  the descriptors directly rather than generating literals in places
  where they are required.
- Add test for the generated echo service metadata
- Regenerate other services

Result:

Adopters can get static information about services.
