### PR TITLE
Prepare for DocC

### DIFF
--- a/Package@swift-5.4.swift
+++ b/Package@swift-5.4.swift
@@ -1,6 +1,6 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.4
 /*
- * Copyright 2017, gRPC Authors All rights reserved.
+ * Copyright 2022, gRPC Authors All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,10 +66,6 @@ let packageDependencies: [Package.Dependency] = [
   .package(
     url: "https://github.com/apple/swift-argument-parser.git",
     from: argumentParserMinimumVersion
-  ),
-  .package(
-    url: "https://github.com/apple/swift-docc-plugin",
-    from: "1.0.0"
   ),
 ].appending(
   .package(

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -1,6 +1,6 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.5
 /*
- * Copyright 2017, gRPC Authors All rights reserved.
+ * Copyright 2022, gRPC Authors All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,10 +66,6 @@ let packageDependencies: [Package.Dependency] = [
   .package(
     url: "https://github.com/apple/swift-argument-parser.git",
     from: argumentParserMinimumVersion
-  ),
-  .package(
-    url: "https://github.com/apple/swift-docc-plugin",
-    from: "1.0.0"
   ),
 ].appending(
   .package(

--- a/scripts/license-check.sh
+++ b/scripts/license-check.sh
@@ -110,6 +110,11 @@ check_copyright_headers() {
         drop_first=1
         expected_lines=15
         ;;
+      */Package@swift-*.*.swift)
+        expected_sha="$SWIFT_SHA"
+        drop_first=1
+        expected_lines=15
+        ;;
       *)
         expected_sha="$SWIFT_SHA"
         drop_first=0


### PR DESCRIPTION
# Motivation
We wanna use DocC for publishing docs.

# Modification
Setup our `Package.swift`  manifests to enable proper doc generation.

# Result
We can now use DocC to generate docs.