### PR TITLE
Expose public creation methods for `GRPCAsyncRequestStream` and `GRPCAsyncResponseStreamWriter`

### DIFF
--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncResponseStreamWriter.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncResponseStreamWriter.swift
@@ -18,7 +18,7 @@
 
 /// Writer for server-streaming RPC handlers to provide responses.
 ///
-/// To enable testability this type provides a static ``GRPCAsyncResponseStreamWriter/makeResponseStreamWriter()``
+/// To enable testability this type provides a static ``GRPCAsyncResponseStreamWriter/makeTestingResponseStreamWriter()``
 /// method which allows you to create a stream that you can drive.
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public struct GRPCAsyncResponseStreamWriter<Response: Sendable>: Sendable {
@@ -69,12 +69,12 @@ public struct GRPCAsyncResponseStreamWriter<Response: Sendable>: Sendable {
     }
   }
 
-  /// Simple struct for the return type of ``GRPCAsyncResponseStreamWriter/makeResponseStreamWriter()``.
+  /// Simple struct for the return type of ``GRPCAsyncResponseStreamWriter/makeTestingResponseStreamWriter()``.
   ///
   /// This struct contains two properties:
   /// 1. The ``writer`` which is the actual ``GRPCAsyncResponseStreamWriter`` and should be passed to the method under testing.
   /// 2. The ``stream`` which can be used to observe the written responses.
-  public struct TestingResponseStreamWriter {
+  public struct TestingStreamWriter {
     /// The actual writer.
     public let writer: GRPCAsyncResponseStreamWriter<Response>
     /// The written responses in a stream.
@@ -134,7 +134,7 @@ public struct GRPCAsyncResponseStreamWriter<Response: Sendable>: Sendable {
   /// - Note: For most tests it is useful to call ``ResponseStream/finish()`` after the async method under testing
   /// resumed. This allows you to easily collect all written responses.
   @inlinable
-  public static func makeResponseStreamWriter() -> TestingResponseStreamWriter {
+  public static func makeTestingResponseStreamWriter() -> TestingStreamWriter {
     var continuation: AsyncStream<(Response, Compression)>.Continuation!
     let asyncStream = AsyncStream<(Response, Compression)> { cont in
       continuation = cont

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncResponseStreamWriter.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncResponseStreamWriter.swift
@@ -147,7 +147,7 @@ public struct GRPCAsyncResponseStreamWriter<Response: Sendable>: Sendable {
       continuation: continuation
     )
 
-    return TestingResponseStreamWriter(writer: writer, stream: responseStream)
+    return TestingStreamWriter(writer: writer, stream: responseStream)
   }
 }
 

--- a/Sources/GRPC/Interceptor/ClientTransportFactory.swift
+++ b/Sources/GRPC/Interceptor/ClientTransportFactory.swift
@@ -304,8 +304,7 @@ internal struct FakeClientTransportFactory<Request, Response> {
   ) where RequestSerializer.Input == Request,
     RequestDeserializer.Output == Request,
     ResponseSerializer.Input == Response,
-    ResponseDeserializer.Output == Response
-  {
+    ResponseDeserializer.Output == Response {
     self.fakeResponseStream = fakeResponseStream
     self.requestSerializer = AnySerializer(wrapping: requestSerializer)
     self.responseDeserializer = AnyDeserializer(wrapping: responseDeserializer)

--- a/Tests/GRPCTests/AsyncAwaitSupport/GRPCAsyncRequestStreamTests.swift
+++ b/Tests/GRPCTests/AsyncAwaitSupport/GRPCAsyncRequestStreamTests.swift
@@ -21,15 +21,12 @@ import XCTest
 @available(macOS 12, iOS 13, tvOS 13, watchOS 6, *)
 final class GRPCAsyncRequestStreamTests: XCTestCase {
   func testRecorder() async throws {
-    var continuation: AsyncThrowingStream<Int, Error>.Continuation!
-    let stream = AsyncThrowingStream<Int, Error> { cont in
-      continuation = cont
-    }
-    let sequence = GRPCAsyncRequestStream<Int>.init(stream)
+    let testingStream = GRPCAsyncRequestStream<Int>.makeTestingRequestStream()
 
-    continuation.yield(1)
+    testingStream.source.yield(1)
+    testingStream.source.finish(throwing: nil)
 
-    let results = try await sequence.prefix(1).collect()
+    let results = try await testingStream.stream.collect()
 
     XCTAssertEqual(results, [1])
   }

--- a/Tests/GRPCTests/AsyncAwaitSupport/GRPCAsyncRequestStreamTests.swift
+++ b/Tests/GRPCTests/AsyncAwaitSupport/GRPCAsyncRequestStreamTests.swift
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#if compiler(>=5.6)
+
+import GRPC
+import XCTest
+
+@available(macOS 12, iOS 13, tvOS 13, watchOS 6, *)
+final class GRPCAsyncRequestStreamTests: XCTestCase {
+  func testRecorder() async throws {
+    var continuation: AsyncThrowingStream<Int, Error>.Continuation!
+    let stream = AsyncThrowingStream<Int, Error> { cont in
+      continuation = cont
+    }
+    let sequence = GRPCAsyncRequestStream<Int>.init(stream)
+
+    continuation.yield(1)
+
+    let results = try await sequence.prefix(1).collect()
+
+    XCTAssertEqual(results, [1])
+  }
+}
+#endif

--- a/Tests/GRPCTests/AsyncAwaitSupport/GRPCAsyncRequestStreamTests.swift
+++ b/Tests/GRPCTests/AsyncAwaitSupport/GRPCAsyncRequestStreamTests.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, gRPC Authors All rights reserved.
+ * Copyright 2022, gRPC Authors All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tests/GRPCTests/AsyncAwaitSupport/GRPCAsyncResponseStreamWriterTests.swift
+++ b/Tests/GRPCTests/AsyncAwaitSupport/GRPCAsyncResponseStreamWriterTests.swift
@@ -24,8 +24,9 @@ final class GRPCAsyncResponseStreamWriterTests: XCTestCase {
     let responseStreamWriter = GRPCAsyncResponseStreamWriter<Int>.makeResponseStreamWriter()
 
     try await responseStreamWriter.writer.send(1, compression: .disabled)
+    responseStreamWriter.stream.finish()
 
-    let results = try await responseStreamWriter.stream.prefix(1).collect()
+    let results = try await responseStreamWriter.stream.collect()
     XCTAssertEqual(results[0].0, 1)
     XCTAssertEqual(results[0].1, .disabled)
   }

--- a/Tests/GRPCTests/AsyncAwaitSupport/GRPCAsyncResponseStreamWriterTests.swift
+++ b/Tests/GRPCTests/AsyncAwaitSupport/GRPCAsyncResponseStreamWriterTests.swift
@@ -21,7 +21,7 @@ import XCTest
 @available(macOS 12, iOS 13, tvOS 13, watchOS 6, *)
 final class GRPCAsyncResponseStreamWriterTests: XCTestCase {
   func testRecorder() async throws {
-    let responseStreamWriter = GRPCAsyncResponseStreamWriter<Int>.makeResponseStreamWriter()
+    let responseStreamWriter = GRPCAsyncResponseStreamWriter<Int>.makeTestingResponseStreamWriter()
 
     try await responseStreamWriter.writer.send(1, compression: .disabled)
     responseStreamWriter.stream.finish()

--- a/Tests/GRPCTests/AsyncAwaitSupport/GRPCAsyncResponseStreamWriterTests.swift
+++ b/Tests/GRPCTests/AsyncAwaitSupport/GRPCAsyncResponseStreamWriterTests.swift
@@ -21,11 +21,11 @@ import XCTest
 @available(macOS 12, iOS 13, tvOS 13, watchOS 6, *)
 final class GRPCAsyncResponseStreamWriterTests: XCTestCase {
   func testRecorder() async throws {
-    let writer = GRPCAsyncResponseStreamWriter<Int>.makeRecordingWriter()
+    let responseStreamWriter = GRPCAsyncResponseStreamWriter<Int>.makeResponseStreamWriter()
 
-    try await writer.writer.send(1, compression: .disabled)
+    try await responseStreamWriter.writer.send(1, compression: .disabled)
 
-    let results = try await writer.responses.prefix(1).collect()
+    let results = try await responseStreamWriter.stream.prefix(1).collect()
     XCTAssertEqual(results[0].0, 1)
     XCTAssertEqual(results[0].1, .disabled)
   }

--- a/Tests/GRPCTests/AsyncAwaitSupport/GRPCAsyncResponseStreamWriterTests.swift
+++ b/Tests/GRPCTests/AsyncAwaitSupport/GRPCAsyncResponseStreamWriterTests.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, gRPC Authors All rights reserved.
+ * Copyright 2022, gRPC Authors All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tests/GRPCTests/AsyncAwaitSupport/GRPCAsyncResponseStreamWriterTests.swift
+++ b/Tests/GRPCTests/AsyncAwaitSupport/GRPCAsyncResponseStreamWriterTests.swift
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#if compiler(>=5.6)
+
+import GRPC
+import XCTest
+
+@available(macOS 12, iOS 13, tvOS 13, watchOS 6, *)
+final class GRPCAsyncResponseStreamWriterTests: XCTestCase {
+  func testRecorder() async throws {
+    let writer = GRPCAsyncResponseStreamWriter<Int>.makeRecordingWriter()
+
+    try await writer.writer.send(1, compression: .disabled)
+
+    let results = try await writer.responses.prefix(1).collect()
+    XCTAssertEqual(results[0].0, 1)
+    XCTAssertEqual(results[0].1, .disabled)
+  }
+}
+#endif


### PR DESCRIPTION
# Motivation
It is highly desirable to be able to write tests against the generated method of a service. Currently, this is close to impossible since both the `GRPCAsyncRequestStream` and the `GRPCAsyncResponseStreamWriter` don't expose a public init so users cannot drive and observe the functions.

# Modification
Adds new public methods to drive and observe the request stream and the response writer.

# Result
We can now properly test gRPC generated server function implementations.