### PR TITLE
Update Github Actions version to v3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     container:
       image: swift
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: "Formatting and License Headers check"
       run: |
         SWIFTFORMAT_VERSION=0.49.4
@@ -41,7 +41,7 @@ jobs:
     container:
       image: ${{ matrix.image }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: 🔧 Build
       run: swift build ${{ matrix.swift-build-flags }}
       timeout-minutes: 20
@@ -100,7 +100,7 @@ jobs:
     container:
       image: ${{ matrix.image }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: 🧮 Allocation Counting Tests
       run: ./Performance/allocations/test-allocation-counts.sh
       env: ${{ matrix.env }}
@@ -120,7 +120,7 @@ jobs:
     container:
       image: ${{ matrix.image }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build without NIOSSL
       run: swift build
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      
+      - uses: actions/checkout@v3
+
       - name: Extract release version
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
@@ -20,7 +20,7 @@ jobs:
       - name: Zip the plugins
         run: |
           zip protoc-grpc-swift-plugins-linux-x86_64-${{ env.RELEASE_VERSION }}.zip protoc-gen-swift protoc-gen-grpc-swift
-      
+
       - name: Upload artifacts
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
Update `actions/checkout@v2` to `actions/checkout@v3` because of Node12 will be out of life after Aril 30, 2022 [[Reference](https://nodejs.org/en/about/releases/)].  
`actions/xxxx@v3` use Node16 whose support lasts until April 30, 2024.