### PR TITLE
Tolerate channel error when connecting

### DIFF
--- a/Sources/GRPC/ConnectionManager.swift
+++ b/Sources/GRPC/ConnectionManager.swift
@@ -591,7 +591,7 @@ internal final class ConnectionManager {
       ])
 
     case .connecting:
-      self.invalidState()
+      self.connectionFailed(withError: error)
 
     case var .active(state):
       state.error = error


### PR DESCRIPTION
Motivation:

In some cases it's possible for the connection manager to pick an error
from the channel when in the connecting state.

For some reason we decided this was not a valid transition despite
another function explicitly allowing an error to be handled while
in this state. The difference is that the other path is triggered by the
'connect()' future rather than coming from the channel directly.

Modifications:

- Call the function for handling failed connection attempts when we
  receive an error from the channel in the connecting state.

Result:

Better tolerate connection errors.