### PR TITLE
Update formatter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: "Formatting and License Headers check"
       run: |
-        SWIFTFORMAT_VERSION=0.46.3
+        SWIFTFORMAT_VERSION=0.49.4
         git clone --depth 1 --branch "$SWIFTFORMAT_VERSION" "https://github.com/nicklockwood/SwiftFormat" "$HOME/SwiftFormat"
         swift build --package-path "$HOME/SwiftFormat" --product swiftformat
         export PATH=$PATH:"$(swift build --package-path "$HOME/SwiftFormat" --show-bin-path)"

--- a/.swiftformat
+++ b/.swiftformat
@@ -37,3 +37,6 @@
 
 # Don't prefer using key paths for trivial closures.
 --disable preferKeyPath
+
+# Put ACLs on declarations within an extension rather than the extension itself.
+--extensionacl on-declarations

--- a/Examples/Google/NaturalLanguage/Sources/main.swift
+++ b/Examples/Google/NaturalLanguage/Sources/main.swift
@@ -56,7 +56,7 @@ func getAuthToken(
   do {
     try provider.withToken { token, error in
       if let token = token,
-        let accessToken = token.AccessToken {
+         let accessToken = token.AccessToken {
         promise.succeed(accessToken)
       } else if let error = error {
         promise.fail(error)

--- a/Examples/Google/SpeechToText/Sources/Launch/SceneDelegate.swift
+++ b/Examples/Google/SpeechToText/Sources/Launch/SceneDelegate.swift
@@ -35,7 +35,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     self.navController?.navigationBar.prefersLargeTitles = false
 
     let viewController: UIViewController = ViewController()
-    navController?.pushViewController(viewController, animated: false)
+    self.navController?.pushViewController(viewController, animated: false)
 
     self.window = UIWindow(windowScene: windowScene)
     self.window!.rootViewController = self.navController

--- a/Examples/Google/SpeechToText/Sources/SpeechService.swift
+++ b/Examples/Google/SpeechToText/Sources/SpeechService.swift
@@ -66,8 +66,10 @@ final class SpeechService {
     )
   }
 
-  func stream(_ data: Data,
-              completion: ((Google_Cloud_Speech_V1_StreamingRecognizeResponse) -> Void)? = nil) {
+  func stream(
+    _ data: Data,
+    completion: ((Google_Cloud_Speech_V1_StreamingRecognizeResponse) -> Void)? = nil
+  ) {
     switch self.state {
     case .idle:
       // Initialize the bidirectional stream

--- a/Examples/Google/SpeechToText/Sources/ViewController.swift
+++ b/Examples/Google/SpeechToText/Sources/ViewController.swift
@@ -56,8 +56,10 @@ final class ViewController: UIViewController {
   private let speechService: SpeechService
   private let audioStreamManager: AudioStreamManager
 
-  init(speechService: SpeechService,
-       audioStreamManager: AudioStreamManager) {
+  init(
+    speechService: SpeechService,
+    audioStreamManager: AudioStreamManager
+  ) {
     self.speechService = speechService
     self.audioStreamManager = audioStreamManager
 

--- a/Performance/QPSBenchmark/Sources/QPSBenchmark/Runtime/AsyncPingPongRequestMaker.swift
+++ b/Performance/QPSBenchmark/Sources/QPSBenchmark/Runtime/AsyncPingPongRequestMaker.swift
@@ -39,11 +39,13 @@ final class AsyncPingPongRequestMaker: RequestMaker {
   ///    - requestMessage: Pre-made request message to use possibly repeatedly.
   ///    - logger: Where to log useful diagnostics.
   ///    - stats: Where to record statistics on latency.
-  init(config: Grpc_Testing_ClientConfig,
-       client: Grpc_Testing_BenchmarkServiceClient,
-       requestMessage: Grpc_Testing_SimpleRequest,
-       logger: Logger,
-       stats: StatsWithLock) {
+  init(
+    config: Grpc_Testing_ClientConfig,
+    client: Grpc_Testing_BenchmarkServiceClient,
+    requestMessage: Grpc_Testing_SimpleRequest,
+    logger: Logger,
+    stats: StatsWithLock
+  ) {
     self.client = client
     self.requestMessage = requestMessage
     self.logger = logger
@@ -70,7 +72,7 @@ final class AsyncPingPongRequestMaker: RequestMaker {
       let endTime = grpcTimeNow()
       self.stats.add(latency: endTime - startTime)
       if !self.stopRequested,
-        self.messagesPerStream == 0 || messagesSent < self.messagesPerStream {
+         self.messagesPerStream == 0 || messagesSent < self.messagesPerStream {
         messagesSent += 1
         startTime = endTime // Use end of previous request as the start of the next.
         streamingCall!.sendMessage(self.requestMessage, promise: nil)

--- a/Performance/QPSBenchmark/Sources/QPSBenchmark/Runtime/AsyncUnaryRequestMaker.swift
+++ b/Performance/QPSBenchmark/Sources/QPSBenchmark/Runtime/AsyncUnaryRequestMaker.swift
@@ -32,11 +32,13 @@ final class AsyncUnaryRequestMaker: RequestMaker {
   ///    - requestMessage: Pre-made request message to use possibly repeatedly.
   ///    - logger: Where to log useful diagnostics.
   ///    - stats: Where to record statistics on latency.
-  init(config: Grpc_Testing_ClientConfig,
-       client: Grpc_Testing_BenchmarkServiceClient,
-       requestMessage: Grpc_Testing_SimpleRequest,
-       logger: Logger,
-       stats: StatsWithLock) {
+  init(
+    config: Grpc_Testing_ClientConfig,
+    client: Grpc_Testing_BenchmarkServiceClient,
+    requestMessage: Grpc_Testing_SimpleRequest,
+    logger: Logger,
+    stats: StatsWithLock
+  ) {
     self.client = client
     self.requestMessage = requestMessage
     self.logger = logger

--- a/Performance/QPSBenchmark/Sources/QPSBenchmark/Runtime/BenchmarkServiceImpl.swift
+++ b/Performance/QPSBenchmark/Sources/QPSBenchmark/Runtime/BenchmarkServiceImpl.swift
@@ -24,8 +24,10 @@ final class AsyncQPSServerImpl: Grpc_Testing_BenchmarkServiceProvider {
 
   /// One request followed by one response.
   /// The server returns the client payload as-is.
-  func unaryCall(request: Grpc_Testing_SimpleRequest,
-                 context: StatusOnlyCallContext) -> EventLoopFuture<Grpc_Testing_SimpleResponse> {
+  func unaryCall(
+    request: Grpc_Testing_SimpleRequest,
+    context: StatusOnlyCallContext
+  ) -> EventLoopFuture<Grpc_Testing_SimpleResponse> {
     do {
       return context.eventLoop
         .makeSucceededFuture(try AsyncQPSServerImpl.processSimpleRPC(request: request))
@@ -93,8 +95,10 @@ final class AsyncQPSServerImpl: Grpc_Testing_BenchmarkServiceProvider {
   }
 
   /// Make a payload for sending back to the client.
-  private static func makePayload(type: Grpc_Testing_PayloadType,
-                                  size: Int) throws -> Grpc_Testing_Payload {
+  private static func makePayload(
+    type: Grpc_Testing_PayloadType,
+    size: Int
+  ) throws -> Grpc_Testing_Payload {
     if type != .compressable {
       // Making a payload which is not compressable is hard - and not implemented in
       // other implementations too.

--- a/Performance/QPSBenchmark/Sources/QPSBenchmark/Runtime/RequestMaker.swift
+++ b/Performance/QPSBenchmark/Sources/QPSBenchmark/Runtime/RequestMaker.swift
@@ -27,11 +27,13 @@ protocol RequestMaker {
   ///    - requestMessage: Pre-made request message to use possibly repeatedly.
   ///    - logger: Where to log useful diagnostics.
   ///    - stats: Where to record statistics on latency.
-  init(config: Grpc_Testing_ClientConfig,
-       client: Grpc_Testing_BenchmarkServiceClient,
-       requestMessage: Grpc_Testing_SimpleRequest,
-       logger: Logger,
-       stats: StatsWithLock)
+  init(
+    config: Grpc_Testing_ClientConfig,
+    client: Grpc_Testing_BenchmarkServiceClient,
+    requestMessage: Grpc_Testing_SimpleRequest,
+    logger: Logger,
+    stats: StatsWithLock
+  )
 
   /// Initiate a request sequence to the server.
   /// - returns: A future which completes when the request-response sequence is complete.

--- a/Performance/QPSBenchmark/Sources/QPSBenchmark/Runtime/StatusCountsSerialisation.swift
+++ b/Performance/QPSBenchmark/Sources/QPSBenchmark/Runtime/StatusCountsSerialisation.swift
@@ -20,7 +20,7 @@ extension StatusCounts {
   /// Convert status count to a protobuf for sending to the driver process.
   /// - returns: The protobuf message for sending.
   public func toRequestResultCounts() -> [Grpc_Testing_RequestResultCount] {
-    return counts.map { (key, value) -> Grpc_Testing_RequestResultCount in
+    return counts.map { key, value -> Grpc_Testing_RequestResultCount in
       var grpc = Grpc_Testing_RequestResultCount()
       grpc.count = value
       grpc.statusCode = Int32(key)

--- a/Performance/QPSBenchmark/Sources/QPSBenchmark/Runtime/WorkerServiceImpl.swift
+++ b/Performance/QPSBenchmark/Sources/QPSBenchmark/Runtime/WorkerServiceImpl.swift
@@ -75,16 +75,20 @@ class WorkerServiceImpl: Grpc_Testing_WorkerServiceProvider {
   }
 
   /// Just return the core count - unary call
-  func coreCount(request: Grpc_Testing_CoreRequest,
-                 context: StatusOnlyCallContext) -> EventLoopFuture<Grpc_Testing_CoreResponse> {
+  func coreCount(
+    request: Grpc_Testing_CoreRequest,
+    context: StatusOnlyCallContext
+  ) -> EventLoopFuture<Grpc_Testing_CoreResponse> {
     context.logger.notice("coreCount queried")
     let cores = Grpc_Testing_CoreResponse.with { $0.cores = Int32(System.coreCount) }
     return context.eventLoop.makeSucceededFuture(cores)
   }
 
   /// Quit this worker
-  func quitWorker(request: Grpc_Testing_Void,
-                  context: StatusOnlyCallContext) -> EventLoopFuture<Grpc_Testing_Void> {
+  func quitWorker(
+    request: Grpc_Testing_Void,
+    context: StatusOnlyCallContext
+  ) -> EventLoopFuture<Grpc_Testing_Void> {
     context.logger.warning("quitWorker called")
     self.finishedPromise.succeed(())
     return context.eventLoop.makeSucceededFuture(Grpc_Testing_Void())
@@ -109,8 +113,10 @@ class WorkerServiceImpl: Grpc_Testing_WorkerServiceProvider {
 
   /// Handle a request to setup a server.
   /// Makes a new server and sets it running.
-  private func handleServerSetup(context: StreamingResponseCallContext<Grpc_Testing_ServerStatus>,
-                                 config: Grpc_Testing_ServerConfig) {
+  private func handleServerSetup(
+    context: StreamingResponseCallContext<Grpc_Testing_ServerStatus>,
+    config: Grpc_Testing_ServerConfig
+  ) {
     context.logger.info("server setup requested")
     guard self.runningServer == nil else {
       context.logger.error("server already running")
@@ -159,8 +165,10 @@ class WorkerServiceImpl: Grpc_Testing_WorkerServiceProvider {
   // MARK: Create Server
 
   /// Start a server running of the requested type.
-  private func runServerBody(context: StreamingResponseCallContext<Grpc_Testing_ServerStatus>,
-                             serverConfig: Grpc_Testing_ServerConfig) {
+  private func runServerBody(
+    context: StreamingResponseCallContext<Grpc_Testing_ServerStatus>,
+    serverConfig: Grpc_Testing_ServerConfig
+  ) {
     var serverConfig = serverConfig
     self.serverPortOverride.map { serverConfig.port = Int32($0) }
 
@@ -228,8 +236,10 @@ class WorkerServiceImpl: Grpc_Testing_WorkerServiceProvider {
   }
 
   /// Setup a client as described by the message from the driver.
-  private func handleClientSetup(context: StreamingResponseCallContext<Grpc_Testing_ClientStatus>,
-                                 config: Grpc_Testing_ClientConfig) {
+  private func handleClientSetup(
+    context: StreamingResponseCallContext<Grpc_Testing_ClientStatus>,
+    config: Grpc_Testing_ClientConfig
+  ) {
     context.logger.info("client setup requested")
     guard self.runningClient == nil else {
       context.logger.error("client already running")
@@ -282,8 +292,10 @@ class WorkerServiceImpl: Grpc_Testing_WorkerServiceProvider {
   // MARK: Create Client
 
   /// Setup and run a client of the requested type.
-  private func runClientBody(context: StreamingResponseCallContext<Grpc_Testing_ClientStatus>,
-                             clientConfig: Grpc_Testing_ClientConfig) {
+  private func runClientBody(
+    context: StreamingResponseCallContext<Grpc_Testing_ClientStatus>,
+    clientConfig: Grpc_Testing_ClientConfig
+  ) {
     do {
       self.runningClient = try WorkerServiceImpl.makeClient(
         context: context,

--- a/Sources/Examples/RouteGuide/Server/RouteGuideProvider.swift
+++ b/Sources/Examples/RouteGuide/Server/RouteGuideProvider.swift
@@ -165,8 +165,8 @@ private func degreesToRadians(_ degrees: Double) -> Double {
   return degrees * .pi / 180.0
 }
 
-private extension Routeguide_Point {
-  func distance(to other: Routeguide_Point) -> Double {
+extension Routeguide_Point {
+  fileprivate func distance(to other: Routeguide_Point) -> Double {
     // Radius of Earth in meters
     let radius = 6_371_000.0
     // Points are in the E7 representation (degrees multiplied by 10**7 and rounded to the nearest

--- a/Sources/GRPC/ClientCalls/ClientCall.swift
+++ b/Sources/GRPC/ClientCalls/ClientCall.swift
@@ -115,8 +115,11 @@ public protocol StreamingRequestClientCall: ClientCall {
   ///   - compression: Whether compression should be used for this message. Ignored if compression
   ///     was not enabled for the RPC.
   ///   - promise: A promise to be fulfilled when all messages have been sent successfully.
-  func sendMessages<S: Sequence>(_ messages: S, compression: Compression,
-                                 promise: EventLoopPromise<Void>?) where S.Element == RequestPayload
+  func sendMessages<S: Sequence>(
+    _ messages: S,
+    compression: Compression,
+    promise: EventLoopPromise<Void>?
+  ) where S.Element == RequestPayload
 
   /// Terminates a stream of messages sent to the service.
   ///
@@ -132,8 +135,10 @@ public protocol StreamingRequestClientCall: ClientCall {
 }
 
 extension StreamingRequestClientCall {
-  public func sendMessage(_ message: RequestPayload,
-                          compression: Compression = .deferToCallDefault) -> EventLoopFuture<Void> {
+  public func sendMessage(
+    _ message: RequestPayload,
+    compression: Compression = .deferToCallDefault
+  ) -> EventLoopFuture<Void> {
     let promise = self.eventLoop.makePromise(of: Void.self)
     self.sendMessage(message, compression: compression, promise: promise)
     return promise.futureResult

--- a/Sources/GRPC/GRPCChannel/GRPCChannelBuilder.swift
+++ b/Sources/GRPC/GRPCChannel/GRPCChannelBuilder.swift
@@ -312,8 +312,8 @@ extension ClientConnection.Builder {
   }
 }
 
-private extension Double {
-  static func seconds(from amount: TimeAmount) -> Double {
+extension Double {
+  fileprivate static func seconds(from amount: TimeAmount) -> Double {
     return Double(amount.nanoseconds) / 1_000_000_000
   }
 }

--- a/Sources/GRPC/GRPCClientStateMachine.swift
+++ b/Sources/GRPC/GRPCClientStateMachine.swift
@@ -747,7 +747,7 @@ extension GRPCClientStateMachine.State {
     // missing then we should avoid the error and propagate the status code and message sent by
     // the server instead.
     if let contentTypeHeader = trailers.first(name: "content-type"),
-      ContentType(value: contentTypeHeader) == nil {
+       ContentType(value: contentTypeHeader) == nil {
       return .failure(.invalidContentType(contentTypeHeader))
     }
 

--- a/Sources/GRPC/GRPCIdleHandler.swift
+++ b/Sources/GRPC/GRPCIdleHandler.swift
@@ -127,7 +127,7 @@ internal final class GRPCIdleHandler: ChannelInboundHandler {
 
     // Max concurrent streams changed.
     if let manager = self.mode.connectionManager,
-      let maxConcurrentStreams = operations.maxConcurrentStreamsChange {
+       let maxConcurrentStreams = operations.maxConcurrentStreamsChange {
       manager.maxConcurrentStreamsChanged(maxConcurrentStreams)
     }
 

--- a/Sources/GRPC/GRPCKeepaliveHandlers.swift
+++ b/Sources/GRPC/GRPCKeepaliveHandlers.swift
@@ -215,8 +215,8 @@ struct PingHandler {
       "Ping strikes are not supported but we're checking for one"
     )
     guard self.activeStreams == 0, self.permitWithoutCalls,
-      let lastReceivedPingDate = self.lastReceivedPingDate,
-      let minimumReceivedPingIntervalWithoutData = self.minimumReceivedPingIntervalWithoutData
+          let lastReceivedPingDate = self.lastReceivedPingDate,
+          let minimumReceivedPingIntervalWithoutData = self.minimumReceivedPingIntervalWithoutData
     else {
       return false
     }
@@ -239,7 +239,7 @@ struct PingHandler {
 
       // The time elapsed since the previous ping is less than the minimum required
       if let lastSentPingDate = self.lastSentPingDate,
-        self.now() - lastSentPingDate < self.minimumSentPingIntervalWithoutData {
+         self.now() - lastSentPingDate < self.minimumSentPingIntervalWithoutData {
         return true
       }
 

--- a/Sources/GRPC/GRPCServerPipelineConfigurator.swift
+++ b/Sources/GRPC/GRPCServerPipelineConfigurator.swift
@@ -405,7 +405,7 @@ struct HTTPVersionParser {
 
     // Read off the Method and Request-URI (and spaces).
     guard readableBytesView.trimPrefix(to: UInt8(ascii: " ")) != nil,
-      readableBytesView.trimPrefix(to: UInt8(ascii: " ")) != nil else {
+          readableBytesView.trimPrefix(to: UInt8(ascii: " ")) != nil else {
       return false
     }
 

--- a/Sources/GRPC/GRPCStatusMessageMarshaller.swift
+++ b/Sources/GRPC/GRPCStatusMessageMarshaller.swift
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+// swiftformat:disable:next enumNamespaces
 public struct GRPCStatusMessageMarshaller {
   /// Adds percent encoding to the given message.
   ///
@@ -130,8 +131,8 @@ extension GRPCStatusMessageMarshaller {
       switch byte {
       case UInt8(ascii: "%"):
         guard let (nextIndex, nextNextIndex) = utf8.nextTwoIndices(after: currentIndex),
-          let nextHex = fromHex(utf8[nextIndex]),
-          let nextNextHex = fromHex(utf8[nextNextIndex])
+              let nextHex = fromHex(utf8[nextIndex]),
+              let nextNextHex = fromHex(utf8[nextNextIndex])
         else {
           // If we can't decode the message, aborting and returning the encoded message is fine
           // according to the spec.

--- a/Sources/GRPC/GRPCTimeout.swift
+++ b/Sources/GRPC/GRPCTimeout.swift
@@ -112,12 +112,12 @@ public struct GRPCTimeout: CustomStringConvertible, Equatable {
   }
 }
 
-private extension Int64 {
+extension Int64 {
   /// Returns the quotient of this value when divided by `divisor` rounded up to the nearest
   /// multiple of `divisor` if the remainder is non-zero.
   ///
   /// - Parameter divisor: The value to divide this value by.
-  func quotientRoundedUp(dividingBy divisor: Int64) -> Int64 {
+  fileprivate func quotientRoundedUp(dividingBy divisor: Int64) -> Int64 {
     let (quotient, remainder) = self.quotientAndRemainder(dividingBy: divisor)
     return quotient + (remainder != 0 ? 1 : 0)
   }

--- a/Sources/GRPC/GRPCWebToHTTP2ServerCodec.swift
+++ b/Sources/GRPC/GRPCWebToHTTP2ServerCodec.swift
@@ -737,8 +737,8 @@ extension GRPCWebToHTTP2ServerCodec.StateMachine.InboundState {
     let action: GRPCWebToHTTP2ServerCodec.StateMachine.Action
 
     if bytesToRead > 0,
-      let base64Encoded = self.requestBuffer!.readString(length: bytesToRead),
-      let base64Decoded = Data(base64Encoded: base64Encoded) {
+       let base64Encoded = self.requestBuffer!.readString(length: bytesToRead),
+       let base64Decoded = Data(base64Encoded: base64Encoded) {
       // Recycle the input buffer and restore the request buffer.
       buffer.clear()
       buffer.writeContiguousBytes(base64Decoded)

--- a/Sources/GRPC/HTTP2ToRawGRPCStateMachine.swift
+++ b/Sources/GRPC/HTTP2ToRawGRPCStateMachine.swift
@@ -311,7 +311,7 @@ extension HTTP2ToRawGRPCStateMachine.State {
     }
 
     guard let callPath = CallPath(requestURI: path),
-      let service = services[Substring(callPath.service)] else {
+          let service = services[Substring(callPath.service)] else {
       return self.methodNotImplemented(path, contentType: contentType)
     }
 
@@ -1292,8 +1292,8 @@ extension HTTP2ToRawGRPCStateMachine {
   ]
 }
 
-private extension HPACKHeaders {
-  mutating func add(contentsOf other: HPACKHeaders, normalize: Bool) {
+extension HPACKHeaders {
+  fileprivate mutating func add(contentsOf other: HPACKHeaders, normalize: Bool) {
     if normalize {
       self.add(contentsOf: other.lazy.map { name, value, indexable in
         (name: name.lowercased(), value: value, indexable: indexable)

--- a/Sources/GRPC/LengthPrefixedMessageWriter.swift
+++ b/Sources/GRPC/LengthPrefixedMessageWriter.swift
@@ -82,8 +82,11 @@ internal struct LengthPrefixedMessageWriter {
   ///   - compressed: Whether the bytes should be compressed. This is ignored if not compression
   ///     mechanism was configured on this writer.
   /// - Returns: A buffer containing the length prefixed bytes.
-  func write(buffer: ByteBuffer, allocator: ByteBufferAllocator,
-             compressed: Bool = true) throws -> ByteBuffer {
+  func write(
+    buffer: ByteBuffer,
+    allocator: ByteBufferAllocator,
+    compressed: Bool = true
+  ) throws -> ByteBuffer {
     if compressed, let compressor = self.compressor {
       return try self.compress(buffer: buffer, using: compressor, allocator: allocator)
     } else if buffer.readerIndex >= 5 {
@@ -130,8 +133,11 @@ internal struct LengthPrefixedMessageWriter {
   /// - Returns: A `ByteBuffer` containing a gRPC length-prefixed message.
   /// - Precondition: `compression.supported` is `true`.
   /// - Note: See `LengthPrefixedMessageReader` for more details on the format.
-  func write(_ payload: GRPCPayload, into buffer: inout ByteBuffer,
-             compressed: Bool = true) throws {
+  func write(
+    _ payload: GRPCPayload,
+    into buffer: inout ByteBuffer,
+    compressed: Bool = true
+  ) throws {
     buffer.reserveCapacity(buffer.writerIndex + LengthPrefixedMessageWriter.metadataLength)
 
     if compressed, let compressor = self.compressor {

--- a/Sources/GRPC/PlatformSupport.swift
+++ b/Sources/GRPC/PlatformSupport.swift
@@ -237,7 +237,7 @@ public enum PlatformSupport {
 
     #if canImport(Network)
     if #available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *),
-      let transportServicesBootstrap = bootstrap as? NIOTSConnectionBootstrap {
+       let transportServicesBootstrap = bootstrap as? NIOTSConnectionBootstrap {
       return transportServicesBootstrap.tlsOptions(from: tlsConfigruation)
     }
     #endif

--- a/Sources/GRPC/Server.swift
+++ b/Sources/GRPC/Server.swift
@@ -119,7 +119,7 @@ public final class Server {
     #if canImport(Network)
     if let tlsConfiguration = configuration.tlsConfiguration {
       if #available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *),
-        let transportServicesBootstrap = bootstrap as? NIOTSListenerBootstrap {
+         let transportServicesBootstrap = bootstrap as? NIOTSListenerBootstrap {
         _ = transportServicesBootstrap.tlsOptions(from: tlsConfiguration)
       }
     }
@@ -157,7 +157,7 @@ public final class Server {
             hasTLS: configuration.tlsConfiguration != nil
           )
           if requiresZeroLengthWorkaround,
-            #available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *) {
+             #available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *) {
             try sync.addHandler(NIOFilterEmptyWritesHandler())
           }
         } catch {
@@ -451,8 +451,8 @@ extension Server {
   }
 }
 
-private extension ServerBootstrapProtocol {
-  func bind(to target: BindTarget) -> EventLoopFuture<Channel> {
+extension ServerBootstrapProtocol {
+  fileprivate func bind(to target: BindTarget) -> EventLoopFuture<Channel> {
     switch target.wrapped {
     case let .hostAndPort(host, port):
       return self.bind(host: host, port: port)

--- a/Sources/GRPC/ServerErrorDelegate.swift
+++ b/Sources/GRPC/ServerErrorDelegate.swift
@@ -65,16 +65,16 @@ public protocol ServerErrorDelegate: AnyObject {
   ) -> GRPCStatusAndTrailers?
 }
 
-public extension ServerErrorDelegate {
-  func observeLibraryError(_ error: Error) {}
+extension ServerErrorDelegate {
+  public func observeLibraryError(_ error: Error) {}
 
-  func transformLibraryError(_ error: Error) -> GRPCStatusAndTrailers? {
+  public func transformLibraryError(_ error: Error) -> GRPCStatusAndTrailers? {
     return nil
   }
 
-  func observeRequestHandlerError(_ error: Error, headers: HPACKHeaders) {}
+  public func observeRequestHandlerError(_ error: Error, headers: HPACKHeaders) {}
 
-  func transformRequestHandlerError(
+  public func transformRequestHandlerError(
     _ error: Error,
     headers: HPACKHeaders
   ) -> GRPCStatusAndTrailers? {

--- a/Sources/GRPCConnectionBackoffInteropTest/main.swift
+++ b/Sources/GRPCConnectionBackoffInteropTest/main.swift
@@ -30,8 +30,10 @@ import NIOPosix
 // Since this is a long running test, print connectivity state changes to stdout with timestamps.
 // We'll redirect logs to stderr so that stdout contains information only relevant to the test.
 class PrintingConnectivityStateDelegate: ConnectivityStateDelegate {
-  func connectivityStateDidChange(from oldState: ConnectivityState,
-                                  to newState: ConnectivityState) {
+  func connectivityStateDidChange(
+    from oldState: ConnectivityState,
+    to newState: ConnectivityState
+  ) {
     print("[\(Date())] connectivity state change: \(oldState) → \(newState)")
   }
 }

--- a/Sources/GRPCInteroperabilityTestsImplementation/TestServiceProvider.swift
+++ b/Sources/GRPCInteroperabilityTestsImplementation/TestServiceProvider.swift
@@ -168,7 +168,7 @@ public class TestServiceProvider: Grpc_Testing_TestServiceProvider {
       switch event {
       case let .message(request):
         if request.expectCompressed.value,
-          !context.headers.contains(name: "grpc-encoding") {
+           !context.headers.contains(name: "grpc-encoding") {
           context.responseStatus = GRPCStatus(
             code: .invalidArgument,
             message: "Expected compressed request, but 'grpc-encoding' was missing"

--- a/Sources/GRPCPerformanceTests/Benchmarks/EmbeddedClientThroughput.swift
+++ b/Sources/GRPCPerformanceTests/Benchmarks/EmbeddedClientThroughput.swift
@@ -70,7 +70,9 @@ class EmbeddedClientThroughput: Benchmark {
 
     self.responseDataChunks = []
     while buffer.readableBytes > 0,
-      let slice = buffer.readSlice(length: min(maximumResponseFrameSize, buffer.readableBytes)) {
+          let slice = buffer.readSlice(
+            length: min(maximumResponseFrameSize, buffer.readableBytes)
+          ) {
       self.responseDataChunks.append(slice)
     }
   }

--- a/Sources/GRPCPerformanceTests/Benchmarks/PercentEncoding.swift
+++ b/Sources/GRPCPerformanceTests/Benchmarks/PercentEncoding.swift
@@ -38,7 +38,7 @@ class PercentEncoding: Benchmark {
   func tearDown() throws {}
 
   func run() throws -> Int {
-    var totalLength: Int = 0
+    var totalLength = 0
 
     for _ in 0 ..< self.iterations {
       var buffer = self.allocator.buffer(capacity: 0)

--- a/Sources/protoc-gen-grpc-swift/Generator-Client.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator-Client.swift
@@ -341,7 +341,7 @@ extension Generator {
 }
 
 extension Generator {
-  fileprivate func printFakeResponseStreams() {
+  private func printFakeResponseStreams() {
     for method in self.service.methods {
       self.println()
 
@@ -356,7 +356,7 @@ extension Generator {
     }
   }
 
-  fileprivate func printUnaryResponse() {
+  private func printUnaryResponse() {
     self.printResponseStream(isUnary: true)
     self.println()
     self.printEnqueueUnaryResponse(isUnary: true)
@@ -364,7 +364,7 @@ extension Generator {
     self.printHasResponseStreamEnqueued()
   }
 
-  fileprivate func printStreamingResponse() {
+  private func printStreamingResponse() {
     self.printResponseStream(isUnary: false)
     self.println()
     self.printEnqueueUnaryResponse(isUnary: false)
@@ -443,7 +443,7 @@ extension Generator {
     self.println("}")
   }
 
-  fileprivate func printTestClient() {
+  private func printTestClient() {
     self
       .println(
         "\(self.access) final class \(self.testClientClassName): \(self.clientProtocolName) {"
@@ -482,14 +482,14 @@ extension Generator {
   }
 }
 
-private extension Generator {
-  var streamType: StreamingType {
+extension Generator {
+  private var streamType: StreamingType {
     return streamingType(self.method)
   }
 }
 
 extension Generator {
-  fileprivate var methodArguments: [String] {
+  private var methodArguments: [String] {
     switch self.streamType {
     case .unary:
       return [
@@ -514,7 +514,7 @@ extension Generator {
     }
   }
 
-  fileprivate var methodArgumentsWithoutDefaults: [String] {
+  private var methodArgumentsWithoutDefaults: [String] {
     return self.methodArguments.map { arg in
       // Remove default arg from call options.
       if arg == "callOptions: CallOptions? = nil" {
@@ -525,13 +525,13 @@ extension Generator {
     }
   }
 
-  fileprivate var methodArgumentsWithoutCallOptions: [String] {
+  private var methodArgumentsWithoutCallOptions: [String] {
     return self.methodArguments.filter {
       !$0.hasPrefix("callOptions: ")
     }
   }
 
-  fileprivate var methodReturnType: String {
+  private var methodReturnType: String {
     switch self.streamType {
     case .unary:
       return "UnaryCall<\(self.methodInputName), \(self.methodOutputName)>"
@@ -548,8 +548,8 @@ extension Generator {
   }
 }
 
-private extension StreamingType {
-  var name: String {
+extension StreamingType {
+  fileprivate var name: String {
     switch self {
     case .unary:
       return "Unary"

--- a/Sources/protoc-gen-grpc-swift/Generator-Names.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator-Names.swift
@@ -17,8 +17,10 @@ import Foundation
 import SwiftProtobuf
 import SwiftProtobufPluginLibrary
 
-internal func nameForPackageService(_ file: FileDescriptor,
-                                    _ service: ServiceDescriptor) -> String {
+internal func nameForPackageService(
+  _ file: FileDescriptor,
+  _ service: ServiceDescriptor
+) -> String {
   if !file.package.isEmpty {
     return SwiftProtobufNamer().typePrefix(forFile: file) + service.name
   } else {
@@ -26,9 +28,11 @@ internal func nameForPackageService(_ file: FileDescriptor,
   }
 }
 
-internal func nameForPackageServiceMethod(_ file: FileDescriptor,
-                                          _ service: ServiceDescriptor,
-                                          _ method: MethodDescriptor) -> String {
+internal func nameForPackageServiceMethod(
+  _ file: FileDescriptor,
+  _ service: ServiceDescriptor,
+  _ method: MethodDescriptor
+) -> String {
   return nameForPackageService(file, service) + method.name
 }
 

--- a/Sources/protoc-gen-grpc-swift/main.swift
+++ b/Sources/protoc-gen-grpc-swift/main.swift
@@ -61,8 +61,11 @@ enum FileNaming: String {
   case DropPath
 }
 
-func outputFileName(component: String, fileDescriptor: FileDescriptor,
-                    fileNamingOption: FileNaming) -> String {
+func outputFileName(
+  component: String,
+  fileDescriptor: FileDescriptor,
+  fileNamingOption: FileNaming
+) -> String {
   let ext = "." + component + ".swift"
   let pathParts = splitPath(pathname: fileDescriptor.name)
   switch fileNamingOption {

--- a/Tests/GRPCTests/ClientTLSFailureTests.swift
+++ b/Tests/GRPCTests/ClientTLSFailureTests.swift
@@ -127,7 +127,7 @@ class ClientTLSFailureTests: GRPCTestCase {
     stateChangeDelegate.waitForExpectedChanges(timeout: .seconds(5))
 
     if let nioSSLError = errorRecorder.errors.first as? NIOSSLError,
-      case .handshakeFailed(.sslError) = nioSSLError {
+       case .handshakeFailed(.sslError) = nioSSLError {
       // Expected case.
     } else {
       XCTFail("Expected NIOSSLError.handshakeFailed(BoringSSL.sslError)")
@@ -209,7 +209,7 @@ class ClientTLSFailureTests: GRPCTestCase {
     stateChangeDelegate.waitForExpectedChanges(timeout: .seconds(5))
 
     if let nioSSLError = errorRecorder.errors.first as? NIOSSLError,
-      case .handshakeFailed(.sslError) = nioSSLError {
+       case .handshakeFailed(.sslError) = nioSSLError {
       // Expected case.
     } else {
       XCTFail("Expected NIOSSLError.handshakeFailed(BoringSSL.sslError)")

--- a/Tests/GRPCTests/ConnectionManagerTests.swift
+++ b/Tests/GRPCTests/ConnectionManagerTests.swift
@@ -1182,8 +1182,10 @@ internal class RecordingConnectivityDelegate: ConnectivityStateDelegate {
     }
   }
 
-  func connectivityStateDidChange(from oldState: ConnectivityState,
-                                  to newState: ConnectivityState) {
+  func connectivityStateDidChange(
+    from oldState: ConnectivityState,
+    to newState: ConnectivityState
+  ) {
     self.serialQueue.async {
       switch self.expectation {
       case let .one(verify):
@@ -1261,8 +1263,8 @@ internal class RecordingConnectivityDelegate: ConnectivityStateDelegate {
   }
 }
 
-private extension ConnectionBackoff {
-  static let oneSecondFixed = ConnectionBackoff(
+extension ConnectionBackoff {
+  fileprivate static let oneSecondFixed = ConnectionBackoff(
     initialBackoff: 1.0,
     maximumBackoff: 1.0,
     multiplier: 1.0,

--- a/Tests/GRPCTests/FakeResponseStreamTests.swift
+++ b/Tests/GRPCTests/FakeResponseStreamTests.swift
@@ -200,9 +200,12 @@ class FakeResponseStreamTests: GRPCTestCase {
   }
 }
 
-private extension EmbeddedChannel {
-  func verifyInbound<Inbound>(as: Inbound.Type = Inbound.self, _ verify: (Inbound) -> Void = { _ in
-  }) {
+extension EmbeddedChannel {
+  fileprivate func verifyInbound<Inbound>(
+    as: Inbound.Type = Inbound.self,
+    _ verify: (Inbound) -> Void = { _ in
+    }
+  ) {
     do {
       if let inbound = try self.readInbound(as: Inbound.self) {
         verify(inbound)
@@ -215,8 +218,8 @@ private extension EmbeddedChannel {
   }
 }
 
-private extension _GRPCClientResponsePart {
-  func assertInitialMetadata(_ verify: (HPACKHeaders) -> Void = { _ in }) {
+extension _GRPCClientResponsePart {
+  fileprivate func assertInitialMetadata(_ verify: (HPACKHeaders) -> Void = { _ in }) {
     switch self {
     case let .initialMetadata(headers):
       verify(headers)
@@ -225,7 +228,7 @@ private extension _GRPCClientResponsePart {
     }
   }
 
-  func assertMessage(_ verify: (Response) -> Void = { _ in }) {
+  fileprivate func assertMessage(_ verify: (Response) -> Void = { _ in }) {
     switch self {
     case let .message(context):
       verify(context.message)
@@ -234,7 +237,7 @@ private extension _GRPCClientResponsePart {
     }
   }
 
-  func assertTrailingMetadata(_ verify: (HPACKHeaders) -> Void = { _ in }) {
+  fileprivate func assertTrailingMetadata(_ verify: (HPACKHeaders) -> Void = { _ in }) {
     switch self {
     case let .trailingMetadata(headers):
       verify(headers)
@@ -243,7 +246,7 @@ private extension _GRPCClientResponsePart {
     }
   }
 
-  func assertStatus(_ verify: (GRPCStatus) -> Void = { _ in }) {
+  fileprivate func assertStatus(_ verify: (GRPCStatus) -> Void = { _ in }) {
     switch self {
     case let .status(status):
       verify(status)

--- a/Tests/GRPCTests/GRPCCustomPayloadTests.swift
+++ b/Tests/GRPCTests/GRPCCustomPayloadTests.swift
@@ -297,8 +297,8 @@ private struct CustomPayload: GRPCPayload, Equatable {
 
   init(serializedByteBuffer: inout ByteBuffer) throws {
     guard let messageLength = serializedByteBuffer.readInteger(as: UInt32.self),
-      let message = serializedByteBuffer.readString(length: Int(messageLength)),
-      let number = serializedByteBuffer.readInteger(as: Int64.self) else {
+          let message = serializedByteBuffer.readString(length: Int(messageLength)),
+          let number = serializedByteBuffer.readInteger(as: Int64.self) else {
       throw GRPCError.DeserializationFailure()
     }
 

--- a/Tests/GRPCTests/GRPCStatusCodeTests.swift
+++ b/Tests/GRPCTests/GRPCStatusCodeTests.swift
@@ -65,7 +65,7 @@ class GRPCStatusCodeTests: GRPCTestCase {
         .writeInbound(self.headersFramePayload(status: status))
     ) { error in
       guard let withContext = error as? GRPCError.WithContext,
-        let invalidHTTPStatus = withContext.error as? GRPCError.InvalidHTTPStatus else {
+            let invalidHTTPStatus = withContext.error as? GRPCError.InvalidHTTPStatus else {
         XCTFail("Unexpected error: \(error)")
         return
       }
@@ -119,7 +119,7 @@ class GRPCStatusCodeTests: GRPCTestCase {
     let headerFramePayload = HTTP2Frame.FramePayload.headers(.init(headers: headers))
     XCTAssertThrowsError(try self.channel.writeInbound(headerFramePayload)) { error in
       guard let withContext = error as? GRPCError.WithContext,
-        let invalidHTTPStatus = withContext.error as? GRPCError.InvalidHTTPStatusWithGRPCStatus
+            let invalidHTTPStatus = withContext.error as? GRPCError.InvalidHTTPStatusWithGRPCStatus
       else {
         XCTFail("Unexpected error: \(error)")
         return

--- a/Tests/GRPCTests/HTTP2MaxConcurrentStreamsTests.swift
+++ b/Tests/GRPCTests/HTTP2MaxConcurrentStreamsTests.swift
@@ -22,7 +22,7 @@ import NIOPosix
 import XCTest
 
 class HTTP2MaxConcurrentStreamsTests: GRPCTestCase {
-  struct Constants {
+  enum Constants {
     static let testTimeout: TimeInterval = 10
 
     static let defaultMaxNumberOfConcurrentStreams =

--- a/Tests/GRPCTests/ServerTLSErrorTests.swift
+++ b/Tests/GRPCTests/ServerTLSErrorTests.swift
@@ -118,7 +118,7 @@ class ServerTLSErrorTests: GRPCTestCase {
     stateChangeDelegate.waitForExpectedChanges(timeout: .seconds(1))
 
     if let nioSSLError = errorDelegate.errors.first as? NIOSSLError,
-      case .failedToLoadCertificate = nioSSLError {
+       case .failedToLoadCertificate = nioSSLError {
       // Expected case.
     } else {
       XCTFail("Expected NIOSSLError.handshakeFailed(BoringSSL.sslError)")

--- a/Tests/GRPCTests/ServerThrowingTests.swift
+++ b/Tests/GRPCTests/ServerThrowingTests.swift
@@ -34,8 +34,10 @@ let transformedMetadata = HPACKHeaders([("transformed", "header")])
 class ImmediateThrowingEchoProvider: Echo_EchoProvider {
   var interceptors: Echo_EchoServerInterceptorFactoryProtocol? { return nil }
 
-  func get(request: Echo_EchoRequest,
-           context: StatusOnlyCallContext) -> EventLoopFuture<Echo_EchoResponse> {
+  func get(
+    request: Echo_EchoRequest,
+    context: StatusOnlyCallContext
+  ) -> EventLoopFuture<Echo_EchoResponse> {
     return context.eventLoop.makeFailedFuture(thrownError)
   }
 
@@ -69,8 +71,10 @@ extension EventLoop {
 class DelayedThrowingEchoProvider: Echo_EchoProvider {
   let interceptors: Echo_EchoServerInterceptorFactoryProtocol? = nil
 
-  func get(request: Echo_EchoRequest,
-           context: StatusOnlyCallContext) -> EventLoopFuture<Echo_EchoResponse> {
+  func get(
+    request: Echo_EchoRequest,
+    context: StatusOnlyCallContext
+  ) -> EventLoopFuture<Echo_EchoResponse> {
     return context.eventLoop.makeFailedFuture(thrownError, delay: 0.01)
   }
 
@@ -120,8 +124,10 @@ class ErrorReturningEchoProvider: ImmediateThrowingEchoProvider {
 }
 
 private class ErrorTransformingDelegate: ServerErrorDelegate {
-  func transformRequestHandlerError(_ error: Error,
-                                    headers: HPACKHeaders) -> GRPCStatusAndTrailers? {
+  func transformRequestHandlerError(
+    _ error: Error,
+    headers: HPACKHeaders
+  ) -> GRPCStatusAndTrailers? {
     return GRPCStatusAndTrailers(status: transformedError, trailers: transformedMetadata)
   }
 }

--- a/Tests/GRPCTests/ServerWebTests.swift
+++ b/Tests/GRPCTests/ServerWebTests.swift
@@ -86,7 +86,7 @@ extension ServerWebTests {
 
     let completionHandlerExpectation = expectation(description: "completion handler called")
 
-    sendOverHTTP1(rpcMethod: "Get", message: message) { data, error in
+    self.sendOverHTTP1(rpcMethod: "Get", message: message) { data, error in
       XCTAssertNil(error)
       if let data = data {
         XCTAssertEqual(String(data: data, encoding: .utf8), expectedResponse)
@@ -109,7 +109,7 @@ extension ServerWebTests {
 
     let completionHandlerExpectation = expectation(description: "completion handler called")
 
-    sendOverHTTP1(rpcMethod: "Get", message: nil) { data, error in
+    self.sendOverHTTP1(rpcMethod: "Get", message: nil) { data, error in
       XCTAssertNil(error)
       if let data = data {
         XCTAssertEqual(String(data: data, encoding: .utf8), expectedResponse)
@@ -164,7 +164,7 @@ extension ServerWebTests {
     let expectedResponse = expectedData.base64EncodedString()
     let completionHandlerExpectation = expectation(description: "completion handler called")
 
-    sendOverHTTP1(rpcMethod: "Expand", message: message) { data, error in
+    self.sendOverHTTP1(rpcMethod: "Expand", message: message) { data, error in
       XCTAssertNil(error)
       if let data = data {
         XCTAssertEqual(String(data: data, encoding: .utf8), expectedResponse)

--- a/Tests/GRPCTests/ZeroLengthWriteTests.swift
+++ b/Tests/GRPCTests/ZeroLengthWriteTests.swift
@@ -116,8 +116,9 @@ final class ZeroLengthWriteTests: GRPCTestCase {
     return expectation
   }
 
-  func debugPipelineExpectation(_ callback: @escaping (Result<NIOFilterEmptyWritesHandler, Error>)
-    -> Void) -> (Channel) -> EventLoopFuture<Void> {
+  func debugPipelineExpectation(
+    _ callback: @escaping (Result<NIOFilterEmptyWritesHandler, Error>) -> Void
+  ) -> (Channel) -> EventLoopFuture<Void> {
     return { channel in
       channel.pipeline.handler(type: NIOFilterEmptyWritesHandler.self).always { result in
         callback(result)

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -21,8 +21,8 @@ REPO="$HERE/.."
 SWIFTFORMAT_DIR="$HERE/.swiftformat-source"
 
 # Important: if this is changed then make sure to update the version
-# in .travis-install.sh as well!
-SWIFTFORMAT_VERSION=0.46.3
+# in the .github/workflows/ci.yaml as well!
+SWIFTFORMAT_VERSION=0.49.4
 
 # Clone SwiftFormat if we don't already have it.
 if [ ! -d "$SWIFTFORMAT_DIR" ]; then


### PR DESCRIPTION
Motivation:

We need to use a newer version of SwiftFormat on the async/await code.
First we should update main so that merging changes into the async
branch is cleaner.

Modifications:

- Update SwiftFormat
- Reformat

Result:

Our version of SwiftFormat is new enough to correctly handle async/await
code.