### PR TITLE
Add cause to GRPCStatus.descrpition if it is non-nil

### DIFF
--- a/Sources/GRPC/GRPCStatus.swift
+++ b/Sources/GRPC/GRPCStatus.swift
@@ -124,9 +124,14 @@ extension GRPCStatus: Equatable {
 
 extension GRPCStatus: CustomStringConvertible {
   public var description: String {
-    if let message = message {
+    switch (self.message, self.cause) {
+    case (.some(let message), .some(let cause)):
+      return "\(self.code): \(message), cause: \(cause)"
+    case (.some(let message), .none):
       return "\(self.code): \(message)"
-    } else {
+    case (.none, .some(let cause)):
+      return "\(self.code), cause: \(cause)"
+    case (.none, .none):
       return "\(self.code)"
     }
   }

--- a/Sources/GRPC/GRPCStatus.swift
+++ b/Sources/GRPC/GRPCStatus.swift
@@ -125,11 +125,11 @@ extension GRPCStatus: Equatable {
 extension GRPCStatus: CustomStringConvertible {
   public var description: String {
     switch (self.message, self.cause) {
-    case (.some(let message), .some(let cause)):
+    case let (.some(message), .some(cause)):
       return "\(self.code): \(message), cause: \(cause)"
-    case (.some(let message), .none):
+    case let (.some(message), .none):
       return "\(self.code): \(message)"
-    case (.none, .some(let cause)):
+    case let (.none, .some(cause)):
       return "\(self.code), cause: \(cause)"
     case (.none, .none):
       return "\(self.code)"

--- a/Tests/GRPCTests/GRPCStatusTests.swift
+++ b/Tests/GRPCTests/GRPCStatusTests.swift
@@ -34,7 +34,7 @@ class GRPCStatusTests: GRPCTestCase {
     )
   }
 
-  func testStatusDescriptionWithMessage() {
+  func testStatusDescriptionWithWithMessageWithoutCause() {
     XCTAssertEqual(
       "ok (0): OK",
       String(describing: GRPCStatus(code: .ok, message: "OK"))
@@ -48,6 +48,36 @@ class GRPCStatusTests: GRPCTestCase {
     XCTAssertEqual(
       "failed precondition (9): invalid state",
       String(describing: GRPCStatus(code: .failedPrecondition, message: "invalid state"))
+    )
+  }
+
+  func testStatusDescriptionWithMessageWithCause() {
+    struct UnderlyingError: Error, CustomStringConvertible {
+      var description: String { "underlying error description" }
+    }
+    let cause = UnderlyingError()
+    XCTAssertEqual(
+      "internal error (13): unknown error processing request, cause: \(cause.description)",
+      String(describing: GRPCStatus(
+        code: .internalError,
+        message: "unknown error processing request",
+        cause: cause
+      ))
+    )
+  }
+
+  func testStatusDescriptionWithoutMessageWithCause() {
+    struct UnderlyingError: Error, CustomStringConvertible {
+      var description: String { "underlying error description" }
+    }
+    let cause = UnderlyingError()
+    XCTAssertEqual(
+      "internal error (13), cause: \(cause.description)",
+      String(describing: GRPCStatus(
+        code: .internalError,
+        message: nil,
+        cause: cause
+      ))
     )
   }
 


### PR DESCRIPTION
Following on from #1290 and #1356, this adds the `cause` to the `GRPCStatus.description` so that it renders usefully in log lines by default.