### PR TITLE
Use swift-atomics

### DIFF
--- a/Performance/QPSBenchmark/Package.swift
+++ b/Performance/QPSBenchmark/Package.swift
@@ -27,6 +27,7 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.32.0"),
     .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.0.0"),
+    .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
     .package(
       url: "https://github.com/swift-server/swift-service-lifecycle.git",
       from: "1.0.0-alpha"
@@ -42,6 +43,7 @@ let package = Package(
       name: "QPSBenchmark",
       dependencies: [
         .product(name: "GRPC", package: "grpc-swift"),
+        .product(name: "Atomics", package: "swift-atomics"),
         .product(name: "NIOCore", package: "swift-nio"),
         .product(name: "NIOPosix", package: "swift-nio"),
         .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),

--- a/Tests/GRPCTests/StreamResponseHandlerRetainCycleTests.swift
+++ b/Tests/GRPCTests/StreamResponseHandlerRetainCycleTests.swift
@@ -57,10 +57,19 @@ final class StreamResponseHandlerRetainCycleTests: GRPCTestCase {
 
   func testHandlerClosureIsReleasedOnceStreamEnds() {
     final class Counter {
-      private let atomic = NIOAtomic.makeAtomic(value: 0)
-      func increment() { self.atomic.add(1) }
+      private let lock = Lock()
+      private var _value = 0
+
+      func increment() {
+        self.lock.withLockVoid {
+          self._value += 1
+        }
+      }
+
       var value: Int {
-        self.atomic.load()
+        return self.lock.withLock {
+          self._value
+        }
       }
     }
 


### PR DESCRIPTION
Motivation:

NIO deprecated its atomics in apple/swift-nio#2204.

Modifications:

- Use swift-atomics in the `QPSBenchmark` sub-package
- Use a lock in the one test which used `NIOAtomic`

Result:

Not using deprecated code.