### PR TITLE
Re-enable 5.6 tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         include:
           - image: swift:5.6-focal
-            swift-test-flags: "--enable-test-discovery --sanitize=thread"
+            swift-test-flags: "--enable-test-discovery"
           - image: swift:5.5-focal
             swift-test-flags: "--enable-test-discovery"
           - image: swift:5.4-focal
@@ -46,8 +46,6 @@ jobs:
       run: swift build ${{ matrix.swift-build-flags }}
       timeout-minutes: 20
     - name: 🧪 Test
-      # Skip tests on 5.6: https://bugs.swift.org/browse/SR-15955
-      if: ${{ matrix.image != 'swift:5.6-focal' }}
       run: swift test ${{ matrix.swift-test-flags }}
       timeout-minutes: 20
   performance-tests:
@@ -127,8 +125,6 @@ jobs:
         GRPC_NO_NIO_SSL: 1
       timeout-minutes: 20
     - name: Test without NIOSSL
-      # Skip tests on 5.6: https://bugs.swift.org/browse/SR-15955
-      if: ${{ matrix.image != 'swift:5.6-focal' }}
       run: swift test --enable-test-discovery
       env:
         GRPC_NO_NIO_SSL: 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,7 @@ jobs:
           - image: swift:5.6-focal
             env:
               MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 429000
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 177000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 176000
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 110000
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 65000
               MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 61000

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,7 @@ jobs:
           - image: swift:5.6-focal
             env:
               MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 429000
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 176000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 177000
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 110000
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 65000
               MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 61000


### PR DESCRIPTION
Motivation:

https://bugs.swift.org/browse/SR-15955 precluded tests from running on
Swift 5.6. This has been resolved in Swift 5.6.1.

Modifications:

- Re-enable tests on 5.6

Result:

Tests run on 5.6