### PR TITLE
Server handler state machine

### DIFF
--- a/Sources/GRPC/AsyncAwaitSupport/AsyncServerHandler/ServerHandlerStateMachine/ServerHandlerStateMachine+Actions.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/AsyncServerHandler/ServerHandlerStateMachine/ServerHandlerStateMachine+Actions.swift
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#if compiler(>=5.6)
+import NIOHPACK
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension ServerHandlerStateMachine {
+  enum HandleMetadataAction {
+    /// Invoke the user handler.
+    case invokeHandler(Ref<UserInfo>, CallHandlerContext)
+    /// Cancel the RPC, the metadata was not expected.
+    case cancel
+  }
+
+  enum HandleMessageAction: Hashable {
+    /// Forward the message to the interceptors, via the interceptor state machine.
+    case forward
+    /// Cancel the RPC, the message was not expected.
+    case cancel
+  }
+
+  /// The same as 'HandleMessageAction.
+  typealias HandleEndAction = HandleMessageAction
+
+  enum SendMessageAction: Equatable {
+    /// Intercept the message, but first intercept the headers if they are non-nil. Must go via
+    /// the interceptor state machine first.
+    case intercept(headers: HPACKHeaders?)
+    /// Drop the message.
+    case drop
+  }
+
+  enum SendStatusAction: Equatable {
+    /// Intercept the status, providing the given trailers.
+    case intercept(trailers: HPACKHeaders)
+    /// Drop the status.
+    case drop
+  }
+
+  enum CancelAction: Hashable {
+    /// Cancel and nil out the handler 'bits'.
+    case cancelAndNilOutHandlerComponents
+    /// Don't do anything.
+    case none
+  }
+}
+#endif // compiler(>=5.6)

--- a/Sources/GRPC/AsyncAwaitSupport/AsyncServerHandler/ServerHandlerStateMachine/ServerHandlerStateMachine+Draining.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/AsyncServerHandler/ServerHandlerStateMachine/ServerHandlerStateMachine+Draining.swift
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#if compiler(>=5.6)
+import NIOHPACK
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension ServerHandlerStateMachine {
+  /// In the 'Draining' state the user handler has been invoked and the request stream has been
+  /// closed (i.e. we have seen 'end' but it has not necessarily been consumed by the user handler).
+  /// We can transition to a new state either by sending the end of the response stream or by
+  /// cancelling.
+  internal struct Draining {
+    typealias NextStateAndOutput<Output> =
+      ServerHandlerStateMachine.NextStateAndOutput<
+        ServerHandlerStateMachine.Draining.NextState,
+        Output
+      >
+
+    /// Whether the response headers have been written yet.
+    private var headersWritten: Bool
+    internal let context: GRPCAsyncServerCallContext
+
+    init(from state: ServerHandlerStateMachine.Handling) {
+      self.headersWritten = state.headersWritten
+      self.context = state.context
+    }
+
+    mutating func handleMetadata() -> Self.NextStateAndOutput<HandleMetadataAction> {
+      // We're already draining, i.e. the inbound stream is closed, cancel the RPC.
+      return .init(nextState: .draining(self), output: .cancel)
+    }
+
+    mutating func handleMessage() -> Self.NextStateAndOutput<HandleMessageAction> {
+      // We're already draining, i.e. the inbound stream is closed, cancel the RPC.
+      return .init(nextState: .draining(self), output: .cancel)
+    }
+
+    mutating func handleEnd() -> Self.NextStateAndOutput<HandleEndAction> {
+      // We're already draining, i.e. the inbound stream is closed, cancel the RPC.
+      return .init(nextState: .draining(self), output: .cancel)
+    }
+
+    mutating func sendMessage() -> Self.NextStateAndOutput<SendMessageAction> {
+      let headers: HPACKHeaders?
+
+      if self.headersWritten {
+        headers = nil
+      } else {
+        self.headersWritten = true
+        headers = self.context.initialResponseMetadata
+      }
+
+      return .init(nextState: .draining(self), output: .intercept(headers: headers))
+    }
+
+    mutating func sendStatus() -> Self.NextStateAndOutput<SendStatusAction> {
+      let trailers = self.context.trailingResponseMetadata
+      return .init(nextState: .finished(from: self), output: .intercept(trailers: trailers))
+    }
+
+    mutating func cancel() -> Self.NextStateAndOutput<CancelAction> {
+      return .init(nextState: .finished(from: self), output: .cancelAndNilOutHandlerComponents)
+    }
+  }
+}
+#endif // compiler(>=5.6)

--- a/Sources/GRPC/AsyncAwaitSupport/AsyncServerHandler/ServerHandlerStateMachine/ServerHandlerStateMachine+Finished.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/AsyncServerHandler/ServerHandlerStateMachine/ServerHandlerStateMachine+Finished.swift
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#if compiler(>=5.6)
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension ServerHandlerStateMachine {
+  internal struct Finished {
+    typealias NextStateAndOutput<Output> = ServerHandlerStateMachine.NextStateAndOutput<
+      ServerHandlerStateMachine.Finished.NextState,
+      Output
+    >
+
+    internal init(from state: ServerHandlerStateMachine.Idle) {}
+    internal init(from state: ServerHandlerStateMachine.Handling) {}
+    internal init(from state: ServerHandlerStateMachine.Draining) {}
+
+    mutating func handleMetadata() -> Self.NextStateAndOutput<HandleMetadataAction> {
+      return .init(nextState: .finished(self), output: .cancel)
+    }
+
+    mutating func handleMessage() -> Self.NextStateAndOutput<HandleMessageAction> {
+      return .init(nextState: .finished(self), output: .cancel)
+    }
+
+    mutating func handleEnd() -> Self.NextStateAndOutput<HandleEndAction> {
+      return .init(nextState: .finished(self), output: .cancel)
+    }
+
+    mutating func sendMessage() -> Self.NextStateAndOutput<SendMessageAction> {
+      return .init(nextState: .finished(self), output: .drop)
+    }
+
+    mutating func sendStatus() -> Self.NextStateAndOutput<SendStatusAction> {
+      return .init(nextState: .finished(self), output: .drop)
+    }
+
+    mutating func cancel() -> Self.NextStateAndOutput<CancelAction> {
+      return .init(nextState: .finished(self), output: .cancelAndNilOutHandlerComponents)
+    }
+  }
+}
+#endif // compiler(>=5.6)

--- a/Sources/GRPC/AsyncAwaitSupport/AsyncServerHandler/ServerHandlerStateMachine/ServerHandlerStateMachine+Handling.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/AsyncServerHandler/ServerHandlerStateMachine/ServerHandlerStateMachine+Handling.swift
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2022, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#if compiler(>=5.6)
+import NIOHPACK
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension ServerHandlerStateMachine {
+  /// In the 'Handling' state the user handler has been invoked and the request stream is open (but
+  /// the request metadata has already been seen). We can transition to a new state either by
+  /// receiving the end of the request stream or by closing the response stream. Cancelling also
+  /// moves us to the finished state.
+  internal struct Handling {
+    typealias NextStateAndOutput<Output> = ServerHandlerStateMachine.NextStateAndOutput<
+      ServerHandlerStateMachine.Handling.NextState,
+      Output
+    >
+
+    /// Whether response headers have been written (they are written lazily rather than on receipt
+    /// of the request headers).
+    internal private(set) var headersWritten: Bool
+
+    /// A context held by user handler which may be used to alter the response headers or trailers.
+    internal let context: GRPCAsyncServerCallContext
+
+    /// Transition from the 'Idle' state.
+    init(from state: ServerHandlerStateMachine.Idle, context: GRPCAsyncServerCallContext) {
+      self.headersWritten = false
+      self.context = context
+    }
+
+    mutating func handleMetadata() -> Self.NextStateAndOutput<HandleMetadataAction> {
+      // We are in the 'Handling' state because we received metadata. If we receive it again we
+      // should cancel the RPC.
+      return .init(nextState: .handling(self), output: .cancel)
+    }
+
+    mutating func handleMessage() -> Self.NextStateAndOutput<HandleMessageAction> {
+      // We can always forward a message since receiving the end of the request stream causes a
+      // transition to the 'draining' state.
+      return .init(nextState: .handling(self), output: .forward)
+    }
+
+    mutating func handleEnd() -> Self.NextStateAndOutput<HandleEndAction> {
+      // The request stream is finished: move to the draining state so the user handler can finish
+      // executing.
+      return .init(nextState: .draining(from: self), output: .forward)
+    }
+
+    mutating func sendMessage() -> Self.NextStateAndOutput<SendMessageAction> {
+      let headers: HPACKHeaders?
+
+      // We send headers once, lazily, when the first message is sent back.
+      if self.headersWritten {
+        headers = nil
+      } else {
+        self.headersWritten = true
+        headers = self.context.initialResponseMetadata
+      }
+
+      return .init(nextState: .handling(self), output: .intercept(headers: headers))
+    }
+
+    mutating func sendStatus() -> Self.NextStateAndOutput<SendStatusAction> {
+      // Sending the status is the final action taken by the user handler. We can always send
+      // them from this state and doing so means the user handler has completed.
+      let trailers = self.context.trailingResponseMetadata
+      return .init(nextState: .finished(from: self), output: .intercept(trailers: trailers))
+    }
+
+    mutating func cancel() -> Self.NextStateAndOutput<CancelAction> {
+      return .init(nextState: .finished(from: self), output: .cancelAndNilOutHandlerComponents)
+    }
+  }
+}
+#endif // compiler(>=5.6)

--- a/Sources/GRPC/AsyncAwaitSupport/AsyncServerHandler/ServerHandlerStateMachine/ServerHandlerStateMachine+Idle.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/AsyncServerHandler/ServerHandlerStateMachine/ServerHandlerStateMachine+Idle.swift
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2022, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#if compiler(>=5.6)
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension ServerHandlerStateMachine {
+  /// In the 'Idle' state nothing has happened. To advance we must either receive metadata (i.e.
+  /// the request headers) and invoke the handler, or we are cancelled.
+  @usableFromInline
+  internal struct Idle {
+    typealias NextStateAndOutput<Output> = ServerHandlerStateMachine.NextStateAndOutput<
+      ServerHandlerStateMachine.Idle.NextState,
+      Output
+    >
+
+    /// A ref to the `UserInfo`. We hold on to this until we're ready to invoke the handler.
+    let userInfoRef: Ref<UserInfo>
+    /// A bag of bits required to construct a context passed to the user handler when it is invoked.
+    let callHandlerContext: CallHandlerContext
+
+    /// The state of the inbound stream, i.e. the request stream.
+    internal private(set) var inboundState: ServerInterceptorStateMachine.InboundStreamState
+
+    init(userInfoRef: Ref<UserInfo>, context: CallHandlerContext) {
+      self.userInfoRef = userInfoRef
+      self.callHandlerContext = context
+      self.inboundState = .idle
+    }
+
+    mutating func handleMetadata() -> Self.NextStateAndOutput<HandleMetadataAction> {
+      let action: HandleMetadataAction
+
+      switch self.inboundState.receiveMetadata() {
+      case .accept:
+        // We tell the caller to invoke the handler immediately: they should then call
+        // 'handlerInvoked' on the state machine which will cause a transition to the next state.
+        action = .invokeHandler(self.userInfoRef, self.callHandlerContext)
+      case .reject:
+        action = .cancel
+      }
+
+      return .init(nextState: .idle(self), output: action)
+    }
+
+    mutating func handleMessage() -> Self.NextStateAndOutput<HandleMessageAction> {
+      // We can't receive a message before the metadata, doing so is a protocol violation.
+      return .init(nextState: .idle(self), output: .cancel)
+    }
+
+    mutating func handleEnd() -> Self.NextStateAndOutput<HandleEndAction> {
+      // Receiving 'end' before we start is odd but okay, just cancel.
+      return .init(nextState: .idle(self), output: .cancel)
+    }
+
+    mutating func handlerInvoked(
+      context: GRPCAsyncServerCallContext
+    ) -> Self.NextStateAndOutput<Void> {
+      // The handler was invoked as a result of receiving metadata. Move to the next state.
+      return .init(nextState: .handling(from: self, context: context))
+    }
+
+    mutating func cancel() -> Self.NextStateAndOutput<CancelAction> {
+      // There's no handler to cancel. Move straight to finished.
+      return .init(nextState: .finished(from: self), output: .none)
+    }
+  }
+}
+#endif // compiler(>=5.6)

--- a/Sources/GRPC/AsyncAwaitSupport/AsyncServerHandler/ServerHandlerStateMachine/ServerHandlerStateMachine.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/AsyncServerHandler/ServerHandlerStateMachine/ServerHandlerStateMachine.swift
@@ -1,0 +1,284 @@
+/*
+ * Copyright 2022, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#if compiler(>=5.6)
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+internal struct ServerHandlerStateMachine {
+  private var state: Self.State
+
+  init(userInfoRef: Ref<UserInfo>, context: CallHandlerContext) {
+    self.state = .idle(.init(userInfoRef: userInfoRef, context: context))
+  }
+
+  mutating func handleMetadata() -> HandleMetadataAction {
+    switch self.state {
+    case var .idle(idle):
+      let nextStateAndOutput = idle.handleMetadata()
+      self.state = nextStateAndOutput.nextState.state
+      return nextStateAndOutput.output
+    case var .handling(handling):
+      let nextStateAndOutput = handling.handleMetadata()
+      self.state = nextStateAndOutput.nextState.state
+      return nextStateAndOutput.output
+    case var .draining(draining):
+      let nextStateAndOutput = draining.handleMetadata()
+      self.state = nextStateAndOutput.nextState.state
+      return nextStateAndOutput.output
+    case var .finished(finished):
+      let nextStateAndOutput = finished.handleMetadata()
+      self.state = nextStateAndOutput.nextState.state
+      return nextStateAndOutput.output
+    }
+  }
+
+  mutating func handleMessage() -> HandleMessageAction {
+    switch self.state {
+    case var .idle(idle):
+      let nextStateAndOutput = idle.handleMessage()
+      self.state = nextStateAndOutput.nextState.state
+      return nextStateAndOutput.output
+    case var .handling(handling):
+      let nextStateAndOutput = handling.handleMessage()
+      self.state = nextStateAndOutput.nextState.state
+      return nextStateAndOutput.output
+    case var .draining(draining):
+      let nextStateAndOutput = draining.handleMessage()
+      self.state = nextStateAndOutput.nextState.state
+      return nextStateAndOutput.output
+    case var .finished(finished):
+      let nextStateAndOutput = finished.handleMessage()
+      self.state = nextStateAndOutput.nextState.state
+      return nextStateAndOutput.output
+    }
+  }
+
+  mutating func handleEnd() -> HandleEndAction {
+    switch self.state {
+    case var .idle(idle):
+      let nextStateAndOutput = idle.handleEnd()
+      self.state = nextStateAndOutput.nextState.state
+      return nextStateAndOutput.output
+    case var .handling(handling):
+      let nextStateAndOutput = handling.handleEnd()
+      self.state = nextStateAndOutput.nextState.state
+      return nextStateAndOutput.output
+    case var .draining(draining):
+      let nextStateAndOutput = draining.handleEnd()
+      self.state = nextStateAndOutput.nextState.state
+      return nextStateAndOutput.output
+    case var .finished(finished):
+      let nextStateAndOutput = finished.handleEnd()
+      self.state = nextStateAndOutput.nextState.state
+      return nextStateAndOutput.output
+    }
+  }
+
+  mutating func sendMessage() -> SendMessageAction {
+    switch self.state {
+    case var .handling(handling):
+      let nextStateAndOutput = handling.sendMessage()
+      self.state = nextStateAndOutput.nextState.state
+      return nextStateAndOutput.output
+    case var .draining(draining):
+      let nextStateAndOutput = draining.sendMessage()
+      self.state = nextStateAndOutput.nextState.state
+      return nextStateAndOutput.output
+    case var .finished(finished):
+      let nextStateAndOutput = finished.sendMessage()
+      self.state = nextStateAndOutput.nextState.state
+      return nextStateAndOutput.output
+    case .idle:
+      preconditionFailure()
+    }
+  }
+
+  mutating func sendStatus() -> SendStatusAction {
+    switch self.state {
+    case var .handling(handling):
+      let nextStateAndOutput = handling.sendStatus()
+      self.state = nextStateAndOutput.nextState.state
+      return nextStateAndOutput.output
+    case var .draining(draining):
+      let nextStateAndOutput = draining.sendStatus()
+      self.state = nextStateAndOutput.nextState.state
+      return nextStateAndOutput.output
+    case var .finished(finished):
+      let nextStateAndOutput = finished.sendStatus()
+      self.state = nextStateAndOutput.nextState.state
+      return nextStateAndOutput.output
+    case .idle:
+      preconditionFailure()
+    }
+  }
+
+  mutating func cancel() -> CancelAction {
+    switch self.state {
+    case var .idle(idle):
+      let nextStateAndOutput = idle.cancel()
+      self.state = nextStateAndOutput.nextState.state
+      return nextStateAndOutput.output
+    case var .handling(handling):
+      let nextStateAndOutput = handling.cancel()
+      self.state = nextStateAndOutput.nextState.state
+      return nextStateAndOutput.output
+    case var .draining(draining):
+      let nextStateAndOutput = draining.cancel()
+      self.state = nextStateAndOutput.nextState.state
+      return nextStateAndOutput.output
+    case var .finished(finished):
+      let nextStateAndOutput = finished.cancel()
+      self.state = nextStateAndOutput.nextState.state
+      return nextStateAndOutput.output
+    }
+  }
+
+  mutating func handlerInvoked(context: GRPCAsyncServerCallContext) {
+    switch self.state {
+    case var .idle(idle):
+      let nextStateAndOutput = idle.handlerInvoked(context: context)
+      self.state = nextStateAndOutput.nextState.state
+      return nextStateAndOutput.output
+    case .handling:
+      preconditionFailure()
+    case .draining:
+      preconditionFailure()
+    case .finished:
+      preconditionFailure()
+    }
+  }
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension ServerHandlerStateMachine {
+  /// The possible states the state machine may be in.
+  fileprivate enum State {
+    case idle(ServerHandlerStateMachine.Idle)
+    case handling(ServerHandlerStateMachine.Handling)
+    case draining(ServerHandlerStateMachine.Draining)
+    case finished(ServerHandlerStateMachine.Finished)
+  }
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension ServerHandlerStateMachine {
+  /// The next state to transition to and any output which may be produced as a
+  /// result of a substate handling an action.
+  internal struct NextStateAndOutput<NextState, Output> {
+    internal var nextState: NextState
+    internal var output: Output
+
+    internal init(nextState: NextState, output: Output) {
+      self.nextState = nextState
+      self.output = output
+    }
+  }
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension ServerHandlerStateMachine.NextStateAndOutput where Output == Void {
+  internal init(nextState: NextState) {
+    self.nextState = nextState
+    self.output = ()
+  }
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension ServerHandlerStateMachine.Idle {
+  /// States which can be reached directly from 'Idle'.
+  internal struct NextState {
+    fileprivate let state: ServerHandlerStateMachine.State
+
+    private init(_ state: ServerHandlerStateMachine.State) {
+      self.state = state
+    }
+
+    internal static func idle(_ state: ServerHandlerStateMachine.Idle) -> Self {
+      return Self(.idle(state))
+    }
+
+    internal static func handling(
+      from: ServerHandlerStateMachine.Idle,
+      context: GRPCAsyncServerCallContext
+    ) -> Self {
+      return Self(.handling(.init(from: from, context: context)))
+    }
+
+    internal static func finished(from: ServerHandlerStateMachine.Idle) -> Self {
+      return Self(.finished(.init(from: from)))
+    }
+  }
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension ServerHandlerStateMachine.Handling {
+  /// States which can be reached directly from 'Handling'.
+  internal struct NextState {
+    fileprivate let state: ServerHandlerStateMachine.State
+
+    private init(_ state: ServerHandlerStateMachine.State) {
+      self.state = state
+    }
+
+    internal static func handling(_ state: ServerHandlerStateMachine.Handling) -> Self {
+      return Self(.handling(state))
+    }
+
+    internal static func draining(from: ServerHandlerStateMachine.Handling) -> Self {
+      return Self(.draining(.init(from: from)))
+    }
+
+    internal static func finished(from: ServerHandlerStateMachine.Handling) -> Self {
+      return Self(.finished(.init(from: from)))
+    }
+  }
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension ServerHandlerStateMachine.Draining {
+  /// States which can be reached directly from 'Draining'.
+  internal struct NextState {
+    fileprivate let state: ServerHandlerStateMachine.State
+
+    private init(_ state: ServerHandlerStateMachine.State) {
+      self.state = state
+    }
+
+    internal static func draining(_ state: ServerHandlerStateMachine.Draining) -> Self {
+      return Self(.draining(state))
+    }
+
+    internal static func finished(from: ServerHandlerStateMachine.Draining) -> Self {
+      return Self(.finished(.init(from: from)))
+    }
+  }
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension ServerHandlerStateMachine.Finished {
+  /// States which can be reached directly from 'Finished'.
+  internal struct NextState {
+    fileprivate let state: ServerHandlerStateMachine.State
+
+    private init(_ state: ServerHandlerStateMachine.State) {
+      self.state = state
+    }
+
+    internal static func finished(_ state: ServerHandlerStateMachine.Finished) -> Self {
+      return Self(.finished(state))
+    }
+  }
+}
+#endif // compiler(>=5.6)

--- a/Tests/GRPCTests/AsyncAwaitSupport/AsyncServerHandler/ServerHandlerStateMachine/ServerHandlerStateMachineTests.swift
+++ b/Tests/GRPCTests/AsyncAwaitSupport/AsyncServerHandler/ServerHandlerStateMachine/ServerHandlerStateMachineTests.swift
@@ -1,0 +1,289 @@
+/*
+ * Copyright 2022, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#if compiler(>=5.6)
+@testable import GRPC
+import NIOCore
+import NIOEmbedded
+import NIOHPACK
+import XCTest
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+internal final class ServerHandlerStateMachineTests: GRPCTestCase {
+  private enum InitialState {
+    case idle
+    case handling
+    case draining
+    case finished
+  }
+
+  private func makeStateMachine(inState state: InitialState = .idle) -> ServerHandlerStateMachine {
+    var stateMachine = ServerHandlerStateMachine(
+      userInfoRef: Ref(UserInfo()),
+      context: self.makeCallHandlerContext()
+    )
+
+    switch state {
+    case .idle:
+      return stateMachine
+    case .handling:
+      stateMachine.handleMetadata().assertInvokeHandler()
+      stateMachine.handlerInvoked(context: self.makeAsyncServerContext())
+      return stateMachine
+    case .draining:
+      stateMachine.handleMetadata().assertInvokeHandler()
+      stateMachine.handlerInvoked(context: self.makeAsyncServerContext())
+      stateMachine.handleEnd().assertForward()
+      return stateMachine
+    case .finished:
+      stateMachine.cancel().assertNone()
+      return stateMachine
+    }
+  }
+
+  private func makeCallHandlerContext() -> CallHandlerContext {
+    let loop = EmbeddedEventLoop()
+    defer {
+      try! loop.syncShutdownGracefully()
+    }
+    return CallHandlerContext(
+      logger: self.logger,
+      encoding: .disabled,
+      eventLoop: loop,
+      path: "",
+      responseWriter: NoOpResponseWriter(),
+      allocator: ByteBufferAllocator(),
+      closeFuture: loop.makeSucceededVoidFuture()
+    )
+  }
+
+  private func makeAsyncServerContext() -> GRPCAsyncServerCallContext {
+    return GRPCAsyncServerCallContext(
+      headers: [:],
+      logger: self.logger,
+      userInfoRef: Ref(UserInfo())
+    )
+  }
+
+  // MARK: - Test Cases
+
+  func testHandleMetadataWhenIdle() {
+    var stateMachine = self.makeStateMachine()
+    // Receiving metadata is the signal to invoke the user handler.
+    stateMachine.handleMetadata().assertInvokeHandler()
+    // On invoking the handler we move to the next state. No output.
+    stateMachine.handlerInvoked(context: self.makeAsyncServerContext())
+  }
+
+  func testHandleMetadataWhenHandling() {
+    var stateMachine = self.makeStateMachine(inState: .handling)
+    // Must not receive metadata more than once.
+    stateMachine.handleMetadata().assertInvokeCancel()
+  }
+
+  func testHandleMetadataWhenDraining() {
+    var stateMachine = self.makeStateMachine(inState: .draining)
+    // We can't receive metadata more than once.
+    stateMachine.handleMetadata().assertInvokeCancel()
+  }
+
+  func testHandleMetadataWhenFinished() {
+    var stateMachine = self.makeStateMachine(inState: .finished)
+    // We can't receive anything when finished.
+    stateMachine.handleMetadata().assertInvokeCancel()
+  }
+
+  func testHandleMessageWhenIdle() {
+    var stateMachine = self.makeStateMachine()
+    // Metadata must be received first.
+    stateMachine.handleMessage().assertCancel()
+  }
+
+  func testHandleMessageWhenHandling() {
+    var stateMachine = self.makeStateMachine(inState: .handling)
+    // Messages are good, we can forward those while handling.
+    for _ in 0 ..< 10 {
+      stateMachine.handleMessage().assertForward()
+    }
+  }
+
+  func testHandleMessageWhenDraining() {
+    var stateMachine = self.makeStateMachine(inState: .draining)
+    // We entered the 'draining' state as we received 'end', another message is a protocol
+    // violation so cancel.
+    stateMachine.handleMessage().assertCancel()
+  }
+
+  func testHandleMessageWhenFinished() {
+    var stateMachine = self.makeStateMachine(inState: .finished)
+    // We can't receive anything when finished.
+    stateMachine.handleMessage().assertCancel()
+  }
+
+  func testHandleEndWhenIdle() {
+    var stateMachine = self.makeStateMachine()
+    // Metadata must be received first.
+    stateMachine.handleEnd().assertCancel()
+  }
+
+  func testHandleEndWhenHandling() {
+    var stateMachine = self.makeStateMachine(inState: .handling)
+    // End is good; it transitions us to the draining state.
+    stateMachine.handleEnd().assertForward()
+  }
+
+  func testHandleEndWhenDraining() {
+    var stateMachine = self.makeStateMachine(inState: .draining)
+    // We entered the 'draining' state as we received 'end', another 'end' is a protocol
+    // violation so cancel.
+    stateMachine.handleEnd().assertCancel()
+  }
+
+  func testHandleEndWhenFinished() {
+    var stateMachine = self.makeStateMachine(inState: .finished)
+    // We can't receive anything when finished.
+    stateMachine.handleEnd().assertCancel()
+  }
+
+  func testSendMessageWhenHandling() {
+    var stateMachine = self.makeStateMachine(inState: .handling)
+    // The first message should prompt headers to be sent as well.
+    stateMachine.sendMessage().assertInterceptHeadersThenMessage()
+    // Additional messages should be just the message.
+    stateMachine.sendMessage().assertInterceptMessage()
+  }
+
+  func testSendMessageWhenDraining() {
+    var stateMachine = self.makeStateMachine(inState: .draining)
+    // The first message should prompt headers to be sent as well.
+    stateMachine.sendMessage().assertInterceptHeadersThenMessage()
+    // Additional messages should be just the message.
+    stateMachine.sendMessage().assertInterceptMessage()
+  }
+
+  func testSendMessageWhenFinished() {
+    var stateMachine = self.makeStateMachine(inState: .finished)
+    // We can't send anything if we're finished.
+    stateMachine.sendMessage().assertDrop()
+  }
+
+  func testSendStatusWhenHandling() {
+    var stateMachine = self.makeStateMachine(inState: .handling)
+    // This moves the state machine to the 'finished' state.
+    stateMachine.sendStatus().assertIntercept()
+  }
+
+  func testSendStatusWhenDraining() {
+    var stateMachine = self.makeStateMachine(inState: .draining)
+    // This moves the state machine to the 'finished' state.
+    stateMachine.sendStatus().assertIntercept()
+  }
+
+  func testSendStatusWhenFinished() {
+    var stateMachine = self.makeStateMachine(inState: .finished)
+    // We can't send anything if we're finished.
+    stateMachine.sendStatus().assertDrop()
+  }
+
+  func testCancelWhenIdle() {
+    var stateMachine = self.makeStateMachine()
+    // Cancelling when idle is effectively a no-op; there's nothing to cancel.
+    stateMachine.cancel().assertNone()
+  }
+
+  func testCancelWhenHandling() {
+    var stateMachine = self.makeStateMachine(inState: .handling)
+    // We have things to cancel in this state.
+    stateMachine.cancel().assertDoCancel()
+  }
+
+  func testCancelWhenDraining() {
+    var stateMachine = self.makeStateMachine(inState: .draining)
+    // We have things to cancel in this state.
+    stateMachine.cancel().assertDoCancel()
+  }
+
+  func testCancelWhenFinished() {
+    var stateMachine = self.makeStateMachine(inState: .finished)
+    stateMachine.cancel().assertDoCancel()
+  }
+}
+
+// MARK: - Action Assertions
+
+extension ServerHandlerStateMachine.HandleMetadataAction {
+  func assertInvokeHandler() {
+    switch self {
+    case .invokeHandler:
+      ()
+    case .cancel:
+      XCTFail("Expected 'invokeHandler' but got \(self)")
+    }
+  }
+
+  func assertInvokeCancel() {
+    switch self {
+    case .cancel:
+      ()
+    case .invokeHandler:
+      XCTFail("Expected 'cancel' but got \(self)")
+    }
+  }
+}
+
+extension ServerHandlerStateMachine.HandleMessageAction {
+  func assertForward() {
+    XCTAssertEqual(self, .forward)
+  }
+
+  func assertCancel() {
+    XCTAssertEqual(self, .cancel)
+  }
+}
+
+extension ServerHandlerStateMachine.SendMessageAction {
+  func assertInterceptHeadersThenMessage() {
+    XCTAssertEqual(self, .intercept(headers: [:]))
+  }
+
+  func assertInterceptMessage() {
+    XCTAssertEqual(self, .intercept(headers: nil))
+  }
+
+  func assertDrop() {
+    XCTAssertEqual(self, .drop)
+  }
+}
+
+extension ServerHandlerStateMachine.SendStatusAction {
+  func assertIntercept() {
+    XCTAssertEqual(self, .intercept(trailers: [:]))
+  }
+
+  func assertDrop() {
+    XCTAssertEqual(self, .drop)
+  }
+}
+
+extension ServerHandlerStateMachine.CancelAction {
+  func assertNone() {
+    XCTAssertEqual(self, .none)
+  }
+
+  func assertDoCancel() {
+    XCTAssertEqual(self, .cancelAndNilOutHandlerComponents)
+  }
+}
+#endif // compiler(>=5.6)


### PR DESCRIPTION
Motivation:

See #1394.

Modifications:

- Add a 'ServerHandlerStateMachine' and tests.
- This is not used anywhere (yet).

Result:

Handler state machine is in place.