### PR TITLE
Add cause to GRPCStatus.processingError for uncaught errors

### DIFF
--- a/Sources/GRPC/GRPCStatus.swift
+++ b/Sources/GRPC/GRPCStatus.swift
@@ -105,10 +105,16 @@ public struct GRPCStatus: Error {
   ///   status code. Use `GRPCStatus.isOk` or check the code directly.
   public static let ok = GRPCStatus(code: .ok, message: nil)
   /// "Internal server error" status.
-  public static let processingError = GRPCStatus(
-    code: .internalError,
-    message: "unknown error processing request"
-  )
+  public static let processingError = Self.processingError()
+
+  public static func processingError(cause: Error? = nil) -> GRPCStatus {
+    return GRPCStatus(
+      code: .internalError,
+      message: "unknown error processing request",
+      cause: cause
+    )
+  }
+
 }
 
 extension GRPCStatus: Equatable {

--- a/Sources/GRPC/GRPCStatus.swift
+++ b/Sources/GRPC/GRPCStatus.swift
@@ -114,7 +114,6 @@ public struct GRPCStatus: Error {
       cause: cause
     )
   }
-
 }
 
 extension GRPCStatus: Equatable {

--- a/Sources/GRPC/GRPCStatus.swift
+++ b/Sources/GRPC/GRPCStatus.swift
@@ -105,9 +105,9 @@ public struct GRPCStatus: Error {
   ///   status code. Use `GRPCStatus.isOk` or check the code directly.
   public static let ok = GRPCStatus(code: .ok, message: nil)
   /// "Internal server error" status.
-  public static let processingError = Self.processingError()
+  public static let processingError = Self.processingError(cause: nil)
 
-  public static func processingError(cause: Error? = nil) -> GRPCStatus {
+  public static func processingError(cause: Error?) -> GRPCStatus {
     return GRPCStatus(
       code: .internalError,
       message: "unknown error processing request",

--- a/Sources/GRPC/ServerErrorProcessor.swift
+++ b/Sources/GRPC/ServerErrorProcessor.swift
@@ -44,7 +44,7 @@ internal enum ServerErrorProcessor {
       trailers = [:]
     } else {
       // Eh... well, we don't what status to use. Use a generic one.
-      status = .processingError
+      status = .processingError(cause: error)
       trailers = [:]
     }
 
@@ -84,7 +84,7 @@ internal enum ServerErrorProcessor {
       mergedTrailers = trailers
     } else {
       // Eh... well, we don't what status to use. Use a generic one.
-      status = .processingError
+      status = .processingError(cause: error)
       mergedTrailers = trailers
     }
 


### PR DESCRIPTION
#1290 and #1306 added a `cause` field to `GRPCStatus` to help understand the underlying error.

This patch adds the `cause` to `GRPCStatus.processingError` which is the status returned when there is an uncaught error when handling requests. 