### PR TITLE
Reduce minimum os requirement and increase swift compiler version

### DIFF
--- a/Sources/Examples/Echo/AsyncAwaitRuntime/ArgumentParser+AsyncAwait.swift
+++ b/Sources/Examples/Echo/AsyncAwaitRuntime/ArgumentParser+AsyncAwait.swift
@@ -17,23 +17,23 @@
 /// NOTE: This file should be removed when the `async` branch of `swift-argument-parser` has been
 ///       released: https://github.com/apple/swift-argument-parser/tree/async
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
 import ArgumentParser
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 protocol AsyncParsableCommand: ParsableCommand {
   mutating func runAsync() async throws
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension AsyncParsableCommand {
   public mutating func run() throws {
     throw CleanExit.helpRequest(self)
   }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension ParsableCommand {
   static func main(_ arguments: [String]? = nil) async {
     do {

--- a/Sources/Examples/Echo/AsyncAwaitRuntime/main.swift
+++ b/Sources/Examples/Echo/AsyncAwaitRuntime/main.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
 import ArgumentParser
 import EchoImplementation
@@ -36,7 +36,7 @@ enum RPC: String, ExpressibleByArgument {
   case update
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 struct Echo: ParsableCommand {
   static var configuration = CommandConfiguration(
     abstract: "An example to run and call a simple gRPC service for echoing messages.",
@@ -115,7 +115,7 @@ struct Echo: ParsableCommand {
 
 // MARK: - Server
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 func startEchoServer(group: EventLoopGroup, port: Int, useTLS: Bool) async throws {
   let builder: Server.Builder
 
@@ -157,7 +157,7 @@ func startEchoServer(group: EventLoopGroup, port: Int, useTLS: Bool) async throw
 
 // MARK: - Client
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 func makeClient(
   group: EventLoopGroup,
   port: Int,
@@ -196,7 +196,7 @@ func makeClient(
   )
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 func callRPC(_ rpc: RPC, using client: Echo_EchoAsyncClient, message: String) async {
   do {
     switch rpc {
@@ -214,13 +214,13 @@ func callRPC(_ rpc: RPC, using client: Echo_EchoAsyncClient, message: String) as
   }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 func echoGet(client: Echo_EchoAsyncClient, message: String) async throws {
   let response = try await client.get(.with { $0.text = message })
   print("get received: \(response.text)")
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 func echoCollect(client: Echo_EchoAsyncClient, message: String) async throws {
   let messages = message.components(separatedBy: " ").map { part in
     Echo_EchoRequest.with { $0.text = part }
@@ -229,14 +229,14 @@ func echoCollect(client: Echo_EchoAsyncClient, message: String) async throws {
   print("collect received: \(response.text)")
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 func echoExpand(client: Echo_EchoAsyncClient, message: String) async throws {
   for try await response in client.expand((.with { $0.text = message })) {
     print("expand received: \(response.text)")
   }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 func echoUpdate(client: Echo_EchoAsyncClient, message: String) async throws {
   let requests = message.components(separatedBy: " ").map { word in
     Echo_EchoRequest.with { $0.text = word }

--- a/Sources/Examples/Echo/Implementation/EchoAsyncProvider.swift
+++ b/Sources/Examples/Echo/Implementation/EchoAsyncProvider.swift
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 import EchoModel
 import GRPC
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public final class EchoAsyncProvider: Echo_EchoAsyncProvider {
   public let interceptors: Echo_EchoServerInterceptorFactoryProtocol?
 
@@ -69,4 +69,4 @@ public final class EchoAsyncProvider: Echo_EchoAsyncProvider {
   }
 }
 
-#endif // compiler(>=5.5) && canImport(_Concurrency)
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)

--- a/Sources/Examples/Echo/Model/echo.grpc.swift
+++ b/Sources/Examples/Echo/Model/echo.grpc.swift
@@ -157,8 +157,8 @@ public final class Echo_EchoClient: Echo_EchoClientProtocol {
   }
 }
 
-#if compiler(>=5.5) && canImport(_Concurrency)
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public protocol Echo_EchoAsyncClientProtocol: GRPCClient {
   static var serviceDescriptor: GRPCServiceDescriptor { get }
   var interceptors: Echo_EchoClientInterceptorFactoryProtocol? { get }
@@ -182,7 +182,7 @@ public protocol Echo_EchoAsyncClientProtocol: GRPCClient {
   ) -> GRPCAsyncBidirectionalStreamingCall<Echo_EchoRequest, Echo_EchoResponse>
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Echo_EchoAsyncClientProtocol {
   public static var serviceDescriptor: GRPCServiceDescriptor {
     return Echo_EchoClientMetadata.serviceDescriptor
@@ -237,7 +237,7 @@ extension Echo_EchoAsyncClientProtocol {
   }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Echo_EchoAsyncClientProtocol {
   public func get(
     _ request: Echo_EchoRequest,
@@ -312,7 +312,7 @@ extension Echo_EchoAsyncClientProtocol {
   }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public struct Echo_EchoAsyncClient: Echo_EchoAsyncClientProtocol {
   public var channel: GRPCChannel
   public var defaultCallOptions: CallOptions
@@ -329,7 +329,7 @@ public struct Echo_EchoAsyncClient: Echo_EchoAsyncClientProtocol {
   }
 }
 
-#endif // compiler(>=5.5) && canImport(_Concurrency)
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
 public protocol Echo_EchoClientInterceptorFactoryProtocol {
 
@@ -573,10 +573,10 @@ extension Echo_EchoProvider {
     }
   }
 }
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
 /// To implement a server, implement an object which conforms to this protocol.
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public protocol Echo_EchoAsyncProvider: CallHandlerProvider {
   static var serviceDescriptor: GRPCServiceDescriptor { get }
   var interceptors: Echo_EchoServerInterceptorFactoryProtocol? { get }
@@ -608,7 +608,7 @@ public protocol Echo_EchoAsyncProvider: CallHandlerProvider {
   ) async throws
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Echo_EchoAsyncProvider {
   public static var serviceDescriptor: GRPCServiceDescriptor {
     return Echo_EchoServerMetadata.serviceDescriptor
@@ -669,7 +669,7 @@ extension Echo_EchoAsyncProvider {
   }
 }
 
-#endif // compiler(>=5.5) && canImport(_Concurrency)
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
 public protocol Echo_EchoServerInterceptorFactoryProtocol {
 

--- a/Sources/Examples/HelloWorld/Model/helloworld.grpc.swift
+++ b/Sources/Examples/HelloWorld/Model/helloworld.grpc.swift
@@ -84,6 +84,76 @@ public final class Helloworld_GreeterClient: Helloworld_GreeterClientProtocol {
   }
 }
 
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+/// The greeting service definition.
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+public protocol Helloworld_GreeterAsyncClientProtocol: GRPCClient {
+  static var serviceDescriptor: GRPCServiceDescriptor { get }
+  var interceptors: Helloworld_GreeterClientInterceptorFactoryProtocol? { get }
+
+  func makeSayHelloCall(
+    _ request: Helloworld_HelloRequest,
+    callOptions: CallOptions?
+  ) -> GRPCAsyncUnaryCall<Helloworld_HelloRequest, Helloworld_HelloReply>
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension Helloworld_GreeterAsyncClientProtocol {
+  public static var serviceDescriptor: GRPCServiceDescriptor {
+    return Helloworld_GreeterClientMetadata.serviceDescriptor
+  }
+
+  public var interceptors: Helloworld_GreeterClientInterceptorFactoryProtocol? {
+    return nil
+  }
+
+  public func makeSayHelloCall(
+    _ request: Helloworld_HelloRequest,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncUnaryCall<Helloworld_HelloRequest, Helloworld_HelloReply> {
+    return self.makeAsyncUnaryCall(
+      path: Helloworld_GreeterClientMetadata.Methods.sayHello.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeSayHelloInterceptors() ?? []
+    )
+  }
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension Helloworld_GreeterAsyncClientProtocol {
+  public func sayHello(
+    _ request: Helloworld_HelloRequest,
+    callOptions: CallOptions? = nil
+  ) async throws -> Helloworld_HelloReply {
+    return try await self.performAsyncUnaryCall(
+      path: Helloworld_GreeterClientMetadata.Methods.sayHello.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeSayHelloInterceptors() ?? []
+    )
+  }
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+public struct Helloworld_GreeterAsyncClient: Helloworld_GreeterAsyncClientProtocol {
+  public var channel: GRPCChannel
+  public var defaultCallOptions: CallOptions
+  public var interceptors: Helloworld_GreeterClientInterceptorFactoryProtocol?
+
+  public init(
+    channel: GRPCChannel,
+    defaultCallOptions: CallOptions = CallOptions(),
+    interceptors: Helloworld_GreeterClientInterceptorFactoryProtocol? = nil
+  ) {
+    self.channel = channel
+    self.defaultCallOptions = defaultCallOptions
+    self.interceptors = interceptors
+  }
+}
+
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)
+
 public protocol Helloworld_GreeterClientInterceptorFactoryProtocol {
 
   /// - Returns: Interceptors to use when invoking 'sayHello'.
@@ -144,6 +214,58 @@ extension Helloworld_GreeterProvider {
     }
   }
 }
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+
+/// The greeting service definition.
+///
+/// To implement a server, implement an object which conforms to this protocol.
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+public protocol Helloworld_GreeterAsyncProvider: CallHandlerProvider {
+  static var serviceDescriptor: GRPCServiceDescriptor { get }
+  var interceptors: Helloworld_GreeterServerInterceptorFactoryProtocol? { get }
+
+  /// Sends a greeting.
+  @Sendable func sayHello(
+    request: Helloworld_HelloRequest,
+    context: GRPCAsyncServerCallContext
+  ) async throws -> Helloworld_HelloReply
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension Helloworld_GreeterAsyncProvider {
+  public static var serviceDescriptor: GRPCServiceDescriptor {
+    return Helloworld_GreeterServerMetadata.serviceDescriptor
+  }
+
+  public var serviceName: Substring {
+    return Helloworld_GreeterServerMetadata.serviceDescriptor.fullName[...]
+  }
+
+  public var interceptors: Helloworld_GreeterServerInterceptorFactoryProtocol? {
+    return nil
+  }
+
+  public func handle(
+    method name: Substring,
+    context: CallHandlerContext
+  ) -> GRPCServerHandlerProtocol? {
+    switch name {
+    case "SayHello":
+      return GRPCAsyncServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Helloworld_HelloRequest>(),
+        responseSerializer: ProtobufSerializer<Helloworld_HelloReply>(),
+        interceptors: self.interceptors?.makeSayHelloInterceptors() ?? [],
+        wrapping: self.sayHello(request:context:)
+      )
+
+    default:
+      return nil
+    }
+  }
+}
+
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
 public protocol Helloworld_GreeterServerInterceptorFactoryProtocol {
 

--- a/Sources/Examples/RouteGuide/Client/main.swift
+++ b/Sources/Examples/RouteGuide/Client/main.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 import ArgumentParser
 import Foundation
 import GRPC
@@ -33,7 +33,7 @@ func loadFeatures() throws -> [Routeguide_Feature] {
 }
 
 /// Makes a `RouteGuide` client for a service hosted on "localhost" and listening on the given port.
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 func makeClient(port: Int, group: EventLoopGroup) throws -> Routeguide_RouteGuideAsyncClient {
   let channel = try GRPCChannelPool.with(
     target: .host("localhost", port: port),
@@ -44,7 +44,7 @@ func makeClient(port: Int, group: EventLoopGroup) throws -> Routeguide_RouteGuid
   return Routeguide_RouteGuideAsyncClient(channel: channel)
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 internal struct RouteGuideExample: @unchecked Sendable {
   private let routeGuide: Routeguide_RouteGuideAsyncClient
   private let features: [Routeguide_Feature]
@@ -88,7 +88,7 @@ internal struct RouteGuideExample: @unchecked Sendable {
   }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension RouteGuideExample {
   /// Get the feature at the given latitude and longitude, if one exists.
   private func getFeature(latitude: Int, longitude: Int) async {
@@ -229,7 +229,7 @@ extension RouteGuideExample {
   }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 struct RouteGuide: ParsableCommand {
   @Option(help: "The port to connect to")
   var port: Int = 1234
@@ -274,4 +274,4 @@ if #available(macOS 12, *) {
 }
 #else
 fatalError("The RouteGuide example requires Swift concurrency features.")
-#endif // compiler(>=5.5) && canImport(_Concurrency)
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)

--- a/Sources/Examples/RouteGuide/Model/route_guide.grpc.swift
+++ b/Sources/Examples/RouteGuide/Model/route_guide.grpc.swift
@@ -175,9 +175,9 @@ public final class Routeguide_RouteGuideClient: Routeguide_RouteGuideClientProto
   }
 }
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 /// Interface exported by the server.
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public protocol Routeguide_RouteGuideAsyncClientProtocol: GRPCClient {
   static var serviceDescriptor: GRPCServiceDescriptor { get }
   var interceptors: Routeguide_RouteGuideClientInterceptorFactoryProtocol? { get }
@@ -201,7 +201,7 @@ public protocol Routeguide_RouteGuideAsyncClientProtocol: GRPCClient {
   ) -> GRPCAsyncBidirectionalStreamingCall<Routeguide_RouteNote, Routeguide_RouteNote>
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Routeguide_RouteGuideAsyncClientProtocol {
   public static var serviceDescriptor: GRPCServiceDescriptor {
     return Routeguide_RouteGuideClientMetadata.serviceDescriptor
@@ -256,7 +256,7 @@ extension Routeguide_RouteGuideAsyncClientProtocol {
   }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Routeguide_RouteGuideAsyncClientProtocol {
   public func getFeature(
     _ request: Routeguide_Point,
@@ -331,7 +331,7 @@ extension Routeguide_RouteGuideAsyncClientProtocol {
   }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public struct Routeguide_RouteGuideAsyncClient: Routeguide_RouteGuideAsyncClientProtocol {
   public var channel: GRPCChannel
   public var defaultCallOptions: CallOptions
@@ -348,7 +348,7 @@ public struct Routeguide_RouteGuideAsyncClient: Routeguide_RouteGuideAsyncClient
   }
 }
 
-#endif // compiler(>=5.5) && canImport(_Concurrency)
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
 public protocol Routeguide_RouteGuideClientInterceptorFactoryProtocol {
 
@@ -492,12 +492,12 @@ extension Routeguide_RouteGuideProvider {
     }
   }
 }
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
 /// Interface exported by the server.
 ///
 /// To implement a server, implement an object which conforms to this protocol.
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public protocol Routeguide_RouteGuideAsyncProvider: CallHandlerProvider {
   static var serviceDescriptor: GRPCServiceDescriptor { get }
   var interceptors: Routeguide_RouteGuideServerInterceptorFactoryProtocol? { get }
@@ -545,7 +545,7 @@ public protocol Routeguide_RouteGuideAsyncProvider: CallHandlerProvider {
   ) async throws
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Routeguide_RouteGuideAsyncProvider {
   public static var serviceDescriptor: GRPCServiceDescriptor {
     return Routeguide_RouteGuideServerMetadata.serviceDescriptor
@@ -606,7 +606,7 @@ extension Routeguide_RouteGuideAsyncProvider {
   }
 }
 
-#endif // compiler(>=5.5) && canImport(_Concurrency)
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
 public protocol Routeguide_RouteGuideServerInterceptorFactoryProtocol {
 

--- a/Sources/Examples/RouteGuide/Server/RouteGuideProvider.swift
+++ b/Sources/Examples/RouteGuide/Server/RouteGuideProvider.swift
@@ -19,9 +19,9 @@ import NIOConcurrencyHelpers
 import NIOCore
 import RouteGuideModel
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 internal final class RouteGuideProvider: Routeguide_RouteGuideAsyncProvider {
   private let features: [Routeguide_Feature]
   private let notes: Notes
@@ -111,7 +111,7 @@ internal final class RouteGuideProvider: Routeguide_RouteGuideAsyncProvider {
   }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 internal final actor Notes {
   private var recordedNotes: [Routeguide_Point: [Routeguide_RouteNote]]
 
@@ -130,7 +130,7 @@ internal final actor Notes {
   }
 }
 
-#endif // compiler(>=5.5) && canImport(_Concurrency)
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
 private func degreesToRadians(_ degrees: Double) -> Double {
   return degrees * .pi / 180.0

--- a/Sources/Examples/RouteGuide/Server/main.swift
+++ b/Sources/Examples/RouteGuide/Server/main.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 import ArgumentParser
 import struct Foundation.Data
 import struct Foundation.URL
@@ -33,7 +33,7 @@ func loadFeatures() throws -> [Routeguide_Feature] {
   return try Routeguide_Feature.array(fromJSONUTF8Data: data)
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 struct RouteGuide: ParsableCommand {
   @Option(help: "The port to listen on for new connections")
   var port = 1234
@@ -76,4 +76,4 @@ if #available(macOS 12, *) {
 }
 #else
 fatalError("The RouteGuide example requires Swift concurrency support.")
-#endif // compiler(>=5.5) && canImport(_Concurrency)
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)

--- a/Sources/GRPC/AsyncAwaitSupport/AsyncWriter.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/AsyncWriter.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 import NIOCore
 
 /// An asynchronous writer which forwards messages to a delegate.
@@ -25,7 +25,7 @@ import NIOCore
 ///
 /// The writer must also be "finished" with a final value: as for writing, calls to ``finish(_:)``
 /// may suspend if the writer has been paused.
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 @usableFromInline
 internal final actor AsyncWriter<Delegate: AsyncWriterDelegate> {
   @usableFromInline
@@ -291,7 +291,7 @@ internal final actor AsyncWriter<Delegate: AsyncWriterDelegate> {
   }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension AsyncWriter where End == Void {
   @inlinable
   internal func finish() async throws {
@@ -334,4 +334,4 @@ internal protocol AsyncWriterDelegate: AnyObject {
   func writeEnd(_ end: End)
 }
 
-#endif // compiler(>=5.5) && canImport(_Concurrency)
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)

--- a/Sources/GRPC/AsyncAwaitSupport/Call+AsyncRequestStreamWriter.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/Call+AsyncRequestStreamWriter.swift
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Call {
   internal func makeRequestStreamWriter() -> GRPCAsyncRequestStreamWriter<Request> {
     let delegate = GRPCAsyncRequestStreamWriter<Request>.Delegate(
@@ -30,4 +30,4 @@ extension Call {
   }
 }
 
-#endif // compiler(>=5.5) && canImport(_Concurrency)
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)

--- a/Sources/GRPC/AsyncAwaitSupport/CancellationError+GRPCStatusTransformable.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/CancellationError+GRPCStatusTransformable.swift
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension CancellationError: GRPCStatusTransformable {
   public func makeGRPCStatus() -> GRPCStatus {
     return GRPCStatus(code: .unavailable, message: nil)

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncBidirectionalStreamingCall.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncBidirectionalStreamingCall.swift
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
 import NIOHPACK
 
 /// Async-await variant of BidirectionalStreamingCall.
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public struct GRPCAsyncBidirectionalStreamingCall<Request, Response> {
   private let call: Call<Request, Response>
   private let responseParts: StreamingResponseParts<Response>
@@ -103,7 +103,7 @@ public struct GRPCAsyncBidirectionalStreamingCall<Request, Response> {
   }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 internal enum AsyncCall {
   internal static func makeResponsePartHandler<Response>(
     responseParts: StreamingResponseParts<Response>,

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncClientStreamingCall.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncClientStreamingCall.swift
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
 import NIOHPACK
 
 /// Async-await variant of `ClientStreamingCall`.
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public struct GRPCAsyncClientStreamingCall<Request, Response> {
   private let call: Call<Request, Response>
   private let responseParts: UnaryResponseParts<Response>

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncRequestStream.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncRequestStream.swift
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
 /// This is currently a wrapper around AsyncThrowingStream because we want to be
 /// able to swap out the implementation for something else in the future.
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public struct GRPCAsyncRequestStream<Element>: AsyncSequence {
   @usableFromInline
   internal typealias _WrappedStream = PassthroughMessageSequence<Element, Error>

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncRequestStreamWriter.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncRequestStreamWriter.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
 /// An object allowing the holder -- a client -- to send requests on an RPC.
 ///
@@ -30,7 +30,7 @@
 /// // Finish the stream to indicate that no more messages will be sent.
 /// try await stream.finish()
 /// ```
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public struct GRPCAsyncRequestStreamWriter<Request> {
   @usableFromInline
   internal let asyncWriter: AsyncWriter<Delegate<Request>>
@@ -74,7 +74,7 @@ public struct GRPCAsyncRequestStreamWriter<Request> {
   }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension GRPCAsyncRequestStreamWriter {
   /// A delegate for the writer which writes messages to an underlying receiver.`
   @usableFromInline
@@ -124,4 +124,4 @@ extension GRPCAsyncRequestStreamWriter {
   }
 }
 
-#endif // compiler(>=5.5) && canImport(_Concurrency)
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncResponseStream.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncResponseStream.swift
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
 /// This is currently a wrapper around AsyncThrowingStream because we want to be
 /// able to swap out the implementation for something else in the future.
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public struct GRPCAsyncResponseStream<Element>: AsyncSequence {
   @usableFromInline
   internal typealias WrappedStream = PassthroughMessageSequence<Element, Error>

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncResponseStreamWriter.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncResponseStreamWriter.swift
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
 /// Writer for server-streaming RPC handlers to provide responses.
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public struct GRPCAsyncResponseStreamWriter<Response> {
   @usableFromInline
   internal typealias Element = (Response, Compression)
@@ -42,7 +42,7 @@ public struct GRPCAsyncResponseStreamWriter<Response> {
   }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 @usableFromInline
 internal final class AsyncResponseStreamWriterDelegate<Response>: AsyncWriterDelegate {
   @usableFromInline

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncServerCallContext.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncServerCallContext.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
 import Logging
 import NIOConcurrencyHelpers
@@ -30,7 +30,7 @@ import NIOHPACK
 // We also considered an `actor` but that felt clunky at the point of use since adopters would need
 // to `await` the retrieval of a logger or the updating of the trailers and each would requrie a
 // promise to glue the NIO and async-await paradigms in the handler.
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public final class GRPCAsyncServerCallContext {
   private let lock = Lock()
 

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncServerHandler.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncServerHandler.swift
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
 import NIOCore
 import NIOHPACK
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public struct GRPCAsyncServerHandler<
   Serializer: MessageSerializer,
   Deserializer: MessageDeserializer
@@ -47,7 +47,7 @@ public struct GRPCAsyncServerHandler<
   }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension GRPCAsyncServerHandler {
   public typealias Request = Deserializer.Output
   public typealias Response = Serializer.Input
@@ -149,7 +149,7 @@ extension GRPCAsyncServerHandler {
   }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 @usableFromInline
 internal final class AsyncServerHandler<
   Serializer: MessageSerializer,

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncServerStreamingCall.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncServerStreamingCall.swift
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
 import NIOHPACK
 
 /// Async-await variant of `ServerStreamingCall`.
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public struct GRPCAsyncServerStreamingCall<Request, Response> {
   private let call: Call<Request, Response>
   private let responseParts: StreamingResponseParts<Response>

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncUnaryCall.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncUnaryCall.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
 import NIOHPACK
 
@@ -21,7 +21,7 @@ import NIOHPACK
 ///
 /// Note: while this object is a `struct`, its implementation delegates to `Call`. It therefore
 /// has reference semantics.
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public struct GRPCAsyncUnaryCall<Request, Response> {
   private let call: Call<Request, Response>
   private let responseParts: UnaryResponseParts<Response>

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCChannel+AsyncAwaitSupport.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCChannel+AsyncAwaitSupport.swift
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
 import SwiftProtobuf
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension GRPCChannel {
   /// Make a unary gRPC call.
   ///

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCClient+AsyncAwaitSupport.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCClient+AsyncAwaitSupport.swift
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
 import SwiftProtobuf
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension GRPCClient {
   public func makeAsyncUnaryCall<Request: Message, Response: Message>(
     path: String,
@@ -150,7 +150,7 @@ extension GRPCClient {
 
 // MARK: - "Simple, but safe" wrappers.
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension GRPCClient {
   public func performAsyncUnaryCall<Request: Message, Response: Message>(
     path: String,
@@ -384,7 +384,7 @@ extension GRPCClient {
   }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension GRPCClient {
   @inlinable
   internal func perform<Request, Response, RequestStream>(
@@ -445,7 +445,7 @@ extension GRPCClient {
   }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension AsyncStream {
   /// Create an `AsyncStream` from a regular (non-async) `Sequence`.
   ///

--- a/Sources/GRPC/AsyncAwaitSupport/PassthroughMessageSequence.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/PassthroughMessageSequence.swift
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
 /// An ``AsyncSequence`` adapter for a ``PassthroughMessageSource``.`
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 @usableFromInline
 internal struct PassthroughMessageSequence<Element, Failure: Error>: AsyncSequence {
   @usableFromInline
@@ -55,4 +55,4 @@ internal struct PassthroughMessageSequence<Element, Failure: Error>: AsyncSequen
   }
 }
 
-#endif // compiler(>=5.5) && canImport(_Concurrency)
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)

--- a/Sources/GRPC/AsyncAwaitSupport/PassthroughMessageSource.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/PassthroughMessageSource.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 import NIOConcurrencyHelpers
 import NIOCore
 
@@ -27,7 +27,7 @@ import NIOCore
 ///
 /// The source must be finished exactly once by calling ``finish()`` or ``finish(throwing:)`` to
 /// indicate that the sequence should end with an error.
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 @usableFromInline
 internal final class PassthroughMessageSource<Element, Failure: Error> {
   @usableFromInline
@@ -160,4 +160,4 @@ internal final class PassthroughMessageSource<Element, Failure: Error> {
   }
 }
 
-#endif // compiler(>=5.5) && canImport(_Concurrency)
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)

--- a/Sources/GRPCInteroperabilityTestModels/Generated/test.grpc.swift
+++ b/Sources/GRPCInteroperabilityTestModels/Generated/test.grpc.swift
@@ -265,10 +265,10 @@ public final class Grpc_Testing_TestServiceClient: Grpc_Testing_TestServiceClien
   }
 }
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 /// A simple service to test the various types of RPCs and experiment with
 /// performance with various types of payload.
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public protocol Grpc_Testing_TestServiceAsyncClientProtocol: GRPCClient {
   static var serviceDescriptor: GRPCServiceDescriptor { get }
   var interceptors: Grpc_Testing_TestServiceClientInterceptorFactoryProtocol? { get }
@@ -311,7 +311,7 @@ public protocol Grpc_Testing_TestServiceAsyncClientProtocol: GRPCClient {
   ) -> GRPCAsyncUnaryCall<Grpc_Testing_Empty, Grpc_Testing_Empty>
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Grpc_Testing_TestServiceAsyncClientProtocol {
   public static var serviceDescriptor: GRPCServiceDescriptor {
     return Grpc_Testing_TestServiceClientMetadata.serviceDescriptor
@@ -412,7 +412,7 @@ extension Grpc_Testing_TestServiceAsyncClientProtocol {
   }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Grpc_Testing_TestServiceAsyncClientProtocol {
   public func emptyCall(
     _ request: Grpc_Testing_Empty,
@@ -547,7 +547,7 @@ extension Grpc_Testing_TestServiceAsyncClientProtocol {
   }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public struct Grpc_Testing_TestServiceAsyncClient: Grpc_Testing_TestServiceAsyncClientProtocol {
   public var channel: GRPCChannel
   public var defaultCallOptions: CallOptions
@@ -564,7 +564,7 @@ public struct Grpc_Testing_TestServiceAsyncClient: Grpc_Testing_TestServiceAsync
   }
 }
 
-#endif // compiler(>=5.5) && canImport(_Concurrency)
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
 public protocol Grpc_Testing_TestServiceClientInterceptorFactoryProtocol {
 
@@ -720,10 +720,10 @@ public final class Grpc_Testing_UnimplementedServiceClient: Grpc_Testing_Unimple
   }
 }
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 /// A simple service NOT implemented at servers so clients can test for
 /// that case.
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public protocol Grpc_Testing_UnimplementedServiceAsyncClientProtocol: GRPCClient {
   static var serviceDescriptor: GRPCServiceDescriptor { get }
   var interceptors: Grpc_Testing_UnimplementedServiceClientInterceptorFactoryProtocol? { get }
@@ -734,7 +734,7 @@ public protocol Grpc_Testing_UnimplementedServiceAsyncClientProtocol: GRPCClient
   ) -> GRPCAsyncUnaryCall<Grpc_Testing_Empty, Grpc_Testing_Empty>
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Grpc_Testing_UnimplementedServiceAsyncClientProtocol {
   public static var serviceDescriptor: GRPCServiceDescriptor {
     return Grpc_Testing_UnimplementedServiceClientMetadata.serviceDescriptor
@@ -757,7 +757,7 @@ extension Grpc_Testing_UnimplementedServiceAsyncClientProtocol {
   }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Grpc_Testing_UnimplementedServiceAsyncClientProtocol {
   public func unimplementedCall(
     _ request: Grpc_Testing_Empty,
@@ -772,7 +772,7 @@ extension Grpc_Testing_UnimplementedServiceAsyncClientProtocol {
   }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public struct Grpc_Testing_UnimplementedServiceAsyncClient: Grpc_Testing_UnimplementedServiceAsyncClientProtocol {
   public var channel: GRPCChannel
   public var defaultCallOptions: CallOptions
@@ -789,7 +789,7 @@ public struct Grpc_Testing_UnimplementedServiceAsyncClient: Grpc_Testing_Unimple
   }
 }
 
-#endif // compiler(>=5.5) && canImport(_Concurrency)
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
 public protocol Grpc_Testing_UnimplementedServiceClientInterceptorFactoryProtocol {
 
@@ -897,9 +897,9 @@ public final class Grpc_Testing_ReconnectServiceClient: Grpc_Testing_ReconnectSe
   }
 }
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 /// A service used to control reconnect server.
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public protocol Grpc_Testing_ReconnectServiceAsyncClientProtocol: GRPCClient {
   static var serviceDescriptor: GRPCServiceDescriptor { get }
   var interceptors: Grpc_Testing_ReconnectServiceClientInterceptorFactoryProtocol? { get }
@@ -915,7 +915,7 @@ public protocol Grpc_Testing_ReconnectServiceAsyncClientProtocol: GRPCClient {
   ) -> GRPCAsyncUnaryCall<Grpc_Testing_Empty, Grpc_Testing_ReconnectInfo>
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Grpc_Testing_ReconnectServiceAsyncClientProtocol {
   public static var serviceDescriptor: GRPCServiceDescriptor {
     return Grpc_Testing_ReconnectServiceClientMetadata.serviceDescriptor
@@ -950,7 +950,7 @@ extension Grpc_Testing_ReconnectServiceAsyncClientProtocol {
   }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Grpc_Testing_ReconnectServiceAsyncClientProtocol {
   public func start(
     _ request: Grpc_Testing_ReconnectParams,
@@ -977,7 +977,7 @@ extension Grpc_Testing_ReconnectServiceAsyncClientProtocol {
   }
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public struct Grpc_Testing_ReconnectServiceAsyncClient: Grpc_Testing_ReconnectServiceAsyncClientProtocol {
   public var channel: GRPCChannel
   public var defaultCallOptions: CallOptions
@@ -994,7 +994,7 @@ public struct Grpc_Testing_ReconnectServiceAsyncClient: Grpc_Testing_ReconnectSe
   }
 }
 
-#endif // compiler(>=5.5) && canImport(_Concurrency)
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
 public protocol Grpc_Testing_ReconnectServiceClientInterceptorFactoryProtocol {
 
@@ -1148,13 +1148,13 @@ extension Grpc_Testing_TestServiceProvider {
     }
   }
 }
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
 /// A simple service to test the various types of RPCs and experiment with
 /// performance with various types of payload.
 ///
 /// To implement a server, implement an object which conforms to this protocol.
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public protocol Grpc_Testing_TestServiceAsyncProvider: CallHandlerProvider {
   static var serviceDescriptor: GRPCServiceDescriptor { get }
   var interceptors: Grpc_Testing_TestServiceServerInterceptorFactoryProtocol? { get }
@@ -1214,7 +1214,7 @@ public protocol Grpc_Testing_TestServiceAsyncProvider: CallHandlerProvider {
   ) async throws
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Grpc_Testing_TestServiceAsyncProvider {
   public static var serviceDescriptor: GRPCServiceDescriptor {
     return Grpc_Testing_TestServiceServerMetadata.serviceDescriptor
@@ -1302,7 +1302,7 @@ extension Grpc_Testing_TestServiceAsyncProvider {
   }
 }
 
-#endif // compiler(>=5.5) && canImport(_Concurrency)
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
 public protocol Grpc_Testing_TestServiceServerInterceptorFactoryProtocol {
 
@@ -1442,13 +1442,13 @@ extension Grpc_Testing_UnimplementedServiceProvider {
     }
   }
 }
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
 /// A simple service NOT implemented at servers so clients can test for
 /// that case.
 ///
 /// To implement a server, implement an object which conforms to this protocol.
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public protocol Grpc_Testing_UnimplementedServiceAsyncProvider: CallHandlerProvider {
   static var serviceDescriptor: GRPCServiceDescriptor { get }
   var interceptors: Grpc_Testing_UnimplementedServiceServerInterceptorFactoryProtocol? { get }
@@ -1460,7 +1460,7 @@ public protocol Grpc_Testing_UnimplementedServiceAsyncProvider: CallHandlerProvi
   ) async throws -> Grpc_Testing_Empty
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Grpc_Testing_UnimplementedServiceAsyncProvider {
   public static var serviceDescriptor: GRPCServiceDescriptor {
     return Grpc_Testing_UnimplementedServiceServerMetadata.serviceDescriptor
@@ -1494,7 +1494,7 @@ extension Grpc_Testing_UnimplementedServiceAsyncProvider {
   }
 }
 
-#endif // compiler(>=5.5) && canImport(_Concurrency)
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
 public protocol Grpc_Testing_UnimplementedServiceServerInterceptorFactoryProtocol {
 
@@ -1566,12 +1566,12 @@ extension Grpc_Testing_ReconnectServiceProvider {
     }
   }
 }
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
 /// A service used to control reconnect server.
 ///
 /// To implement a server, implement an object which conforms to this protocol.
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public protocol Grpc_Testing_ReconnectServiceAsyncProvider: CallHandlerProvider {
   static var serviceDescriptor: GRPCServiceDescriptor { get }
   var interceptors: Grpc_Testing_ReconnectServiceServerInterceptorFactoryProtocol? { get }
@@ -1587,7 +1587,7 @@ public protocol Grpc_Testing_ReconnectServiceAsyncProvider: CallHandlerProvider 
   ) async throws -> Grpc_Testing_ReconnectInfo
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Grpc_Testing_ReconnectServiceAsyncProvider {
   public static var serviceDescriptor: GRPCServiceDescriptor {
     return Grpc_Testing_ReconnectServiceServerMetadata.serviceDescriptor
@@ -1630,7 +1630,7 @@ extension Grpc_Testing_ReconnectServiceAsyncProvider {
   }
 }
 
-#endif // compiler(>=5.5) && canImport(_Concurrency)
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
 public protocol Grpc_Testing_ReconnectServiceServerInterceptorFactoryProtocol {
 

--- a/Sources/GRPCInteroperabilityTestModels/unimplemented_call.patch
+++ b/Sources/GRPCInteroperabilityTestModels/unimplemented_call.patch
@@ -40,7 +40,7 @@
 -  ) async throws -> Grpc_Testing_Empty
  }
  
- @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+ @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 @@ -1210,15 +1190,6 @@
          wrapping: self.halfDuplexCall(requests:responseStream:context:)
        )

--- a/Sources/GRPCInteroperabilityTestsImplementation/TestServiceAsyncProvider.swift
+++ b/Sources/GRPCInteroperabilityTestsImplementation/TestServiceAsyncProvider.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5)
+#if compiler(>=5.5.2)
 import Foundation
 import GRPC
 import GRPCInteroperabilityTestModels
@@ -22,7 +22,7 @@ import NIOCore
 /// An async service provider for the gRPC interoperability test suite.
 ///
 /// See: https://github.com/grpc/grpc/blob/master/doc/interop-test-descriptions.md#server
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public class TestServiceAsyncProvider: Grpc_Testing_TestServiceAsyncProvider {
   public var interceptors: Grpc_Testing_TestServiceServerInterceptorFactoryProtocol?
 

--- a/Sources/protoc-gen-grpc-swift/Generator.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator.swift
@@ -166,14 +166,14 @@ class Generator {
   }
 
   func printAvailabilityForAsyncAwait() {
-    self.println("@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)")
+    self.println("@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)")
   }
 
   func printIfCompilerGuardForAsyncAwait() {
-    self.println("#if compiler(>=5.5) && canImport(_Concurrency)")
+    self.println("#if compiler(>=5.5.2) && canImport(_Concurrency)")
   }
 
   func printEndCompilerGuardForAsyncAwait() {
-    self.println("#endif // compiler(>=5.5) && canImport(_Concurrency)")
+    self.println("#endif // compiler(>=5.5.2) && canImport(_Concurrency)")
   }
 }

--- a/Tests/GRPCTests/AsyncAwaitSupport/AsyncIntegrationTests.swift
+++ b/Tests/GRPCTests/AsyncAwaitSupport/AsyncIntegrationTests.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5)
+#if compiler(>=5.5.2)
 import EchoImplementation
 import EchoModel
 import GRPC
@@ -22,7 +22,7 @@ import NIOHPACK
 import NIOPosix
 import XCTest
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class AsyncIntegrationTests: GRPCTestCase {
   private var group: EventLoopGroup!
   private var server: Server!

--- a/Tests/GRPCTests/AsyncAwaitSupport/AsyncSequence+Helpers.swift
+++ b/Tests/GRPCTests/AsyncAwaitSupport/AsyncSequence+Helpers.swift
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5)
+#if compiler(>=5.5.2)
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension AsyncSequence {
   internal func collect() async throws -> [Element] {
     return try await self.reduce(into: []) { accumulated, next in

--- a/Tests/GRPCTests/AsyncAwaitSupport/AsyncWriterTests.swift
+++ b/Tests/GRPCTests/AsyncAwaitSupport/AsyncWriterTests.swift
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5)
+#if compiler(>=5.5.2)
 @testable import GRPC
 import NIOConcurrencyHelpers
 import XCTest
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 internal class AsyncWriterTests: GRPCTestCase {
   func testSingleWriterHappyPath() async throws {
     let delegate = CollectingDelegate<String, Int>()

--- a/Tests/GRPCTests/AsyncAwaitSupport/InterceptorsAsyncTests.swift
+++ b/Tests/GRPCTests/AsyncAwaitSupport/InterceptorsAsyncTests.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5)
+#if compiler(>=5.5.2)
 import EchoImplementation
 import EchoModel
 import GRPC
@@ -24,7 +24,7 @@ import NIOPosix
 import SwiftProtobuf
 import XCTest
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 class InterceptorsAsyncTests: GRPCTestCase {
   private var group: EventLoopGroup!
   private var server: Server!

--- a/Tests/GRPCTests/AsyncAwaitSupport/PassthroughMessageSourceTests.swift
+++ b/Tests/GRPCTests/AsyncAwaitSupport/PassthroughMessageSourceTests.swift
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5)
+#if compiler(>=5.5.2)
 @testable import GRPC
 import XCTest
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 class PassthroughMessageSourceTests: GRPCTestCase {
   func testBasicUsage() async throws {
     let source = PassthroughMessageSource<String, Never>()

--- a/Tests/GRPCTests/AsyncAwaitSupport/XCTest+AsyncAwait.swift
+++ b/Tests/GRPCTests/AsyncAwaitSupport/XCTest+AsyncAwait.swift
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5)
+#if compiler(>=5.5.2)
 import XCTest
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 internal func XCTAssertThrowsError<T>(
   _ expression: @autoclosure () async throws -> T,
   verify: (Error) -> Void = { _ in },

--- a/Tests/GRPCTests/EchoMetadataTests.swift
+++ b/Tests/GRPCTests/EchoMetadataTests.swift
@@ -81,8 +81,8 @@ internal final class EchoMetadataTests: GRPCTestCase {
     self.testServiceDescriptor(Echo_EchoClientMetadata.serviceDescriptor)
     self.testServiceDescriptor(Echo_EchoServerMetadata.serviceDescriptor)
 
-    #if swift(>=5.5)
-    if #available(macOS 12, *) {
+    #if swift(>=5.5.2)
+    if #available(macOS 10.15, *) {
       self.testServiceDescriptor(Echo_EchoAsyncClient.serviceDescriptor)
     }
     #endif

--- a/Tests/GRPCTests/GRPCAsyncClientCallTests.swift
+++ b/Tests/GRPCTests/GRPCAsyncClientCallTests.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5)
+#if compiler(>=5.5.2)
 
 import EchoImplementation
 import EchoModel
@@ -22,7 +22,7 @@ import NIOHPACK
 import NIOPosix
 import XCTest
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 class GRPCAsyncClientCallTests: GRPCTestCase {
   private var group: MultiThreadedEventLoopGroup?
   private var server: Server?
@@ -207,7 +207,7 @@ class GRPCAsyncClientCallTests: GRPCTestCase {
 
 // Workaround https://bugs.swift.org/browse/SR-15070 (compiler crashes when defining a class/actor
 // in an async context).
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 fileprivate actor RequestResponseCounter {
   var numResponses = 0
   var numRequests = 0

--- a/Tests/GRPCTests/GRPCAsyncServerHandlerTests.swift
+++ b/Tests/GRPCTests/GRPCAsyncServerHandlerTests.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5)
+#if compiler(>=5.5.2)
 
 @testable import GRPC
 import NIOCore
@@ -21,7 +21,7 @@ import XCTest
 
 // MARK: - Tests
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 class AsyncServerHandlerTests: ServerHandlerTestCaseBase {
   private func makeHandler(
     encoding: ServerMessageEncoding = .disabled,

--- a/Tests/GRPCTests/GRPCInteroperabilityTests.swift
+++ b/Tests/GRPCTests/GRPCInteroperabilityTests.swift
@@ -176,8 +176,8 @@ class GRPCSecureInteroperabilityTests: GRPCInsecureInteroperabilityTests {
 }
 #endif // canImport(NIOSSL)
 
-#if compiler(>=5.5)
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+#if compiler(>=5.5.2)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 class GRPCInsecureInteroperabilityAsyncTests: GRPCInsecureInteroperabilityTests {
   override func makeProvider() -> CallHandlerProvider {
     return TestServiceAsyncProvider()
@@ -185,7 +185,7 @@ class GRPCInsecureInteroperabilityAsyncTests: GRPCInsecureInteroperabilityTests 
 }
 
 #if canImport(NIOSSL)
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 class GRPCSecureInteroperabilityAsyncTests: GRPCInsecureInteroperabilityAsyncTests {
   override var useTLS: Bool { return true }
 }

--- a/Tests/GRPCTests/XCTestHelpers.swift
+++ b/Tests/GRPCTests/XCTestHelpers.swift
@@ -660,9 +660,9 @@ struct ExpressionMatcher<Value> {
   }
 }
 
-#if compiler(>=5.5)
+#if compiler(>=5.5.2)
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 func assertThat<Value>(
   _ expression: @autoclosure @escaping () async throws -> Value,
   _ matcher: Matcher<Value>,
@@ -673,7 +673,7 @@ func assertThat<Value>(
   await assertThat(try await expression(), .doesNotThrow(matcher), file: file, line: line)
 }
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 func assertThat<Value>(
   _ expression: @autoclosure @escaping () async throws -> Value,
   _ matcher: ExpressionMatcher<Value>,


### PR DESCRIPTION
With Xcode 13.2 we can use swift concurrency on older OSes. I followed swift-nio's implementation of this and adopted it in grpc-swift.
Tested with Xcode 13.0 and Xcode 13.2. Also tested in my project that use both Server and Client implementations. Everything compiles and runs. 