### PR TITLE
Add missing 'Sendable' conformance

### DIFF
--- a/Sources/Examples/Echo/Model/echo.grpc.swift
+++ b/Sources/Examples/Echo/Model/echo.grpc.swift
@@ -316,7 +316,7 @@ extension Echo_EchoAsyncClientProtocol {
   public func collect<RequestStream>(
     _ requests: RequestStream,
     callOptions: CallOptions? = nil
-  ) async throws -> Echo_EchoResponse where RequestStream: AsyncSequence, RequestStream.Element == Echo_EchoRequest {
+  ) async throws -> Echo_EchoResponse where RequestStream: AsyncSequence & Sendable, RequestStream.Element == Echo_EchoRequest {
     return try await self.performAsyncClientStreamingCall(
       path: Echo_EchoClientMetadata.Methods.collect.path,
       requests: requests,
@@ -340,7 +340,7 @@ extension Echo_EchoAsyncClientProtocol {
   public func update<RequestStream>(
     _ requests: RequestStream,
     callOptions: CallOptions? = nil
-  ) -> GRPCAsyncResponseStream<Echo_EchoResponse> where RequestStream: AsyncSequence, RequestStream.Element == Echo_EchoRequest {
+  ) -> GRPCAsyncResponseStream<Echo_EchoResponse> where RequestStream: AsyncSequence & Sendable, RequestStream.Element == Echo_EchoRequest {
     return self.performAsyncBidirectionalStreamingCall(
       path: Echo_EchoClientMetadata.Methods.update.path,
       requests: requests,

--- a/Sources/Examples/RouteGuide/Model/route_guide.grpc.swift
+++ b/Sources/Examples/RouteGuide/Model/route_guide.grpc.swift
@@ -335,7 +335,7 @@ extension Routeguide_RouteGuideAsyncClientProtocol {
   public func recordRoute<RequestStream>(
     _ requests: RequestStream,
     callOptions: CallOptions? = nil
-  ) async throws -> Routeguide_RouteSummary where RequestStream: AsyncSequence, RequestStream.Element == Routeguide_Point {
+  ) async throws -> Routeguide_RouteSummary where RequestStream: AsyncSequence & Sendable, RequestStream.Element == Routeguide_Point {
     return try await self.performAsyncClientStreamingCall(
       path: Routeguide_RouteGuideClientMetadata.Methods.recordRoute.path,
       requests: requests,
@@ -359,7 +359,7 @@ extension Routeguide_RouteGuideAsyncClientProtocol {
   public func routeChat<RequestStream>(
     _ requests: RequestStream,
     callOptions: CallOptions? = nil
-  ) -> GRPCAsyncResponseStream<Routeguide_RouteNote> where RequestStream: AsyncSequence, RequestStream.Element == Routeguide_RouteNote {
+  ) -> GRPCAsyncResponseStream<Routeguide_RouteNote> where RequestStream: AsyncSequence & Sendable, RequestStream.Element == Routeguide_RouteNote {
     return self.performAsyncBidirectionalStreamingCall(
       path: Routeguide_RouteGuideClientMetadata.Methods.routeChat.path,
       requests: requests,

--- a/Sources/GRPC/AsyncAwaitSupport/AsyncWriter.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/AsyncWriter.swift
@@ -57,7 +57,7 @@ internal final actor AsyncWriter<Delegate: AsyncWriterDelegate>: Sendable {
   typealias PendingEnd = _Pending<End>
 
   @usableFromInline
-  internal enum _CompletionState {
+  internal enum _CompletionState: Sendable {
     /// Finish hasn't been called yet. May move to `pending` or `completed`.
     case incomplete
     /// Finish has been called but the writer is paused. May move to `completed`.

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncBidirectionalStreamingCall.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncBidirectionalStreamingCall.swift
@@ -19,7 +19,7 @@ import NIOHPACK
 
 /// Async-await variant of BidirectionalStreamingCall.
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-public struct GRPCAsyncBidirectionalStreamingCall<Request: Sendable, Response: Sendable> {
+public struct GRPCAsyncBidirectionalStreamingCall<Request: Sendable, Response: Sendable>: Sendable {
   private let call: Call<Request, Response>
   private let responseParts: StreamingResponseParts<Response>
   private let responseSource: PassthroughMessageSource<Response, Error>

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncClientStreamingCall.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncClientStreamingCall.swift
@@ -19,7 +19,7 @@ import NIOHPACK
 
 /// Async-await variant of `ClientStreamingCall`.
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-public struct GRPCAsyncClientStreamingCall<Request: Sendable, Response: Sendable> {
+public struct GRPCAsyncClientStreamingCall<Request: Sendable, Response: Sendable>: Sendable {
   private let call: Call<Request, Response>
   private let responseParts: UnaryResponseParts<Response>
 

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncRequestStream.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncRequestStream.swift
@@ -52,4 +52,9 @@ public struct GRPCAsyncRequestStream<Element: Sendable>: AsyncSequence {
   }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension GRPCAsyncRequestStream: Sendable where Element: Sendable {}
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension GRPCAsyncRequestStream.Iterator: Sendable where Element: Sendable {}
+
 #endif

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncRequestStreamWriter.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncRequestStreamWriter.swift
@@ -31,7 +31,7 @@
 /// try await stream.finish()
 /// ```
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-public struct GRPCAsyncRequestStreamWriter<Request: Sendable> {
+public struct GRPCAsyncRequestStreamWriter<Request: Sendable>: Sendable {
   @usableFromInline
   internal let asyncWriter: AsyncWriter<Delegate<Request>>
 

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncResponseStream.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncResponseStream.swift
@@ -49,4 +49,9 @@ public struct GRPCAsyncResponseStream<Element>: AsyncSequence {
   }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension GRPCAsyncResponseStream: Sendable where Element: Sendable {}
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension GRPCAsyncResponseStream.Iterator: Sendable where Element: Sendable {}
+
 #endif

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncResponseStreamWriter.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncResponseStreamWriter.swift
@@ -18,7 +18,7 @@
 
 /// Writer for server-streaming RPC handlers to provide responses.
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-public struct GRPCAsyncResponseStreamWriter<Response: Sendable> {
+public struct GRPCAsyncResponseStreamWriter<Response: Sendable>: Sendable {
   @usableFromInline
   internal typealias Element = (Response, Compression)
 

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncUnaryCall.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncUnaryCall.swift
@@ -22,7 +22,7 @@ import NIOHPACK
 /// Note: while this object is a `struct`, its implementation delegates to `Call`. It therefore
 /// has reference semantics.
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-public struct GRPCAsyncUnaryCall<Request: Sendable, Response: Sendable> {
+public struct GRPCAsyncUnaryCall<Request: Sendable, Response: Sendable>: Sendable {
   private let call: Call<Request, Response>
   private let responseParts: UnaryResponseParts<Response>
 

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCClient+AsyncAwaitSupport.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCClient+AsyncAwaitSupport.swift
@@ -19,7 +19,7 @@ import SwiftProtobuf
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension GRPCClient {
-  public func makeAsyncUnaryCall<Request: Message, Response: Message>(
+  public func makeAsyncUnaryCall<Request: Message & Sendable, Response: Message & Sendable>(
     path: String,
     request: Request,
     callOptions: CallOptions? = nil,
@@ -34,7 +34,7 @@ extension GRPCClient {
     )
   }
 
-  public func makeAsyncUnaryCall<Request: GRPCPayload, Response: GRPCPayload>(
+  public func makeAsyncUnaryCall<Request: GRPCPayload & Sendable, Response: GRPCPayload & Sendable>(
     path: String,
     request: Request,
     callOptions: CallOptions? = nil,
@@ -50,8 +50,8 @@ extension GRPCClient {
   }
 
   public func makeAsyncServerStreamingCall<
-    Request: SwiftProtobuf.Message,
-    Response: SwiftProtobuf.Message
+    Request: SwiftProtobuf.Message & Sendable,
+    Response: SwiftProtobuf.Message & Sendable
   >(
     path: String,
     request: Request,
@@ -67,7 +67,10 @@ extension GRPCClient {
     )
   }
 
-  public func makeAsyncServerStreamingCall<Request: GRPCPayload, Response: GRPCPayload>(
+  public func makeAsyncServerStreamingCall<
+    Request: GRPCPayload & Sendable,
+    Response: GRPCPayload & Sendable
+  >(
     path: String,
     request: Request,
     callOptions: CallOptions? = nil,
@@ -83,8 +86,8 @@ extension GRPCClient {
   }
 
   public func makeAsyncClientStreamingCall<
-    Request: SwiftProtobuf.Message,
-    Response: SwiftProtobuf.Message
+    Request: SwiftProtobuf.Message & Sendable,
+    Response: SwiftProtobuf.Message & Sendable
   >(
     path: String,
     callOptions: CallOptions? = nil,
@@ -99,7 +102,10 @@ extension GRPCClient {
     )
   }
 
-  public func makeAsyncClientStreamingCall<Request: GRPCPayload, Response: GRPCPayload>(
+  public func makeAsyncClientStreamingCall<
+    Request: GRPCPayload & Sendable,
+    Response: GRPCPayload & Sendable
+  >(
     path: String,
     callOptions: CallOptions? = nil,
     interceptors: [ClientInterceptor<Request, Response>] = [],
@@ -114,8 +120,8 @@ extension GRPCClient {
   }
 
   public func makeAsyncBidirectionalStreamingCall<
-    Request: SwiftProtobuf.Message,
-    Response: SwiftProtobuf.Message
+    Request: SwiftProtobuf.Message & Sendable,
+    Response: SwiftProtobuf.Message & Sendable
   >(
     path: String,
     callOptions: CallOptions? = nil,
@@ -131,8 +137,8 @@ extension GRPCClient {
   }
 
   public func makeAsyncBidirectionalStreamingCall<
-    Request: GRPCPayload,
-    Response: GRPCPayload
+    Request: GRPCPayload & Sendable,
+    Response: GRPCPayload & Sendable
   >(
     path: String,
     callOptions: CallOptions? = nil,
@@ -152,7 +158,7 @@ extension GRPCClient {
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension GRPCClient {
-  public func performAsyncUnaryCall<Request: Message, Response: Message>(
+  public func performAsyncUnaryCall<Request: Message & Sendable, Response: Message & Sendable>(
     path: String,
     request: Request,
     callOptions: CallOptions? = nil,
@@ -167,7 +173,10 @@ extension GRPCClient {
     ).response
   }
 
-  public func performAsyncUnaryCall<Request: GRPCPayload, Response: GRPCPayload>(
+  public func performAsyncUnaryCall<
+    Request: GRPCPayload & Sendable,
+    Response: GRPCPayload & Sendable
+  >(
     path: String,
     request: Request,
     callOptions: CallOptions? = nil,
@@ -183,8 +192,8 @@ extension GRPCClient {
   }
 
   public func performAsyncServerStreamingCall<
-    Request: SwiftProtobuf.Message,
-    Response: SwiftProtobuf.Message
+    Request: SwiftProtobuf.Message & Sendable,
+    Response: SwiftProtobuf.Message & Sendable
   >(
     path: String,
     request: Request,
@@ -200,7 +209,10 @@ extension GRPCClient {
     ).responseStream
   }
 
-  public func performAsyncServerStreamingCall<Request: GRPCPayload, Response: GRPCPayload>(
+  public func performAsyncServerStreamingCall<
+    Request: GRPCPayload & Sendable,
+    Response: GRPCPayload & Sendable
+  >(
     path: String,
     request: Request,
     callOptions: CallOptions? = nil,
@@ -216,9 +228,9 @@ extension GRPCClient {
   }
 
   public func performAsyncClientStreamingCall<
-    Request: SwiftProtobuf.Message,
-    Response: SwiftProtobuf.Message,
-    RequestStream
+    Request: SwiftProtobuf.Message & Sendable,
+    Response: SwiftProtobuf.Message & Sendable,
+    RequestStream: AsyncSequence & Sendable
   >(
     path: String,
     requests: RequestStream,
@@ -226,8 +238,7 @@ extension GRPCClient {
     interceptors: [ClientInterceptor<Request, Response>] = [],
     requestType: Request.Type = Request.self,
     responseType: Response.Type = Response.self
-  ) async throws -> Response
-    where RequestStream: AsyncSequence, RequestStream.Element == Request {
+  ) async throws -> Response where RequestStream.Element == Request {
     let call = self.channel.makeAsyncClientStreamingCall(
       path: path,
       callOptions: callOptions ?? self.defaultCallOptions,
@@ -237,9 +248,9 @@ extension GRPCClient {
   }
 
   public func performAsyncClientStreamingCall<
-    Request: GRPCPayload,
-    Response: GRPCPayload,
-    RequestStream
+    Request: GRPCPayload & Sendable,
+    Response: GRPCPayload & Sendable,
+    RequestStream: AsyncSequence & Sendable
   >(
     path: String,
     requests: RequestStream,
@@ -247,8 +258,7 @@ extension GRPCClient {
     interceptors: [ClientInterceptor<Request, Response>] = [],
     requestType: Request.Type = Request.self,
     responseType: Response.Type = Response.self
-  ) async throws -> Response
-    where RequestStream: AsyncSequence, RequestStream.Element == Request {
+  ) async throws -> Response where RequestStream.Element == Request {
     let call = self.channel.makeAsyncClientStreamingCall(
       path: path,
       callOptions: callOptions ?? self.defaultCallOptions,
@@ -258,92 +268,8 @@ extension GRPCClient {
   }
 
   public func performAsyncClientStreamingCall<
-    Request: SwiftProtobuf.Message,
-    Response: SwiftProtobuf.Message,
-    RequestStream
-  >(
-    path: String,
-    requests: RequestStream,
-    callOptions: CallOptions? = nil,
-    interceptors: [ClientInterceptor<Request, Response>] = [],
-    requestType: Request.Type = Request.self,
-    responseType: Response.Type = Response.self
-  ) async throws -> Response
-    where RequestStream: Sequence, RequestStream.Element == Request {
-    let call = self.channel.makeAsyncClientStreamingCall(
-      path: path,
-      callOptions: callOptions ?? self.defaultCallOptions,
-      interceptors: interceptors
-    )
-    return try await self.perform(call, with: AsyncStream(wrapping: requests))
-  }
-
-  public func performAsyncClientStreamingCall<
-    Request: GRPCPayload,
-    Response: GRPCPayload,
-    RequestStream
-  >(
-    path: String,
-    requests: RequestStream,
-    callOptions: CallOptions? = nil,
-    interceptors: [ClientInterceptor<Request, Response>] = [],
-    requestType: Request.Type = Request.self,
-    responseType: Response.Type = Response.self
-  ) async throws -> Response
-    where RequestStream: Sequence, RequestStream.Element == Request {
-    let call = self.channel.makeAsyncClientStreamingCall(
-      path: path,
-      callOptions: callOptions ?? self.defaultCallOptions,
-      interceptors: interceptors
-    )
-    return try await self.perform(call, with: AsyncStream(wrapping: requests))
-  }
-
-  public func performAsyncBidirectionalStreamingCall<
-    Request: SwiftProtobuf.Message,
-    Response: SwiftProtobuf.Message,
-    RequestStream: AsyncSequence
-  >(
-    path: String,
-    requests: RequestStream,
-    callOptions: CallOptions? = nil,
-    interceptors: [ClientInterceptor<Request, Response>] = [],
-    requestType: Request.Type = Request.self,
-    responseType: Response.Type = Response.self
-  ) -> GRPCAsyncResponseStream<Response>
-    where RequestStream.Element == Request {
-    let call = self.channel.makeAsyncBidirectionalStreamingCall(
-      path: path,
-      callOptions: callOptions ?? self.defaultCallOptions,
-      interceptors: interceptors
-    )
-    return self.perform(call, with: requests)
-  }
-
-  public func performAsyncBidirectionalStreamingCall<
-    Request: GRPCPayload,
-    Response: GRPCPayload,
-    RequestStream: AsyncSequence
-  >(
-    path: String,
-    requests: RequestStream,
-    callOptions: CallOptions? = nil,
-    interceptors: [ClientInterceptor<Request, Response>] = [],
-    requestType: Request.Type = Request.self,
-    responseType: Response.Type = Response.self
-  ) -> GRPCAsyncResponseStream<Response>
-    where RequestStream.Element == Request {
-    let call = self.channel.makeAsyncBidirectionalStreamingCall(
-      path: path,
-      callOptions: callOptions ?? self.defaultCallOptions,
-      interceptors: interceptors
-    )
-    return self.perform(call, with: requests)
-  }
-
-  public func performAsyncBidirectionalStreamingCall<
-    Request: SwiftProtobuf.Message,
-    Response: SwiftProtobuf.Message,
+    Request: SwiftProtobuf.Message & Sendable,
+    Response: SwiftProtobuf.Message & Sendable,
     RequestStream: Sequence
   >(
     path: String,
@@ -352,8 +278,89 @@ extension GRPCClient {
     interceptors: [ClientInterceptor<Request, Response>] = [],
     requestType: Request.Type = Request.self,
     responseType: Response.Type = Response.self
+  ) async throws -> Response where RequestStream.Element == Request {
+    let call = self.channel.makeAsyncClientStreamingCall(
+      path: path,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: interceptors
+    )
+    return try await self.perform(call, with: AsyncStream(wrapping: requests))
+  }
+
+  public func performAsyncClientStreamingCall<
+    Request: GRPCPayload & Sendable,
+    Response: GRPCPayload & Sendable,
+    RequestStream: Sequence
+  >(
+    path: String,
+    requests: RequestStream,
+    callOptions: CallOptions? = nil,
+    interceptors: [ClientInterceptor<Request, Response>] = [],
+    requestType: Request.Type = Request.self,
+    responseType: Response.Type = Response.self
+  ) async throws -> Response where RequestStream.Element == Request {
+    let call = self.channel.makeAsyncClientStreamingCall(
+      path: path,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: interceptors
+    )
+    return try await self.perform(call, with: AsyncStream(wrapping: requests))
+  }
+
+  public func performAsyncBidirectionalStreamingCall<
+    Request: SwiftProtobuf.Message & Sendable,
+    Response: SwiftProtobuf.Message & Sendable,
+    RequestStream: AsyncSequence
+  >(
+    path: String,
+    requests: RequestStream,
+    callOptions: CallOptions? = nil,
+    interceptors: [ClientInterceptor<Request, Response>] = [],
+    requestType: Request.Type = Request.self,
+    responseType: Response.Type = Response.self
   ) -> GRPCAsyncResponseStream<Response>
     where RequestStream.Element == Request {
+    let call = self.channel.makeAsyncBidirectionalStreamingCall(
+      path: path,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: interceptors
+    )
+    return self.perform(call, with: requests)
+  }
+
+  public func performAsyncBidirectionalStreamingCall<
+    Request: GRPCPayload & Sendable,
+    Response: GRPCPayload & Sendable,
+    RequestStream: AsyncSequence
+  >(
+    path: String,
+    requests: RequestStream,
+    callOptions: CallOptions? = nil,
+    interceptors: [ClientInterceptor<Request, Response>] = [],
+    requestType: Request.Type = Request.self,
+    responseType: Response.Type = Response.self
+  ) -> GRPCAsyncResponseStream<Response>
+    where RequestStream.Element == Request {
+    let call = self.channel.makeAsyncBidirectionalStreamingCall(
+      path: path,
+      callOptions: callOptions ?? self.defaultCallOptions,
+      interceptors: interceptors
+    )
+    return self.perform(call, with: requests)
+  }
+
+  public func performAsyncBidirectionalStreamingCall<
+    Request: SwiftProtobuf.Message & Sendable,
+    Response: SwiftProtobuf.Message & Sendable,
+    RequestStream: Sequence
+  >(
+    path: String,
+    requests: RequestStream,
+    callOptions: CallOptions? = nil,
+    interceptors: [ClientInterceptor<Request, Response>] = [],
+    requestType: Request.Type = Request.self,
+    responseType: Response.Type = Response.self
+  ) -> GRPCAsyncResponseStream<Response> where RequestStream.Element == Request {
     let call = self.channel.makeAsyncBidirectionalStreamingCall(
       path: path,
       callOptions: callOptions ?? self.defaultCallOptions,
@@ -363,8 +370,8 @@ extension GRPCClient {
   }
 
   public func performAsyncBidirectionalStreamingCall<
-    Request: GRPCPayload,
-    Response: GRPCPayload,
+    Request: GRPCPayload & Sendable,
+    Response: GRPCPayload & Sendable,
     RequestStream: Sequence
   >(
     path: String,
@@ -373,8 +380,7 @@ extension GRPCClient {
     interceptors: [ClientInterceptor<Request, Response>] = [],
     requestType: Request.Type = Request.self,
     responseType: Response.Type = Response.self
-  ) -> GRPCAsyncResponseStream<Response>
-    where RequestStream.Element == Request {
+  ) -> GRPCAsyncResponseStream<Response> where RequestStream.Element == Request {
     let call = self.channel.makeAsyncBidirectionalStreamingCall(
       path: path,
       callOptions: callOptions ?? self.defaultCallOptions,
@@ -387,11 +393,14 @@ extension GRPCClient {
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension GRPCClient {
   @inlinable
-  internal func perform<Request, Response, RequestStream>(
+  internal func perform<
+    Request: Sendable,
+    Response: Sendable,
+    RequestStream: AsyncSequence & Sendable
+  >(
     _ call: GRPCAsyncClientStreamingCall<Request, Response>,
     with requests: RequestStream
-  ) async throws -> Response
-    where RequestStream: AsyncSequence, RequestStream.Element == Request {
+  ) async throws -> Response where RequestStream.Element == Request {
     // We use a detached task because we use cancellation to signal early, but successful exit.
     let requestsTask = Task.detached {
       try Task.checkCancellation()
@@ -420,12 +429,14 @@ extension GRPCClient {
   }
 
   @inlinable
-  internal func perform<Request, Response, RequestStream>(
+  internal func perform<
+    Request: Sendable,
+    Response: Sendable,
+    RequestStream: AsyncSequence & Sendable
+  >(
     _ call: GRPCAsyncBidirectionalStreamingCall<Request, Response>,
     with requests: RequestStream
-  )
-    -> GRPCAsyncResponseStream<Response>
-    where RequestStream: AsyncSequence, RequestStream.Element == Request {
+  ) -> GRPCAsyncResponseStream<Response> where RequestStream.Element == Request {
     Task {
       try await withTaskCancellationHandler {
         try Task.checkCancellation()

--- a/Sources/GRPC/AsyncAwaitSupport/PassthroughMessageSequence.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/PassthroughMessageSequence.swift
@@ -55,4 +55,9 @@ internal struct PassthroughMessageSequence<Element, Failure: Error>: AsyncSequen
   }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension PassthroughMessageSequence: Sendable where Element: Sendable {}
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension PassthroughMessageSequence.Iterator: Sendable where Element: Sendable {}
+
 #endif // compiler(>=5.6)

--- a/Sources/GRPC/AsyncAwaitSupport/PassthroughMessageSource.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/PassthroughMessageSource.swift
@@ -160,4 +160,8 @@ internal final class PassthroughMessageSource<Element, Failure: Error> {
   }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+// @unchecked is ok: mutable state is accessed/modified via a lock.
+extension PassthroughMessageSource: @unchecked Sendable where Element: Sendable {}
+
 #endif // compiler(>=5.6)

--- a/Sources/GRPC/ClientCalls/Call.swift
+++ b/Sources/GRPC/ClientCalls/Call.swift
@@ -37,7 +37,7 @@ import protocol SwiftProtobuf.Message
 ///
 /// Callers are not able to create `Call` objects directly, rather they must be created via an
 /// object conforming to `GRPCChannel` such as `ClientConnection`.
-public class Call<Request, Response> {
+public final class Call<Request, Response> {
   @usableFromInline
   internal enum State {
     /// Idle, waiting to be invoked.
@@ -417,3 +417,8 @@ extension Call {
     self._send(.metadata(self.options.customMetadata), promise: nil)
   }
 }
+
+#if compiler(>=5.6)
+// @unchecked is ok: all mutable state is accessed/modified from the appropriate event loop.
+extension Call: @unchecked Sendable where Request: Sendable, Response: Sendable {}
+#endif

--- a/Sources/GRPC/ClientCalls/ResponseContainers.swift
+++ b/Sources/GRPC/ClientCalls/ResponseContainers.swift
@@ -190,3 +190,9 @@ extension Error {
     }
   }
 }
+
+#if compiler(>=5.6)
+// @unchecked is ok: all mutable state is accessed/modified from an appropriate event loop.
+extension UnaryResponseParts: @unchecked Sendable where Response: Sendable {}
+extension StreamingResponseParts: @unchecked Sendable where Response: Sendable {}
+#endif

--- a/Tests/GRPCTests/Codegen/Normalization/normalization.grpc.swift
+++ b/Tests/GRPCTests/Codegen/Normalization/normalization.grpc.swift
@@ -500,7 +500,7 @@ extension Normalization_NormalizationAsyncClientProtocol {
   internal func ClientStreaming<RequestStream>(
     _ requests: RequestStream,
     callOptions: CallOptions? = nil
-  ) async throws -> Normalization_FunctionName where RequestStream: AsyncSequence, RequestStream.Element == SwiftProtobuf.Google_Protobuf_Empty {
+  ) async throws -> Normalization_FunctionName where RequestStream: AsyncSequence & Sendable, RequestStream.Element == SwiftProtobuf.Google_Protobuf_Empty {
     return try await self.performAsyncClientStreamingCall(
       path: Normalization_NormalizationClientMetadata.Methods.ClientStreaming.path,
       requests: requests,
@@ -524,7 +524,7 @@ extension Normalization_NormalizationAsyncClientProtocol {
   internal func clientStreaming<RequestStream>(
     _ requests: RequestStream,
     callOptions: CallOptions? = nil
-  ) async throws -> Normalization_FunctionName where RequestStream: AsyncSequence, RequestStream.Element == SwiftProtobuf.Google_Protobuf_Empty {
+  ) async throws -> Normalization_FunctionName where RequestStream: AsyncSequence & Sendable, RequestStream.Element == SwiftProtobuf.Google_Protobuf_Empty {
     return try await self.performAsyncClientStreamingCall(
       path: Normalization_NormalizationClientMetadata.Methods.clientStreaming.path,
       requests: requests,
@@ -548,7 +548,7 @@ extension Normalization_NormalizationAsyncClientProtocol {
   internal func BidirectionalStreaming<RequestStream>(
     _ requests: RequestStream,
     callOptions: CallOptions? = nil
-  ) -> GRPCAsyncResponseStream<Normalization_FunctionName> where RequestStream: AsyncSequence, RequestStream.Element == SwiftProtobuf.Google_Protobuf_Empty {
+  ) -> GRPCAsyncResponseStream<Normalization_FunctionName> where RequestStream: AsyncSequence & Sendable, RequestStream.Element == SwiftProtobuf.Google_Protobuf_Empty {
     return self.performAsyncBidirectionalStreamingCall(
       path: Normalization_NormalizationClientMetadata.Methods.BidirectionalStreaming.path,
       requests: requests,
@@ -572,7 +572,7 @@ extension Normalization_NormalizationAsyncClientProtocol {
   internal func bidirectionalStreaming<RequestStream>(
     _ requests: RequestStream,
     callOptions: CallOptions? = nil
-  ) -> GRPCAsyncResponseStream<Normalization_FunctionName> where RequestStream: AsyncSequence, RequestStream.Element == SwiftProtobuf.Google_Protobuf_Empty {
+  ) -> GRPCAsyncResponseStream<Normalization_FunctionName> where RequestStream: AsyncSequence & Sendable, RequestStream.Element == SwiftProtobuf.Google_Protobuf_Empty {
     return self.performAsyncBidirectionalStreamingCall(
       path: Normalization_NormalizationClientMetadata.Methods.bidirectionalStreaming.path,
       requests: requests,


### PR DESCRIPTION
Motivation:

Sendable conformance was missing in a handful of places which generates
warnings in newer toolchains.

Modifications:

- Make client calls Sendable
- Client call wrappers should require Sendable types (this was
  implicitly enfored by calls requiring request and response types to be
  Sendable). This also requires the async sequence of requests to be
  Sendable for calls where requests are streamed which required a
  codegen change.
- Make the various gRPC async sequence types conditionally Sendable

Result:

Fewer warnings