### PR TITLE
ConnectionPool Waiter should store its timeout task

### DIFF
--- a/Sources/GRPC/ConnectionPool/ConnectionPool+Waiter.swift
+++ b/Sources/GRPC/ConnectionPool/ConnectionPool+Waiter.swift
@@ -71,7 +71,7 @@ extension ConnectionPool {
       execute body: @escaping () -> Void
     ) {
       assert(self._scheduledTimeout == nil)
-      eventLoop.scheduleTask(deadline: self._deadline, body)
+      self._scheduledTimeout = eventLoop.scheduleTask(deadline: self._deadline, body)
     }
 
     /// Returns a boolean value indicating whether the deadline for this waiter occurs after the


### PR DESCRIPTION
Motivation:

Connection pool waiters have a scheduled tasks for to timeout waiting.
This is cancelled and set to `nil` when the waiter is succeeded or
failed. Hoever, when scheduling a task the task was never stored! This
would lead to the potentially firing when the deadline expired although
the effect of this would be a no-op.

Modifications:

- Capture the waiters scheduled task
- Add a test

Result:

Cancelled tasks are actually cancelled.