### PR TITLE
Add more flexibility to perf tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -232,6 +232,7 @@ extension Target {
     name: "GRPCPerformanceTests",
     dependencies: [
       .grpc,
+      .grpcSampleData,
       .nioCore,
       .nioEmbedded,
       .nioPosix,


### PR DESCRIPTION
Motivation:

It's useful to run the perf tests in different configurations, e.g. to
compare NIOTS with NIOPosix or to measure the affect of using TLS.

Modifications:

Add two options to the perf test suite:
- `--use-nio-transport-services`: uses a NIOTS event loop group if
  available on the host platform and,
- `--use-tls`: uses TLS if the test runs both a client and server

Also exposes a `--repeats` option.

Result:

Tests are more flexible.