### PR TITLE
Refactor the async server call context

### DIFF
--- a/Sources/GRPC/AsyncAwaitSupport/AsyncServerHandler/ServerHandlerStateMachine/ServerHandlerStateMachine+Finished.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/AsyncServerHandler/ServerHandlerStateMachine/ServerHandlerStateMachine+Finished.swift
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #if compiler(>=5.6)
+import NIOHPACK
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension ServerHandlerStateMachine {
@@ -31,6 +32,20 @@ extension ServerHandlerStateMachine {
     internal init(from state: ServerHandlerStateMachine.Handling) {}
     @inlinable
     internal init(from state: ServerHandlerStateMachine.Draining) {}
+
+    @inlinable
+    mutating func setResponseHeaders(
+      _ headers: HPACKHeaders
+    ) -> Self.NextStateAndOutput<Void> {
+      return .init(nextState: .finished(self))
+    }
+
+    @inlinable
+    mutating func setResponseTrailers(
+      _ metadata: HPACKHeaders
+    ) -> Self.NextStateAndOutput<Void> {
+      return .init(nextState: .finished(self))
+    }
 
     @inlinable
     mutating func handleMetadata() -> Self.NextStateAndOutput<HandleMetadataAction> {


### PR DESCRIPTION
Motivation:

The async call context provided to async server methods provides an API
to access request headers and the logger as well as modify the response
headers, trailers and user info.

This is currently implemented as a class with its mutable state
protected by a lock. This works fine but is racy: the response headers
can be updated after writing the first message and still be sent before
that message (as writing the message requires executing onto the event
loop).

Modifications:

- Turn the context into a `struct` and break it into request and
  response components.
- Request components are immutable.
- Response components are mutable via `async` calls which execute onto
  the underlying event loop.
- This introduces allocations as the work is submitted onto the
  event loop, however setting headers is not a frequent operation and is
  worth the trade off for a less surprising API.
- Trap when headers/trailers are set after they have been sent
  (this is an assertion failre).

Result:

- Async server context has a less surprising API
- Setting headers/trailers is not racy