### PR TITLE
Always generate async code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ ${XCODEPROJ}:
 	protoc $< \
 		--proto_path=$(dir $<) \
 		--plugin=${PROTOC_GEN_GRPC_SWIFT} \
-		--grpc-swift_opt=Visibility=Public,ExperimentalAsyncClient=true,ExperimentalAsyncServer=true \
+		--grpc-swift_opt=Visibility=Public \
 		--grpc-swift_out=$(dir $<)
 
 ECHO_PROTO=Sources/Examples/Echo/Model/echo.proto
@@ -78,7 +78,7 @@ ${ECHO_GRPC}: ${ECHO_PROTO} ${PROTOC_GEN_GRPC_SWIFT}
 	protoc $< \
 		--proto_path=$(dir $<) \
 		--plugin=${PROTOC_GEN_GRPC_SWIFT} \
-		--grpc-swift_opt=Visibility=Public,TestClient=true,ExperimentalAsyncClient=true,ExperimentalAsyncServer=true \
+		--grpc-swift_opt=Visibility=Public,TestClient=true \
 		--grpc-swift_out=$(dir $<)
 
 # Generates protobufs and gRPC client and server for the Echo example

--- a/Performance/QPSBenchmark/Package.swift
+++ b/Performance/QPSBenchmark/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
     .package(
       name: "SwiftProtobuf",
       url: "https://github.com/apple/swift-protobuf.git",
-      from: "1.9.0"
+      from: "1.19.0"
     ),
   ],
   targets: [

--- a/Performance/QPSBenchmark/Sources/QPSBenchmark/Model/benchmark_service.grpc.swift
+++ b/Performance/QPSBenchmark/Sources/QPSBenchmark/Model/benchmark_service.grpc.swift
@@ -73,7 +73,7 @@ extension Grpc_Testing_BenchmarkServiceClientProtocol {
     callOptions: CallOptions? = nil
   ) -> UnaryCall<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse> {
     return self.makeUnaryCall(
-      path: "/grpc.testing.BenchmarkService/UnaryCall",
+      path: Grpc_Testing_BenchmarkServiceClientMetadata.Methods.unaryCall.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeUnaryCallInterceptors() ?? []
@@ -96,7 +96,7 @@ extension Grpc_Testing_BenchmarkServiceClientProtocol {
     handler: @escaping (Grpc_Testing_SimpleResponse) -> Void
   ) -> BidirectionalStreamingCall<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse> {
     return self.makeBidirectionalStreamingCall(
-      path: "/grpc.testing.BenchmarkService/StreamingCall",
+      path: Grpc_Testing_BenchmarkServiceClientMetadata.Methods.streamingCall.path,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeStreamingCallInterceptors() ?? [],
       handler: handler
@@ -116,7 +116,7 @@ extension Grpc_Testing_BenchmarkServiceClientProtocol {
     callOptions: CallOptions? = nil
   ) -> ClientStreamingCall<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse> {
     return self.makeClientStreamingCall(
-      path: "/grpc.testing.BenchmarkService/StreamingFromClient",
+      path: Grpc_Testing_BenchmarkServiceClientMetadata.Methods.streamingFromClient.path,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeStreamingFromClientInterceptors() ?? []
     )
@@ -136,7 +136,7 @@ extension Grpc_Testing_BenchmarkServiceClientProtocol {
     handler: @escaping (Grpc_Testing_SimpleResponse) -> Void
   ) -> ServerStreamingCall<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse> {
     return self.makeServerStreamingCall(
-      path: "/grpc.testing.BenchmarkService/StreamingFromServer",
+      path: Grpc_Testing_BenchmarkServiceClientMetadata.Methods.streamingFromServer.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeStreamingFromServerInterceptors() ?? [],
@@ -159,30 +159,12 @@ extension Grpc_Testing_BenchmarkServiceClientProtocol {
     handler: @escaping (Grpc_Testing_SimpleResponse) -> Void
   ) -> BidirectionalStreamingCall<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse> {
     return self.makeBidirectionalStreamingCall(
-      path: "/grpc.testing.BenchmarkService/StreamingBothWays",
+      path: Grpc_Testing_BenchmarkServiceClientMetadata.Methods.streamingBothWays.path,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeStreamingBothWaysInterceptors() ?? [],
       handler: handler
     )
   }
-}
-
-public protocol Grpc_Testing_BenchmarkServiceClientInterceptorFactoryProtocol {
-
-  /// - Returns: Interceptors to use when invoking 'unaryCall'.
-  func makeUnaryCallInterceptors() -> [ClientInterceptor<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse>]
-
-  /// - Returns: Interceptors to use when invoking 'streamingCall'.
-  func makeStreamingCallInterceptors() -> [ClientInterceptor<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse>]
-
-  /// - Returns: Interceptors to use when invoking 'streamingFromClient'.
-  func makeStreamingFromClientInterceptors() -> [ClientInterceptor<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse>]
-
-  /// - Returns: Interceptors to use when invoking 'streamingFromServer'.
-  func makeStreamingFromServerInterceptors() -> [ClientInterceptor<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse>]
-
-  /// - Returns: Interceptors to use when invoking 'streamingBothWays'.
-  func makeStreamingBothWaysInterceptors() -> [ClientInterceptor<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse>]
 }
 
 public final class Grpc_Testing_BenchmarkServiceClient: Grpc_Testing_BenchmarkServiceClientProtocol {
@@ -204,6 +186,282 @@ public final class Grpc_Testing_BenchmarkServiceClient: Grpc_Testing_BenchmarkSe
     self.channel = channel
     self.defaultCallOptions = defaultCallOptions
     self.interceptors = interceptors
+  }
+}
+
+#if compiler(>=5.6)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+public protocol Grpc_Testing_BenchmarkServiceAsyncClientProtocol: GRPCClient {
+  static var serviceDescriptor: GRPCServiceDescriptor { get }
+  var interceptors: Grpc_Testing_BenchmarkServiceClientInterceptorFactoryProtocol? { get }
+
+  func makeUnaryCallCall(
+    _ request: Grpc_Testing_SimpleRequest,
+    callOptions: CallOptions?
+  ) -> GRPCAsyncUnaryCall<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse>
+
+  func makeStreamingCallCall(
+    callOptions: CallOptions?
+  ) -> GRPCAsyncBidirectionalStreamingCall<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse>
+
+  func makeStreamingFromClientCall(
+    callOptions: CallOptions?
+  ) -> GRPCAsyncClientStreamingCall<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse>
+
+  func makeStreamingFromServerCall(
+    _ request: Grpc_Testing_SimpleRequest,
+    callOptions: CallOptions?
+  ) -> GRPCAsyncServerStreamingCall<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse>
+
+  func makeStreamingBothWaysCall(
+    callOptions: CallOptions?
+  ) -> GRPCAsyncBidirectionalStreamingCall<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse>
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension Grpc_Testing_BenchmarkServiceAsyncClientProtocol {
+  public static var serviceDescriptor: GRPCServiceDescriptor {
+    return Grpc_Testing_BenchmarkServiceClientMetadata.serviceDescriptor
+  }
+
+  public var interceptors: Grpc_Testing_BenchmarkServiceClientInterceptorFactoryProtocol? {
+    return nil
+  }
+
+  public func makeUnaryCallCall(
+    _ request: Grpc_Testing_SimpleRequest,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncUnaryCall<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse> {
+    return self.makeAsyncUnaryCall(
+      path: Grpc_Testing_BenchmarkServiceClientMetadata.Methods.unaryCall.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeUnaryCallInterceptors() ?? []
+    )
+  }
+
+  public func makeStreamingCallCall(
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncBidirectionalStreamingCall<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse> {
+    return self.makeAsyncBidirectionalStreamingCall(
+      path: Grpc_Testing_BenchmarkServiceClientMetadata.Methods.streamingCall.path,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeStreamingCallInterceptors() ?? []
+    )
+  }
+
+  public func makeStreamingFromClientCall(
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncClientStreamingCall<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse> {
+    return self.makeAsyncClientStreamingCall(
+      path: Grpc_Testing_BenchmarkServiceClientMetadata.Methods.streamingFromClient.path,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeStreamingFromClientInterceptors() ?? []
+    )
+  }
+
+  public func makeStreamingFromServerCall(
+    _ request: Grpc_Testing_SimpleRequest,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncServerStreamingCall<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse> {
+    return self.makeAsyncServerStreamingCall(
+      path: Grpc_Testing_BenchmarkServiceClientMetadata.Methods.streamingFromServer.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeStreamingFromServerInterceptors() ?? []
+    )
+  }
+
+  public func makeStreamingBothWaysCall(
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncBidirectionalStreamingCall<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse> {
+    return self.makeAsyncBidirectionalStreamingCall(
+      path: Grpc_Testing_BenchmarkServiceClientMetadata.Methods.streamingBothWays.path,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeStreamingBothWaysInterceptors() ?? []
+    )
+  }
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension Grpc_Testing_BenchmarkServiceAsyncClientProtocol {
+  public func unaryCall(
+    _ request: Grpc_Testing_SimpleRequest,
+    callOptions: CallOptions? = nil
+  ) async throws -> Grpc_Testing_SimpleResponse {
+    return try await self.performAsyncUnaryCall(
+      path: Grpc_Testing_BenchmarkServiceClientMetadata.Methods.unaryCall.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeUnaryCallInterceptors() ?? []
+    )
+  }
+
+  public func streamingCall<RequestStream>(
+    _ requests: RequestStream,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncResponseStream<Grpc_Testing_SimpleResponse> where RequestStream: Sequence, RequestStream.Element == Grpc_Testing_SimpleRequest {
+    return self.performAsyncBidirectionalStreamingCall(
+      path: Grpc_Testing_BenchmarkServiceClientMetadata.Methods.streamingCall.path,
+      requests: requests,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeStreamingCallInterceptors() ?? []
+    )
+  }
+
+  public func streamingCall<RequestStream>(
+    _ requests: RequestStream,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncResponseStream<Grpc_Testing_SimpleResponse> where RequestStream: AsyncSequence, RequestStream.Element == Grpc_Testing_SimpleRequest {
+    return self.performAsyncBidirectionalStreamingCall(
+      path: Grpc_Testing_BenchmarkServiceClientMetadata.Methods.streamingCall.path,
+      requests: requests,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeStreamingCallInterceptors() ?? []
+    )
+  }
+
+  public func streamingFromClient<RequestStream>(
+    _ requests: RequestStream,
+    callOptions: CallOptions? = nil
+  ) async throws -> Grpc_Testing_SimpleResponse where RequestStream: Sequence, RequestStream.Element == Grpc_Testing_SimpleRequest {
+    return try await self.performAsyncClientStreamingCall(
+      path: Grpc_Testing_BenchmarkServiceClientMetadata.Methods.streamingFromClient.path,
+      requests: requests,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeStreamingFromClientInterceptors() ?? []
+    )
+  }
+
+  public func streamingFromClient<RequestStream>(
+    _ requests: RequestStream,
+    callOptions: CallOptions? = nil
+  ) async throws -> Grpc_Testing_SimpleResponse where RequestStream: AsyncSequence, RequestStream.Element == Grpc_Testing_SimpleRequest {
+    return try await self.performAsyncClientStreamingCall(
+      path: Grpc_Testing_BenchmarkServiceClientMetadata.Methods.streamingFromClient.path,
+      requests: requests,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeStreamingFromClientInterceptors() ?? []
+    )
+  }
+
+  public func streamingFromServer(
+    _ request: Grpc_Testing_SimpleRequest,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncResponseStream<Grpc_Testing_SimpleResponse> {
+    return self.performAsyncServerStreamingCall(
+      path: Grpc_Testing_BenchmarkServiceClientMetadata.Methods.streamingFromServer.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeStreamingFromServerInterceptors() ?? []
+    )
+  }
+
+  public func streamingBothWays<RequestStream>(
+    _ requests: RequestStream,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncResponseStream<Grpc_Testing_SimpleResponse> where RequestStream: Sequence, RequestStream.Element == Grpc_Testing_SimpleRequest {
+    return self.performAsyncBidirectionalStreamingCall(
+      path: Grpc_Testing_BenchmarkServiceClientMetadata.Methods.streamingBothWays.path,
+      requests: requests,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeStreamingBothWaysInterceptors() ?? []
+    )
+  }
+
+  public func streamingBothWays<RequestStream>(
+    _ requests: RequestStream,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncResponseStream<Grpc_Testing_SimpleResponse> where RequestStream: AsyncSequence, RequestStream.Element == Grpc_Testing_SimpleRequest {
+    return self.performAsyncBidirectionalStreamingCall(
+      path: Grpc_Testing_BenchmarkServiceClientMetadata.Methods.streamingBothWays.path,
+      requests: requests,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeStreamingBothWaysInterceptors() ?? []
+    )
+  }
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+public struct Grpc_Testing_BenchmarkServiceAsyncClient: Grpc_Testing_BenchmarkServiceAsyncClientProtocol {
+  public var channel: GRPCChannel
+  public var defaultCallOptions: CallOptions
+  public var interceptors: Grpc_Testing_BenchmarkServiceClientInterceptorFactoryProtocol?
+
+  public init(
+    channel: GRPCChannel,
+    defaultCallOptions: CallOptions = CallOptions(),
+    interceptors: Grpc_Testing_BenchmarkServiceClientInterceptorFactoryProtocol? = nil
+  ) {
+    self.channel = channel
+    self.defaultCallOptions = defaultCallOptions
+    self.interceptors = interceptors
+  }
+}
+
+#endif // compiler(>=5.6)
+
+public protocol Grpc_Testing_BenchmarkServiceClientInterceptorFactoryProtocol {
+
+  /// - Returns: Interceptors to use when invoking 'unaryCall'.
+  func makeUnaryCallInterceptors() -> [ClientInterceptor<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse>]
+
+  /// - Returns: Interceptors to use when invoking 'streamingCall'.
+  func makeStreamingCallInterceptors() -> [ClientInterceptor<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse>]
+
+  /// - Returns: Interceptors to use when invoking 'streamingFromClient'.
+  func makeStreamingFromClientInterceptors() -> [ClientInterceptor<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse>]
+
+  /// - Returns: Interceptors to use when invoking 'streamingFromServer'.
+  func makeStreamingFromServerInterceptors() -> [ClientInterceptor<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse>]
+
+  /// - Returns: Interceptors to use when invoking 'streamingBothWays'.
+  func makeStreamingBothWaysInterceptors() -> [ClientInterceptor<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse>]
+}
+
+public enum Grpc_Testing_BenchmarkServiceClientMetadata {
+  public static let serviceDescriptor = GRPCServiceDescriptor(
+    name: "BenchmarkService",
+    fullName: "grpc.testing.BenchmarkService",
+    methods: [
+      Grpc_Testing_BenchmarkServiceClientMetadata.Methods.unaryCall,
+      Grpc_Testing_BenchmarkServiceClientMetadata.Methods.streamingCall,
+      Grpc_Testing_BenchmarkServiceClientMetadata.Methods.streamingFromClient,
+      Grpc_Testing_BenchmarkServiceClientMetadata.Methods.streamingFromServer,
+      Grpc_Testing_BenchmarkServiceClientMetadata.Methods.streamingBothWays,
+    ]
+  )
+
+  public enum Methods {
+    public static let unaryCall = GRPCMethodDescriptor(
+      name: "UnaryCall",
+      path: "/grpc.testing.BenchmarkService/UnaryCall",
+      type: GRPCCallType.unary
+    )
+
+    public static let streamingCall = GRPCMethodDescriptor(
+      name: "StreamingCall",
+      path: "/grpc.testing.BenchmarkService/StreamingCall",
+      type: GRPCCallType.bidirectionalStreaming
+    )
+
+    public static let streamingFromClient = GRPCMethodDescriptor(
+      name: "StreamingFromClient",
+      path: "/grpc.testing.BenchmarkService/StreamingFromClient",
+      type: GRPCCallType.clientStreaming
+    )
+
+    public static let streamingFromServer = GRPCMethodDescriptor(
+      name: "StreamingFromServer",
+      path: "/grpc.testing.BenchmarkService/StreamingFromServer",
+      type: GRPCCallType.serverStreaming
+    )
+
+    public static let streamingBothWays = GRPCMethodDescriptor(
+      name: "StreamingBothWays",
+      path: "/grpc.testing.BenchmarkService/StreamingBothWays",
+      type: GRPCCallType.bidirectionalStreaming
+    )
   }
 }
 
@@ -234,7 +492,9 @@ public protocol Grpc_Testing_BenchmarkServiceProvider: CallHandlerProvider {
 }
 
 extension Grpc_Testing_BenchmarkServiceProvider {
-  public var serviceName: Substring { return "grpc.testing.BenchmarkService" }
+  public var serviceName: Substring {
+    return Grpc_Testing_BenchmarkServiceServerMetadata.serviceDescriptor.fullName[...]
+  }
 
   /// Determines, calls and returns the appropriate request handler, depending on the request's method.
   /// Returns nil for methods not handled by this service.
@@ -294,6 +554,126 @@ extension Grpc_Testing_BenchmarkServiceProvider {
   }
 }
 
+#if compiler(>=5.6)
+
+/// To implement a server, implement an object which conforms to this protocol.
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+public protocol Grpc_Testing_BenchmarkServiceAsyncProvider: CallHandlerProvider {
+  static var serviceDescriptor: GRPCServiceDescriptor { get }
+  var interceptors: Grpc_Testing_BenchmarkServiceServerInterceptorFactoryProtocol? { get }
+
+  /// One request followed by one response.
+  /// The server returns the client payload as-is.
+  @Sendable func unaryCall(
+    request: Grpc_Testing_SimpleRequest,
+    context: GRPCAsyncServerCallContext
+  ) async throws -> Grpc_Testing_SimpleResponse
+
+  /// Repeated sequence of one request followed by one response.
+  /// Should be called streaming ping-pong
+  /// The server returns the client payload as-is on each response
+  @Sendable func streamingCall(
+    requestStream: GRPCAsyncRequestStream<Grpc_Testing_SimpleRequest>,
+    responseStream: GRPCAsyncResponseStreamWriter<Grpc_Testing_SimpleResponse>,
+    context: GRPCAsyncServerCallContext
+  ) async throws
+
+  /// Single-sided unbounded streaming from client to server
+  /// The server returns the client payload as-is once the client does WritesDone
+  @Sendable func streamingFromClient(
+    requestStream: GRPCAsyncRequestStream<Grpc_Testing_SimpleRequest>,
+    context: GRPCAsyncServerCallContext
+  ) async throws -> Grpc_Testing_SimpleResponse
+
+  /// Single-sided unbounded streaming from server to client
+  /// The server repeatedly returns the client payload as-is
+  @Sendable func streamingFromServer(
+    request: Grpc_Testing_SimpleRequest,
+    responseStream: GRPCAsyncResponseStreamWriter<Grpc_Testing_SimpleResponse>,
+    context: GRPCAsyncServerCallContext
+  ) async throws
+
+  /// Two-sided unbounded streaming between server to client
+  /// Both sides send the content of their own choice to the other
+  @Sendable func streamingBothWays(
+    requestStream: GRPCAsyncRequestStream<Grpc_Testing_SimpleRequest>,
+    responseStream: GRPCAsyncResponseStreamWriter<Grpc_Testing_SimpleResponse>,
+    context: GRPCAsyncServerCallContext
+  ) async throws
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension Grpc_Testing_BenchmarkServiceAsyncProvider {
+  public static var serviceDescriptor: GRPCServiceDescriptor {
+    return Grpc_Testing_BenchmarkServiceServerMetadata.serviceDescriptor
+  }
+
+  public var serviceName: Substring {
+    return Grpc_Testing_BenchmarkServiceServerMetadata.serviceDescriptor.fullName[...]
+  }
+
+  public var interceptors: Grpc_Testing_BenchmarkServiceServerInterceptorFactoryProtocol? {
+    return nil
+  }
+
+  public func handle(
+    method name: Substring,
+    context: CallHandlerContext
+  ) -> GRPCServerHandlerProtocol? {
+    switch name {
+    case "UnaryCall":
+      return GRPCAsyncServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Grpc_Testing_SimpleRequest>(),
+        responseSerializer: ProtobufSerializer<Grpc_Testing_SimpleResponse>(),
+        interceptors: self.interceptors?.makeUnaryCallInterceptors() ?? [],
+        wrapping: self.unaryCall(request:context:)
+      )
+
+    case "StreamingCall":
+      return GRPCAsyncServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Grpc_Testing_SimpleRequest>(),
+        responseSerializer: ProtobufSerializer<Grpc_Testing_SimpleResponse>(),
+        interceptors: self.interceptors?.makeStreamingCallInterceptors() ?? [],
+        wrapping: self.streamingCall(requestStream:responseStream:context:)
+      )
+
+    case "StreamingFromClient":
+      return GRPCAsyncServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Grpc_Testing_SimpleRequest>(),
+        responseSerializer: ProtobufSerializer<Grpc_Testing_SimpleResponse>(),
+        interceptors: self.interceptors?.makeStreamingFromClientInterceptors() ?? [],
+        wrapping: self.streamingFromClient(requestStream:context:)
+      )
+
+    case "StreamingFromServer":
+      return GRPCAsyncServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Grpc_Testing_SimpleRequest>(),
+        responseSerializer: ProtobufSerializer<Grpc_Testing_SimpleResponse>(),
+        interceptors: self.interceptors?.makeStreamingFromServerInterceptors() ?? [],
+        wrapping: self.streamingFromServer(request:responseStream:context:)
+      )
+
+    case "StreamingBothWays":
+      return GRPCAsyncServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Grpc_Testing_SimpleRequest>(),
+        responseSerializer: ProtobufSerializer<Grpc_Testing_SimpleResponse>(),
+        interceptors: self.interceptors?.makeStreamingBothWaysInterceptors() ?? [],
+        wrapping: self.streamingBothWays(requestStream:responseStream:context:)
+      )
+
+    default:
+      return nil
+    }
+  }
+}
+
+#endif // compiler(>=5.6)
+
 public protocol Grpc_Testing_BenchmarkServiceServerInterceptorFactoryProtocol {
 
   /// - Returns: Interceptors to use when handling 'unaryCall'.
@@ -315,4 +695,50 @@ public protocol Grpc_Testing_BenchmarkServiceServerInterceptorFactoryProtocol {
   /// - Returns: Interceptors to use when handling 'streamingBothWays'.
   ///   Defaults to calling `self.makeInterceptors()`.
   func makeStreamingBothWaysInterceptors() -> [ServerInterceptor<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse>]
+}
+
+public enum Grpc_Testing_BenchmarkServiceServerMetadata {
+  public static let serviceDescriptor = GRPCServiceDescriptor(
+    name: "BenchmarkService",
+    fullName: "grpc.testing.BenchmarkService",
+    methods: [
+      Grpc_Testing_BenchmarkServiceServerMetadata.Methods.unaryCall,
+      Grpc_Testing_BenchmarkServiceServerMetadata.Methods.streamingCall,
+      Grpc_Testing_BenchmarkServiceServerMetadata.Methods.streamingFromClient,
+      Grpc_Testing_BenchmarkServiceServerMetadata.Methods.streamingFromServer,
+      Grpc_Testing_BenchmarkServiceServerMetadata.Methods.streamingBothWays,
+    ]
+  )
+
+  public enum Methods {
+    public static let unaryCall = GRPCMethodDescriptor(
+      name: "UnaryCall",
+      path: "/grpc.testing.BenchmarkService/UnaryCall",
+      type: GRPCCallType.unary
+    )
+
+    public static let streamingCall = GRPCMethodDescriptor(
+      name: "StreamingCall",
+      path: "/grpc.testing.BenchmarkService/StreamingCall",
+      type: GRPCCallType.bidirectionalStreaming
+    )
+
+    public static let streamingFromClient = GRPCMethodDescriptor(
+      name: "StreamingFromClient",
+      path: "/grpc.testing.BenchmarkService/StreamingFromClient",
+      type: GRPCCallType.clientStreaming
+    )
+
+    public static let streamingFromServer = GRPCMethodDescriptor(
+      name: "StreamingFromServer",
+      path: "/grpc.testing.BenchmarkService/StreamingFromServer",
+      type: GRPCCallType.serverStreaming
+    )
+
+    public static let streamingBothWays = GRPCMethodDescriptor(
+      name: "StreamingBothWays",
+      path: "/grpc.testing.BenchmarkService/StreamingBothWays",
+      type: GRPCCallType.bidirectionalStreaming
+    )
+  }
 }

--- a/Performance/QPSBenchmark/Sources/QPSBenchmark/Model/control.pb.swift
+++ b/Performance/QPSBenchmark/Sources/QPSBenchmark/Model/control.pb.swift
@@ -1007,6 +1007,35 @@ public struct Grpc_Testing_ScenarioResult {
   fileprivate var _summary: Grpc_Testing_ScenarioResultSummary? = nil
 }
 
+#if swift(>=5.5) && canImport(_Concurrency)
+extension Grpc_Testing_ClientType: @unchecked Sendable {}
+extension Grpc_Testing_ServerType: @unchecked Sendable {}
+extension Grpc_Testing_RpcType: @unchecked Sendable {}
+extension Grpc_Testing_PoissonParams: @unchecked Sendable {}
+extension Grpc_Testing_ClosedLoopParams: @unchecked Sendable {}
+extension Grpc_Testing_LoadParams: @unchecked Sendable {}
+extension Grpc_Testing_LoadParams.OneOf_Load: @unchecked Sendable {}
+extension Grpc_Testing_SecurityParams: @unchecked Sendable {}
+extension Grpc_Testing_ChannelArg: @unchecked Sendable {}
+extension Grpc_Testing_ChannelArg.OneOf_Value: @unchecked Sendable {}
+extension Grpc_Testing_ClientConfig: @unchecked Sendable {}
+extension Grpc_Testing_ClientStatus: @unchecked Sendable {}
+extension Grpc_Testing_Mark: @unchecked Sendable {}
+extension Grpc_Testing_ClientArgs: @unchecked Sendable {}
+extension Grpc_Testing_ClientArgs.OneOf_Argtype: @unchecked Sendable {}
+extension Grpc_Testing_ServerConfig: @unchecked Sendable {}
+extension Grpc_Testing_ServerArgs: @unchecked Sendable {}
+extension Grpc_Testing_ServerArgs.OneOf_Argtype: @unchecked Sendable {}
+extension Grpc_Testing_ServerStatus: @unchecked Sendable {}
+extension Grpc_Testing_CoreRequest: @unchecked Sendable {}
+extension Grpc_Testing_CoreResponse: @unchecked Sendable {}
+extension Grpc_Testing_Void: @unchecked Sendable {}
+extension Grpc_Testing_Scenario: @unchecked Sendable {}
+extension Grpc_Testing_Scenarios: @unchecked Sendable {}
+extension Grpc_Testing_ScenarioResultSummary: @unchecked Sendable {}
+extension Grpc_Testing_ScenarioResult: @unchecked Sendable {}
+#endif  // swift(>=5.5) && canImport(_Concurrency)
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "grpc.testing"
@@ -1106,21 +1135,29 @@ extension Grpc_Testing_LoadParams: SwiftProtobuf.Message, SwiftProtobuf._Message
       switch fieldNumber {
       case 1: try {
         var v: Grpc_Testing_ClosedLoopParams?
+        var hadOneofValue = false
         if let current = self.load {
-          try decoder.handleConflictingOneOf()
+          hadOneofValue = true
           if case .closedLoop(let m) = current {v = m}
         }
         try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {self.load = .closedLoop(v)}
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.load = .closedLoop(v)
+        }
       }()
       case 2: try {
         var v: Grpc_Testing_PoissonParams?
+        var hadOneofValue = false
         if let current = self.load {
-          try decoder.handleConflictingOneOf()
+          hadOneofValue = true
           if case .poisson(let m) = current {v = m}
         }
         try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {self.load = .poisson(v)}
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.load = .poisson(v)
+        }
       }()
       default: break
       }
@@ -1129,8 +1166,9 @@ extension Grpc_Testing_LoadParams: SwiftProtobuf.Message, SwiftProtobuf._Message
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
-    // allocates stack space for every case branch when no optimizations are
-    // enabled. https://github.com/apple/swift-protobuf/issues/1034
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     switch self.load {
     case .closedLoop?: try {
       guard case .closedLoop(let v)? = self.load else { preconditionFailure() }
@@ -1212,16 +1250,20 @@ extension Grpc_Testing_ChannelArg: SwiftProtobuf.Message, SwiftProtobuf._Message
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularStringField(value: &self.name) }()
       case 2: try {
-        if self.value != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.value = .strValue(v)}
+        if let v = v {
+          if self.value != nil {try decoder.handleConflictingOneOf()}
+          self.value = .strValue(v)
+        }
       }()
       case 3: try {
-        if self.value != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.value = .intValue(v)}
+        if let v = v {
+          if self.value != nil {try decoder.handleConflictingOneOf()}
+          self.value = .intValue(v)
+        }
       }()
       default: break
       }
@@ -1229,12 +1271,13 @@ extension Grpc_Testing_ChannelArg: SwiftProtobuf.Message, SwiftProtobuf._Message
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if !self.name.isEmpty {
       try visitor.visitSingularStringField(value: self.name, fieldNumber: 1)
     }
-    // The use of inline closures is to circumvent an issue where the compiler
-    // allocates stack space for every case branch when no optimizations are
-    // enabled. https://github.com/apple/swift-protobuf/issues/1034
     switch self.value {
     case .strValue?: try {
       guard case .strValue(let v)? = self.value else { preconditionFailure() }
@@ -1371,15 +1414,19 @@ extension Grpc_Testing_ClientConfig: SwiftProtobuf.Message, SwiftProtobuf._Messa
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every if/case branch local when no optimizations
+      // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+      // https://github.com/apple/swift-protobuf/issues/1182
       if !_storage._serverTargets.isEmpty {
         try visitor.visitRepeatedStringField(value: _storage._serverTargets, fieldNumber: 1)
       }
       if _storage._clientType != .syncClient {
         try visitor.visitSingularEnumField(value: _storage._clientType, fieldNumber: 2)
       }
-      if let v = _storage._securityParams {
+      try { if let v = _storage._securityParams {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-      }
+      } }()
       if _storage._outstandingRpcsPerChannel != 0 {
         try visitor.visitSingularInt32Field(value: _storage._outstandingRpcsPerChannel, fieldNumber: 4)
       }
@@ -1392,15 +1439,15 @@ extension Grpc_Testing_ClientConfig: SwiftProtobuf.Message, SwiftProtobuf._Messa
       if _storage._rpcType != .unary {
         try visitor.visitSingularEnumField(value: _storage._rpcType, fieldNumber: 8)
       }
-      if let v = _storage._loadParams {
+      try { if let v = _storage._loadParams {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 10)
-      }
-      if let v = _storage._payloadConfig {
+      } }()
+      try { if let v = _storage._payloadConfig {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
-      }
-      if let v = _storage._histogramParams {
+      } }()
+      try { if let v = _storage._histogramParams {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 12)
-      }
+      } }()
       if !_storage._coreList.isEmpty {
         try visitor.visitPackedInt32Field(value: _storage._coreList, fieldNumber: 13)
       }
@@ -1484,9 +1531,13 @@ extension Grpc_Testing_ClientStatus: SwiftProtobuf.Message, SwiftProtobuf._Messa
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._stats {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._stats {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -1544,21 +1595,29 @@ extension Grpc_Testing_ClientArgs: SwiftProtobuf.Message, SwiftProtobuf._Message
       switch fieldNumber {
       case 1: try {
         var v: Grpc_Testing_ClientConfig?
+        var hadOneofValue = false
         if let current = self.argtype {
-          try decoder.handleConflictingOneOf()
+          hadOneofValue = true
           if case .setup(let m) = current {v = m}
         }
         try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {self.argtype = .setup(v)}
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.argtype = .setup(v)
+        }
       }()
       case 2: try {
         var v: Grpc_Testing_Mark?
+        var hadOneofValue = false
         if let current = self.argtype {
-          try decoder.handleConflictingOneOf()
+          hadOneofValue = true
           if case .mark(let m) = current {v = m}
         }
         try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {self.argtype = .mark(v)}
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.argtype = .mark(v)
+        }
       }()
       default: break
       }
@@ -1567,8 +1626,9 @@ extension Grpc_Testing_ClientArgs: SwiftProtobuf.Message, SwiftProtobuf._Message
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
-    // allocates stack space for every case branch when no optimizations are
-    // enabled. https://github.com/apple/swift-protobuf/issues/1034
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     switch self.argtype {
     case .setup?: try {
       guard case .setup(let v)? = self.argtype else { preconditionFailure() }
@@ -1631,12 +1691,16 @@ extension Grpc_Testing_ServerConfig: SwiftProtobuf.Message, SwiftProtobuf._Messa
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if self.serverType != .syncServer {
       try visitor.visitSingularEnumField(value: self.serverType, fieldNumber: 1)
     }
-    if let v = self._securityParams {
+    try { if let v = self._securityParams {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    }
+    } }()
     if self.port != 0 {
       try visitor.visitSingularInt32Field(value: self.port, fieldNumber: 4)
     }
@@ -1646,9 +1710,9 @@ extension Grpc_Testing_ServerConfig: SwiftProtobuf.Message, SwiftProtobuf._Messa
     if self.coreLimit != 0 {
       try visitor.visitSingularInt32Field(value: self.coreLimit, fieldNumber: 8)
     }
-    if let v = self._payloadConfig {
+    try { if let v = self._payloadConfig {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 9)
-    }
+    } }()
     if !self.coreList.isEmpty {
       try visitor.visitPackedInt32Field(value: self.coreList, fieldNumber: 10)
     }
@@ -1703,21 +1767,29 @@ extension Grpc_Testing_ServerArgs: SwiftProtobuf.Message, SwiftProtobuf._Message
       switch fieldNumber {
       case 1: try {
         var v: Grpc_Testing_ServerConfig?
+        var hadOneofValue = false
         if let current = self.argtype {
-          try decoder.handleConflictingOneOf()
+          hadOneofValue = true
           if case .setup(let m) = current {v = m}
         }
         try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {self.argtype = .setup(v)}
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.argtype = .setup(v)
+        }
       }()
       case 2: try {
         var v: Grpc_Testing_Mark?
+        var hadOneofValue = false
         if let current = self.argtype {
-          try decoder.handleConflictingOneOf()
+          hadOneofValue = true
           if case .mark(let m) = current {v = m}
         }
         try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {self.argtype = .mark(v)}
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.argtype = .mark(v)
+        }
       }()
       default: break
       }
@@ -1726,8 +1798,9 @@ extension Grpc_Testing_ServerArgs: SwiftProtobuf.Message, SwiftProtobuf._Message
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
-    // allocates stack space for every case branch when no optimizations are
-    // enabled. https://github.com/apple/swift-protobuf/issues/1034
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     switch self.argtype {
     case .setup?: try {
       guard case .setup(let v)? = self.argtype else { preconditionFailure() }
@@ -1772,9 +1845,13 @@ extension Grpc_Testing_ServerStatus: SwiftProtobuf.Message, SwiftProtobuf._Messa
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._stats {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._stats {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
+    } }()
     if self.port != 0 {
       try visitor.visitSingularInt32Field(value: self.port, fieldNumber: 2)
     }
@@ -1933,18 +2010,22 @@ extension Grpc_Testing_Scenario: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every if/case branch local when no optimizations
+      // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+      // https://github.com/apple/swift-protobuf/issues/1182
       if !_storage._name.isEmpty {
         try visitor.visitSingularStringField(value: _storage._name, fieldNumber: 1)
       }
-      if let v = _storage._clientConfig {
+      try { if let v = _storage._clientConfig {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-      }
+      } }()
       if _storage._numClients != 0 {
         try visitor.visitSingularInt32Field(value: _storage._numClients, fieldNumber: 3)
       }
-      if let v = _storage._serverConfig {
+      try { if let v = _storage._serverConfig {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
-      }
+      } }()
       if _storage._numServers != 0 {
         try visitor.visitSingularInt32Field(value: _storage._numServers, fieldNumber: 5)
       }
@@ -2250,12 +2331,16 @@ extension Grpc_Testing_ScenarioResult: SwiftProtobuf.Message, SwiftProtobuf._Mes
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._scenario {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._scenario {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
-    if let v = self._latencies {
+    } }()
+    try { if let v = self._latencies {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    }
+    } }()
     if !self.clientStats.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.clientStats, fieldNumber: 3)
     }
@@ -2265,9 +2350,9 @@ extension Grpc_Testing_ScenarioResult: SwiftProtobuf.Message, SwiftProtobuf._Mes
     if !self.serverCores.isEmpty {
       try visitor.visitPackedInt32Field(value: self.serverCores, fieldNumber: 5)
     }
-    if let v = self._summary {
+    try { if let v = self._summary {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
-    }
+    } }()
     if !self.clientSuccess.isEmpty {
       try visitor.visitPackedBoolField(value: self.clientSuccess, fieldNumber: 7)
     }

--- a/Performance/QPSBenchmark/Sources/QPSBenchmark/Model/core_stats.pb.swift
+++ b/Performance/QPSBenchmark/Sources/QPSBenchmark/Model/core_stats.pb.swift
@@ -126,6 +126,14 @@ public struct Grpc_Core_Stats {
   public init() {}
 }
 
+#if swift(>=5.5) && canImport(_Concurrency)
+extension Grpc_Core_Bucket: @unchecked Sendable {}
+extension Grpc_Core_Histogram: @unchecked Sendable {}
+extension Grpc_Core_Metric: @unchecked Sendable {}
+extension Grpc_Core_Metric.OneOf_Value: @unchecked Sendable {}
+extension Grpc_Core_Stats: @unchecked Sendable {}
+#endif  // swift(>=5.5) && canImport(_Concurrency)
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "grpc.core"
@@ -216,19 +224,25 @@ extension Grpc_Core_Metric: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularStringField(value: &self.name) }()
       case 10: try {
-        if self.value != nil {try decoder.handleConflictingOneOf()}
         var v: UInt64?
         try decoder.decodeSingularUInt64Field(value: &v)
-        if let v = v {self.value = .count(v)}
+        if let v = v {
+          if self.value != nil {try decoder.handleConflictingOneOf()}
+          self.value = .count(v)
+        }
       }()
       case 11: try {
         var v: Grpc_Core_Histogram?
+        var hadOneofValue = false
         if let current = self.value {
-          try decoder.handleConflictingOneOf()
+          hadOneofValue = true
           if case .histogram(let m) = current {v = m}
         }
         try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {self.value = .histogram(v)}
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.value = .histogram(v)
+        }
       }()
       default: break
       }
@@ -236,12 +250,13 @@ extension Grpc_Core_Metric: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if !self.name.isEmpty {
       try visitor.visitSingularStringField(value: self.name, fieldNumber: 1)
     }
-    // The use of inline closures is to circumvent an issue where the compiler
-    // allocates stack space for every case branch when no optimizations are
-    // enabled. https://github.com/apple/swift-protobuf/issues/1034
     switch self.value {
     case .count?: try {
       guard case .count(let v)? = self.value else { preconditionFailure() }

--- a/Performance/QPSBenchmark/Sources/QPSBenchmark/Model/messages.pb.swift
+++ b/Performance/QPSBenchmark/Sources/QPSBenchmark/Model/messages.pb.swift
@@ -526,6 +526,26 @@ public struct Grpc_Testing_LoadBalancerStatsResponse {
   public init() {}
 }
 
+#if swift(>=5.5) && canImport(_Concurrency)
+extension Grpc_Testing_PayloadType: @unchecked Sendable {}
+extension Grpc_Testing_GrpclbRouteType: @unchecked Sendable {}
+extension Grpc_Testing_BoolValue: @unchecked Sendable {}
+extension Grpc_Testing_Payload: @unchecked Sendable {}
+extension Grpc_Testing_EchoStatus: @unchecked Sendable {}
+extension Grpc_Testing_SimpleRequest: @unchecked Sendable {}
+extension Grpc_Testing_SimpleResponse: @unchecked Sendable {}
+extension Grpc_Testing_StreamingInputCallRequest: @unchecked Sendable {}
+extension Grpc_Testing_StreamingInputCallResponse: @unchecked Sendable {}
+extension Grpc_Testing_ResponseParameters: @unchecked Sendable {}
+extension Grpc_Testing_StreamingOutputCallRequest: @unchecked Sendable {}
+extension Grpc_Testing_StreamingOutputCallResponse: @unchecked Sendable {}
+extension Grpc_Testing_ReconnectParams: @unchecked Sendable {}
+extension Grpc_Testing_ReconnectInfo: @unchecked Sendable {}
+extension Grpc_Testing_LoadBalancerStatsRequest: @unchecked Sendable {}
+extension Grpc_Testing_LoadBalancerStatsResponse: @unchecked Sendable {}
+extension Grpc_Testing_LoadBalancerStatsResponse.RpcsByPeer: @unchecked Sendable {}
+#endif  // swift(>=5.5) && canImport(_Concurrency)
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "grpc.testing"
@@ -689,30 +709,34 @@ extension Grpc_Testing_SimpleRequest: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if self.responseType != .compressable {
       try visitor.visitSingularEnumField(value: self.responseType, fieldNumber: 1)
     }
     if self.responseSize != 0 {
       try visitor.visitSingularInt32Field(value: self.responseSize, fieldNumber: 2)
     }
-    if let v = self._payload {
+    try { if let v = self._payload {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-    }
+    } }()
     if self.fillUsername != false {
       try visitor.visitSingularBoolField(value: self.fillUsername, fieldNumber: 4)
     }
     if self.fillOauthScope != false {
       try visitor.visitSingularBoolField(value: self.fillOauthScope, fieldNumber: 5)
     }
-    if let v = self._responseCompressed {
+    try { if let v = self._responseCompressed {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
-    }
-    if let v = self._responseStatus {
+    } }()
+    try { if let v = self._responseStatus {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
-    }
-    if let v = self._expectCompressed {
+    } }()
+    try { if let v = self._expectCompressed {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
-    }
+    } }()
     if self.fillServerID != false {
       try visitor.visitSingularBoolField(value: self.fillServerID, fieldNumber: 9)
     }
@@ -767,9 +791,13 @@ extension Grpc_Testing_SimpleResponse: SwiftProtobuf.Message, SwiftProtobuf._Mes
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._payload {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._payload {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
+    } }()
     if !self.username.isEmpty {
       try visitor.visitSingularStringField(value: self.username, fieldNumber: 2)
     }
@@ -821,12 +849,16 @@ extension Grpc_Testing_StreamingInputCallRequest: SwiftProtobuf.Message, SwiftPr
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._payload {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._payload {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
-    if let v = self._expectCompressed {
+    } }()
+    try { if let v = self._expectCompressed {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -893,15 +925,19 @@ extension Grpc_Testing_ResponseParameters: SwiftProtobuf.Message, SwiftProtobuf.
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if self.size != 0 {
       try visitor.visitSingularInt32Field(value: self.size, fieldNumber: 1)
     }
     if self.intervalUs != 0 {
       try visitor.visitSingularInt32Field(value: self.intervalUs, fieldNumber: 2)
     }
-    if let v = self._compressed {
+    try { if let v = self._compressed {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -939,18 +975,22 @@ extension Grpc_Testing_StreamingOutputCallRequest: SwiftProtobuf.Message, SwiftP
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if self.responseType != .compressable {
       try visitor.visitSingularEnumField(value: self.responseType, fieldNumber: 1)
     }
     if !self.responseParameters.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.responseParameters, fieldNumber: 2)
     }
-    if let v = self._payload {
+    try { if let v = self._payload {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-    }
-    if let v = self._responseStatus {
+    } }()
+    try { if let v = self._responseStatus {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -983,9 +1023,13 @@ extension Grpc_Testing_StreamingOutputCallResponse: SwiftProtobuf.Message, Swift
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._payload {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._payload {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 

--- a/Performance/QPSBenchmark/Sources/QPSBenchmark/Model/payloads.pb.swift
+++ b/Performance/QPSBenchmark/Sources/QPSBenchmark/Model/payloads.pb.swift
@@ -139,6 +139,14 @@ public struct Grpc_Testing_PayloadConfig {
   public init() {}
 }
 
+#if swift(>=5.5) && canImport(_Concurrency)
+extension Grpc_Testing_ByteBufferParams: @unchecked Sendable {}
+extension Grpc_Testing_SimpleProtoParams: @unchecked Sendable {}
+extension Grpc_Testing_ComplexProtoParams: @unchecked Sendable {}
+extension Grpc_Testing_PayloadConfig: @unchecked Sendable {}
+extension Grpc_Testing_PayloadConfig.OneOf_Payload: @unchecked Sendable {}
+#endif  // swift(>=5.5) && canImport(_Concurrency)
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "grpc.testing"
@@ -254,30 +262,42 @@ extension Grpc_Testing_PayloadConfig: SwiftProtobuf.Message, SwiftProtobuf._Mess
       switch fieldNumber {
       case 1: try {
         var v: Grpc_Testing_ByteBufferParams?
+        var hadOneofValue = false
         if let current = self.payload {
-          try decoder.handleConflictingOneOf()
+          hadOneofValue = true
           if case .bytebufParams(let m) = current {v = m}
         }
         try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {self.payload = .bytebufParams(v)}
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payload = .bytebufParams(v)
+        }
       }()
       case 2: try {
         var v: Grpc_Testing_SimpleProtoParams?
+        var hadOneofValue = false
         if let current = self.payload {
-          try decoder.handleConflictingOneOf()
+          hadOneofValue = true
           if case .simpleParams(let m) = current {v = m}
         }
         try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {self.payload = .simpleParams(v)}
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payload = .simpleParams(v)
+        }
       }()
       case 3: try {
         var v: Grpc_Testing_ComplexProtoParams?
+        var hadOneofValue = false
         if let current = self.payload {
-          try decoder.handleConflictingOneOf()
+          hadOneofValue = true
           if case .complexParams(let m) = current {v = m}
         }
         try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {self.payload = .complexParams(v)}
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payload = .complexParams(v)
+        }
       }()
       default: break
       }
@@ -286,8 +306,9 @@ extension Grpc_Testing_PayloadConfig: SwiftProtobuf.Message, SwiftProtobuf._Mess
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
-    // allocates stack space for every case branch when no optimizations are
-    // enabled. https://github.com/apple/swift-protobuf/issues/1034
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     switch self.payload {
     case .bytebufParams?: try {
       guard case .bytebufParams(let v)? = self.payload else { preconditionFailure() }

--- a/Performance/QPSBenchmark/Sources/QPSBenchmark/Model/stats.pb.swift
+++ b/Performance/QPSBenchmark/Sources/QPSBenchmark/Model/stats.pb.swift
@@ -175,6 +175,14 @@ public struct Grpc_Testing_ClientStats {
   fileprivate var _coreStats: Grpc_Core_Stats? = nil
 }
 
+#if swift(>=5.5) && canImport(_Concurrency)
+extension Grpc_Testing_ServerStats: @unchecked Sendable {}
+extension Grpc_Testing_HistogramParams: @unchecked Sendable {}
+extension Grpc_Testing_HistogramData: @unchecked Sendable {}
+extension Grpc_Testing_RequestResultCount: @unchecked Sendable {}
+extension Grpc_Testing_ClientStats: @unchecked Sendable {}
+#endif  // swift(>=5.5) && canImport(_Concurrency)
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "grpc.testing"
@@ -210,6 +218,10 @@ extension Grpc_Testing_ServerStats: SwiftProtobuf.Message, SwiftProtobuf._Messag
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if self.timeElapsed != 0 {
       try visitor.visitSingularDoubleField(value: self.timeElapsed, fieldNumber: 1)
     }
@@ -228,9 +240,9 @@ extension Grpc_Testing_ServerStats: SwiftProtobuf.Message, SwiftProtobuf._Messag
     if self.cqPollCount != 0 {
       try visitor.visitSingularUInt64Field(value: self.cqPollCount, fieldNumber: 6)
     }
-    if let v = self._coreStats {
+    try { if let v = self._coreStats {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -416,9 +428,13 @@ extension Grpc_Testing_ClientStats: SwiftProtobuf.Message, SwiftProtobuf._Messag
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._latencies {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._latencies {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
+    } }()
     if self.timeElapsed != 0 {
       try visitor.visitSingularDoubleField(value: self.timeElapsed, fieldNumber: 2)
     }
@@ -434,9 +450,9 @@ extension Grpc_Testing_ClientStats: SwiftProtobuf.Message, SwiftProtobuf._Messag
     if self.cqPollCount != 0 {
       try visitor.visitSingularUInt64Field(value: self.cqPollCount, fieldNumber: 6)
     }
-    if let v = self._coreStats {
+    try { if let v = self._coreStats {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 

--- a/Performance/QPSBenchmark/Sources/QPSBenchmark/Model/worker_service.grpc.swift
+++ b/Performance/QPSBenchmark/Sources/QPSBenchmark/Model/worker_service.grpc.swift
@@ -75,7 +75,7 @@ extension Grpc_Testing_WorkerServiceClientProtocol {
     handler: @escaping (Grpc_Testing_ServerStatus) -> Void
   ) -> BidirectionalStreamingCall<Grpc_Testing_ServerArgs, Grpc_Testing_ServerStatus> {
     return self.makeBidirectionalStreamingCall(
-      path: "/grpc.testing.WorkerService/RunServer",
+      path: Grpc_Testing_WorkerServiceClientMetadata.Methods.runServer.path,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeRunServerInterceptors() ?? [],
       handler: handler
@@ -101,7 +101,7 @@ extension Grpc_Testing_WorkerServiceClientProtocol {
     handler: @escaping (Grpc_Testing_ClientStatus) -> Void
   ) -> BidirectionalStreamingCall<Grpc_Testing_ClientArgs, Grpc_Testing_ClientStatus> {
     return self.makeBidirectionalStreamingCall(
-      path: "/grpc.testing.WorkerService/RunClient",
+      path: Grpc_Testing_WorkerServiceClientMetadata.Methods.runClient.path,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeRunClientInterceptors() ?? [],
       handler: handler
@@ -119,7 +119,7 @@ extension Grpc_Testing_WorkerServiceClientProtocol {
     callOptions: CallOptions? = nil
   ) -> UnaryCall<Grpc_Testing_CoreRequest, Grpc_Testing_CoreResponse> {
     return self.makeUnaryCall(
-      path: "/grpc.testing.WorkerService/CoreCount",
+      path: Grpc_Testing_WorkerServiceClientMetadata.Methods.coreCount.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeCoreCountInterceptors() ?? []
@@ -137,27 +137,12 @@ extension Grpc_Testing_WorkerServiceClientProtocol {
     callOptions: CallOptions? = nil
   ) -> UnaryCall<Grpc_Testing_Void, Grpc_Testing_Void> {
     return self.makeUnaryCall(
-      path: "/grpc.testing.WorkerService/QuitWorker",
+      path: Grpc_Testing_WorkerServiceClientMetadata.Methods.quitWorker.path,
       request: request,
       callOptions: callOptions ?? self.defaultCallOptions,
       interceptors: self.interceptors?.makeQuitWorkerInterceptors() ?? []
     )
   }
-}
-
-public protocol Grpc_Testing_WorkerServiceClientInterceptorFactoryProtocol {
-
-  /// - Returns: Interceptors to use when invoking 'runServer'.
-  func makeRunServerInterceptors() -> [ClientInterceptor<Grpc_Testing_ServerArgs, Grpc_Testing_ServerStatus>]
-
-  /// - Returns: Interceptors to use when invoking 'runClient'.
-  func makeRunClientInterceptors() -> [ClientInterceptor<Grpc_Testing_ClientArgs, Grpc_Testing_ClientStatus>]
-
-  /// - Returns: Interceptors to use when invoking 'coreCount'.
-  func makeCoreCountInterceptors() -> [ClientInterceptor<Grpc_Testing_CoreRequest, Grpc_Testing_CoreResponse>]
-
-  /// - Returns: Interceptors to use when invoking 'quitWorker'.
-  func makeQuitWorkerInterceptors() -> [ClientInterceptor<Grpc_Testing_Void, Grpc_Testing_Void>]
 }
 
 public final class Grpc_Testing_WorkerServiceClient: Grpc_Testing_WorkerServiceClientProtocol {
@@ -179,6 +164,234 @@ public final class Grpc_Testing_WorkerServiceClient: Grpc_Testing_WorkerServiceC
     self.channel = channel
     self.defaultCallOptions = defaultCallOptions
     self.interceptors = interceptors
+  }
+}
+
+#if compiler(>=5.6)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+public protocol Grpc_Testing_WorkerServiceAsyncClientProtocol: GRPCClient {
+  static var serviceDescriptor: GRPCServiceDescriptor { get }
+  var interceptors: Grpc_Testing_WorkerServiceClientInterceptorFactoryProtocol? { get }
+
+  func makeRunServerCall(
+    callOptions: CallOptions?
+  ) -> GRPCAsyncBidirectionalStreamingCall<Grpc_Testing_ServerArgs, Grpc_Testing_ServerStatus>
+
+  func makeRunClientCall(
+    callOptions: CallOptions?
+  ) -> GRPCAsyncBidirectionalStreamingCall<Grpc_Testing_ClientArgs, Grpc_Testing_ClientStatus>
+
+  func makeCoreCountCall(
+    _ request: Grpc_Testing_CoreRequest,
+    callOptions: CallOptions?
+  ) -> GRPCAsyncUnaryCall<Grpc_Testing_CoreRequest, Grpc_Testing_CoreResponse>
+
+  func makeQuitWorkerCall(
+    _ request: Grpc_Testing_Void,
+    callOptions: CallOptions?
+  ) -> GRPCAsyncUnaryCall<Grpc_Testing_Void, Grpc_Testing_Void>
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension Grpc_Testing_WorkerServiceAsyncClientProtocol {
+  public static var serviceDescriptor: GRPCServiceDescriptor {
+    return Grpc_Testing_WorkerServiceClientMetadata.serviceDescriptor
+  }
+
+  public var interceptors: Grpc_Testing_WorkerServiceClientInterceptorFactoryProtocol? {
+    return nil
+  }
+
+  public func makeRunServerCall(
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncBidirectionalStreamingCall<Grpc_Testing_ServerArgs, Grpc_Testing_ServerStatus> {
+    return self.makeAsyncBidirectionalStreamingCall(
+      path: Grpc_Testing_WorkerServiceClientMetadata.Methods.runServer.path,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeRunServerInterceptors() ?? []
+    )
+  }
+
+  public func makeRunClientCall(
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncBidirectionalStreamingCall<Grpc_Testing_ClientArgs, Grpc_Testing_ClientStatus> {
+    return self.makeAsyncBidirectionalStreamingCall(
+      path: Grpc_Testing_WorkerServiceClientMetadata.Methods.runClient.path,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeRunClientInterceptors() ?? []
+    )
+  }
+
+  public func makeCoreCountCall(
+    _ request: Grpc_Testing_CoreRequest,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncUnaryCall<Grpc_Testing_CoreRequest, Grpc_Testing_CoreResponse> {
+    return self.makeAsyncUnaryCall(
+      path: Grpc_Testing_WorkerServiceClientMetadata.Methods.coreCount.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeCoreCountInterceptors() ?? []
+    )
+  }
+
+  public func makeQuitWorkerCall(
+    _ request: Grpc_Testing_Void,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncUnaryCall<Grpc_Testing_Void, Grpc_Testing_Void> {
+    return self.makeAsyncUnaryCall(
+      path: Grpc_Testing_WorkerServiceClientMetadata.Methods.quitWorker.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeQuitWorkerInterceptors() ?? []
+    )
+  }
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension Grpc_Testing_WorkerServiceAsyncClientProtocol {
+  public func runServer<RequestStream>(
+    _ requests: RequestStream,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncResponseStream<Grpc_Testing_ServerStatus> where RequestStream: Sequence, RequestStream.Element == Grpc_Testing_ServerArgs {
+    return self.performAsyncBidirectionalStreamingCall(
+      path: Grpc_Testing_WorkerServiceClientMetadata.Methods.runServer.path,
+      requests: requests,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeRunServerInterceptors() ?? []
+    )
+  }
+
+  public func runServer<RequestStream>(
+    _ requests: RequestStream,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncResponseStream<Grpc_Testing_ServerStatus> where RequestStream: AsyncSequence, RequestStream.Element == Grpc_Testing_ServerArgs {
+    return self.performAsyncBidirectionalStreamingCall(
+      path: Grpc_Testing_WorkerServiceClientMetadata.Methods.runServer.path,
+      requests: requests,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeRunServerInterceptors() ?? []
+    )
+  }
+
+  public func runClient<RequestStream>(
+    _ requests: RequestStream,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncResponseStream<Grpc_Testing_ClientStatus> where RequestStream: Sequence, RequestStream.Element == Grpc_Testing_ClientArgs {
+    return self.performAsyncBidirectionalStreamingCall(
+      path: Grpc_Testing_WorkerServiceClientMetadata.Methods.runClient.path,
+      requests: requests,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeRunClientInterceptors() ?? []
+    )
+  }
+
+  public func runClient<RequestStream>(
+    _ requests: RequestStream,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncResponseStream<Grpc_Testing_ClientStatus> where RequestStream: AsyncSequence, RequestStream.Element == Grpc_Testing_ClientArgs {
+    return self.performAsyncBidirectionalStreamingCall(
+      path: Grpc_Testing_WorkerServiceClientMetadata.Methods.runClient.path,
+      requests: requests,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeRunClientInterceptors() ?? []
+    )
+  }
+
+  public func coreCount(
+    _ request: Grpc_Testing_CoreRequest,
+    callOptions: CallOptions? = nil
+  ) async throws -> Grpc_Testing_CoreResponse {
+    return try await self.performAsyncUnaryCall(
+      path: Grpc_Testing_WorkerServiceClientMetadata.Methods.coreCount.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeCoreCountInterceptors() ?? []
+    )
+  }
+
+  public func quitWorker(
+    _ request: Grpc_Testing_Void,
+    callOptions: CallOptions? = nil
+  ) async throws -> Grpc_Testing_Void {
+    return try await self.performAsyncUnaryCall(
+      path: Grpc_Testing_WorkerServiceClientMetadata.Methods.quitWorker.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeQuitWorkerInterceptors() ?? []
+    )
+  }
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+public struct Grpc_Testing_WorkerServiceAsyncClient: Grpc_Testing_WorkerServiceAsyncClientProtocol {
+  public var channel: GRPCChannel
+  public var defaultCallOptions: CallOptions
+  public var interceptors: Grpc_Testing_WorkerServiceClientInterceptorFactoryProtocol?
+
+  public init(
+    channel: GRPCChannel,
+    defaultCallOptions: CallOptions = CallOptions(),
+    interceptors: Grpc_Testing_WorkerServiceClientInterceptorFactoryProtocol? = nil
+  ) {
+    self.channel = channel
+    self.defaultCallOptions = defaultCallOptions
+    self.interceptors = interceptors
+  }
+}
+
+#endif // compiler(>=5.6)
+
+public protocol Grpc_Testing_WorkerServiceClientInterceptorFactoryProtocol {
+
+  /// - Returns: Interceptors to use when invoking 'runServer'.
+  func makeRunServerInterceptors() -> [ClientInterceptor<Grpc_Testing_ServerArgs, Grpc_Testing_ServerStatus>]
+
+  /// - Returns: Interceptors to use when invoking 'runClient'.
+  func makeRunClientInterceptors() -> [ClientInterceptor<Grpc_Testing_ClientArgs, Grpc_Testing_ClientStatus>]
+
+  /// - Returns: Interceptors to use when invoking 'coreCount'.
+  func makeCoreCountInterceptors() -> [ClientInterceptor<Grpc_Testing_CoreRequest, Grpc_Testing_CoreResponse>]
+
+  /// - Returns: Interceptors to use when invoking 'quitWorker'.
+  func makeQuitWorkerInterceptors() -> [ClientInterceptor<Grpc_Testing_Void, Grpc_Testing_Void>]
+}
+
+public enum Grpc_Testing_WorkerServiceClientMetadata {
+  public static let serviceDescriptor = GRPCServiceDescriptor(
+    name: "WorkerService",
+    fullName: "grpc.testing.WorkerService",
+    methods: [
+      Grpc_Testing_WorkerServiceClientMetadata.Methods.runServer,
+      Grpc_Testing_WorkerServiceClientMetadata.Methods.runClient,
+      Grpc_Testing_WorkerServiceClientMetadata.Methods.coreCount,
+      Grpc_Testing_WorkerServiceClientMetadata.Methods.quitWorker,
+    ]
+  )
+
+  public enum Methods {
+    public static let runServer = GRPCMethodDescriptor(
+      name: "RunServer",
+      path: "/grpc.testing.WorkerService/RunServer",
+      type: GRPCCallType.bidirectionalStreaming
+    )
+
+    public static let runClient = GRPCMethodDescriptor(
+      name: "RunClient",
+      path: "/grpc.testing.WorkerService/RunClient",
+      type: GRPCCallType.bidirectionalStreaming
+    )
+
+    public static let coreCount = GRPCMethodDescriptor(
+      name: "CoreCount",
+      path: "/grpc.testing.WorkerService/CoreCount",
+      type: GRPCCallType.unary
+    )
+
+    public static let quitWorker = GRPCMethodDescriptor(
+      name: "QuitWorker",
+      path: "/grpc.testing.WorkerService/QuitWorker",
+      type: GRPCCallType.unary
+    )
   }
 }
 
@@ -210,7 +423,9 @@ public protocol Grpc_Testing_WorkerServiceProvider: CallHandlerProvider {
 }
 
 extension Grpc_Testing_WorkerServiceProvider {
-  public var serviceName: Substring { return "grpc.testing.WorkerService" }
+  public var serviceName: Substring {
+    return Grpc_Testing_WorkerServiceServerMetadata.serviceDescriptor.fullName[...]
+  }
 
   /// Determines, calls and returns the appropriate request handler, depending on the request's method.
   /// Returns nil for methods not handled by this service.
@@ -261,6 +476,114 @@ extension Grpc_Testing_WorkerServiceProvider {
   }
 }
 
+#if compiler(>=5.6)
+
+/// To implement a server, implement an object which conforms to this protocol.
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+public protocol Grpc_Testing_WorkerServiceAsyncProvider: CallHandlerProvider {
+  static var serviceDescriptor: GRPCServiceDescriptor { get }
+  var interceptors: Grpc_Testing_WorkerServiceServerInterceptorFactoryProtocol? { get }
+
+  /// Start server with specified workload.
+  /// First request sent specifies the ServerConfig followed by ServerStatus
+  /// response. After that, a "Mark" can be sent anytime to request the latest
+  /// stats. Closing the stream will initiate shutdown of the test server
+  /// and once the shutdown has finished, the OK status is sent to terminate
+  /// this RPC.
+  @Sendable func runServer(
+    requestStream: GRPCAsyncRequestStream<Grpc_Testing_ServerArgs>,
+    responseStream: GRPCAsyncResponseStreamWriter<Grpc_Testing_ServerStatus>,
+    context: GRPCAsyncServerCallContext
+  ) async throws
+
+  /// Start client with specified workload.
+  /// First request sent specifies the ClientConfig followed by ClientStatus
+  /// response. After that, a "Mark" can be sent anytime to request the latest
+  /// stats. Closing the stream will initiate shutdown of the test client
+  /// and once the shutdown has finished, the OK status is sent to terminate
+  /// this RPC.
+  @Sendable func runClient(
+    requestStream: GRPCAsyncRequestStream<Grpc_Testing_ClientArgs>,
+    responseStream: GRPCAsyncResponseStreamWriter<Grpc_Testing_ClientStatus>,
+    context: GRPCAsyncServerCallContext
+  ) async throws
+
+  /// Just return the core count - unary call
+  @Sendable func coreCount(
+    request: Grpc_Testing_CoreRequest,
+    context: GRPCAsyncServerCallContext
+  ) async throws -> Grpc_Testing_CoreResponse
+
+  /// Quit this worker
+  @Sendable func quitWorker(
+    request: Grpc_Testing_Void,
+    context: GRPCAsyncServerCallContext
+  ) async throws -> Grpc_Testing_Void
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension Grpc_Testing_WorkerServiceAsyncProvider {
+  public static var serviceDescriptor: GRPCServiceDescriptor {
+    return Grpc_Testing_WorkerServiceServerMetadata.serviceDescriptor
+  }
+
+  public var serviceName: Substring {
+    return Grpc_Testing_WorkerServiceServerMetadata.serviceDescriptor.fullName[...]
+  }
+
+  public var interceptors: Grpc_Testing_WorkerServiceServerInterceptorFactoryProtocol? {
+    return nil
+  }
+
+  public func handle(
+    method name: Substring,
+    context: CallHandlerContext
+  ) -> GRPCServerHandlerProtocol? {
+    switch name {
+    case "RunServer":
+      return GRPCAsyncServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Grpc_Testing_ServerArgs>(),
+        responseSerializer: ProtobufSerializer<Grpc_Testing_ServerStatus>(),
+        interceptors: self.interceptors?.makeRunServerInterceptors() ?? [],
+        wrapping: self.runServer(requestStream:responseStream:context:)
+      )
+
+    case "RunClient":
+      return GRPCAsyncServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Grpc_Testing_ClientArgs>(),
+        responseSerializer: ProtobufSerializer<Grpc_Testing_ClientStatus>(),
+        interceptors: self.interceptors?.makeRunClientInterceptors() ?? [],
+        wrapping: self.runClient(requestStream:responseStream:context:)
+      )
+
+    case "CoreCount":
+      return GRPCAsyncServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Grpc_Testing_CoreRequest>(),
+        responseSerializer: ProtobufSerializer<Grpc_Testing_CoreResponse>(),
+        interceptors: self.interceptors?.makeCoreCountInterceptors() ?? [],
+        wrapping: self.coreCount(request:context:)
+      )
+
+    case "QuitWorker":
+      return GRPCAsyncServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<Grpc_Testing_Void>(),
+        responseSerializer: ProtobufSerializer<Grpc_Testing_Void>(),
+        interceptors: self.interceptors?.makeQuitWorkerInterceptors() ?? [],
+        wrapping: self.quitWorker(request:context:)
+      )
+
+    default:
+      return nil
+    }
+  }
+}
+
+#endif // compiler(>=5.6)
+
 public protocol Grpc_Testing_WorkerServiceServerInterceptorFactoryProtocol {
 
   /// - Returns: Interceptors to use when handling 'runServer'.
@@ -278,4 +601,43 @@ public protocol Grpc_Testing_WorkerServiceServerInterceptorFactoryProtocol {
   /// - Returns: Interceptors to use when handling 'quitWorker'.
   ///   Defaults to calling `self.makeInterceptors()`.
   func makeQuitWorkerInterceptors() -> [ServerInterceptor<Grpc_Testing_Void, Grpc_Testing_Void>]
+}
+
+public enum Grpc_Testing_WorkerServiceServerMetadata {
+  public static let serviceDescriptor = GRPCServiceDescriptor(
+    name: "WorkerService",
+    fullName: "grpc.testing.WorkerService",
+    methods: [
+      Grpc_Testing_WorkerServiceServerMetadata.Methods.runServer,
+      Grpc_Testing_WorkerServiceServerMetadata.Methods.runClient,
+      Grpc_Testing_WorkerServiceServerMetadata.Methods.coreCount,
+      Grpc_Testing_WorkerServiceServerMetadata.Methods.quitWorker,
+    ]
+  )
+
+  public enum Methods {
+    public static let runServer = GRPCMethodDescriptor(
+      name: "RunServer",
+      path: "/grpc.testing.WorkerService/RunServer",
+      type: GRPCCallType.bidirectionalStreaming
+    )
+
+    public static let runClient = GRPCMethodDescriptor(
+      name: "RunClient",
+      path: "/grpc.testing.WorkerService/RunClient",
+      type: GRPCCallType.bidirectionalStreaming
+    )
+
+    public static let coreCount = GRPCMethodDescriptor(
+      name: "CoreCount",
+      path: "/grpc.testing.WorkerService/CoreCount",
+      type: GRPCCallType.unary
+    )
+
+    public static let quitWorker = GRPCMethodDescriptor(
+      name: "QuitWorker",
+      path: "/grpc.testing.WorkerService/QuitWorker",
+      type: GRPCCallType.unary
+    )
+  }
 }

--- a/Sources/Examples/Echo/Model/echo.grpc.swift
+++ b/Sources/Examples/Echo/Model/echo.grpc.swift
@@ -573,6 +573,7 @@ extension Echo_EchoProvider {
     }
   }
 }
+
 #if compiler(>=5.6)
 
 /// To implement a server, implement an object which conforms to this protocol.

--- a/Sources/Examples/HelloWorld/Model/helloworld.grpc.swift
+++ b/Sources/Examples/HelloWorld/Model/helloworld.grpc.swift
@@ -214,6 +214,7 @@ extension Helloworld_GreeterProvider {
     }
   }
 }
+
 #if compiler(>=5.6)
 
 /// The greeting service definition.

--- a/Sources/Examples/RouteGuide/Model/route_guide.grpc.swift
+++ b/Sources/Examples/RouteGuide/Model/route_guide.grpc.swift
@@ -492,6 +492,7 @@ extension Routeguide_RouteGuideProvider {
     }
   }
 }
+
 #if compiler(>=5.6)
 
 /// Interface exported by the server.

--- a/Sources/GRPCInteroperabilityTestModels/Generated/test.grpc.swift
+++ b/Sources/GRPCInteroperabilityTestModels/Generated/test.grpc.swift
@@ -1148,6 +1148,7 @@ extension Grpc_Testing_TestServiceProvider {
     }
   }
 }
+
 #if compiler(>=5.6)
 
 /// A simple service to test the various types of RPCs and experiment with
@@ -1442,6 +1443,7 @@ extension Grpc_Testing_UnimplementedServiceProvider {
     }
   }
 }
+
 #if compiler(>=5.6)
 
 /// A simple service NOT implemented at servers so clients can test for
@@ -1566,6 +1568,7 @@ extension Grpc_Testing_ReconnectServiceProvider {
     }
   }
 }
+
 #if compiler(>=5.6)
 
 /// A service used to control reconnect server.

--- a/Sources/GRPCInteroperabilityTestModels/generate.sh
+++ b/Sources/GRPCInteroperabilityTestModels/generate.sh
@@ -18,7 +18,7 @@ VISIBILITY="Public"
   --swift_out=${OUTPUT} \
   --swift_opt=FileNaming=${FILE_NAMING},Visibility=${VISIBILITY} \
   --grpc-swift_out=${OUTPUT} \
-  --grpc-swift_opt=FileNaming=${FILE_NAMING},Visibility=${VISIBILITY},ExperimentalAsyncClient=true,ExperimentalAsyncServer=true)
+  --grpc-swift_opt=FileNaming=${FILE_NAMING},Visibility=${VISIBILITY})
 
 (cd "${CURRENT_SCRIPT_DIR}" && protoc "src/proto/grpc/testing/empty.proto" \
   --plugin=${PLUGIN_SWIFT} \
@@ -26,7 +26,7 @@ VISIBILITY="Public"
   --swift_out=${OUTPUT} \
   --swift_opt=FileNaming=${FILE_NAMING},Visibility=${VISIBILITY} \
   --grpc-swift_out=${OUTPUT} \
-  --grpc-swift_opt=FileNaming=${FILE_NAMING},Visibility=${VISIBILITY},ExperimentalAsyncClient=true,ExperimentalAsyncServer=true)
+  --grpc-swift_opt=FileNaming=${FILE_NAMING},Visibility=${VISIBILITY})
 
 (cd "${CURRENT_SCRIPT_DIR}" && protoc "src/proto/grpc/testing/messages.proto" \
   --plugin=${PLUGIN_SWIFT} \
@@ -34,7 +34,7 @@ VISIBILITY="Public"
   --swift_out=${OUTPUT} \
   --swift_opt=FileNaming=${FILE_NAMING},Visibility=${VISIBILITY} \
   --grpc-swift_out=${OUTPUT} \
-  --grpc-swift_opt=FileNaming=${FILE_NAMING},Visibility=${VISIBILITY},ExperimentalAsyncClient=true,ExperimentalAsyncServer=true)
+  --grpc-swift_opt=FileNaming=${FILE_NAMING},Visibility=${VISIBILITY})
 
 # The generated code needs to be modified to support testing an unimplemented method.
 # On the server side, the generated code needs to be removed so the server has no

--- a/Sources/protoc-gen-grpc-swift/Generator-Client.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator-Client.swift
@@ -26,9 +26,6 @@ extension Generator {
       self.printClientProtocolExtension()
       self.println()
       self.printServiceClientImplementation()
-    }
-
-    if self.options.generateAsyncClient {
       self.println()
       self.printIfCompilerGuardForAsyncAwait()
       self.printAsyncServiceClientProtocol()
@@ -40,11 +37,8 @@ extension Generator {
       self.printAsyncServiceClientImplementation()
       self.println()
       self.printEndCompilerGuardForAsyncAwait()
-    }
-
-    // Both implementations share definitions for interceptors and metadata.
-    if self.options.generateClient || self.options.generateAsyncClient {
       self.println()
+      // Both implementations share definitions for interceptors and metadata.
       self.printServiceClientInterceptorFactoryProtocol()
       self.println()
       self.printClientMetadata()

--- a/Sources/protoc-gen-grpc-swift/Generator-Server.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator-Server.swift
@@ -23,9 +23,7 @@ extension Generator {
       self.printServerProtocol()
       self.println()
       self.printServerProtocolExtension()
-    }
-
-    if self.options.generateAsyncServer {
+      self.println()
       self.printIfCompilerGuardForAsyncAwait()
       self.println()
       self.printServerProtocolAsyncAwait()
@@ -33,11 +31,8 @@ extension Generator {
       self.printServerProtocolExtensionAsyncAwait()
       self.println()
       self.printEndCompilerGuardForAsyncAwait()
-    }
-
-    // Both implementations share definitions for interceptors and metadata.
-    if self.options.generateServer || self.options.generateAsyncServer {
       self.println()
+      // Both implementations share definitions for interceptors and metadata.
       self.printServerInterceptorFactoryProtocol()
       self.println()
       self.printServerMetadata()

--- a/Sources/protoc-gen-grpc-swift/Generator.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator.swift
@@ -157,7 +157,7 @@ class Generator {
     }
     self.println()
 
-    if self.options.generateServer || self.options.generateAsyncServer {
+    if self.options.generateServer {
       for service in self.file.services {
         self.service = service
         printServer()

--- a/Sources/protoc-gen-grpc-swift/options.swift
+++ b/Sources/protoc-gen-grpc-swift/options.swift
@@ -54,10 +54,8 @@ final class GeneratorOptions {
   private(set) var visibility = Visibility.internal
 
   private(set) var generateServer = true
-  private(set) var generateAsyncServer = false
 
   private(set) var generateClient = true
-  private(set) var generateAsyncClient = false
   private(set) var generateTestClient = false
 
   private(set) var keepMethodCasing = false
@@ -84,23 +82,9 @@ final class GeneratorOptions {
           throw GenerationError.invalidParameterValue(name: pair.key, value: pair.value)
         }
 
-      case "ExperimentalAsyncServer":
-        if let value = Bool(pair.value) {
-          self.generateAsyncServer = value
-        } else {
-          throw GenerationError.invalidParameterValue(name: pair.key, value: pair.value)
-        }
-
       case "Client":
         if let value = Bool(pair.value) {
           self.generateClient = value
-        } else {
-          throw GenerationError.invalidParameterValue(name: pair.key, value: pair.value)
-        }
-
-      case "ExperimentalAsyncClient":
-        if let value = Bool(pair.value) {
-          self.generateAsyncClient = value
         } else {
           throw GenerationError.invalidParameterValue(name: pair.key, value: pair.value)
         }

--- a/Tests/GRPCTests/Codegen/Normalization/normalization.grpc.swift
+++ b/Tests/GRPCTests/Codegen/Normalization/normalization.grpc.swift
@@ -255,6 +255,314 @@ internal final class Normalization_NormalizationClient: Normalization_Normalizat
   }
 }
 
+#if compiler(>=5.6)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+internal protocol Normalization_NormalizationAsyncClientProtocol: GRPCClient {
+  static var serviceDescriptor: GRPCServiceDescriptor { get }
+  var interceptors: Normalization_NormalizationClientInterceptorFactoryProtocol? { get }
+
+  func makeUnaryCall(
+    _ request: SwiftProtobuf.Google_Protobuf_Empty,
+    callOptions: CallOptions?
+  ) -> GRPCAsyncUnaryCall<SwiftProtobuf.Google_Protobuf_Empty, Normalization_FunctionName>
+
+  func makeunaryCall(
+    _ request: SwiftProtobuf.Google_Protobuf_Empty,
+    callOptions: CallOptions?
+  ) -> GRPCAsyncUnaryCall<SwiftProtobuf.Google_Protobuf_Empty, Normalization_FunctionName>
+
+  func makeServerStreamingCall(
+    _ request: SwiftProtobuf.Google_Protobuf_Empty,
+    callOptions: CallOptions?
+  ) -> GRPCAsyncServerStreamingCall<SwiftProtobuf.Google_Protobuf_Empty, Normalization_FunctionName>
+
+  func makeserverStreamingCall(
+    _ request: SwiftProtobuf.Google_Protobuf_Empty,
+    callOptions: CallOptions?
+  ) -> GRPCAsyncServerStreamingCall<SwiftProtobuf.Google_Protobuf_Empty, Normalization_FunctionName>
+
+  func makeClientStreamingCall(
+    callOptions: CallOptions?
+  ) -> GRPCAsyncClientStreamingCall<SwiftProtobuf.Google_Protobuf_Empty, Normalization_FunctionName>
+
+  func makeclientStreamingCall(
+    callOptions: CallOptions?
+  ) -> GRPCAsyncClientStreamingCall<SwiftProtobuf.Google_Protobuf_Empty, Normalization_FunctionName>
+
+  func makeBidirectionalStreamingCall(
+    callOptions: CallOptions?
+  ) -> GRPCAsyncBidirectionalStreamingCall<SwiftProtobuf.Google_Protobuf_Empty, Normalization_FunctionName>
+
+  func makebidirectionalStreamingCall(
+    callOptions: CallOptions?
+  ) -> GRPCAsyncBidirectionalStreamingCall<SwiftProtobuf.Google_Protobuf_Empty, Normalization_FunctionName>
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension Normalization_NormalizationAsyncClientProtocol {
+  internal static var serviceDescriptor: GRPCServiceDescriptor {
+    return Normalization_NormalizationClientMetadata.serviceDescriptor
+  }
+
+  internal var interceptors: Normalization_NormalizationClientInterceptorFactoryProtocol? {
+    return nil
+  }
+
+  internal func makeUnaryCall(
+    _ request: SwiftProtobuf.Google_Protobuf_Empty,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncUnaryCall<SwiftProtobuf.Google_Protobuf_Empty, Normalization_FunctionName> {
+    return self.makeAsyncUnaryCall(
+      path: Normalization_NormalizationClientMetadata.Methods.Unary.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeUnaryInterceptors() ?? []
+    )
+  }
+
+  internal func makeunaryCall(
+    _ request: SwiftProtobuf.Google_Protobuf_Empty,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncUnaryCall<SwiftProtobuf.Google_Protobuf_Empty, Normalization_FunctionName> {
+    return self.makeAsyncUnaryCall(
+      path: Normalization_NormalizationClientMetadata.Methods.unary.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeunaryInterceptors() ?? []
+    )
+  }
+
+  internal func makeServerStreamingCall(
+    _ request: SwiftProtobuf.Google_Protobuf_Empty,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncServerStreamingCall<SwiftProtobuf.Google_Protobuf_Empty, Normalization_FunctionName> {
+    return self.makeAsyncServerStreamingCall(
+      path: Normalization_NormalizationClientMetadata.Methods.ServerStreaming.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeServerStreamingInterceptors() ?? []
+    )
+  }
+
+  internal func makeserverStreamingCall(
+    _ request: SwiftProtobuf.Google_Protobuf_Empty,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncServerStreamingCall<SwiftProtobuf.Google_Protobuf_Empty, Normalization_FunctionName> {
+    return self.makeAsyncServerStreamingCall(
+      path: Normalization_NormalizationClientMetadata.Methods.serverStreaming.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeserverStreamingInterceptors() ?? []
+    )
+  }
+
+  internal func makeClientStreamingCall(
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncClientStreamingCall<SwiftProtobuf.Google_Protobuf_Empty, Normalization_FunctionName> {
+    return self.makeAsyncClientStreamingCall(
+      path: Normalization_NormalizationClientMetadata.Methods.ClientStreaming.path,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeClientStreamingInterceptors() ?? []
+    )
+  }
+
+  internal func makeclientStreamingCall(
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncClientStreamingCall<SwiftProtobuf.Google_Protobuf_Empty, Normalization_FunctionName> {
+    return self.makeAsyncClientStreamingCall(
+      path: Normalization_NormalizationClientMetadata.Methods.clientStreaming.path,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeclientStreamingInterceptors() ?? []
+    )
+  }
+
+  internal func makeBidirectionalStreamingCall(
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncBidirectionalStreamingCall<SwiftProtobuf.Google_Protobuf_Empty, Normalization_FunctionName> {
+    return self.makeAsyncBidirectionalStreamingCall(
+      path: Normalization_NormalizationClientMetadata.Methods.BidirectionalStreaming.path,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeBidirectionalStreamingInterceptors() ?? []
+    )
+  }
+
+  internal func makebidirectionalStreamingCall(
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncBidirectionalStreamingCall<SwiftProtobuf.Google_Protobuf_Empty, Normalization_FunctionName> {
+    return self.makeAsyncBidirectionalStreamingCall(
+      path: Normalization_NormalizationClientMetadata.Methods.bidirectionalStreaming.path,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makebidirectionalStreamingInterceptors() ?? []
+    )
+  }
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension Normalization_NormalizationAsyncClientProtocol {
+  internal func Unary(
+    _ request: SwiftProtobuf.Google_Protobuf_Empty,
+    callOptions: CallOptions? = nil
+  ) async throws -> Normalization_FunctionName {
+    return try await self.performAsyncUnaryCall(
+      path: Normalization_NormalizationClientMetadata.Methods.Unary.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeUnaryInterceptors() ?? []
+    )
+  }
+
+  internal func unary(
+    _ request: SwiftProtobuf.Google_Protobuf_Empty,
+    callOptions: CallOptions? = nil
+  ) async throws -> Normalization_FunctionName {
+    return try await self.performAsyncUnaryCall(
+      path: Normalization_NormalizationClientMetadata.Methods.unary.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeunaryInterceptors() ?? []
+    )
+  }
+
+  internal func ServerStreaming(
+    _ request: SwiftProtobuf.Google_Protobuf_Empty,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncResponseStream<Normalization_FunctionName> {
+    return self.performAsyncServerStreamingCall(
+      path: Normalization_NormalizationClientMetadata.Methods.ServerStreaming.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeServerStreamingInterceptors() ?? []
+    )
+  }
+
+  internal func serverStreaming(
+    _ request: SwiftProtobuf.Google_Protobuf_Empty,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncResponseStream<Normalization_FunctionName> {
+    return self.performAsyncServerStreamingCall(
+      path: Normalization_NormalizationClientMetadata.Methods.serverStreaming.path,
+      request: request,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeserverStreamingInterceptors() ?? []
+    )
+  }
+
+  internal func ClientStreaming<RequestStream>(
+    _ requests: RequestStream,
+    callOptions: CallOptions? = nil
+  ) async throws -> Normalization_FunctionName where RequestStream: Sequence, RequestStream.Element == SwiftProtobuf.Google_Protobuf_Empty {
+    return try await self.performAsyncClientStreamingCall(
+      path: Normalization_NormalizationClientMetadata.Methods.ClientStreaming.path,
+      requests: requests,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeClientStreamingInterceptors() ?? []
+    )
+  }
+
+  internal func ClientStreaming<RequestStream>(
+    _ requests: RequestStream,
+    callOptions: CallOptions? = nil
+  ) async throws -> Normalization_FunctionName where RequestStream: AsyncSequence, RequestStream.Element == SwiftProtobuf.Google_Protobuf_Empty {
+    return try await self.performAsyncClientStreamingCall(
+      path: Normalization_NormalizationClientMetadata.Methods.ClientStreaming.path,
+      requests: requests,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeClientStreamingInterceptors() ?? []
+    )
+  }
+
+  internal func clientStreaming<RequestStream>(
+    _ requests: RequestStream,
+    callOptions: CallOptions? = nil
+  ) async throws -> Normalization_FunctionName where RequestStream: Sequence, RequestStream.Element == SwiftProtobuf.Google_Protobuf_Empty {
+    return try await self.performAsyncClientStreamingCall(
+      path: Normalization_NormalizationClientMetadata.Methods.clientStreaming.path,
+      requests: requests,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeclientStreamingInterceptors() ?? []
+    )
+  }
+
+  internal func clientStreaming<RequestStream>(
+    _ requests: RequestStream,
+    callOptions: CallOptions? = nil
+  ) async throws -> Normalization_FunctionName where RequestStream: AsyncSequence, RequestStream.Element == SwiftProtobuf.Google_Protobuf_Empty {
+    return try await self.performAsyncClientStreamingCall(
+      path: Normalization_NormalizationClientMetadata.Methods.clientStreaming.path,
+      requests: requests,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeclientStreamingInterceptors() ?? []
+    )
+  }
+
+  internal func BidirectionalStreaming<RequestStream>(
+    _ requests: RequestStream,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncResponseStream<Normalization_FunctionName> where RequestStream: Sequence, RequestStream.Element == SwiftProtobuf.Google_Protobuf_Empty {
+    return self.performAsyncBidirectionalStreamingCall(
+      path: Normalization_NormalizationClientMetadata.Methods.BidirectionalStreaming.path,
+      requests: requests,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeBidirectionalStreamingInterceptors() ?? []
+    )
+  }
+
+  internal func BidirectionalStreaming<RequestStream>(
+    _ requests: RequestStream,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncResponseStream<Normalization_FunctionName> where RequestStream: AsyncSequence, RequestStream.Element == SwiftProtobuf.Google_Protobuf_Empty {
+    return self.performAsyncBidirectionalStreamingCall(
+      path: Normalization_NormalizationClientMetadata.Methods.BidirectionalStreaming.path,
+      requests: requests,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makeBidirectionalStreamingInterceptors() ?? []
+    )
+  }
+
+  internal func bidirectionalStreaming<RequestStream>(
+    _ requests: RequestStream,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncResponseStream<Normalization_FunctionName> where RequestStream: Sequence, RequestStream.Element == SwiftProtobuf.Google_Protobuf_Empty {
+    return self.performAsyncBidirectionalStreamingCall(
+      path: Normalization_NormalizationClientMetadata.Methods.bidirectionalStreaming.path,
+      requests: requests,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makebidirectionalStreamingInterceptors() ?? []
+    )
+  }
+
+  internal func bidirectionalStreaming<RequestStream>(
+    _ requests: RequestStream,
+    callOptions: CallOptions? = nil
+  ) -> GRPCAsyncResponseStream<Normalization_FunctionName> where RequestStream: AsyncSequence, RequestStream.Element == SwiftProtobuf.Google_Protobuf_Empty {
+    return self.performAsyncBidirectionalStreamingCall(
+      path: Normalization_NormalizationClientMetadata.Methods.bidirectionalStreaming.path,
+      requests: requests,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: self.interceptors?.makebidirectionalStreamingInterceptors() ?? []
+    )
+  }
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+internal struct Normalization_NormalizationAsyncClient: Normalization_NormalizationAsyncClientProtocol {
+  internal var channel: GRPCChannel
+  internal var defaultCallOptions: CallOptions
+  internal var interceptors: Normalization_NormalizationClientInterceptorFactoryProtocol?
+
+  internal init(
+    channel: GRPCChannel,
+    defaultCallOptions: CallOptions = CallOptions(),
+    interceptors: Normalization_NormalizationClientInterceptorFactoryProtocol? = nil
+  ) {
+    self.channel = channel
+    self.defaultCallOptions = defaultCallOptions
+    self.interceptors = interceptors
+  }
+}
+
+#endif // compiler(>=5.6)
+
 internal protocol Normalization_NormalizationClientInterceptorFactoryProtocol {
 
   /// - Returns: Interceptors to use when invoking 'Unary'.
@@ -459,6 +767,158 @@ extension Normalization_NormalizationProvider {
     }
   }
 }
+
+#if compiler(>=5.6)
+
+/// To implement a server, implement an object which conforms to this protocol.
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+internal protocol Normalization_NormalizationAsyncProvider: CallHandlerProvider {
+  static var serviceDescriptor: GRPCServiceDescriptor { get }
+  var interceptors: Normalization_NormalizationServerInterceptorFactoryProtocol? { get }
+
+  @Sendable func Unary(
+    request: SwiftProtobuf.Google_Protobuf_Empty,
+    context: GRPCAsyncServerCallContext
+  ) async throws -> Normalization_FunctionName
+
+  @Sendable func unary(
+    request: SwiftProtobuf.Google_Protobuf_Empty,
+    context: GRPCAsyncServerCallContext
+  ) async throws -> Normalization_FunctionName
+
+  @Sendable func ServerStreaming(
+    request: SwiftProtobuf.Google_Protobuf_Empty,
+    responseStream: GRPCAsyncResponseStreamWriter<Normalization_FunctionName>,
+    context: GRPCAsyncServerCallContext
+  ) async throws
+
+  @Sendable func serverStreaming(
+    request: SwiftProtobuf.Google_Protobuf_Empty,
+    responseStream: GRPCAsyncResponseStreamWriter<Normalization_FunctionName>,
+    context: GRPCAsyncServerCallContext
+  ) async throws
+
+  @Sendable func ClientStreaming(
+    requestStream: GRPCAsyncRequestStream<SwiftProtobuf.Google_Protobuf_Empty>,
+    context: GRPCAsyncServerCallContext
+  ) async throws -> Normalization_FunctionName
+
+  @Sendable func clientStreaming(
+    requestStream: GRPCAsyncRequestStream<SwiftProtobuf.Google_Protobuf_Empty>,
+    context: GRPCAsyncServerCallContext
+  ) async throws -> Normalization_FunctionName
+
+  @Sendable func BidirectionalStreaming(
+    requestStream: GRPCAsyncRequestStream<SwiftProtobuf.Google_Protobuf_Empty>,
+    responseStream: GRPCAsyncResponseStreamWriter<Normalization_FunctionName>,
+    context: GRPCAsyncServerCallContext
+  ) async throws
+
+  @Sendable func bidirectionalStreaming(
+    requestStream: GRPCAsyncRequestStream<SwiftProtobuf.Google_Protobuf_Empty>,
+    responseStream: GRPCAsyncResponseStreamWriter<Normalization_FunctionName>,
+    context: GRPCAsyncServerCallContext
+  ) async throws
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension Normalization_NormalizationAsyncProvider {
+  internal static var serviceDescriptor: GRPCServiceDescriptor {
+    return Normalization_NormalizationServerMetadata.serviceDescriptor
+  }
+
+  internal var serviceName: Substring {
+    return Normalization_NormalizationServerMetadata.serviceDescriptor.fullName[...]
+  }
+
+  internal var interceptors: Normalization_NormalizationServerInterceptorFactoryProtocol? {
+    return nil
+  }
+
+  internal func handle(
+    method name: Substring,
+    context: CallHandlerContext
+  ) -> GRPCServerHandlerProtocol? {
+    switch name {
+    case "Unary":
+      return GRPCAsyncServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<SwiftProtobuf.Google_Protobuf_Empty>(),
+        responseSerializer: ProtobufSerializer<Normalization_FunctionName>(),
+        interceptors: self.interceptors?.makeUnaryInterceptors() ?? [],
+        wrapping: self.Unary(request:context:)
+      )
+
+    case "unary":
+      return GRPCAsyncServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<SwiftProtobuf.Google_Protobuf_Empty>(),
+        responseSerializer: ProtobufSerializer<Normalization_FunctionName>(),
+        interceptors: self.interceptors?.makeunaryInterceptors() ?? [],
+        wrapping: self.unary(request:context:)
+      )
+
+    case "ServerStreaming":
+      return GRPCAsyncServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<SwiftProtobuf.Google_Protobuf_Empty>(),
+        responseSerializer: ProtobufSerializer<Normalization_FunctionName>(),
+        interceptors: self.interceptors?.makeServerStreamingInterceptors() ?? [],
+        wrapping: self.ServerStreaming(request:responseStream:context:)
+      )
+
+    case "serverStreaming":
+      return GRPCAsyncServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<SwiftProtobuf.Google_Protobuf_Empty>(),
+        responseSerializer: ProtobufSerializer<Normalization_FunctionName>(),
+        interceptors: self.interceptors?.makeserverStreamingInterceptors() ?? [],
+        wrapping: self.serverStreaming(request:responseStream:context:)
+      )
+
+    case "ClientStreaming":
+      return GRPCAsyncServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<SwiftProtobuf.Google_Protobuf_Empty>(),
+        responseSerializer: ProtobufSerializer<Normalization_FunctionName>(),
+        interceptors: self.interceptors?.makeClientStreamingInterceptors() ?? [],
+        wrapping: self.ClientStreaming(requestStream:context:)
+      )
+
+    case "clientStreaming":
+      return GRPCAsyncServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<SwiftProtobuf.Google_Protobuf_Empty>(),
+        responseSerializer: ProtobufSerializer<Normalization_FunctionName>(),
+        interceptors: self.interceptors?.makeclientStreamingInterceptors() ?? [],
+        wrapping: self.clientStreaming(requestStream:context:)
+      )
+
+    case "BidirectionalStreaming":
+      return GRPCAsyncServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<SwiftProtobuf.Google_Protobuf_Empty>(),
+        responseSerializer: ProtobufSerializer<Normalization_FunctionName>(),
+        interceptors: self.interceptors?.makeBidirectionalStreamingInterceptors() ?? [],
+        wrapping: self.BidirectionalStreaming(requestStream:responseStream:context:)
+      )
+
+    case "bidirectionalStreaming":
+      return GRPCAsyncServerHandler(
+        context: context,
+        requestDeserializer: ProtobufDeserializer<SwiftProtobuf.Google_Protobuf_Empty>(),
+        responseSerializer: ProtobufSerializer<Normalization_FunctionName>(),
+        interceptors: self.interceptors?.makebidirectionalStreamingInterceptors() ?? [],
+        wrapping: self.bidirectionalStreaming(requestStream:responseStream:context:)
+      )
+
+    default:
+      return nil
+    }
+  }
+}
+
+#endif // compiler(>=5.6)
 
 internal protocol Normalization_NormalizationServerInterceptorFactoryProtocol {
 

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -48,22 +48,6 @@ protocol.
 - **Possible values:** true, false
 - **Default value:** true
 
-### ExperimentalAsyncServer
-
-The **ExperimentalAsyncServer** option determines whether async/await style
-server code is generated. See also [README.md](../README.md).
-
-- **Possible values:** true, false
-- **Default value:** false
-
-### ExperimentalAsyncClient
-
-The **ExperimentalAsyncClient** option determines whether async/await style
-client code is generated. See also [README.md](../README.md).
-
-- **Possible values:** true, false
-- **Default value:** false
-
 ### TestClient
 
 The **TestClient** option determines whether test client code is generated.


### PR DESCRIPTION
Motivation:
    
Async code generation currently requires opting in. We should make it
the default alongside the NIO-based code so that it's easier to find.
    
Modifications:
    
- Remove the async options from the generator.
- Update the generator to always emit async code behind compiler guards.
- Update plugin docs.
- Regenerate code.
    
Result:
    
Async code is easier to find.