### PR TITLE
Got error: 'SecTrustEvaluateAsyncWithError' is only available in macO…

### DIFF
--- a/Tests/GRPCTests/GRPCNetworkFrameworkTests.swift
+++ b/Tests/GRPCTests/GRPCNetworkFrameworkTests.swift
@@ -27,7 +27,7 @@ import NIOTransportServices
 import Security
 import XCTest
 
-@available(macOS 10.14, iOS 12.0, watchOS 6.0, tvOS 12.0, *)
+@available(macOS 10.15, iOS 12.0, watchOS 6.0, tvOS 12.0, *)
 final class GRPCNetworkFrameworkTests: GRPCTestCase {
   private var server: Server!
   private var client: ClientConnection!


### PR DESCRIPTION
…S 10.15 or newer, thus bump the `@available` to `macOS 10.15`