### PR TITLE
Update minimum HTTP/2 version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let packageDependencies: [Package.Dependency] = [
   ),
   .package(
     url: "https://github.com/apple/swift-nio-http2.git",
-    from: "1.18.2"
+    from: "1.19.2"
   ),
   .package(
     url: "https://github.com/apple/swift-nio-transport-services.git",


### PR DESCRIPTION
Motivation:

HTTP/2 1.19.2 includes fixes for a number of vulnerabilties. We should
require adopters to use at least this version of HTTP/2 moving forward.

Modifications:

- Bump minimum HTTP/2 version to 1.19.2

Result:

- HTTP/2 version will be 1.19.2 or newer.