### PR TITLE
Use forward looking SwiftProtobuf API

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -48,7 +48,7 @@ let packageDependencies: [Package.Dependency] = [
   ),
   .package(
     url: "https://github.com/apple/swift-protobuf.git",
-    from: "1.20.1"
+    from: "1.20.2"
   ),
   .package(
     url: "https://github.com/apple/swift-log.git",

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -49,7 +49,7 @@ let packageDependencies: [Package.Dependency] = [
   .package(
     name: "SwiftProtobuf",
     url: "https://github.com/apple/swift-protobuf.git",
-    from: "1.19.0"
+    from: "1.20.2"
   ),
   .package(
     url: "https://github.com/apple/swift-log.git",

--- a/Sources/protoc-gen-grpc-swift/StreamingType.swift
+++ b/Sources/protoc-gen-grpc-swift/StreamingType.swift
@@ -38,14 +38,14 @@ extension StreamingType {
 }
 
 internal func streamingType(_ method: MethodDescriptor) -> StreamingType {
-  if method.proto.clientStreaming {
-    if method.proto.serverStreaming {
+  if method.clientStreaming {
+    if method.serverStreaming {
       return .bidirectionalStreaming
     } else {
       return .clientStreaming
     }
   } else {
-    if method.proto.serverStreaming {
+    if method.serverStreaming {
       return .serverStreaming
     } else {
       return .unary

--- a/Sources/protoc-gen-grpc-swift/main.swift
+++ b/Sources/protoc-gen-grpc-swift/main.swift
@@ -125,8 +125,8 @@ func main() throws {
 
   // Only generate output for services.
   for name in request.fileToGenerate {
-    let fileDescriptor = descriptorSet.lookupFileDescriptor(protoName: name)
-    if !fileDescriptor.services.isEmpty {
+    if let fileDescriptor = descriptorSet.fileDescriptor(named: name),
+       !fileDescriptor.services.isEmpty {
       let grpcFileName = uniqueOutputFileName(
         component: "grpc",
         fileDescriptor: fileDescriptor,


### PR DESCRIPTION
Motivation:

SwiftProtobuf would like to remove some of the plugin library 
code in its next major release. We would like to allow gRPC to
rely on SwiftProtobuf in both major versions.

We use a few of the APIs marked for removal but can switch
away from them easily as replacement APIs have been backported
to the 1.x branch.

Modifications:

- Raise the minimum protobuf version
- Use the new APIs

Result:

- We can depend on protobuf 1.x and 2.x when it becomes available.