### PR TITLE
Update the RouteGuide example and tutorial

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ ${XCODEPROJ}:
 	protoc $< \
 		--proto_path=$(dir $<) \
 		--plugin=${PROTOC_GEN_GRPC_SWIFT} \
-		--grpc-swift_opt=Visibility=Public \
+		--grpc-swift_opt=Visibility=Public,ExperimentalAsyncClient=true,ExperimentalAsyncServer=true \
 		--grpc-swift_out=$(dir $<)
 
 ECHO_PROTO=Sources/Examples/Echo/Model/echo.proto

--- a/Sources/Examples/RouteGuide/Client/main.swift
+++ b/Sources/Examples/RouteGuide/Client/main.swift
@@ -13,177 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#if compiler(>=5.5) && canImport(_Concurrency)
 import ArgumentParser
 import Foundation
 import GRPC
 import NIOCore
 import NIOPosix
 import RouteGuideModel
-
-/// Makes a `RouteGuide` client for a service hosted on "localhost" and listening on the given port.
-func makeClient(port: Int, group: EventLoopGroup) throws -> Routeguide_RouteGuideClient {
-  let channel = try GRPCChannelPool.with(
-    target: .host("localhost", port: port),
-    transportSecurity: .plaintext,
-    eventLoopGroup: group
-  )
-
-  return Routeguide_RouteGuideClient(channel: channel)
-}
-
-/// Unary call example. Calls `getFeature` and prints the response.
-func getFeature(using client: Routeguide_RouteGuideClient, latitude: Int, longitude: Int) {
-  print("→ GetFeature: lat=\(latitude) lon=\(longitude)")
-
-  let point: Routeguide_Point = .with {
-    $0.latitude = numericCast(latitude)
-    $0.longitude = numericCast(longitude)
-  }
-
-  let call = client.getFeature(point)
-  let feature: Routeguide_Feature
-
-  do {
-    feature = try call.response.wait()
-  } catch {
-    print("RPC failed: \(error)")
-    return
-  }
-
-  let lat = feature.location.latitude
-  let lon = feature.location.longitude
-
-  if !feature.name.isEmpty {
-    print("Found feature called '\(feature.name)' at \(lat), \(lon)")
-  } else {
-    print("Found no feature at \(lat), \(lon)")
-  }
-}
-
-/// Server-streaming example. Calls `listFeatures` with a rectangle of interest. Prints each
-/// response feature as it arrives.
-func listFeatures(
-  using client: Routeguide_RouteGuideClient,
-  lowLatitude: Int,
-  lowLongitude: Int,
-  highLatitude: Int,
-  highLongitude: Int
-) {
-  print(
-    "→ ListFeatures: lowLat=\(lowLatitude) lowLon=\(lowLongitude), hiLat=\(highLatitude) hiLon=\(highLongitude)"
-  )
-
-  let rectangle: Routeguide_Rectangle = .with {
-    $0.lo = .with {
-      $0.latitude = numericCast(lowLatitude)
-      $0.longitude = numericCast(lowLongitude)
-    }
-    $0.hi = .with {
-      $0.latitude = numericCast(highLatitude)
-      $0.longitude = numericCast(highLongitude)
-    }
-  }
-
-  var resultCount = 1
-  let call = client.listFeatures(rectangle) { feature in
-    print("Result #\(resultCount): \(feature)")
-    resultCount += 1
-  }
-
-  let status = try! call.status.recover { _ in .processingError }.wait()
-  if status.code != .ok {
-    print("RPC failed: \(status)")
-  }
-}
-
-/// Client-streaming example. Sends `featuresToVisit` randomly chosen points from `features` with
-/// a variable delay in between. Prints the statistics when they are sent from the server.
-public func recordRoute(
-  using client: Routeguide_RouteGuideClient,
-  features: [Routeguide_Feature],
-  featuresToVisit: Int
-) {
-  print("→ RecordRoute")
-  let options = CallOptions(timeLimit: .timeout(.minutes(1)))
-  let call = client.recordRoute(callOptions: options)
-
-  call.response.whenSuccess { summary in
-    print(
-      "Finished trip with \(summary.pointCount) points. Passed \(summary.featureCount) features. " +
-        "Travelled \(summary.distance) meters. It took \(summary.elapsedTime) seconds."
-    )
-  }
-
-  call.response.whenFailure { error in
-    print("RecordRoute Failed: \(error)")
-  }
-
-  call.status.whenComplete { _ in
-    print("Finished RecordRoute")
-  }
-
-  for _ in 0 ..< featuresToVisit {
-    let index = Int.random(in: 0 ..< features.count)
-    let point = features[index].location
-    print("Visiting point \(point.latitude), \(point.longitude)")
-    call.sendMessage(point, promise: nil)
-
-    // Sleep for a bit before sending the next one.
-    Thread.sleep(forTimeInterval: TimeInterval.random(in: 0.5 ..< 1.5))
-  }
-
-  call.sendEnd(promise: nil)
-
-  // Wait for the call to end.
-  _ = try! call.status.wait()
-}
-
-/// Bidirectional example. Send some chat messages, and print any chat messages that are sent from
-/// the server.
-func routeChat(using client: Routeguide_RouteGuideClient) {
-  print("→ RouteChat")
-
-  let call = client.routeChat { note in
-    print(
-      "Got message \"\(note.message)\" at \(note.location.latitude), \(note.location.longitude)"
-    )
-  }
-
-  call.status.whenSuccess { status in
-    if status.code == .ok {
-      print("Finished RouteChat")
-    } else {
-      print("RouteChat Failed: \(status)")
-    }
-  }
-
-  let noteContent = [
-    ("First message", 0, 0),
-    ("Second message", 0, 1),
-    ("Third message", 1, 0),
-    ("Fourth message", 1, 1),
-  ]
-
-  for (message, latitude, longitude) in noteContent {
-    let note: Routeguide_RouteNote = .with {
-      $0.message = message
-      $0.location = .with {
-        $0.latitude = Int32(latitude)
-        $0.longitude = Int32(longitude)
-      }
-    }
-
-    print(
-      "Sending message \"\(note.message)\" at \(note.location.latitude), \(note.location.longitude)"
-    )
-    call.sendMessage(note, promise: nil)
-  }
-  // Mark the end of the stream.
-  call.sendEnd(promise: nil)
-
-  // Wait for the call to end.
-  _ = try! call.status.wait()
-}
 
 /// Loads the features from `route_guide_db.json`, assumed to be in the directory above this file.
 func loadFeatures() throws -> [Routeguide_Feature] {
@@ -196,6 +32,204 @@ func loadFeatures() throws -> [Routeguide_Feature] {
   return try Routeguide_Feature.array(fromJSONUTF8Data: data)
 }
 
+/// Makes a `RouteGuide` client for a service hosted on "localhost" and listening on the given port.
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+func makeClient(port: Int, group: EventLoopGroup) throws -> Routeguide_RouteGuideAsyncClient {
+  let channel = try GRPCChannelPool.with(
+    target: .host("localhost", port: port),
+    transportSecurity: .plaintext,
+    eventLoopGroup: group
+  )
+
+  return Routeguide_RouteGuideAsyncClient(channel: channel)
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+internal struct RouteGuideExample: @unchecked Sendable {
+  private let routeGuide: Routeguide_RouteGuideAsyncClient
+  private let features: [Routeguide_Feature]
+
+  init(routeGuide: Routeguide_RouteGuideAsyncClient, features: [Routeguide_Feature]) {
+    self.routeGuide = routeGuide
+    self.features = features
+  }
+
+  func runAndBlockUntilCompletion() {
+    let group = DispatchGroup()
+    group.enter()
+
+    Task {
+      defer {
+        group.leave()
+      }
+
+      // Look for a valid feature.
+      await self.getFeature(latitude: 409_146_138, longitude: -746_188_906)
+
+      // Look for a missing feature.
+      await self.getFeature(latitude: 0, longitude: 0)
+
+      // Looking for features between 40, -75 and 42, -73.
+      await self.listFeatures(
+        lowLatitude: 400_000_000,
+        lowLongitude: -750_000_000,
+        highLatitude: 420_000_000,
+        highLongitude: -730_000_000
+      )
+
+      // Record a few randomly selected points from the features file.
+      await self.recordRoute(features: features, featuresToVisit: 10)
+
+      // Send and receive some notes.
+      await self.routeChat()
+    }
+
+    group.wait()
+  }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension RouteGuideExample {
+  /// Get the feature at the given latitude and longitude, if one exists.
+  private func getFeature(latitude: Int, longitude: Int) async {
+    print("\n→ GetFeature: lat=\(latitude) lon=\(longitude)")
+
+    let point: Routeguide_Point = .with {
+      $0.latitude = numericCast(latitude)
+      $0.longitude = numericCast(longitude)
+    }
+
+    do {
+      let feature = try await self.routeGuide.getFeature(point)
+
+      if !feature.name.isEmpty {
+        print("Found feature called '\(feature.name)' at \(feature.location)")
+      } else {
+        print("Found no feature at \(feature.location)")
+      }
+    } catch {
+      print("RPC failed: \(error)")
+    }
+  }
+
+  /// List all features in the area bounded by the high and low latitude and longitudes.
+  private func listFeatures(
+    lowLatitude: Int,
+    lowLongitude: Int,
+    highLatitude: Int,
+    highLongitude: Int
+  ) async {
+    print(
+      "\n→ ListFeatures: lowLat=\(lowLatitude) lowLon=\(lowLongitude), hiLat=\(highLatitude) hiLon=\(highLongitude)"
+    )
+
+    let rectangle: Routeguide_Rectangle = .with {
+      $0.lo = .with {
+        $0.latitude = numericCast(lowLatitude)
+        $0.longitude = numericCast(lowLongitude)
+      }
+      $0.hi = .with {
+        $0.latitude = numericCast(highLatitude)
+        $0.longitude = numericCast(highLongitude)
+      }
+    }
+
+    do {
+      var resultCount = 1
+      for try await feature in self.routeGuide.listFeatures(rectangle) {
+        print("Result #\(resultCount): \(feature)")
+        resultCount += 1
+      }
+    } catch {
+      print("RPC failed: \(error)")
+    }
+  }
+
+  /// Record a route for `featuresToVisit` features selected randomly from `features` and print a
+  /// summary of the route.
+  private func recordRoute(
+    features: [Routeguide_Feature],
+    featuresToVisit: Int
+  ) async {
+    print("\n→ RecordRoute")
+    let recordRoute = self.routeGuide.makeRecordRouteCall()
+
+    do {
+      for i in 1 ... featuresToVisit {
+        if let feature = features.randomElement() {
+          let point = feature.location
+          print("Visiting point #\(i) at \(point)")
+          try await recordRoute.requestStream.send(point)
+
+          // Sleep for 0.2s ... 1.0s before sending the next point.
+          try await Task.sleep(nanoseconds: UInt64.random(in: UInt64(2e8) ... UInt64(1e9)))
+        }
+      }
+
+      try await recordRoute.requestStream.finish()
+      let summary = try await recordRoute.response
+
+      print(
+        "Finished trip with \(summary.pointCount) points. Passed \(summary.featureCount) features. " +
+          "Travelled \(summary.distance) meters. It took \(summary.elapsedTime) seconds."
+      )
+    } catch {
+      print("RecordRoute Failed: \(error)")
+    }
+  }
+
+  /// Record notes at given locations, printing each all other messages which have previously been
+  /// recorded at the same location.
+  private func routeChat() async {
+    print("\n→ RouteChat")
+
+    let notes = [
+      ("First message", 0, 0),
+      ("Second message", 0, 1),
+      ("Third message", 1, 0),
+      ("Fourth message", 1, 1),
+    ].map { message, latitude, longitude in
+      Routeguide_RouteNote.with {
+        $0.message = message
+        $0.location = .with {
+          $0.latitude = Int32(latitude)
+          $0.longitude = Int32(longitude)
+        }
+      }
+    }
+
+    do {
+      try await withThrowingTaskGroup(of: Void.self) { group in
+        let routeChat = self.routeGuide.makeRouteChatCall()
+
+        // Add a task to send each message adding a small sleep between each.
+        group.addTask {
+          for note in notes {
+            print("Sending message '\(note.message)' at \(note.location)")
+            try await routeChat.requestStream.send(note)
+            // Sleep for 0.2s ... 1.0s before sending the next note.
+            try await Task.sleep(nanoseconds: UInt64.random(in: UInt64(2e8) ... UInt64(1e9)))
+          }
+
+          try await routeChat.requestStream.finish()
+        }
+
+        // Add a task to print each message received on the response stream.
+        group.addTask {
+          for try await note in routeChat.responseStream {
+            print("Received message '\(note.message)' at \(note.location)")
+          }
+        }
+
+        try await group.waitForAll()
+      }
+    } catch {
+      print("RouteChat Failed: \(error)")
+    }
+  }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 struct RouteGuide: ParsableCommand {
   @Option(help: "The port to connect to")
   var port: Int = 1234
@@ -209,33 +243,35 @@ struct RouteGuide: ParsableCommand {
       try? group.syncShutdownGracefully()
     }
 
-    // Make a client, make sure we close it when we're done.
     let routeGuide = try makeClient(port: self.port, group: group)
     defer {
       try? routeGuide.channel.close().wait()
     }
 
-    // Look for a valid feature.
-    getFeature(using: routeGuide, latitude: 409_146_138, longitude: -746_188_906)
-
-    // Look for a missing feature.
-    getFeature(using: routeGuide, latitude: 0, longitude: 0)
-
-    // Looking for features between 40, -75 and 42, -73.
-    listFeatures(
-      using: routeGuide,
-      lowLatitude: 400_000_000,
-      lowLongitude: -750_000_000,
-      highLatitude: 420_000_000,
-      highLongitude: -730_000_000
-    )
-
-    // Record a few randomly selected points from the features file.
-    recordRoute(using: routeGuide, features: features, featuresToVisit: 10)
-
-    // Send and receive some notes.
-    routeChat(using: routeGuide)
+    // ArgumentParser did not support async/await at the point in time this was written. Block
+    // this thread while the example runs.
+    let example = RouteGuideExample(routeGuide: routeGuide, features: features)
+    example.runAndBlockUntilCompletion()
   }
 }
 
-RouteGuide.main()
+extension Routeguide_Point: CustomStringConvertible {
+  public var description: String {
+    return "(\(self.latitude), \(self.longitude))"
+  }
+}
+
+extension Routeguide_Feature: CustomStringConvertible {
+  public var description: String {
+    return "\(self.name) at \(self.location)"
+  }
+}
+
+if #available(macOS 12, *) {
+  RouteGuide.main()
+} else {
+  fatalError("The RouteGuide example requires macOS 12 or newer.")
+}
+#else
+fatalError("The RouteGuide example requires Swift concurrency features.")
+#endif // compiler(>=5.5) && canImport(_Concurrency)

--- a/Sources/Examples/RouteGuide/Model/route_guide.grpc.swift
+++ b/Sources/Examples/RouteGuide/Model/route_guide.grpc.swift
@@ -175,6 +175,181 @@ public final class Routeguide_RouteGuideClient: Routeguide_RouteGuideClientProto
   }
 }
 
+#if compiler(>=5.5) && canImport(_Concurrency)
+/// Interface exported by the server.
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public protocol Routeguide_RouteGuideAsyncClientProtocol: GRPCClient {
+  static var serviceDescriptor: GRPCServiceDescriptor { get }
+  var interceptors: Routeguide_RouteGuideClientInterceptorFactoryProtocol? { get }
+
+  func makeGetFeatureCall(
+    _ request: Routeguide_Point,
+    callOptions: CallOptions?
+  ) -> GRPCAsyncUnaryCall<Routeguide_Point, Routeguide_Feature>
+
+  func makeListFeaturesCall(
+    _ request: Routeguide_Rectangle,
+    callOptions: CallOptions?
+  ) -> GRPCAsyncServerStreamingCall<Routeguide_Rectangle, Routeguide_Feature>
+
+  func makeRecordRouteCall(
+    callOptions: CallOptions?
+  ) -> GRPCAsyncClientStreamingCall<Routeguide_Point, Routeguide_RouteSummary>
+
+  func makeRouteChatCall(
+    callOptions: CallOptions?
+  ) -> GRPCAsyncBidirectionalStreamingCall<Routeguide_RouteNote, Routeguide_RouteNote>
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension Routeguide_RouteGuideAsyncClientProtocol {
+  public static var serviceDescriptor: GRPCServiceDescriptor {
+    return Routeguide_RouteGuideClientMetadata.serviceDescriptor
+  }
+
+  public var interceptors: Routeguide_RouteGuideClientInterceptorFactoryProtocol? {
+    return nil
+  }
+
+  public func makeGetFeatureCall(
+    _ request: Routeguide_Point,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncUnaryCall<Routeguide_Point, Routeguide_Feature> {
+    return self.makeAsyncUnaryCall(
+      path: Routeguide_RouteGuideClientMetadata.Methods.getFeature.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeGetFeatureInterceptors() ?? []
+    )
+  }
+
+  public func makeListFeaturesCall(
+    _ request: Routeguide_Rectangle,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncServerStreamingCall<Routeguide_Rectangle, Routeguide_Feature> {
+    return self.makeAsyncServerStreamingCall(
+      path: Routeguide_RouteGuideClientMetadata.Methods.listFeatures.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeListFeaturesInterceptors() ?? []
+    )
+  }
+
+  public func makeRecordRouteCall(
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncClientStreamingCall<Routeguide_Point, Routeguide_RouteSummary> {
+    return self.makeAsyncClientStreamingCall(
+      path: Routeguide_RouteGuideClientMetadata.Methods.recordRoute.path,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeRecordRouteInterceptors() ?? []
+    )
+  }
+
+  public func makeRouteChatCall(
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncBidirectionalStreamingCall<Routeguide_RouteNote, Routeguide_RouteNote> {
+    return self.makeAsyncBidirectionalStreamingCall(
+      path: Routeguide_RouteGuideClientMetadata.Methods.routeChat.path,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeRouteChatInterceptors() ?? []
+    )
+  }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension Routeguide_RouteGuideAsyncClientProtocol {
+  public func getFeature(
+    _ request: Routeguide_Point,
+    callOptions: CallOptions? = nil
+  ) async throws -> Routeguide_Feature {
+    return try await self.performAsyncUnaryCall(
+      path: Routeguide_RouteGuideClientMetadata.Methods.getFeature.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeGetFeatureInterceptors() ?? []
+    )
+  }
+
+  public func listFeatures(
+    _ request: Routeguide_Rectangle,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncResponseStream<Routeguide_Feature> {
+    return self.performAsyncServerStreamingCall(
+      path: Routeguide_RouteGuideClientMetadata.Methods.listFeatures.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeListFeaturesInterceptors() ?? []
+    )
+  }
+
+  public func recordRoute<RequestStream>(
+    _ requests: RequestStream,
+    callOptions: CallOptions? = nil
+  ) async throws -> Routeguide_RouteSummary where RequestStream: Sequence, RequestStream.Element == Routeguide_Point {
+    return try await self.performAsyncClientStreamingCall(
+      path: Routeguide_RouteGuideClientMetadata.Methods.recordRoute.path,
+      requests: requests,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeRecordRouteInterceptors() ?? []
+    )
+  }
+
+  public func recordRoute<RequestStream>(
+    _ requests: RequestStream,
+    callOptions: CallOptions? = nil
+  ) async throws -> Routeguide_RouteSummary where RequestStream: AsyncSequence, RequestStream.Element == Routeguide_Point {
+    return try await self.performAsyncClientStreamingCall(
+      path: Routeguide_RouteGuideClientMetadata.Methods.recordRoute.path,
+      requests: requests,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeRecordRouteInterceptors() ?? []
+    )
+  }
+
+  public func routeChat<RequestStream>(
+    _ requests: RequestStream,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncResponseStream<Routeguide_RouteNote> where RequestStream: Sequence, RequestStream.Element == Routeguide_RouteNote {
+    return self.performAsyncBidirectionalStreamingCall(
+      path: Routeguide_RouteGuideClientMetadata.Methods.routeChat.path,
+      requests: requests,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeRouteChatInterceptors() ?? []
+    )
+  }
+
+  public func routeChat<RequestStream>(
+    _ requests: RequestStream,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncResponseStream<Routeguide_RouteNote> where RequestStream: AsyncSequence, RequestStream.Element == Routeguide_RouteNote {
+    return self.performAsyncBidirectionalStreamingCall(
+      path: Routeguide_RouteGuideClientMetadata.Methods.routeChat.path,
+      requests: requests,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeRouteChatInterceptors() ?? []
+    )
+  }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public struct Routeguide_RouteGuideAsyncClient: Routeguide_RouteGuideAsyncClientProtocol {
+  public var channel: GRPCChannel
+  public var defaultCallOptions: CallOptions
+  public var interceptors: Routeguide_RouteGuideClientInterceptorFactoryProtocol?
+
+  public init(
+    channel: GRPCChannel,
+    defaultCallOptions: CallOptions = CallOptions(),
+    interceptors: Routeguide_RouteGuideClientInterceptorFactoryProtocol? = nil
+  ) {
+    self.channel = channel
+    self.defaultCallOptions = defaultCallOptions
+    self.interceptors = interceptors
+  }
+}
+
+#endif // compiler(>=5.5) && canImport(_Concurrency)
+
 public protocol Routeguide_RouteGuideClientInterceptorFactoryProtocol {
 
   /// - Returns: Interceptors to use when invoking 'getFeature'.
@@ -317,6 +492,121 @@ extension Routeguide_RouteGuideProvider {
     }
   }
 }
+#if compiler(>=5.5) && canImport(_Concurrency)
+
+/// Interface exported by the server.
+///
+/// To implement a server, implement an object which conforms to this protocol.
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public protocol Routeguide_RouteGuideAsyncProvider: CallHandlerProvider {
+  static var serviceDescriptor: GRPCServiceDescriptor { get }
+  var interceptors: Routeguide_RouteGuideServerInterceptorFactoryProtocol? { get }
+
+  /// A simple RPC.
+  ///
+  /// Obtains the feature at a given position.
+  ///
+  /// A feature with an empty name is returned if there's no feature at the given
+  /// position.
+  @Sendable func getFeature(
+    request: Routeguide_Point,
+    context: GRPCAsyncServerCallContext
+  ) async throws -> Routeguide_Feature
+
+  /// A server-to-client streaming RPC.
+  ///
+  /// Obtains the Features available within the given Rectangle.  Results are
+  /// streamed rather than returned at once (e.g. in a response message with a
+  /// repeated field), as the rectangle may cover a large area and contain a
+  /// huge number of features.
+  @Sendable func listFeatures(
+    request: Routeguide_Rectangle,
+    responseStream: GRPCAsyncResponseStreamWriter<Routeguide_Feature>,
+    context: GRPCAsyncServerCallContext
+  ) async throws
+
+  /// A client-to-server streaming RPC.
+  ///
+  /// Accepts a stream of Points on a route being traversed, returning a
+  /// RouteSummary when traversal is completed.
+  @Sendable func recordRoute(
+    requestStream: GRPCAsyncRequestStream<Routeguide_Point>,
+    context: GRPCAsyncServerCallContext
+  ) async throws -> Routeguide_RouteSummary
+
+  /// A Bidirectional streaming RPC.
+  ///
+  /// Accepts a stream of RouteNotes sent while a route is being traversed,
+  /// while receiving other RouteNotes (e.g. from other users).
+  @Sendable func routeChat(
+    requestStream: GRPCAsyncRequestStream<Routeguide_RouteNote>,
+    responseStream: GRPCAsyncResponseStreamWriter<Routeguide_RouteNote>,
+    context: GRPCAsyncServerCallContext
+  ) async throws
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension Routeguide_RouteGuideAsyncProvider {
+  public static var serviceDescriptor: GRPCServiceDescriptor {
+    return Routeguide_RouteGuideServerMetadata.serviceDescriptor
+  }
+
+  public var serviceName: Substring {
+    return Routeguide_RouteGuideServerMetadata.serviceDescriptor.fullName[...]
+  }
+
+  public var interceptors: Routeguide_RouteGuideServerInterceptorFactoryProtocol? {
+    return nil
+  }
+
+  public func handle(
+    method name: Substring,
+    context: CallHandlerContext
+  ) -> GRPCServerHandlerProtocol? {
+    switch name {
+    case "GetFeature":
+      return GRPCAsyncServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Routeguide_Point>(),
+        responseSerializer: ProtobufSerializer<Routeguide_Feature>(),
+        interceptors: self.interceptors?.makeGetFeatureInterceptors() ?? [],
+        wrapping: self.getFeature(request:context:)
+      )
+
+    case "ListFeatures":
+      return GRPCAsyncServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Routeguide_Rectangle>(),
+        responseSerializer: ProtobufSerializer<Routeguide_Feature>(),
+        interceptors: self.interceptors?.makeListFeaturesInterceptors() ?? [],
+        wrapping: self.listFeatures(request:responseStream:context:)
+      )
+
+    case "RecordRoute":
+      return GRPCAsyncServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Routeguide_Point>(),
+        responseSerializer: ProtobufSerializer<Routeguide_RouteSummary>(),
+        interceptors: self.interceptors?.makeRecordRouteInterceptors() ?? [],
+        wrapping: self.recordRoute(requestStream:context:)
+      )
+
+    case "RouteChat":
+      return GRPCAsyncServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Routeguide_RouteNote>(),
+        responseSerializer: ProtobufSerializer<Routeguide_RouteNote>(),
+        interceptors: self.interceptors?.makeRouteChatInterceptors() ?? [],
+        wrapping: self.routeChat(requestStream:responseStream:context:)
+      )
+
+    default:
+      return nil
+    }
+  }
+}
+
+#endif // compiler(>=5.5) && canImport(_Concurrency)
 
 public protocol Routeguide_RouteGuideServerInterceptorFactoryProtocol {
 

--- a/Sources/Examples/RouteGuide/Server/RouteGuideProvider.swift
+++ b/Sources/Examples/RouteGuide/Server/RouteGuideProvider.swift
@@ -19,153 +19,124 @@ import NIOConcurrencyHelpers
 import NIOCore
 import RouteGuideModel
 
-class RouteGuideProvider: Routeguide_RouteGuideProvider {
-  internal var interceptors: Routeguide_RouteGuideServerInterceptorFactoryProtocol?
+#if compiler(>=5.5) && canImport(_Concurrency)
 
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+internal final class RouteGuideProvider: Routeguide_RouteGuideAsyncProvider {
   private let features: [Routeguide_Feature]
-  private var notes: [Routeguide_Point: [Routeguide_RouteNote]] = [:]
-  private var lock = Lock()
+  private let notes: Notes
 
-  init(features: [Routeguide_Feature]) {
+  internal init(features: [Routeguide_Feature]) {
     self.features = features
+    self.notes = Notes()
   }
 
-  /// A simple RPC.
-  ///
-  /// Obtains the feature at a given position.
-  ///
-  /// A feature with an empty name is returned if there's no feature at the given position.
-  func getFeature(
+  internal func getFeature(
     request point: Routeguide_Point,
-    context: StatusOnlyCallContext
-  ) -> EventLoopFuture<Routeguide_Feature> {
-    return context.eventLoop.makeSucceededFuture(self.checkFeature(at: point))
+    context: GRPCAsyncServerCallContext
+  ) async throws -> Routeguide_Feature {
+    return self.lookupFeature(at: point) ?? .unnamedFeature(at: point)
   }
 
-  /// A server-to-client streaming RPC.
-  ///
-  /// Obtains the Features available within the given Rectangle. Results are streamed rather than
-  /// returned at once (e.g. in a response message with a repeated field), as the rectangle may
-  /// cover a large area and contain a huge number of features.
-  func listFeatures(
+  internal func listFeatures(
     request: Routeguide_Rectangle,
-    context: StreamingResponseCallContext<Routeguide_Feature>
-  ) -> EventLoopFuture<GRPCStatus> {
-    let left = min(request.lo.longitude, request.hi.longitude)
-    let right = max(request.lo.longitude, request.hi.longitude)
-    let top = max(request.lo.latitude, request.hi.latitude)
-    let bottom = max(request.lo.latitude, request.hi.latitude)
+    responseStream: GRPCAsyncResponseStreamWriter<Routeguide_Feature>,
+    context: GRPCAsyncServerCallContext
+  ) async throws {
+    let longitudeRange = request.lo.longitude ... request.hi.longitude
+    let latitudeRange = request.lo.latitude ... request.hi.latitude
 
-    self.features.lazy.filter { feature in
-      !feature.name.isEmpty
-        && feature.location.longitude >= left
-        && feature.location.longitude <= right
-        && feature.location.latitude >= bottom
-        && feature.location.latitude <= top
-    }.forEach {
-      _ = context.sendResponse($0)
+    for feature in self.features where !feature.name.isEmpty {
+      if feature.location.isWithin(latitude: latitudeRange, longitude: longitudeRange) {
+        try await responseStream.send(feature)
+      }
     }
-
-    return context.eventLoop.makeSucceededFuture(.ok)
   }
 
-  /// A client-to-server streaming RPC.
-  ///
-  /// Accepts a stream of Points on a route being traversed, returning a RouteSummary when traversal
-  /// is completed.
-  func recordRoute(
-    context: UnaryResponseCallContext<Routeguide_RouteSummary>
-  ) -> EventLoopFuture<(StreamEvent<Routeguide_Point>) -> Void> {
+  internal func recordRoute(
+    requestStream points: GRPCAsyncRequestStream<Routeguide_Point>,
+    context: GRPCAsyncServerCallContext
+  ) async throws -> Routeguide_RouteSummary {
     var pointCount: Int32 = 0
     var featureCount: Int32 = 0
     var distance = 0.0
     var previousPoint: Routeguide_Point?
-    let startTime = Date()
+    let startTimeNanos = DispatchTime.now().uptimeNanoseconds
 
-    return context.eventLoop.makeSucceededFuture({ event in
-      switch event {
-      case let .message(point):
-        pointCount += 1
-        if !self.checkFeature(at: point).name.isEmpty {
-          featureCount += 1
-        }
+    for try await point in points {
+      pointCount += 1
 
-        // For each point after the first, add the incremental distance from the previous point to
-        // the total distance value.
-        if let previous = previousPoint {
-          distance += previous.distance(to: point)
-        }
-        previousPoint = point
-
-      case .end:
-        let seconds = Date().timeIntervalSince(startTime)
-        let summary = Routeguide_RouteSummary.with {
-          $0.pointCount = pointCount
-          $0.featureCount = featureCount
-          $0.elapsedTime = Int32(seconds)
-          $0.distance = Int32(distance)
-        }
-        context.responsePromise.succeed(summary)
+      if let feature = self.lookupFeature(at: point), !feature.name.isEmpty {
+        featureCount += 1
       }
-    })
+
+      if let previous = previousPoint {
+        distance += previous.distance(to: point)
+      }
+
+      previousPoint = point
+    }
+
+    let durationInNanos = DispatchTime.now().uptimeNanoseconds - startTimeNanos
+    let durationInSeconds = Double(durationInNanos) / 1e9
+
+    return .with {
+      $0.pointCount = pointCount
+      $0.featureCount = featureCount
+      $0.elapsedTime = Int32(durationInSeconds)
+      $0.distance = Int32(distance)
+    }
   }
 
-  /// A Bidirectional streaming RPC.
-  ///
-  /// Accepts a stream of RouteNotes sent while a route is being traversed, while receiving other
-  /// RouteNotes (e.g. from other users).
-  func routeChat(
-    context: StreamingResponseCallContext<Routeguide_RouteNote>
-  ) -> EventLoopFuture<(StreamEvent<Routeguide_RouteNote>) -> Void> {
-    return context.eventLoop.makeSucceededFuture({ event in
-      switch event {
-      case let .message(note):
-        // Get any notes at the location of request note.
-        var notes = self.lock.withLock {
-          self.notes[note.location, default: []]
-        }
+  internal func routeChat(
+    requestStream: GRPCAsyncRequestStream<Routeguide_RouteNote>,
+    responseStream: GRPCAsyncResponseStreamWriter<Routeguide_RouteNote>,
+    context: GRPCAsyncServerCallContext
+  ) async throws {
+    for try await note in requestStream {
+      let existingNotes = await self.notes.addNote(note, to: note.location)
 
-        // Respond with all previous notes at this location.
-        for note in notes {
-          _ = context.sendResponse(note)
-        }
-
-        // Add the new note and update the stored notes.
-        notes.append(note)
-        self.lock.withLockVoid {
-          self.notes[note.location] = notes
-        }
-
-      case .end:
-        context.statusPromise.succeed(.ok)
+      // Respond with all existing notes.
+      for existingNote in existingNotes {
+        try await responseStream.send(existingNote)
       }
-    })
-  }
-}
-
-extension RouteGuideProvider {
-  private func getOrCreateNotes(for point: Routeguide_Point) -> [Routeguide_RouteNote] {
-    return self.lock.withLock {
-      self.notes[point, default: []]
     }
   }
 
   /// Returns a feature at the given location or an unnamed feature if none exist at that location.
-  private func checkFeature(at location: Routeguide_Point) -> Routeguide_Feature {
+  private func lookupFeature(at location: Routeguide_Point) -> Routeguide_Feature? {
     return self.features.first(where: {
       $0.location.latitude == location.latitude && $0.location.longitude == location.longitude
-    }) ?? Routeguide_Feature.with {
-      $0.name = ""
-      $0.location = location
-    }
+    })
   }
 }
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+internal final actor Notes {
+  private var recordedNotes: [Routeguide_Point: [Routeguide_RouteNote]]
+
+  internal init() {
+    self.recordedNotes = [:]
+  }
+
+  /// Record a note at the given location and return the all notes which were previously recorded
+  /// at the location.
+  internal func addNote(
+    _ note: Routeguide_RouteNote,
+    to location: Routeguide_Point
+  ) -> ArraySlice<Routeguide_RouteNote> {
+    self.recordedNotes[location, default: []].append(note)
+    return self.recordedNotes[location]!.dropLast(1)
+  }
+}
+
+#endif // compiler(>=5.5) && canImport(_Concurrency)
 
 private func degreesToRadians(_ degrees: Double) -> Double {
   return degrees * .pi / 180.0
 }
 
-private extension Routeguide_Point {
+extension Routeguide_Point {
   func distance(to other: Routeguide_Point) -> Double {
     // Radius of Earth in meters
     let radius = 6_371_000.0
@@ -186,5 +157,21 @@ private extension Routeguide_Point {
     let c = 2 * atan2(sqrt(a), sqrt(1 - a))
 
     return radius * c
+  }
+
+  func isWithin<Range: RangeExpression>(
+    latitude: Range,
+    longitude: Range
+  ) -> Bool where Range.Bound == Int32 {
+    return latitude.contains(self.latitude) && longitude.contains(self.longitude)
+  }
+}
+
+extension Routeguide_Feature {
+  static func unnamedFeature(at location: Routeguide_Point) -> Routeguide_Feature {
+    return .with {
+      $0.name = ""
+      $0.location = location
+    }
   }
 }

--- a/Sources/Examples/RouteGuide/Server/main.swift
+++ b/Sources/Examples/RouteGuide/Server/main.swift
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#if compiler(>=5.5) && canImport(_Concurrency)
 import ArgumentParser
 import struct Foundation.Data
 import struct Foundation.URL
@@ -32,6 +33,7 @@ func loadFeatures() throws -> [Routeguide_Feature] {
   return try Routeguide_Feature.array(fromJSONUTF8Data: data)
 }
 
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 struct RouteGuide: ParsableCommand {
   @Option(help: "The port to listen on for new connections")
   var port = 1234
@@ -67,4 +69,11 @@ struct RouteGuide: ParsableCommand {
   }
 }
 
-RouteGuide.main()
+if #available(macOS 12, *) {
+  RouteGuide.main()
+} else {
+  fatalError("The RouteGuide example requires macOS 12 or newer.")
+}
+#else
+fatalError("The RouteGuide example requires Swift concurrency support.")
+#endif // compiler(>=5.5) && canImport(_Concurrency)

--- a/docs/basic-tutorial.md
+++ b/docs/basic-tutorial.md
@@ -36,10 +36,11 @@ updating.
 The example code for our tutorial is in
 [grpc/grpc-swift/Sources/Examples/RouteGuide][routeguide-source].
 To download the example, clone the latest release in `grpc-swift` repository by
-running the following command:
+running the following command (replacing `x.y.z` with the latest release, for
+example `1.7.0`):
 
 ```sh
-$ git clone -b 1.0.0 https://github.com/grpc/grpc-swift
+$ git clone -b x.y.z https://github.com/grpc/grpc-swift
 ```
 
 Then change your current directory to `grpc-swift/Sources/Examples/RouteGuide`:
@@ -166,7 +167,7 @@ $ protoc Sources/Examples/RouteGuide/Model/route_guide.proto \
     --swift_opt=Visibility=Public \
     --swift_out=Sources/Examples/RouteGuide/Model \
     --plugin=./.build/debug/protoc-gen-grpc-swift \
-    --grpc-swift_opt=Visibility=Public \
+    --grpc-swift_opt=Visibility=Public,AsyncClient=True,AsyncServer=True \
     --grpc-swift_out=Sources/Examples/RouteGuide/Model
 ```
 
@@ -174,7 +175,9 @@ We invoke the protocol buffer compiler `protoc` with the path to our service
 definition `route_guide.proto` as well as specifying the path to search for
 imports. We then specify the path to the [Swift Protobuf][swift-protobuf] plugin
 and any options. In our case the generated code is in a separate module to the
-client and server, so the generated code must have `Public` visibility. We then
+client and server, so the generated code must have `Public` visibility. We also
+specified that the 'async' client and server should be generated. The 'async'
+versions use Swift concurrency features introduced in Swift 5.5. We then
 specify the directory into which the generated messages should be written. The
 remainder of the arguments are very similar but pertain to the generation of the
 service code and use the `protoc-gen-grpc-swift` plugin.
@@ -200,10 +203,10 @@ Let's take a closer look at how it works.
 #### Implementing RouteGuide
 
 As you can see, our server has a `RouteGuideProvider` class that extends the
-generated `Routeguide_RouteGuideProvider` protocol:
+generated `Routeguide_RouteGuideAsyncProvider` protocol:
 
 ```swift
-class RouteGuideProvider: Routeguide_RouteGuideProvider {
+final class RouteGuideProvider: Routeguide_RouteGuideAsyncProvider {
 ...
 }
 ```
@@ -223,40 +226,39 @@ in a `Feature`.
 /// A feature with an empty name is returned if there's no feature at the given position.
 func getFeature(
   request point: Routeguide_Point,
-  context: StatusOnlyCallContext
-) -> EventLoopFuture<Routeguide_Feature> {
-  return context.eventLoop.makeSucceededFuture(self.checkFeature(at: point))
-}
-
-...
-
-/// Returns a feature at the given location or an unnamed feature if none exist at that location.
-private func checkFeature(
-  at location: Routeguide_Point
-) -> Routeguide_Feature {
-  return self.features.first(where: {
-    return $0.location.latitude == location.latitude
-      && $0.location.longitude == location.longitude
-  }) ?? Routeguide_Feature.with {  // No feature was found: return an unnamed feature.
+  context: GRPCAsyncServerCallContext
+) async throws -> Routeguide_Feature {
+  return self.lookupFeature(at: point) ?? Routeguide_Feature.with {
+    // No feature was found: return an unnamed feature.
     $0.name = ""
     $0.location = location
   }
 }
+
+/// Returns a feature at the given location or an unnamed feature if none exist at that location.
+private func lookupFeature(
+  at location: Routeguide_Point
+) -> Routeguide_Feature? {
+  return self.features.first(where: {
+    return $0.location.latitude == location.latitude
+      && $0.location.longitude == location.longitude
+  })
+}
 ```
 
-`getFeature()` takes two parameters:
+`getFeature(request:context:)` takes two parameters:
 
 - `Routeguide_Point`: the request
-- `StatusOnlyCallContext`: a context which exposes status and trailing metadata
-  fields that you can change if needed.
+- `GRPCAsyncServerCallContext`: a context which exposes various pieces of
+  information about the call.
 
 To return our response to the client and complete the call:
 
 1. We construct and populate a `Routeguide_Feature` response object to return to
    the client, as specified in our service definition. In this example, we do
-   this in a separate private `checkFeature()` method.
-2. We return the an [`EventLoopFuture`][nio-elf] succeeded with the result from
-   `checkFeature()`.
+   this in a separate private `lookupFeature(at:)` method.
+2. We return the feature returned from `lookupFeature(at:)` or an unnamed one if
+   there was no feature at the given location.
 
 ##### Server-side streaming RPC
 
@@ -272,37 +274,29 @@ client.
 /// cover a large area and contain a huge number of features.
 func listFeatures(
   request: Routeguide_Rectangle,
-  context: StreamingResponseCallContext<Routeguide_Feature>
-) -> EventLoopFuture<GRPCStatus> {
-  let left = min(request.lo.longitude, request.hi.longitude)
-  let right = max(request.lo.longitude, request.hi.longitude)
-  let top = max(request.lo.latitude, request.hi.latitude)
-  let bottom = max(request.lo.latitude, request.hi.latitude)
+  responseStream: GRPCAsyncResponseStreamWriter<Routeguide_Feature>,
+  context: GRPCAsyncServerCallContext
+) async throws {
+  let longitudeRange = request.lo.longitude ... request.hi.longitude
+  let latitudeRange = request.lo.latitude ... request.hi.latitude
 
-  self.features.lazy.filter { feature in
-    return !feature.name.isEmpty
-      && feature.location.longitude >= left
-      && feature.location.longitude <= right
-      && feature.location.latitude >= bottom
-      && feature.location.latitude <= top
-  }.forEach {
-    _ = context.sendResponse($0)
+  for feature in self.features where !feature.name.isEmpty {
+    if feature.location.isWithin(latitude: latitudeRange, longitude: longitudeRange) {
+      try await responseStream.send(feature)
+    }
   }
-
-  return context.eventLoop.makeSucceededFuture(.ok)
 }
 ```
 
 Like the simple RPC, this method gets a request object (the
-`Routeguide_Rectangle` in which our client wants to find `Routeguide_Feature`s)
-and a `StreamingResponseCallContext` context.
+`Routeguide_Rectangle` in which our client wants to find `Routeguide_Feature`s),
+a stream to write responses on and a context.
 
 This time, we get as many `Routeguide_Feature` objects as we need to return to
 the client (in this case, we select them from the service's feature collection
 based on whether they're inside our request `Routeguide_Rectangle`), and write
-them each in turn to the response observer using the contexts `sendResponse()`
-method. Finally, we return a future `.ok` status to tell gRPC that we've
-finished writing responses.
+them each in turn to the response stream using `send(_:)` method on
+`responseStream`.
 
 ##### Client-side streaming RPC
 
@@ -315,97 +309,97 @@ return a single `Routeguide_RouteSummary` with information about their trip.
 ///
 /// Accepts a stream of Points on a route being traversed, returning a RouteSummary when traversal
 /// is completed.
-func recordRoute(
-  context: UnaryResponseCallContext<Routeguide_RouteSummary>
-) -> EventLoopFuture<(StreamEvent<Routeguide_Point>) -> Void> {
+internal func recordRoute(
+  requestStream points: GRPCAsyncRequestStream<Routeguide_Point>,
+  context: GRPCAsyncServerCallContext
+) async throws -> Routeguide_RouteSummary {
   var pointCount: Int32 = 0
   var featureCount: Int32 = 0
   var distance = 0.0
   var previousPoint: Routeguide_Point?
-  let startTime = Date()
+  let startTimeNanos = DispatchTime.now().uptimeNanoseconds
 
-  return context.eventLoop.makeSucceededFuture({ event in
-    switch event {
-    case .message(let point):
-      pointCount += 1
-      if !self.checkFeature(at: point).name.isEmpty {
-        featureCount += 1
-      }
+  for try await point in points {
+    pointCount += 1
 
-      // For each point after the first, add the incremental distance from the previous point to
-      // the total distance value.
-      if let previous = previousPoint {
-        distance += previous.distance(to: point)
-      }
-      previousPoint = point
-
-    case .end:
-      let seconds = Date().timeIntervalSince(startTime)
-      let summary = Routeguide_RouteSummary.with {
-        $0.pointCount = pointCount
-        $0.featureCount = featureCount
-        $0.elapsedTime = Int32(seconds)
-        $0.distance = Int32(distance)
-      }
-      context.responsePromise.succeed(summary)
+    if let feature = self.lookupFeature(at: point), !feature.name.isEmpty {
+      featureCount += 1
     }
-  })
+
+    if let previous = previousPoint {
+      distance += previous.distance(to: point)
+    }
+
+    previousPoint = point
+  }
+
+  let durationInNanos = DispatchTime.now().uptimeNanoseconds - startTimeNanos
+  let durationInSeconds = Double(durationInNanos) / 1e9
+
+  return .with {
+    $0.pointCount = pointCount
+    $0.featureCount = featureCount
+    $0.elapsedTime = Int32(durationInSeconds)
+    $0.distance = Int32(distance)
+  }
 }
 ```
 
-As you can see our method gets a `UnaryResponseCallContext` parameter, but
-this time it returns a future `StreamEvent` handler for the client to write
-its `Routeguide_Point`s.
+As you can see our method gets a `GRPCAsyncServerCallContext` parameter and a
+request stream of points and returns a summary.
 
-In the method body we instantiate an anonymous `StreamEvent` handler to return,
-in which we:
+In the method body we iterate over the asynchronous stream of points send by the
+client. For each point we:
 
-- Get features and other information each time the client writes a
-  `Routeguide_Point` to the message stream if the event is a `.message`.
-- Populate and build our `Routeguide_RouteSummary` when the *client* has
-  finished writing messages (the event is `.end`). We then succeed the
-  response promise on the context with our `Routeguide_RouteSummary`.
+- Check if there is a feature at that point.
+- Calculate the distance between the point and the last point we saw.
+
+After the *client* has finished sending points we populate and return a
+`Routeguide_RouteSummary`.
 
 ##### Bidirectional streaming RPC
 
-Finally, let's look at our bidirectional streaming RPC `RouteChat()`.
+Finally, let's look at our bidirectional streaming RPC `routeChat()`.
 
 ```swift
 func routeChat(
-  context: StreamingResponseCallContext<Routeguide_RouteNote>
-) -> EventLoopFuture<(StreamEvent<Routeguide_RouteNote>) -> Void> {
-  return context.eventLoop.makeSucceededFuture({ event in
-    switch event {
-    case .message(let note):
-      // Get any notes at the location of request note.
-      var notes = self.lock.withLock {
-        self.notes[note.location, default: []]
-      }
+  requestStream: GRPCAsyncRequestStream<Routeguide_RouteNote>,
+  responseStream: GRPCAsyncResponseStreamWriter<Routeguide_RouteNote>,
+  context: GRPCAsyncServerCallContext
+) async throws {
+  for try await note in requestStream {
+    let existingNotes = await self.notes.addNote(note, to: note.location)
 
-      // Respond with all previous notes at this location.
-      for note in notes {
-        _ = context.sendResponse(note)
-      }
-
-      // Add the new note and update the stored notes.
-      notes.append(note)
-      self.lock.withLockVoid {
-        self.notes[note.location] = notes
-      }
-
-    case .end:
-      context.statusPromise.succeed(.ok)
+    // Respond with all existing notes.
+    for existingNote in existingNotes {
+      try await responseStream.send(existingNote)
     }
-  })
+  }
+}
+
+final actor Notes {
+  private var recordedNotes: [Routeguide_Point: [Routeguide_RouteNote]] = [:]
+
+  /// Record a note at the given location and return the all notes which were previously recorded
+  /// at the location.
+  func addNote(
+    _ note: Routeguide_RouteNote,
+    to location: Routeguide_Point
+  ) -> ArraySlice<Routeguide_RouteNote> {
+    self.recordedNotes[location, default: []].append(note)
+    return self.recordedNotes[location]!.dropLast(1)
+  }
 }
 ```
 
-As with the server-side streaming RPC we accept  a `StreamingResponseCallContext`
-but return a `StreamEvent` handler (like the client-side streaming RPC). The syntax
-for reading and writing here is exactly the same as for our client-streaming and
-server-streaming methods. Although each side will always get the other's
-messages in the order they were written, both the client and server can read and
-write in any order — the streams operate completely independently.
+Here we receive a request stream of `Routeguide_RouteNote`s and a response
+stream of `Routeguide_RouteNote`s as well as the `GRPCAsyncServerCallContext`
+we got in other RPCs.
+
+For the route chat for iterate over the stream of notes sent by the *client* and
+for each note we add it to a `Notes` helper `actor`. When a note is added to
+the `Notes` `actor` all notes previously recorded at the same location are
+returned and are sent back to the client.
 
 #### Starting the server
 
@@ -484,7 +478,7 @@ let channel = try GRPCChannelPool.with(
   eventLoopGroup: group
 )
 
-let client = Routeguide_RouteGuideClient(channel: channel)
+let routeGuide = Routeguide_RouteGuideAsyncClient(channel: channel)
 ```
 
 #### Calling service methods
@@ -502,19 +496,15 @@ let point: Routeguide_Point = .with {
   $0.longitude = longitude
 }
 
-let call = client.getFeature(point)
-// Block on the response future.
-let feature = try call.response.wait()
+let feature = try await routeGuide.getFeature(point)
 ```
 
 We create and populate a request protocol buffer object (in our case
-`Routeguide_Point`), pass it to the `getFeature()` method on our stub, and get back a
-call object which has [`EventLoopFuture`][nio-elf]s for the initial metadata,
-response (in our case a `Routeguide_Feature`), trailing metadata and call
-status. We can make the call synchronous by `wait()`-ing on the response.
+`Routeguide_Point`), pass it to the `getFeature()` method on our stub, and
+`await` the response `Routeguide_Feature`.
 
-If an error occurs, it is encoded as a `GRPCStatus`. The status of a call is
-*always* made available as the `status` on the call object.
+If an error occurs, it is encoded as a `GRPCStatus` and thrown whilst
+`await`-ing the response.
 
 ##### Server-side streaming RPC
 
@@ -533,17 +523,15 @@ let rectangle: Routeguide_Rectangle = .with {
   }
 }
 
-let call = client.listFeatures(rectangle) { feature in
+for try await feature in routeGuide.listFeatures(rectangle) {
   print("Received feature: \(feature)")
 }
-
-_ = try call.status.wait()
 ```
 
 As you can see, it's very similar to the simple RPC we just looked at, except
-the `call` object does not have a `response` and `listFeatures` accepts a
-callback for responses. Here we `wait()` on the `status` to determine when the
-call has completed.
+the `listFeatures(_:)` returns a stream of responses. Here we `await` each
+response on the stream, once we finish iterating the response stream the call is
+complete.
 
 ##### Client-side streaming RPC
 
@@ -552,116 +540,60 @@ Now for something a little more complicated: the client-side streaming method
 get back a single `Routeguide_RouteSummary`.
 
 ```swift
-public func recordRoute(
-  using client: Routeguide_RouteGuideServiceClient,
-  features: [Routeguide_Feature],
-  featuresToVisit: Int
-) {
-  print("→ RecordRoute")
-  let options = CallOptions(timeout: .minutes(rounding: 1))
-  let call = client.recordRoute(callOptions: options)
+let recordRoute = routeGuide.makeRecordRouteCall()
 
-  call.response.whenSuccess { summary in
-    print(
-      "Finished trip with \(summary.pointCount) points. Passed \(summary.featureCount) features. " +
-      "Travelled \(summary.distance) meters. It took \(summary.elapsedTime) seconds."
-    )
+for _ in 1 ... featuresToVisit {
+  if let feature = features.randomElement() {
+    let point = feature.location
+    try await recordRoute.requestStream.send(point)
   }
-
-  call.response.whenFailure { error in
-    print("RecordRoute Failed: \(error)")
-  }
-
-  call.status.whenComplete { _ in
-    print("Finished RecordRoute")
-  }
-
-  for _ in 0..<featuresToVisit {
-    let index = Int.random(in: 0..<features.count)
-    let point = features[index].location
-    print("Visiting point \(point.latitude), \(point.longitude)")
-    call.sendMessage(point, promise: nil)
-
-    // Sleep for a bit before sending the next one.
-    Thread.sleep(forTimeInterval: TimeInterval.random(in: 0.5..<1.5))
-  }
-
-  call.sendEnd(promise: nil)
-
-  // Wait for the call to end.
-  _ = try! call.status.wait()
 }
+
+try await recordRoute.requestStream.finish()
+let summary = try await recordRoute.response
 ```
 
-As you can see, the `call` object also has a `response`
-[`EventLoopFuture`][nio-elf] for the `Routeguide_RouteSummary`. It also has
-methods to send requests to the server.
+Here we we create a record route call. It has a request stream and a single
+`await`-able response for the `Routeguide_RouteSummary`.
 
-We call `call.sendMessage` for each point we want to send to the server.
-`sendMessage` has two variants, one accepting an
-[`EventLoopPromise<Void>?`][nio-promise] and one returning an
-[`EventLoopFuture<Void>`][nio-elf]. These values will be fulfilled when the
-client has written the request to the network. In our case we don't need to know
-when this is so we provide a `nil` promise.
+We call `recordRoute.requestStream.send(_:)` for each point we want to send to the
+server and `await` for the call to accept the request.
 
-Note that there also two `sendMessages()` methods (one accepting an
-`EventLoopPromise<Void>?` and one returning an `EventLoopFuture<Void>`) for
-sending multiple messages at a time,
-
-Once we've finished writing points, we call `call.sendEnd(promise: nil)` to
-tell gRPC that we've finished writing on the client side. Once we're done, we
-wait on our `call.status` to check that the server has completed on its side.
+Once we've finished writing points, we call `recordRoute.requestStream.finish()`
+to tell gRPC that we've finished writing on the client side. Once we're done, we
+`await` on the `recordRoute.summary` to check that the server responded with.
 
 ##### Bidirectional streaming RPC
 
 Finally, let's look at our bidirectional streaming RPC `RouteChat`.
 
 ```swift
-func routeChat(using client: Routeguide_RouteGuideServiceClient) {
-  print("→ RouteChat")
+let notes: [Routeguide_RouteNote] = ...
 
-  let call = client.routeChat { note in
-    print("Got message \"\(note.message)\" at \(note.location.latitude), \(note.location.longitude)")
+try await withThrowingTaskGroup(of: Void.self) { group in
+  let routeChat = self.routeGuide.makeRouteChatCall()
+
+  group.addTask {
+    for note in notes {
+      try await routeChat.requestStream.send(note)
+    }
+    try await routeChat.requestStream.finish()
   }
 
-  call.status.whenSuccess { status in
-    if status.code == .ok {
-      print("Finished RouteChat")
-    } else {
-      print("RouteChat Failed: \(status)")
+  group.addTask {
+    for try await note in routeChat.responseStream {
+      print("Received message '\(note.message)' at \(note.location)")
     }
   }
 
-  let noteContent = [
-    ("First message", 0, 0),
-    ("Second message", 0, 1),
-    ("Third message", 1, 0),
-    ("Fourth message", 1, 1)
-  ]
-
-  for (message, latitude, longitude) in noteContent {
-    let note: Routeguide_RouteNote = .with {
-      $0.message = message
-      $0.location = .with {
-        $0.latitude = Int32(latitude)
-        $0.longitude = Int32(longitude)
-      }
-    }
-
-    print("Sending message \"\(note.message)\" at \(note.location.latitude), \(note.location.longitude)")
-    call.sendMessage(note, promise: nil)
-  }
-  // Mark the end of the stream.
-  call.sendEnd(promise: nil)
-
-  // Wait for the call to end.
-  _ = try! call.status.wait()
+  try await group.waitForAll()
 }
 ```
 
-As with our client-side streaming example, we have a `call` object with methods
-for sending messages to the server. We invoke our RPC with a handler for responses,
-just like the server-side streaming example.
+As with our client-side streaming example, we have a `routeChat` call object
+with a `requestStream` but a `responseStream` instead of a single `await`-able
+response. In this example we create a task group and create separate tasks for
+sending requests and receiving responses and await for both to complete.
 
 ### Try it out!
 
@@ -669,8 +601,6 @@ Follow the instructions in the Route Guide example directory
 [README][routeguide-readme] to build and run the client and server.
 
 [grpc-docs]: https://grpc.io/docs/
-[nio-elf]: https://apple.github.io/swift-nio/docs/current/NIO/Classes/EventLoopFuture.html
-[nio-promise]: https://apple.github.io/swift-nio/docs/current/NIO/Structs/EventLoopPromise.html
 [protobuf-docs]: https://developers.google.com/protocol-buffers/docs/proto3
 [protobuf-releases]: https://github.com/google/protobuf/releases
 [protocol-buffers]: https://developers.google.com/protocol-buffers/docs/overview
@@ -679,5 +609,5 @@ Follow the instructions in the Route Guide example directory
 [routeguide-provider]: ../Sources/Examples/RouteGuide/Server/RouteGuideProvider.swift
 [routeguide-readme]: ../Sources/Examples/RouteGuide/README.md
 [routeguide-source]: ../Sources/Examples/RouteGuide
-[swift-protobuf-guide]: https://github.com/apple/swift-protobuf/blob/master/Documentation/API.md
+[swift-protobuf-guide]: https://github.com/apple/swift-protobuf/blob/main/Documentation/API.md
 [swift-protobuf]: https://github.com/apple/swift-protobuf


### PR DESCRIPTION
Motivation:

Our examples should be up-to-date. The RouteGuide example currently uses
the NIO event-loop-future API, it should use the async/await API
instead.

Modifications:

- Convert the route guide example to async/await
- Update the corresponding tutorial

Result:

RouteGuide is more up-to-date