### PR TITLE
Bump minimum protobuf version to 1.19.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -49,7 +49,7 @@ let packageDependencies: [Package.Dependency] = [
   .package(
     name: "SwiftProtobuf",
     url: "https://github.com/apple/swift-protobuf.git",
-    from: "1.9.0"
+    from: "1.19.0"
   ),
   .package(
     url: "https://github.com/apple/swift-log.git",

--- a/Sources/Examples/Echo/Model/echo.pb.swift
+++ b/Sources/Examples/Echo/Model/echo.pb.swift
@@ -60,6 +60,11 @@ public struct Echo_EchoResponse {
   public init() {}
 }
 
+#if swift(>=5.5) && canImport(_Concurrency)
+extension Echo_EchoRequest: @unchecked Sendable {}
+extension Echo_EchoResponse: @unchecked Sendable {}
+#endif  // swift(>=5.5) && canImport(_Concurrency)
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "echo"

--- a/Sources/Examples/HelloWorld/Model/helloworld.grpc.swift
+++ b/Sources/Examples/HelloWorld/Model/helloworld.grpc.swift
@@ -84,6 +84,76 @@ public final class Helloworld_GreeterClient: Helloworld_GreeterClientProtocol {
   }
 }
 
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+/// The greeting service definition.
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+public protocol Helloworld_GreeterAsyncClientProtocol: GRPCClient {
+  static var serviceDescriptor: GRPCServiceDescriptor { get }
+  var interceptors: Helloworld_GreeterClientInterceptorFactoryProtocol? { get }
+
+  func makeSayHelloCall(
+    _ request: Helloworld_HelloRequest,
+    callOptions: CallOptions?
+  ) -> GRPCAsyncUnaryCall<Helloworld_HelloRequest, Helloworld_HelloReply>
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension Helloworld_GreeterAsyncClientProtocol {
+  public static var serviceDescriptor: GRPCServiceDescriptor {
+    return Helloworld_GreeterClientMetadata.serviceDescriptor
+  }
+
+  public var interceptors: Helloworld_GreeterClientInterceptorFactoryProtocol? {
+    return nil
+  }
+
+  public func makeSayHelloCall(
+    _ request: Helloworld_HelloRequest,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncUnaryCall<Helloworld_HelloRequest, Helloworld_HelloReply> {
+    return self.makeAsyncUnaryCall(
+      path: Helloworld_GreeterClientMetadata.Methods.sayHello.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeSayHelloInterceptors() ?? []
+    )
+  }
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension Helloworld_GreeterAsyncClientProtocol {
+  public func sayHello(
+    _ request: Helloworld_HelloRequest,
+    callOptions: CallOptions? = nil
+  ) async throws -> Helloworld_HelloReply {
+    return try await self.performAsyncUnaryCall(
+      path: Helloworld_GreeterClientMetadata.Methods.sayHello.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeSayHelloInterceptors() ?? []
+    )
+  }
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+public struct Helloworld_GreeterAsyncClient: Helloworld_GreeterAsyncClientProtocol {
+  public var channel: GRPCChannel
+  public var defaultCallOptions: CallOptions
+  public var interceptors: Helloworld_GreeterClientInterceptorFactoryProtocol?
+
+  public init(
+    channel: GRPCChannel,
+    defaultCallOptions: CallOptions = CallOptions(),
+    interceptors: Helloworld_GreeterClientInterceptorFactoryProtocol? = nil
+  ) {
+    self.channel = channel
+    self.defaultCallOptions = defaultCallOptions
+    self.interceptors = interceptors
+  }
+}
+
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)
+
 public protocol Helloworld_GreeterClientInterceptorFactoryProtocol {
 
   /// - Returns: Interceptors to use when invoking 'sayHello'.
@@ -144,6 +214,58 @@ extension Helloworld_GreeterProvider {
     }
   }
 }
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+
+/// The greeting service definition.
+///
+/// To implement a server, implement an object which conforms to this protocol.
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+public protocol Helloworld_GreeterAsyncProvider: CallHandlerProvider {
+  static var serviceDescriptor: GRPCServiceDescriptor { get }
+  var interceptors: Helloworld_GreeterServerInterceptorFactoryProtocol? { get }
+
+  /// Sends a greeting.
+  @Sendable func sayHello(
+    request: Helloworld_HelloRequest,
+    context: GRPCAsyncServerCallContext
+  ) async throws -> Helloworld_HelloReply
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension Helloworld_GreeterAsyncProvider {
+  public static var serviceDescriptor: GRPCServiceDescriptor {
+    return Helloworld_GreeterServerMetadata.serviceDescriptor
+  }
+
+  public var serviceName: Substring {
+    return Helloworld_GreeterServerMetadata.serviceDescriptor.fullName[...]
+  }
+
+  public var interceptors: Helloworld_GreeterServerInterceptorFactoryProtocol? {
+    return nil
+  }
+
+  public func handle(
+    method name: Substring,
+    context: CallHandlerContext
+  ) -> GRPCServerHandlerProtocol? {
+    switch name {
+    case "SayHello":
+      return GRPCAsyncServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Helloworld_HelloRequest>(),
+        responseSerializer: ProtobufSerializer<Helloworld_HelloReply>(),
+        interceptors: self.interceptors?.makeSayHelloInterceptors() ?? [],
+        wrapping: self.sayHello(request:context:)
+      )
+
+    default:
+      return nil
+    }
+  }
+}
+
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)
 
 public protocol Helloworld_GreeterServerInterceptorFactoryProtocol {
 

--- a/Sources/Examples/HelloWorld/Model/helloworld.pb.swift
+++ b/Sources/Examples/HelloWorld/Model/helloworld.pb.swift
@@ -60,6 +60,11 @@ public struct Helloworld_HelloReply {
   public init() {}
 }
 
+#if swift(>=5.5) && canImport(_Concurrency)
+extension Helloworld_HelloRequest: @unchecked Sendable {}
+extension Helloworld_HelloReply: @unchecked Sendable {}
+#endif  // swift(>=5.5) && canImport(_Concurrency)
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "helloworld"

--- a/Sources/GRPCInteroperabilityTestModels/Generated/empty.pb.swift
+++ b/Sources/GRPCInteroperabilityTestModels/Generated/empty.pb.swift
@@ -51,6 +51,10 @@ public struct Grpc_Testing_Empty {
   public init() {}
 }
 
+#if swift(>=5.5) && canImport(_Concurrency)
+extension Grpc_Testing_Empty: @unchecked Sendable {}
+#endif  // swift(>=5.5) && canImport(_Concurrency)
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "grpc.testing"

--- a/Sources/GRPCInteroperabilityTestModels/Generated/messages.pb.swift
+++ b/Sources/GRPCInteroperabilityTestModels/Generated/messages.pb.swift
@@ -407,6 +407,22 @@ public struct Grpc_Testing_ReconnectInfo {
   public init() {}
 }
 
+#if swift(>=5.5) && canImport(_Concurrency)
+extension Grpc_Testing_PayloadType: @unchecked Sendable {}
+extension Grpc_Testing_BoolValue: @unchecked Sendable {}
+extension Grpc_Testing_Payload: @unchecked Sendable {}
+extension Grpc_Testing_EchoStatus: @unchecked Sendable {}
+extension Grpc_Testing_SimpleRequest: @unchecked Sendable {}
+extension Grpc_Testing_SimpleResponse: @unchecked Sendable {}
+extension Grpc_Testing_StreamingInputCallRequest: @unchecked Sendable {}
+extension Grpc_Testing_StreamingInputCallResponse: @unchecked Sendable {}
+extension Grpc_Testing_ResponseParameters: @unchecked Sendable {}
+extension Grpc_Testing_StreamingOutputCallRequest: @unchecked Sendable {}
+extension Grpc_Testing_StreamingOutputCallResponse: @unchecked Sendable {}
+extension Grpc_Testing_ReconnectParams: @unchecked Sendable {}
+extension Grpc_Testing_ReconnectInfo: @unchecked Sendable {}
+#endif  // swift(>=5.5) && canImport(_Concurrency)
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "grpc.testing"


### PR DESCRIPTION
Motivation:

swift-protobuf added `Sendable` conformance to generated messages in
the 1.19.0 release.

Modifications:

- Bump minimum protobuf version
- Regenerate examples and interop tests

Result:

Protobuf messages are `Sendable`