### PR TITLE
Raise minimum Swift version for async/await

### DIFF
--- a/Sources/Examples/Echo/AsyncAwaitRuntime/ArgumentParser+AsyncAwait.swift
+++ b/Sources/Examples/Echo/AsyncAwaitRuntime/ArgumentParser+AsyncAwait.swift
@@ -17,7 +17,7 @@
 /// NOTE: This file should be removed when the `async` branch of `swift-argument-parser` has been
 ///       released: https://github.com/apple/swift-argument-parser/tree/async
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6)
 
 import ArgumentParser
 

--- a/Sources/Examples/Echo/AsyncAwaitRuntime/main.swift
+++ b/Sources/Examples/Echo/AsyncAwaitRuntime/main.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6)
 
 import ArgumentParser
 import EchoImplementation

--- a/Sources/Examples/Echo/Implementation/EchoAsyncProvider.swift
+++ b/Sources/Examples/Echo/Implementation/EchoAsyncProvider.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6)
 import EchoModel
 import GRPC
 
@@ -69,4 +69,4 @@ public final class EchoAsyncProvider: Echo_EchoAsyncProvider {
   }
 }
 
-#endif // compiler(>=5.5.2) && canImport(_Concurrency)
+#endif // compiler(>=5.6)

--- a/Sources/Examples/Echo/Model/echo.grpc.swift
+++ b/Sources/Examples/Echo/Model/echo.grpc.swift
@@ -157,7 +157,7 @@ public final class Echo_EchoClient: Echo_EchoClientProtocol {
   }
 }
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6)
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public protocol Echo_EchoAsyncClientProtocol: GRPCClient {
   static var serviceDescriptor: GRPCServiceDescriptor { get }
@@ -329,7 +329,7 @@ public struct Echo_EchoAsyncClient: Echo_EchoAsyncClientProtocol {
   }
 }
 
-#endif // compiler(>=5.5.2) && canImport(_Concurrency)
+#endif // compiler(>=5.6)
 
 public protocol Echo_EchoClientInterceptorFactoryProtocol {
 
@@ -573,7 +573,7 @@ extension Echo_EchoProvider {
     }
   }
 }
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6)
 
 /// To implement a server, implement an object which conforms to this protocol.
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
@@ -669,7 +669,7 @@ extension Echo_EchoAsyncProvider {
   }
 }
 
-#endif // compiler(>=5.5.2) && canImport(_Concurrency)
+#endif // compiler(>=5.6)
 
 public protocol Echo_EchoServerInterceptorFactoryProtocol {
 

--- a/Sources/Examples/HelloWorld/Model/helloworld.grpc.swift
+++ b/Sources/Examples/HelloWorld/Model/helloworld.grpc.swift
@@ -84,7 +84,7 @@ public final class Helloworld_GreeterClient: Helloworld_GreeterClientProtocol {
   }
 }
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6)
 /// The greeting service definition.
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public protocol Helloworld_GreeterAsyncClientProtocol: GRPCClient {
@@ -152,7 +152,7 @@ public struct Helloworld_GreeterAsyncClient: Helloworld_GreeterAsyncClientProtoc
   }
 }
 
-#endif // compiler(>=5.5.2) && canImport(_Concurrency)
+#endif // compiler(>=5.6)
 
 public protocol Helloworld_GreeterClientInterceptorFactoryProtocol {
 
@@ -214,7 +214,7 @@ extension Helloworld_GreeterProvider {
     }
   }
 }
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6)
 
 /// The greeting service definition.
 ///
@@ -265,7 +265,7 @@ extension Helloworld_GreeterAsyncProvider {
   }
 }
 
-#endif // compiler(>=5.5.2) && canImport(_Concurrency)
+#endif // compiler(>=5.6)
 
 public protocol Helloworld_GreeterServerInterceptorFactoryProtocol {
 

--- a/Sources/Examples/RouteGuide/Client/main.swift
+++ b/Sources/Examples/RouteGuide/Client/main.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6)
 import ArgumentParser
 import Foundation
 import GRPC
@@ -274,4 +274,4 @@ if #available(macOS 12, *) {
 }
 #else
 fatalError("The RouteGuide example requires Swift concurrency features.")
-#endif // compiler(>=5.5.2) && canImport(_Concurrency)
+#endif // compiler(>=5.6)

--- a/Sources/Examples/RouteGuide/Model/route_guide.grpc.swift
+++ b/Sources/Examples/RouteGuide/Model/route_guide.grpc.swift
@@ -175,7 +175,7 @@ public final class Routeguide_RouteGuideClient: Routeguide_RouteGuideClientProto
   }
 }
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6)
 /// Interface exported by the server.
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public protocol Routeguide_RouteGuideAsyncClientProtocol: GRPCClient {
@@ -348,7 +348,7 @@ public struct Routeguide_RouteGuideAsyncClient: Routeguide_RouteGuideAsyncClient
   }
 }
 
-#endif // compiler(>=5.5.2) && canImport(_Concurrency)
+#endif // compiler(>=5.6)
 
 public protocol Routeguide_RouteGuideClientInterceptorFactoryProtocol {
 
@@ -492,7 +492,7 @@ extension Routeguide_RouteGuideProvider {
     }
   }
 }
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6)
 
 /// Interface exported by the server.
 ///
@@ -606,7 +606,7 @@ extension Routeguide_RouteGuideAsyncProvider {
   }
 }
 
-#endif // compiler(>=5.5.2) && canImport(_Concurrency)
+#endif // compiler(>=5.6)
 
 public protocol Routeguide_RouteGuideServerInterceptorFactoryProtocol {
 

--- a/Sources/Examples/RouteGuide/Server/RouteGuideProvider.swift
+++ b/Sources/Examples/RouteGuide/Server/RouteGuideProvider.swift
@@ -19,7 +19,7 @@ import NIOConcurrencyHelpers
 import NIOCore
 import RouteGuideModel
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6)
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 internal final class RouteGuideProvider: Routeguide_RouteGuideAsyncProvider {
@@ -130,7 +130,7 @@ internal final actor Notes {
   }
 }
 
-#endif // compiler(>=5.5.2) && canImport(_Concurrency)
+#endif // compiler(>=5.6)
 
 private func degreesToRadians(_ degrees: Double) -> Double {
   return degrees * .pi / 180.0

--- a/Sources/Examples/RouteGuide/Server/main.swift
+++ b/Sources/Examples/RouteGuide/Server/main.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6)
 import ArgumentParser
 import struct Foundation.Data
 import struct Foundation.URL
@@ -76,4 +76,4 @@ if #available(macOS 12, *) {
 }
 #else
 fatalError("The RouteGuide example requires Swift concurrency support.")
-#endif // compiler(>=5.5.2) && canImport(_Concurrency)
+#endif // compiler(>=5.6)

--- a/Sources/GRPC/AsyncAwaitSupport/AsyncWriter.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/AsyncWriter.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6)
 import NIOCore
 
 /// An asynchronous writer which forwards messages to a delegate.
@@ -334,4 +334,4 @@ internal protocol AsyncWriterDelegate: AnyObject {
   func writeEnd(_ end: End)
 }
 
-#endif // compiler(>=5.5.2) && canImport(_Concurrency)
+#endif // compiler(>=5.6)

--- a/Sources/GRPC/AsyncAwaitSupport/Call+AsyncRequestStreamWriter.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/Call+AsyncRequestStreamWriter.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6)
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Call {
@@ -30,4 +30,4 @@ extension Call {
   }
 }
 
-#endif // compiler(>=5.5.2) && canImport(_Concurrency)
+#endif // compiler(>=5.6)

--- a/Sources/GRPC/AsyncAwaitSupport/CancellationError+GRPCStatusTransformable.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/CancellationError+GRPCStatusTransformable.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6)
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension CancellationError: GRPCStatusTransformable {

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncBidirectionalStreamingCall.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncBidirectionalStreamingCall.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6)
 
 import NIOHPACK
 

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncClientStreamingCall.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncClientStreamingCall.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6)
 
 import NIOHPACK
 

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncRequestStream.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncRequestStream.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6)
 
 /// This is currently a wrapper around AsyncThrowingStream because we want to be
 /// able to swap out the implementation for something else in the future.

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncRequestStreamWriter.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncRequestStreamWriter.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6)
 
 /// An object allowing the holder -- a client -- to send requests on an RPC.
 ///
@@ -124,4 +124,4 @@ extension GRPCAsyncRequestStreamWriter {
   }
 }
 
-#endif // compiler(>=5.5.2) && canImport(_Concurrency)
+#endif // compiler(>=5.6)

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncResponseStream.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncResponseStream.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6)
 
 /// This is currently a wrapper around AsyncThrowingStream because we want to be
 /// able to swap out the implementation for something else in the future.

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncResponseStreamWriter.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncResponseStreamWriter.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6)
 
 /// Writer for server-streaming RPC handlers to provide responses.
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncServerCallContext.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncServerCallContext.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6)
 
 import Logging
 import NIOConcurrencyHelpers

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncServerHandler.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncServerHandler.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6)
 
 import NIOCore
 import NIOHPACK

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncServerStreamingCall.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncServerStreamingCall.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6)
 
 import NIOHPACK
 

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncUnaryCall.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncUnaryCall.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6)
 
 import NIOHPACK
 

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCChannel+AsyncAwaitSupport.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCChannel+AsyncAwaitSupport.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6)
 
 import SwiftProtobuf
 

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCClient+AsyncAwaitSupport.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCClient+AsyncAwaitSupport.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6)
 
 import SwiftProtobuf
 

--- a/Sources/GRPC/AsyncAwaitSupport/PassthroughMessageSequence.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/PassthroughMessageSequence.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6)
 
 /// An ``AsyncSequence`` adapter for a ``PassthroughMessageSource``.`
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
@@ -55,4 +55,4 @@ internal struct PassthroughMessageSequence<Element, Failure: Error>: AsyncSequen
   }
 }
 
-#endif // compiler(>=5.5.2) && canImport(_Concurrency)
+#endif // compiler(>=5.6)

--- a/Sources/GRPC/AsyncAwaitSupport/PassthroughMessageSource.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/PassthroughMessageSource.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6)
 import NIOConcurrencyHelpers
 import NIOCore
 
@@ -160,4 +160,4 @@ internal final class PassthroughMessageSource<Element, Failure: Error> {
   }
 }
 
-#endif // compiler(>=5.5.2) && canImport(_Concurrency)
+#endif // compiler(>=5.6)

--- a/Sources/GRPCInteroperabilityTestModels/Generated/test.grpc.swift
+++ b/Sources/GRPCInteroperabilityTestModels/Generated/test.grpc.swift
@@ -265,7 +265,7 @@ public final class Grpc_Testing_TestServiceClient: Grpc_Testing_TestServiceClien
   }
 }
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6)
 /// A simple service to test the various types of RPCs and experiment with
 /// performance with various types of payload.
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
@@ -564,7 +564,7 @@ public struct Grpc_Testing_TestServiceAsyncClient: Grpc_Testing_TestServiceAsync
   }
 }
 
-#endif // compiler(>=5.5.2) && canImport(_Concurrency)
+#endif // compiler(>=5.6)
 
 public protocol Grpc_Testing_TestServiceClientInterceptorFactoryProtocol {
 
@@ -720,7 +720,7 @@ public final class Grpc_Testing_UnimplementedServiceClient: Grpc_Testing_Unimple
   }
 }
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6)
 /// A simple service NOT implemented at servers so clients can test for
 /// that case.
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
@@ -789,7 +789,7 @@ public struct Grpc_Testing_UnimplementedServiceAsyncClient: Grpc_Testing_Unimple
   }
 }
 
-#endif // compiler(>=5.5.2) && canImport(_Concurrency)
+#endif // compiler(>=5.6)
 
 public protocol Grpc_Testing_UnimplementedServiceClientInterceptorFactoryProtocol {
 
@@ -897,7 +897,7 @@ public final class Grpc_Testing_ReconnectServiceClient: Grpc_Testing_ReconnectSe
   }
 }
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6)
 /// A service used to control reconnect server.
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public protocol Grpc_Testing_ReconnectServiceAsyncClientProtocol: GRPCClient {
@@ -994,7 +994,7 @@ public struct Grpc_Testing_ReconnectServiceAsyncClient: Grpc_Testing_ReconnectSe
   }
 }
 
-#endif // compiler(>=5.5.2) && canImport(_Concurrency)
+#endif // compiler(>=5.6)
 
 public protocol Grpc_Testing_ReconnectServiceClientInterceptorFactoryProtocol {
 
@@ -1148,7 +1148,7 @@ extension Grpc_Testing_TestServiceProvider {
     }
   }
 }
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6)
 
 /// A simple service to test the various types of RPCs and experiment with
 /// performance with various types of payload.
@@ -1302,7 +1302,7 @@ extension Grpc_Testing_TestServiceAsyncProvider {
   }
 }
 
-#endif // compiler(>=5.5.2) && canImport(_Concurrency)
+#endif // compiler(>=5.6)
 
 public protocol Grpc_Testing_TestServiceServerInterceptorFactoryProtocol {
 
@@ -1442,7 +1442,7 @@ extension Grpc_Testing_UnimplementedServiceProvider {
     }
   }
 }
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6)
 
 /// A simple service NOT implemented at servers so clients can test for
 /// that case.
@@ -1494,7 +1494,7 @@ extension Grpc_Testing_UnimplementedServiceAsyncProvider {
   }
 }
 
-#endif // compiler(>=5.5.2) && canImport(_Concurrency)
+#endif // compiler(>=5.6)
 
 public protocol Grpc_Testing_UnimplementedServiceServerInterceptorFactoryProtocol {
 
@@ -1566,7 +1566,7 @@ extension Grpc_Testing_ReconnectServiceProvider {
     }
   }
 }
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6)
 
 /// A service used to control reconnect server.
 ///
@@ -1630,7 +1630,7 @@ extension Grpc_Testing_ReconnectServiceAsyncProvider {
   }
 }
 
-#endif // compiler(>=5.5.2) && canImport(_Concurrency)
+#endif // compiler(>=5.6)
 
 public protocol Grpc_Testing_ReconnectServiceServerInterceptorFactoryProtocol {
 

--- a/Sources/GRPCInteroperabilityTestsImplementation/TestServiceAsyncProvider.swift
+++ b/Sources/GRPCInteroperabilityTestsImplementation/TestServiceAsyncProvider.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5)
+#if compiler(>=5.6)
 import Foundation
 import GRPC
 import GRPCInteroperabilityTestModels
@@ -217,4 +217,4 @@ public class TestServiceAsyncProvider: Grpc_Testing_TestServiceAsyncProvider {
     )
   }
 }
-#endif // compiler(>=5.5)
+#endif // compiler(>=5.6)

--- a/Sources/protoc-gen-grpc-swift/Generator.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator.swift
@@ -170,10 +170,10 @@ class Generator {
   }
 
   func printIfCompilerGuardForAsyncAwait() {
-    self.println("#if compiler(>=5.5.2) && canImport(_Concurrency)")
+    self.println("#if compiler(>=5.6)")
   }
 
   func printEndCompilerGuardForAsyncAwait() {
-    self.println("#endif // compiler(>=5.5.2) && canImport(_Concurrency)")
+    self.println("#endif // compiler(>=5.6)")
   }
 }

--- a/Tests/GRPCTests/AsyncAwaitSupport/AsyncIntegrationTests.swift
+++ b/Tests/GRPCTests/AsyncAwaitSupport/AsyncIntegrationTests.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5)
+#if compiler(>=5.6)
 import EchoImplementation
 import EchoModel
 import GRPC
@@ -196,4 +196,4 @@ extension HPACKHeaders {
   }
 }
 
-#endif // compiler(>=5.5)
+#endif // compiler(>=5.6)

--- a/Tests/GRPCTests/AsyncAwaitSupport/AsyncSequence+Helpers.swift
+++ b/Tests/GRPCTests/AsyncAwaitSupport/AsyncSequence+Helpers.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5)
+#if compiler(>=5.6)
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension AsyncSequence {
@@ -28,4 +28,4 @@ extension AsyncSequence {
   }
 }
 
-#endif // compiler(>=5.5)
+#endif // compiler(>=5.6)

--- a/Tests/GRPCTests/AsyncAwaitSupport/AsyncWriterTests.swift
+++ b/Tests/GRPCTests/AsyncAwaitSupport/AsyncWriterTests.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5)
+#if compiler(>=5.6)
 @testable import GRPC
 import NIOConcurrencyHelpers
 import XCTest
@@ -271,4 +271,4 @@ fileprivate final class CollectingDelegate<Element, End>: AsyncWriterDelegate {
   }
 }
 
-#endif // compiler(>=5.5)
+#endif // compiler(>=5.6)

--- a/Tests/GRPCTests/AsyncAwaitSupport/InterceptorsAsyncTests.swift
+++ b/Tests/GRPCTests/AsyncAwaitSupport/InterceptorsAsyncTests.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5)
+#if compiler(>=5.6)
 import EchoImplementation
 import EchoModel
 import GRPC

--- a/Tests/GRPCTests/AsyncAwaitSupport/PassthroughMessageSourceTests.swift
+++ b/Tests/GRPCTests/AsyncAwaitSupport/PassthroughMessageSourceTests.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5)
+#if compiler(>=5.6)
 @testable import GRPC
 import XCTest
 
@@ -130,4 +130,4 @@ class PassthroughMessageSourceTests: GRPCTestCase {
 
 fileprivate struct TestError: Error {}
 
-#endif // compiler(>=5.5)
+#endif // compiler(>=5.6)

--- a/Tests/GRPCTests/AsyncAwaitSupport/XCTest+AsyncAwait.swift
+++ b/Tests/GRPCTests/AsyncAwaitSupport/XCTest+AsyncAwait.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5)
+#if compiler(>=5.6)
 import XCTest
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
@@ -31,4 +31,4 @@ internal func XCTAssertThrowsError<T>(
   }
 }
 
-#endif // compiler(>=5.5)
+#endif // compiler(>=5.6)

--- a/Tests/GRPCTests/EchoMetadataTests.swift
+++ b/Tests/GRPCTests/EchoMetadataTests.swift
@@ -81,7 +81,7 @@ internal final class EchoMetadataTests: GRPCTestCase {
     self.testServiceDescriptor(Echo_EchoClientMetadata.serviceDescriptor)
     self.testServiceDescriptor(Echo_EchoServerMetadata.serviceDescriptor)
 
-    #if swift(>=5.5)
+    #if swift(>=5.6)
     if #available(macOS 12, *) {
       self.testServiceDescriptor(Echo_EchoAsyncClient.serviceDescriptor)
     }

--- a/Tests/GRPCTests/GRPCAsyncClientCallTests.swift
+++ b/Tests/GRPCTests/GRPCAsyncClientCallTests.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5)
+#if compiler(>=5.6)
 
 import EchoImplementation
 import EchoModel

--- a/Tests/GRPCTests/GRPCAsyncServerHandlerTests.swift
+++ b/Tests/GRPCTests/GRPCAsyncServerHandlerTests.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5)
+#if compiler(>=5.6)
 
 @testable import GRPC
 import NIOCore

--- a/Tests/GRPCTests/GRPCInteroperabilityTests.swift
+++ b/Tests/GRPCTests/GRPCInteroperabilityTests.swift
@@ -176,7 +176,7 @@ class GRPCSecureInteroperabilityTests: GRPCInsecureInteroperabilityTests {
 }
 #endif // canImport(NIOSSL)
 
-#if compiler(>=5.5)
+#if compiler(>=5.6)
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 class GRPCInsecureInteroperabilityAsyncTests: GRPCInsecureInteroperabilityTests {
   override func makeProvider() -> CallHandlerProvider {
@@ -190,4 +190,4 @@ class GRPCSecureInteroperabilityAsyncTests: GRPCInsecureInteroperabilityAsyncTes
   override var useTLS: Bool { return true }
 }
 #endif // canImport(NIOSSL)
-#endif // compiler(>=5.5)
+#endif // compiler(>=5.6)

--- a/Tests/GRPCTests/XCTestHelpers.swift
+++ b/Tests/GRPCTests/XCTestHelpers.swift
@@ -660,7 +660,7 @@ struct ExpressionMatcher<Value> {
   }
 }
 
-#if compiler(>=5.5)
+#if compiler(>=5.6)
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 func assertThat<Value>(


### PR DESCRIPTION
Motivation:

The latest 5.5 Swift compiler is not too pleased with some of the
`Sendable` annotations which causes the compiler to crash. This is fixed
in 5.6. Given we haven't released this to 'main' yet and Swift 5.6 has
been around for a little while we should just raise the minimum Swift
version which supports async/await.

Modifications:

- Raise the minimum Swift version for async/await to 5.6.

Result:

Compiler is happier.