### PR TITLE
Make `Sendable` protocols `@preconcurrency`

### DIFF
--- a/Sources/GRPC/AsyncAwaitSupport/GRPCSendable.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCSendable.swift
@@ -17,9 +17,16 @@
 import NIOCore
 
 #if compiler(>=5.6)
-@preconcurrency public typealias GRPCSendable = Swift.Sendable
+public typealias GRPCSendable = Swift.Sendable
 #else
 public typealias GRPCSendable = Any
+#endif // compiler(>=5.6)
+
+#if compiler(>=5.6)
+@preconcurrency
+public protocol GRPCPreconcurrencySendable: Sendable {}
+#else
+public protocol GRPCPreconcurrencySendable {}
 #endif // compiler(>=5.6)
 
 #if compiler(>=5.6)

--- a/Sources/GRPC/ClientErrorDelegate.swift
+++ b/Sources/GRPC/ClientErrorDelegate.swift
@@ -22,7 +22,7 @@ import Logging
 /// The intended use of this protocol is with `ClientConnection`. In order to avoid retain
 /// cycles, classes implementing this delegate **must not** maintain a strong reference to the
 /// `ClientConnection`.
-public protocol ClientErrorDelegate: AnyObject, GRPCSendable {
+public protocol ClientErrorDelegate: AnyObject, GRPCPreconcurrencySendable {
   /// Called when the client catches an error.
   ///
   /// - Parameters:

--- a/Sources/GRPC/ConnectivityState.swift
+++ b/Sources/GRPC/ConnectivityState.swift
@@ -47,7 +47,7 @@ public enum ConnectivityState: GRPCSendable {
   case shutdown
 }
 
-public protocol ConnectivityStateDelegate: AnyObject, GRPCSendable {
+public protocol ConnectivityStateDelegate: AnyObject, GRPCPreconcurrencySendable {
   /// Called when a change in `ConnectivityState` has occurred.
   ///
   /// - Parameter oldState: The old connectivity state.

--- a/Sources/GRPC/GRPCChannel/GRPCChannel.swift
+++ b/Sources/GRPC/GRPCChannel/GRPCChannel.swift
@@ -17,7 +17,7 @@ import NIOCore
 import NIOHTTP2
 import SwiftProtobuf
 
-public protocol GRPCChannel: GRPCSendable {
+public protocol GRPCChannel: GRPCPreconcurrencySendable {
   /// Makes a gRPC call on the channel with requests and responses conforming to
   /// `SwiftProtobuf.Message`.
   ///

--- a/Sources/GRPC/GRPCClient.swift
+++ b/Sources/GRPC/GRPCClient.swift
@@ -19,7 +19,7 @@ import NIOHTTP2
 import SwiftProtobuf
 
 /// A gRPC client.
-public protocol GRPCClient: GRPCSendable {
+public protocol GRPCClient: GRPCPreconcurrencySendable {
   /// The gRPC channel over which RPCs are sent and received. Note that this is distinct
   /// from `NIO.Channel`.
   var channel: GRPCChannel { get }


### PR DESCRIPTION
Motivation:

Protocols in the gRPC API predate `Sendable` but are required to be
`Sendable` should be marked with `@preconcurrency`.

Modifications:

- Add `GRPCPreconcurrencySendable`
- Make relevant protocols as `GRPCPreconcurrencySendable` rather than
  just `GRPCSendable`.

Result:

Better `Sendable` checking.