### PR TITLE
Add co-operative cancellation to async writer and passthrough source

### DIFF
--- a/Sources/GRPC/AsyncAwaitSupport/PassthroughMessageSequence.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/PassthroughMessageSequence.swift
@@ -50,6 +50,7 @@ internal struct PassthroughMessageSequence<Element, Failure: Error>: AsyncSequen
 
     @inlinable
     internal func next() async throws -> Element? {
+      // The storage handles co-operative cancellation, so we don't bother checking here.
       return try await self._storage.consumeNextElement()
     }
   }

--- a/Sources/GRPC/AsyncAwaitSupport/PassthroughMessageSource.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/PassthroughMessageSource.swift
@@ -158,7 +158,7 @@ internal final class PassthroughMessageSource<Element, Failure: Error> {
         self._lock.unlock()
       }
     } onCancel: {
-      let continuation = self._lock.withLock {
+      let continuation: CheckedContinuation<Element?, Error>? = self._lock.withLock {
         let cont = self._continuation
         self._continuation = nil
         return cont

--- a/Sources/GRPC/AsyncAwaitSupport/PassthroughMessageSource.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/PassthroughMessageSource.swift
@@ -108,12 +108,14 @@ internal final class PassthroughMessageSource<Element, Failure: Error> {
     let result: _YieldResult = self._lock.withLock {
       if self._isTerminated {
         return .alreadyTerminated
-      } else if let continuation = self._continuation {
+      } else {
         self._isTerminated = isTerminator
+      }
+
+      if let continuation = self._continuation {
         self._continuation = nil
         return .resume(continuation)
       } else {
-        self._isTerminated = isTerminator
         self._continuationResults.append(continuationResult)
         return .queued(self._continuationResults.count)
       }
@@ -138,28 +140,31 @@ internal final class PassthroughMessageSource<Element, Failure: Error> {
 
   @inlinable
   internal func consumeNextElement() async throws -> Element? {
-    return try await withCheckedThrowingContinuation {
-      self._consumeNextElement(continuation: $0)
+    self._lock.lock()
+    if let nextResult = self._continuationResults.popFirst() {
+      self._lock.unlock()
+      return try nextResult.get()
+    } else if self._isTerminated {
+      self._lock.unlock()
+      return nil
     }
-  }
 
-  @inlinable
-  internal func _consumeNextElement(continuation: CheckedContinuation<Element?, Error>) {
-    let continuationResult: _ContinuationResult? = self._lock.withLock {
-      if let nextResult = self._continuationResults.popFirst() {
-        return nextResult
-      } else if self._isTerminated {
-        return .success(nil)
-      } else {
+    // Slow path; we need a continuation.
+    return try await withTaskCancellationHandler {
+      try await withCheckedThrowingContinuation { continuation in
         // Nothing buffered and not terminated yet: save the continuation for later.
         precondition(self._continuation == nil)
         self._continuation = continuation
-        return nil
+        self._lock.unlock()
       }
-    }
+    } onCancel: {
+      let continuation = self._lock.withLock {
+        let cont = self._continuation
+        self._continuation = nil
+        return cont
+      }
 
-    if let continuationResult = continuationResult {
-      continuation.resume(with: continuationResult)
+      continuation?.resume(throwing: CancellationError())
     }
   }
 }

--- a/Tests/GRPCTests/AsyncAwaitSupport/XCTest+AsyncAwait.swift
+++ b/Tests/GRPCTests/AsyncAwaitSupport/XCTest+AsyncAwait.swift
@@ -31,4 +31,44 @@ internal func XCTAssertThrowsError<T>(
   }
 }
 
+fileprivate enum TaskResult<Result> {
+  case operation(Result)
+  case cancellation
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+func withTaskCancelledAfter<Result>(
+  nanoseconds: UInt64,
+  operation: @escaping @Sendable () async -> Result
+) async throws {
+  try await withThrowingTaskGroup(of: TaskResult<Result>.self) { group in
+    group.addTask {
+      return .operation(await operation())
+    }
+
+    group.addTask {
+      try await Task.sleep(nanoseconds: nanoseconds)
+      return .cancellation
+    }
+
+    // Only the sleeping task can throw if it's cancelled, in which case we want to throw.
+    let firstResult = try await group.next()
+    // A task completed, cancel the rest.
+    group.cancelAll()
+
+    // Check which task completed.
+    switch firstResult {
+    case .cancellation:
+      () // Fine, what we expect.
+    case .operation:
+      XCTFail("Operation completed before cancellation")
+    case .none:
+      XCTFail("No tasks completed")
+    }
+
+    // Wait for the other task. The operation cannot, only the sleeping task can.
+    try await group.waitForAll()
+  }
+}
+
 #endif // compiler(>=5.6)


### PR DESCRIPTION
Motivation:

Whenever we create continuations we should be careful to add support for
co-operative cancellation via a cancellation handler.

Modifications:

- Add co-operative cancellation to the async write and passthrough
  source
- Tests

Result:

Better cancellation support