### PR TITLE
Ignore state machine inputs in unexpected states

### DIFF
--- a/Sources/GRPC/GRPCIdleHandlerStateMachine.swift
+++ b/Sources/GRPC/GRPCIdleHandlerStateMachine.swift
@@ -516,10 +516,8 @@ struct GRPCIdleHandlerStateMachine {
     case let .quiescing(state):
       let streamID = state.lastPeerInitiatedStreamID
       operations.sendGoAwayFrame(lastPeerInitiatedStreamID: streamID)
-    case .operating, .waitingToIdle:
-      // We can only ratchet down the stream ID if we're already quiescing.
-      preconditionFailure()
-    case .closing, .closed:
+    case .operating, .waitingToIdle, .closing, .closed:
+      // We can only need to ratchet down the stream ID if we're already quiescing.
       ()
     }
 

--- a/Sources/GRPC/Version.swift
+++ b/Sources/GRPC/Version.swift
@@ -22,7 +22,7 @@ internal enum Version {
   internal static let minor = 7
 
   /// The patch version.
-  internal static let patch = 2
+  internal static let patch = 3
 
   /// The version string.
   internal static let versionString = "\(major).\(minor).\(patch)"


### PR DESCRIPTION
Motivation:

When we ratchet down the last stream ID in a GOAWAY frame, we should
only do it if we're quiescing. If we aren't quiescing then we should
just ignore the request to do it.

Modifications:

- Ignore requests to ratchet down the last stream ID in a GOAWAY if
  we're not quiescing.

Result:

Fewer traps.