### PR TITLE
Use correct naming for making async calls

### DIFF
--- a/Sources/protoc-gen-grpc-swift/Generator-Client+AsyncAwait.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator-Client+AsyncAwait.swift
@@ -54,7 +54,7 @@ extension Generator {
         }
 
         self.printFunction(
-          name: "make\(self.method.name)Call",
+          name: self.methodMakeFunctionCallName,
           arguments: arguments,
           returnType: "\(callType)<\(self.methodInputName), \(self.methodOutputName)>",
           bodyBuilder: nil
@@ -101,7 +101,7 @@ extension Generator {
         switch rpcType {
         case .unary, .serverStreaming:
           self.printFunction(
-            name: "make\(self.method.name)Call",
+            name: self.methodMakeFunctionCallName,
             arguments: [
               "_ request: \(self.methodInputName)",
               "callOptions: \(Types.clientCallOptions)? = nil",
@@ -121,7 +121,7 @@ extension Generator {
 
         case .clientStreaming, .bidirectionalStreaming:
           self.printFunction(
-            name: "make\(self.method.name)Call",
+            name: self.methodMakeFunctionCallName,
             arguments: ["callOptions: \(Types.clientCallOptions)? = nil"],
             returnType: "\(callType)<\(self.methodInputName), \(self.methodOutputName)>",
             access: self.access

--- a/Sources/protoc-gen-grpc-swift/Generator-Names.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator-Names.swift
@@ -119,6 +119,19 @@ extension Generator {
     return self.sanitize(fieldName: name)
   }
 
+  internal var methodMakeFunctionCallName: String {
+    let name: String
+
+    if self.options.keepMethodCasing {
+      name = self.method.name
+    } else {
+      name = NamingUtils.toUpperCamelCase(self.method.name)
+    }
+
+    let fnName = "make\(name)Call"
+    return self.sanitize(fieldName: fnName)
+  }
+
   internal func sanitize(fieldName string: String) -> String {
     if quotableFieldNames.contains(string) {
       return "`\(string)`"


### PR DESCRIPTION
Motivation:

Generated 'makeMethodCall' functions on the async client use the casing
of 'Method' as it is defined in the .proto file. Methods are defined in
the proto file with 'UpperCamel' casing, so 'makeUpperCamelCall' is
correctly cased. However a 'lowerCamel' method would be generated as
'makelowerCamelCall'. We should instead coerce it to be
'makeLowerCamelCall'.

We missed this in other areas too, as an example, for interceptors we
will generate 'makelowerCamelCallInterceptors'. Unfortunately we can't
change this one without the risk of breaking adopters. However, since
async is yet to be stable API we can fix this one.

Modifications:

- Use upper camel casing for 'makeMethodCall' function names

Result:

Better naming.