### PR TITLE
Make path available in async calls

### DIFF
--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncBidirectionalStreamingCall.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncBidirectionalStreamingCall.swift
@@ -35,6 +35,11 @@ public struct GRPCAsyncBidirectionalStreamingCall<Request: Sendable, Response: S
     return self.call.options
   }
 
+  /// The path used to make the RPC.
+  public var path: String {
+    return self.call.path
+  }
+
   /// Cancel this RPC if it hasn't already completed.
   public func cancel() {
     self.call.cancel(promise: nil)

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncClientStreamingCall.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncClientStreamingCall.swift
@@ -31,6 +31,11 @@ public struct GRPCAsyncClientStreamingCall<Request: Sendable, Response: Sendable
     return self.call.options
   }
 
+  /// The path used to make the RPC.
+  public var path: String {
+    return self.call.path
+  }
+
   /// Cancel this RPC if it hasn't already completed.
   public func cancel() {
     self.call.cancel(promise: nil)

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncServerStreamingCall.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncServerStreamingCall.swift
@@ -32,6 +32,11 @@ public struct GRPCAsyncServerStreamingCall<Request: Sendable, Response: Sendable
     return self.call.options
   }
 
+  /// The path used to make the RPC.
+  public var path: String {
+    return self.call.path
+  }
+
   /// Cancel this RPC if it hasn't already completed.
   public func cancel() {
     self.call.cancel(promise: nil)

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncUnaryCall.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncUnaryCall.swift
@@ -31,6 +31,11 @@ public struct GRPCAsyncUnaryCall<Request: Sendable, Response: Sendable>: Sendabl
     self.call.options
   }
 
+  /// The path used to make the RPC.
+  public var path: String {
+    self.call.path
+  }
+
   /// Cancel this RPC if it hasn't already completed.
   public func cancel() {
     self.call.cancel(promise: nil)


### PR DESCRIPTION
This PR adds a `path` property to async client calls. There was a similar issue with non async calls before. (#1236)