### PR TITLE
Remove preconcurrency imports of NIOHPACK

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -44,7 +44,7 @@ let packageDependencies: [Package.Dependency] = [
   ),
   .package(
     url: "https://github.com/apple/swift-nio-http2.git",
-    from: "1.19.2"
+    from: "1.22.0"
   ),
   .package(
     url: "https://github.com/apple/swift-nio-transport-services.git",

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncServerCallContext.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncServerCallContext.swift
@@ -17,7 +17,7 @@
 
 @preconcurrency import Logging
 import NIOConcurrencyHelpers
-@preconcurrency import NIOHPACK
+import NIOHPACK
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public struct GRPCAsyncServerCallContext: Sendable {

--- a/Sources/GRPC/CallOptions.swift
+++ b/Sources/GRPC/CallOptions.swift
@@ -18,13 +18,12 @@ import struct Foundation.UUID
 #if swift(>=5.6)
 @preconcurrency import Logging
 @preconcurrency import NIOCore
-@preconcurrency import NIOHPACK
 #else
 import Logging
 import NIOCore
-import NIOHPACK
 #endif // swift(>=5.6)
 
+import NIOHPACK
 import NIOHTTP1
 import NIOHTTP2
 


### PR DESCRIPTION
Motivation:

Support for Sendable was added to swift-nio-http2 in 1.22.0 so the
`@preconcurrency` import of `NIOHPACK` is no longer required (and
produces warnings).

Modifications:

- Update minimum HTTP/2 version
- Remove `@preconcurrency` from `NIOHPACK` imports

Result:

Fewer warnings