### PR TITLE
Build release plugins as universal binaries

### DIFF
--- a/scripts/bundle-plugins-for-release.sh
+++ b/scripts/bundle-plugins-for-release.sh
@@ -45,11 +45,13 @@ stage_bin="${stage}/bin"
 mkdir -p "${stage_bin}"
 
 # Make the plugins.
-make -C "${root}" plugins
+swift build -c release --arch arm64 --arch x86_64 --product protoc-gen-grpc-swift
+swift build -c release --arch arm64 --arch x86_64 --product protoc-gen-swift
+binpath=$(swift build -c release --arch arm64 --arch x86_64 --show-bin-path)
 
 # Copy them to the stage.
-cp "${root}/protoc-gen-grpc-swift" "${stage_bin}"
-cp "${root}/protoc-gen-swift" "${stage_bin}"
+cp "${binpath}/protoc-gen-grpc-swift" "${stage_bin}"
+cp "${binpath}/protoc-gen-swift" "${stage_bin}"
 
 # Copy the LICENSE to the stage.
 cp "${root}/LICENSE" "${stage}"


### PR DESCRIPTION
Motivation:

We upload protoc plugins for each release. As it stands, the
architecture these plugins are built for is that of the machine building
them. We should upload universal binaries instead.

Modifications:

- Modify the bundling script to build universal binaries

Result:

Better platform support for the uploaded macOS plugins.