### PR TITLE
Update allocation counter limits

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,44 +53,34 @@ jobs:
         include:
           - image: swift:5.5-focal
             env:
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 504000
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 216000
-              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 112000
-              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 67000
-              MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 63000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 205000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 212000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 212000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 480000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 201000
+              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 110000
+              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 65000
+              MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 61000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 194000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 201000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 201000
           - image: swift:5.4-focal
             env:
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 504000
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 216000
-              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 112000
-              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 67000
-              MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 63000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 205000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 212000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 212000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 480000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 201000
+              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 110000
+              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 65000
+              MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 61000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 194000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 201000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 201000
           - image: swift:5.3-focal
             env:
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 505000
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 217000
-              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 112000
-              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 67000
-              MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 63000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 206000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 213000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 213000
-          - image: swift:5.2-bionic
-            env:
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 516000
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 219000
-              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 112000
-              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 67000
-              MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 63000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 207000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 214000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 214000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 481000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 202000
+              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 110000
+              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 65000
+              MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 61000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 195000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 202000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 202000
     name: Performance Tests on ${{ matrix.image }}
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
Motivation:

A recent NIO release reduced allocations which has thrown off our
expected counts.

Modifications:

Update allocation limits.

Result:

Limits are more appropriate.

(cherry picked from commit 4dc17a880a9fe4e85db0ef4101c82804ca15233c)