### PR TITLE
Make all tests discoverable on Linux

### DIFF
--- a/Tests/GRPCTests/FunctionalTests.swift
+++ b/Tests/GRPCTests/FunctionalTests.swift
@@ -259,11 +259,107 @@ class FunctionalTestsAnonymousClient: FunctionalTestsInsecureTransport {
   override var transportSecurity: TransportSecurity {
     return .anonymousClient
   }
+
+  override func testUnary() throws {
+    try super.testUnary()
+  }
+
+  override func testUnaryLotsOfRequests() throws {
+    try super.testUnaryLotsOfRequests()
+  }
+
+  override func testUnaryWithLargeData() throws {
+    try super.testUnaryWithLargeData()
+  }
+
+  override func testUnaryEmptyRequest() throws {
+    try super.testUnaryEmptyRequest()
+  }
+
+  override func testClientStreaming() {
+    super.testClientStreaming()
+  }
+
+  override func testClientStreamingLotsOfMessages() throws {
+    try super.testClientStreamingLotsOfMessages()
+  }
+
+  override func testServerStreaming() {
+    super.testServerStreaming()
+  }
+
+  override func testServerStreamingLotsOfMessages() {
+    super.testServerStreamingLotsOfMessages()
+  }
+
+  override func testBidirectionalStreamingBatched() throws {
+    try super.testBidirectionalStreamingBatched()
+  }
+
+  override func testBidirectionalStreamingPingPong() throws {
+    try super.testBidirectionalStreamingPingPong()
+  }
+
+  override func testBidirectionalStreamingLotsOfMessagesBatched() throws {
+    try super.testBidirectionalStreamingLotsOfMessagesBatched()
+  }
+
+  override func testBidirectionalStreamingLotsOfMessagesPingPong() throws {
+    try super.testBidirectionalStreamingLotsOfMessagesPingPong()
+  }
 }
 
 class FunctionalTestsMutualAuthentication: FunctionalTestsInsecureTransport {
   override var transportSecurity: TransportSecurity {
     return .mutualAuthentication
+  }
+
+  override func testUnary() throws {
+    try super.testUnary()
+  }
+
+  override func testUnaryLotsOfRequests() throws {
+    try super.testUnaryLotsOfRequests()
+  }
+
+  override func testUnaryWithLargeData() throws {
+    try super.testUnaryWithLargeData()
+  }
+
+  override func testUnaryEmptyRequest() throws {
+    try super.testUnaryEmptyRequest()
+  }
+
+  override func testClientStreaming() {
+    super.testClientStreaming()
+  }
+
+  override func testClientStreamingLotsOfMessages() throws {
+    try super.testClientStreamingLotsOfMessages()
+  }
+
+  override func testServerStreaming() {
+    super.testServerStreaming()
+  }
+
+  override func testServerStreamingLotsOfMessages() {
+    super.testServerStreamingLotsOfMessages()
+  }
+
+  override func testBidirectionalStreamingBatched() throws {
+    try super.testBidirectionalStreamingBatched()
+  }
+
+  override func testBidirectionalStreamingPingPong() throws {
+    try super.testBidirectionalStreamingPingPong()
+  }
+
+  override func testBidirectionalStreamingLotsOfMessagesBatched() throws {
+    try super.testBidirectionalStreamingLotsOfMessagesBatched()
+  }
+
+  override func testBidirectionalStreamingLotsOfMessagesPingPong() throws {
+    try super.testBidirectionalStreamingLotsOfMessagesPingPong()
   }
 }
 #endif // canImport(NIOSSL)
@@ -364,12 +460,108 @@ class FunctionalTestsAnonymousClientNIOTS: FunctionalTestsInsecureTransportNIOTS
   override var transportSecurity: TransportSecurity {
     return .anonymousClient
   }
+
+  override func testUnary() throws {
+    try super.testUnary()
+  }
+
+  override func testUnaryLotsOfRequests() throws {
+    try super.testUnaryLotsOfRequests()
+  }
+
+  override func testUnaryWithLargeData() throws {
+    try super.testUnaryWithLargeData()
+  }
+
+  override func testUnaryEmptyRequest() throws {
+    try super.testUnaryEmptyRequest()
+  }
+
+  override func testClientStreaming() {
+    super.testClientStreaming()
+  }
+
+  override func testClientStreamingLotsOfMessages() throws {
+    try super.testClientStreamingLotsOfMessages()
+  }
+
+  override func testServerStreaming() {
+    super.testServerStreaming()
+  }
+
+  override func testServerStreamingLotsOfMessages() {
+    super.testServerStreamingLotsOfMessages()
+  }
+
+  override func testBidirectionalStreamingBatched() throws {
+    try super.testBidirectionalStreamingBatched()
+  }
+
+  override func testBidirectionalStreamingPingPong() throws {
+    try super.testBidirectionalStreamingPingPong()
+  }
+
+  override func testBidirectionalStreamingLotsOfMessagesBatched() throws {
+    try super.testBidirectionalStreamingLotsOfMessagesBatched()
+  }
+
+  override func testBidirectionalStreamingLotsOfMessagesPingPong() throws {
+    try super.testBidirectionalStreamingLotsOfMessagesPingPong()
+  }
 }
 
 @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
 class FunctionalTestsMutualAuthenticationNIOTS: FunctionalTestsInsecureTransportNIOTS {
   override var transportSecurity: TransportSecurity {
     return .mutualAuthentication
+  }
+
+  override func testUnary() throws {
+    try super.testUnary()
+  }
+
+  override func testUnaryLotsOfRequests() throws {
+    try super.testUnaryLotsOfRequests()
+  }
+
+  override func testUnaryWithLargeData() throws {
+    try super.testUnaryWithLargeData()
+  }
+
+  override func testUnaryEmptyRequest() throws {
+    try super.testUnaryEmptyRequest()
+  }
+
+  override func testClientStreaming() {
+    super.testClientStreaming()
+  }
+
+  override func testClientStreamingLotsOfMessages() throws {
+    try super.testClientStreamingLotsOfMessages()
+  }
+
+  override func testServerStreaming() {
+    super.testServerStreaming()
+  }
+
+  override func testServerStreamingLotsOfMessages() {
+    super.testServerStreamingLotsOfMessages()
+  }
+
+  override func testBidirectionalStreamingBatched() throws {
+    try super.testBidirectionalStreamingBatched()
+  }
+
+  override func testBidirectionalStreamingPingPong() throws {
+    try super.testBidirectionalStreamingPingPong()
+  }
+
+  override func testBidirectionalStreamingLotsOfMessagesBatched() throws {
+    try super.testBidirectionalStreamingLotsOfMessagesBatched()
+  }
+
+  override func testBidirectionalStreamingLotsOfMessagesPingPong() throws {
+    try super.testBidirectionalStreamingLotsOfMessagesPingPong()
   }
 }
 #endif // canImport(NIOSSL)

--- a/Tests/GRPCTests/GRPCInteroperabilityTests.swift
+++ b/Tests/GRPCTests/GRPCInteroperabilityTests.swift
@@ -168,5 +168,81 @@ class GRPCInsecureInteroperabilityTests: GRPCTestCase {
 #if canImport(NIOSSL)
 class GRPCSecureInteroperabilityTests: GRPCInsecureInteroperabilityTests {
   override var useTLS: Bool { return true }
+
+  override func testEmptyUnary() {
+    super.testEmptyUnary()
+  }
+
+  override func testCacheableUnary() {
+    super.testCacheableUnary()
+  }
+
+  override func testLargeUnary() {
+    super.testLargeUnary()
+  }
+
+  override func testClientCompressedUnary() {
+    super.testClientCompressedUnary()
+  }
+
+  override func testServerCompressedUnary() {
+    super.testServerCompressedUnary()
+  }
+
+  override func testClientStreaming() {
+    super.testClientStreaming()
+  }
+
+  override func testClientCompressedStreaming() {
+    super.testClientCompressedStreaming()
+  }
+
+  override func testServerStreaming() {
+    super.testServerStreaming()
+  }
+
+  override func testServerCompressedStreaming() {
+    super.testServerCompressedStreaming()
+  }
+
+  override func testPingPong() {
+    super.testPingPong()
+  }
+
+  override func testEmptyStream() {
+    super.testEmptyStream()
+  }
+
+  override func testCustomMetadata() {
+    super.testCustomMetadata()
+  }
+
+  override func testStatusCodeAndMessage() {
+    super.testStatusCodeAndMessage()
+  }
+
+  override func testSpecialStatusAndMessage() {
+    super.testSpecialStatusAndMessage()
+  }
+
+  override func testUnimplementedMethod() {
+    super.testUnimplementedMethod()
+  }
+
+  override func testUnimplementedService() {
+    super.testUnimplementedService()
+  }
+
+  override func testCancelAfterBegin() {
+    super.testCancelAfterBegin()
+  }
+
+  override func testCancelAfterFirstResponse() {
+    super.testCancelAfterFirstResponse()
+  }
+
+  override func testTimeoutOnSleepingServer() {
+    super.testTimeoutOnSleepingServer()
+  }
 }
 #endif // canImport(NIOSSL)

--- a/Tests/GRPCTests/ServerThrowingTests.swift
+++ b/Tests/GRPCTests/ServerThrowingTests.swift
@@ -139,27 +139,7 @@ class ServerThrowingTests: EchoTestCaseBase {
   }
 
   override func makeEchoProvider() -> Echo_EchoProvider { return ImmediateThrowingEchoProvider() }
-}
 
-class ServerDelayedThrowingTests: ServerThrowingTests {
-  override func makeEchoProvider() -> Echo_EchoProvider { return DelayedThrowingEchoProvider() }
-}
-
-class ClientThrowingWhenServerReturningErrorTests: ServerThrowingTests {
-  override func makeEchoProvider() -> Echo_EchoProvider { return ErrorReturningEchoProvider() }
-}
-
-class ServerErrorTransformingTests: ServerThrowingTests {
-  override var expectedError: GRPCStatus { return transformedError }
-  override var expectedMetadata: HPACKHeaders? {
-    return HPACKHeaders([("grpc-status", "10"), ("grpc-message", "transformed error"),
-                         ("transformed", "header")])
-  }
-
-  override func makeErrorDelegate() -> ServerErrorDelegate? { return ErrorTransformingDelegate() }
-}
-
-extension ServerThrowingTests {
   func testUnary() throws {
     let call = client.get(Echo_EchoRequest(text: "foo"))
     XCTAssertEqual(self.expectedError, try call.status.wait())
@@ -220,5 +200,71 @@ extension ServerThrowingTests {
         XCTAssertTrue(trailers[name].contains(value))
       }
     }
+  }
+}
+
+class ServerDelayedThrowingTests: ServerThrowingTests {
+  override func makeEchoProvider() -> Echo_EchoProvider { return DelayedThrowingEchoProvider() }
+
+  override func testUnary() throws {
+    try super.testUnary()
+  }
+
+  override func testClientStreaming() throws {
+    try super.testClientStreaming()
+  }
+
+  override func testServerStreaming() throws {
+    try super.testServerStreaming()
+  }
+
+  override func testBidirectionalStreaming() throws {
+    try super.testBidirectionalStreaming()
+  }
+}
+
+class ClientThrowingWhenServerReturningErrorTests: ServerThrowingTests {
+  override func makeEchoProvider() -> Echo_EchoProvider { return ErrorReturningEchoProvider() }
+
+  override func testUnary() throws {
+    try super.testUnary()
+  }
+
+  override func testClientStreaming() throws {
+    try super.testClientStreaming()
+  }
+
+  override func testServerStreaming() throws {
+    try super.testServerStreaming()
+  }
+
+  override func testBidirectionalStreaming() throws {
+    try super.testBidirectionalStreaming()
+  }
+}
+
+class ServerErrorTransformingTests: ServerThrowingTests {
+  override var expectedError: GRPCStatus { return transformedError }
+  override var expectedMetadata: HPACKHeaders? {
+    return HPACKHeaders([("grpc-status", "10"), ("grpc-message", "transformed error"),
+                         ("transformed", "header")])
+  }
+
+  override func makeErrorDelegate() -> ServerErrorDelegate? { return ErrorTransformingDelegate() }
+
+  override func testUnary() throws {
+    try super.testUnary()
+  }
+
+  override func testClientStreaming() throws {
+    try super.testClientStreaming()
+  }
+
+  override func testServerStreaming() throws {
+    try super.testServerStreaming()
+  }
+
+  override func testBidirectionalStreaming() throws {
+    try super.testBidirectionalStreaming()
   }
 }


### PR DESCRIPTION
Motivation:

Test discovery on Linux relies on source code analysis. Tests in
subclasses which do not explicitly redeclare each test are missed. As a
result, a number of tests are not run on Linux.

Modifications:

- Explicitly redeclare tests in subclasses.

Result:

- Resolves #1392