### PR TITLE
Fix preconcurrency warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let includeNIOSSL = ProcessInfo.processInfo.environment["GRPC_NO_NIO_SSL"] == ni
 let packageDependencies: [Package.Dependency] = [
   .package(
     url: "https://github.com/apple/swift-nio.git",
-    from: "2.36.0"
+    from: "2.41.1"
   ),
   .package(
     url: "https://github.com/apple/swift-nio-http2.git",
@@ -52,7 +52,7 @@ let packageDependencies: [Package.Dependency] = [
   ),
   .package(
     url: "https://github.com/apple/swift-log.git",
-    from: "1.4.0"
+    from: "1.4.4"
   ),
   .package(
     url: "https://github.com/apple/swift-argument-parser.git",

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncServerCallContext.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncServerCallContext.swift
@@ -15,7 +15,7 @@
  */
 #if compiler(>=5.6)
 
-@preconcurrency import Logging
+import Logging
 import NIOConcurrencyHelpers
 import NIOHPACK
 

--- a/Sources/GRPC/CallOptions.swift
+++ b/Sources/GRPC/CallOptions.swift
@@ -15,14 +15,9 @@
  */
 import struct Foundation.UUID
 
-#if swift(>=5.6)
-@preconcurrency import Logging
-@preconcurrency import NIOCore
-#else
-import Logging
 import NIOCore
-#endif // swift(>=5.6)
 
+import Logging
 import NIOHPACK
 import NIOHTTP1
 import NIOHTTP2

--- a/Sources/GRPC/ClientConnection.swift
+++ b/Sources/GRPC/ClientConnection.swift
@@ -15,14 +15,12 @@
  */
 #if swift(>=5.6)
 @preconcurrency import Foundation
-@preconcurrency import Logging
-@preconcurrency import NIOCore
 #else
 import Foundation
-import Logging
-import NIOCore
 #endif // swift(>=5.6)
 
+import Logging
+import NIOCore
 import NIOHPACK
 import NIOHTTP2
 #if canImport(NIOSSL)

--- a/Sources/GRPC/ConnectionKeepalive.swift
+++ b/Sources/GRPC/ConnectionKeepalive.swift
@@ -13,11 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if swift(>=5.6)
-@preconcurrency import NIOCore
-#else
 import NIOCore
-#endif // swift(>=5.6)
 
 /// Provides keepalive pings.
 ///

--- a/Sources/GRPC/ConnectionPool/GRPCChannelPool.swift
+++ b/Sources/GRPC/ConnectionPool/GRPCChannelPool.swift
@@ -13,13 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if swift(>=5.6)
-@preconcurrency import Logging
-@preconcurrency import NIOCore
-#else
 import Logging
 import NIOCore
-#endif // swift(>=5.6)
 import NIOPosix
 
 public enum GRPCChannelPool {

--- a/Sources/GRPC/PlatformSupport.swift
+++ b/Sources/GRPC/PlatformSupport.swift
@@ -121,7 +121,13 @@ public protocol ClientBootstrapProtocol {
 
   func connectTimeout(_ timeout: TimeAmount) -> Self
   func channelOption<T>(_ option: T, value: T.Value) -> Self where T: ChannelOption
+
+  #if swift(>=5.7)
+  @preconcurrency
+  func channelInitializer(_ handler: @escaping @Sendable (Channel) -> EventLoopFuture<Void>) -> Self
+  #else
   func channelInitializer(_ handler: @escaping (Channel) -> EventLoopFuture<Void>) -> Self
+  #endif
 }
 
 extension ClientBootstrapProtocol {
@@ -149,10 +155,25 @@ public protocol ServerBootstrapProtocol {
   func bind(unixDomainSocketPath: String) -> EventLoopFuture<Channel>
   func withBoundSocket(_ connectedSocket: NIOBSDSocket.Handle) -> EventLoopFuture<Channel>
 
-  func serverChannelInitializer(_ initializer: @escaping (Channel) -> EventLoopFuture<Void>) -> Self
+  #if swift(>=5.7)
+  @preconcurrency
+  func serverChannelInitializer(
+    _ handler: @escaping @Sendable (Channel) -> EventLoopFuture<Void>
+  ) -> Self
+  #else
+  func serverChannelInitializer(_ handler: @escaping (Channel) -> EventLoopFuture<Void>) -> Self
+  #endif
+
   func serverChannelOption<T>(_ option: T, value: T.Value) -> Self where T: ChannelOption
 
-  func childChannelInitializer(_ initializer: @escaping (Channel) -> EventLoopFuture<Void>) -> Self
+  #if swift(>=5.7)
+  @preconcurrency
+  func childChannelInitializer(_ handler: @escaping @Sendable (Channel) -> EventLoopFuture<Void>)
+    -> Self
+  #else
+  func childChannelInitializer(_ handler: @escaping (Channel) -> EventLoopFuture<Void>) -> Self
+  #endif
+
   func childChannelOption<T>(_ option: T, value: T.Value) -> Self where T: ChannelOption
 }
 

--- a/Sources/GRPC/TimeLimit.swift
+++ b/Sources/GRPC/TimeLimit.swift
@@ -14,11 +14,7 @@
  * limitations under the License.
  */
 import Dispatch
-#if swift(>=5.6)
-@preconcurrency import NIOCore
-#else
 import NIOCore
-#endif // swift(>=5.6)
 
 /// A time limit for an RPC.
 ///


### PR DESCRIPTION
Motivation:

NIO and Logging have now adopted Sendable so the `@preconcurrency` imports now emit warnings.

Modifications:

- Raise minimum required version to the versions with `Sendable` support
- Remove `@preconcurrency` imports

Result:

No more warnings.