### PR TITLE
Raise minimum NIO version to 2.36.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let argumentParserMinimumVersion: Version = "1.0.0"
 let packageDependencies: [Package.Dependency] = [
   .package(
     url: "https://github.com/apple/swift-nio.git",
-    from: "2.32.0"
+    from: "2.36.0"
   ),
   .package(
     url: "https://github.com/apple/swift-nio-http2.git",


### PR DESCRIPTION
With the merge of the async/await support to main we now require NIO
2.36.0, which is the release that contains the new availability
requirements for EventLoopFuture.get

Resolves #1443