### PR TITLE
Update swift-nio version, allocation test max values and alloc-limits.sh

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,24 +56,24 @@ jobs:
         include:
           - image: swiftlang/swift:nightly-focal
             env:
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 429000
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 177000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 428000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 176000
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 112000
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 67000
               MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 63000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 175000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 182000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 182000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 174000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 181000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 181000
           - image: swift:5.7-jammy
             env:
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 429000
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 177000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 428000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 176000
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 112000
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 67000
               MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 63000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 175000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 182000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 182000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 174000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 181000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 181000
           - image: swift:5.6-focal
             env:
               MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 429000

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,31 +56,31 @@ jobs:
         include:
           - image: swiftlang/swift:nightly-focal
             env:
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 428000
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 176000
-              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 110000
-              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 65000
-              MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 61000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 174000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 181000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 181000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 429000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 177000
+              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 112000
+              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 67000
+              MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 63000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 175000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 182000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 182000
           - image: swift:5.7-jammy
             env:
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 428000
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 176000
-              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 110000
-              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 65000
-              MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 61000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 174000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 181000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 181000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 429000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 177000
+              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 112000
+              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 67000
+              MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 63000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 175000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 182000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 182000
           - image: swift:5.6-focal
             env:
               MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 429000
               MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 177000
-              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 110000
-              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 65000
-              MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 61000
+              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 112000
+              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 67000
+              MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 63000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 175000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 182000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 182000
@@ -88,9 +88,9 @@ jobs:
             env:
               MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 459000
               MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 189000
-              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 110000
-              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 65000
-              MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 61000
+              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 112000
+              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 67000
+              MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 63000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 186000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 193000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 193000

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let includeNIOSSL = ProcessInfo.processInfo.environment["GRPC_NO_NIO_SSL"] == ni
 let packageDependencies: [Package.Dependency] = [
   .package(
     url: "https://github.com/apple/swift-nio.git",
-    from: "2.41.1"
+    from: "2.42.0"
   ),
   .package(
     url: "https://github.com/apple/swift-nio-http2.git",

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -32,7 +32,7 @@ let includeNIOSSL = ProcessInfo.processInfo.environment["GRPC_NO_NIO_SSL"] == ni
 let packageDependencies: [Package.Dependency] = [
   .package(
     url: "https://github.com/apple/swift-nio.git",
-    from: "2.36.0"
+    from: "2.42.0"
   ),
   .package(
     url: "https://github.com/apple/swift-nio-http2.git",

--- a/Performance/allocations/tests/test_bidi_1k_rpcs.swift
+++ b/Performance/allocations/tests/test_bidi_1k_rpcs.swift
@@ -48,7 +48,7 @@ class BidiPingPongBenchmark: Benchmark {
   }
 
   func run() throws -> Int {
-    let echo = Echo_EchoClient(channel: self.client)
+    let echo = Echo_EchoNIOClient(channel: self.client)
     var statusCodeSum = 0
 
     // We'll use this semaphore to make sure we're ping-ponging request-response

--- a/Sources/GRPC/AsyncAwaitSupport/PassthroughMessageSource.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/PassthroughMessageSource.swift
@@ -38,7 +38,7 @@ internal final class PassthroughMessageSource<Element: Sendable, Failure: Error>
   /// - Important: We use a `class` with a lock rather than an `actor` as we must guarantee that
   ///   calls to ``yield(_:)`` are not reordered.
   @usableFromInline
-  internal let _lock: Lock
+  internal let _lock: NIOLock
 
   /// A queue of elements which may be consumed as soon as there is demand.
   @usableFromInline
@@ -56,7 +56,7 @@ internal final class PassthroughMessageSource<Element: Sendable, Failure: Error>
 
   @usableFromInline
   internal init(initialBufferCapacity: Int = 16) {
-    self._lock = Lock()
+    self._lock = NIOLock()
     self._continuationResults = CircularBuffer(initialCapacity: initialBufferCapacity)
     self._continuation = nil
     self._isTerminated = false

--- a/Sources/GRPC/ConnectionManager.swift
+++ b/Sources/GRPC/ConnectionManager.swift
@@ -279,7 +279,7 @@ internal final class ConnectionManager {
 
   private let connectionID: String
   private var channelNumber: UInt64
-  private var channelNumberLock = Lock()
+  private var channelNumberLock = NIOLock()
 
   private var _connectionIDAndNumber: String {
     return "\(self.connectionID)/\(self.channelNumber)"
@@ -292,7 +292,7 @@ internal final class ConnectionManager {
   }
 
   private func updateConnectionID() {
-    self.channelNumberLock.withLockVoid {
+    self.channelNumberLock.withLock {
       self.channelNumber &+= 1
       self.logger[metadataKey: MetadataKey.connectionID] = "\(self._connectionIDAndNumber)"
     }

--- a/Sources/GRPC/ConnectivityState.swift
+++ b/Sources/GRPC/ConnectivityState.swift
@@ -74,10 +74,10 @@ extension ConnectivityStateMonitor: @unchecked Sendable {}
 #endif // compiler(>=5.6)
 
 public class ConnectivityStateMonitor {
-  private let stateLock = Lock()
+  private let stateLock = NIOLock()
   private var _state: ConnectivityState = .idle
 
-  private let delegateLock = Lock()
+  private let delegateLock = NIOLock()
   private var _delegate: ConnectivityStateDelegate?
   private let delegateCallbackQueue: DispatchQueue
 
@@ -105,7 +105,7 @@ public class ConnectivityStateMonitor {
       }
     }
     set {
-      self.delegateLock.withLockVoid {
+      self.delegateLock.withLock {
         self._delegate = newValue
       }
     }

--- a/Tests/GRPCTests/AsyncAwaitSupport/AsyncWriterTests.swift
+++ b/Tests/GRPCTests/AsyncAwaitSupport/AsyncWriterTests.swift
@@ -277,7 +277,7 @@ fileprivate final class CollectingDelegate<
   Element: Sendable,
   End: Sendable
 >: AsyncWriterDelegate, @unchecked Sendable {
-  private let lock = Lock()
+  private let lock = NIOLock()
   private var _elements: [Element] = []
   private var _end: End?
 
@@ -290,13 +290,13 @@ fileprivate final class CollectingDelegate<
   }
 
   internal func write(_ element: Element) {
-    self.lock.withLockVoid {
+    self.lock.withLock {
       self._elements.append(element)
     }
   }
 
   internal func writeEnd(_ end: End) {
-    self.lock.withLockVoid {
+    self.lock.withLock {
       self._end = end
     }
   }

--- a/Tests/GRPCTests/CapturingLogHandler.swift
+++ b/Tests/GRPCTests/CapturingLogHandler.swift
@@ -20,7 +20,7 @@ import NIOConcurrencyHelpers
 
 /// A `LogHandler` factory which captures all logs emitted by the handlers it makes.
 internal class CapturingLogHandlerFactory {
-  private var lock = Lock()
+  private var lock = NIOLock()
   private var _logs: [CapturedLog] = []
 
   private var logFormatter: CapturedLogFormatter?
@@ -45,7 +45,7 @@ internal class CapturingLogHandlerFactory {
   /// Make a `LogHandler` whose logs will be recorded by this factory.
   func make(_ label: String) -> LogHandler {
     return CapturingLogHandler(label: label) { log in
-      self.lock.withLockVoid {
+      self.lock.withLock {
         self._logs.append(log)
       }
 

--- a/Tests/GRPCTests/ClientQuiescingTests.swift
+++ b/Tests/GRPCTests/ClientQuiescingTests.swift
@@ -425,10 +425,10 @@ extension ClientQuiescingTests {
     }
 
     private var state = _State.active(0)
-    private let lock = Lock()
+    private let lock = NIOLock()
 
     internal func assert(_ state: State, line: UInt = #line) {
-      self.lock.withLockVoid {
+      self.lock.withLock {
         switch (self.state, state) {
         case (.active, .active),
              (.shutdownRequested, .shutdownRequested),
@@ -441,7 +441,7 @@ extension ClientQuiescingTests {
     }
 
     internal func willStartRPC() {
-      self.lock.withLockVoid {
+      self.lock.withLock {
         switch self.state {
         case let .active(outstandingRPCs):
           self.state = .active(outstandingRPCs + 1)
@@ -458,7 +458,7 @@ extension ClientQuiescingTests {
     }
 
     internal func didFinishRPC() {
-      self.lock.withLockVoid {
+      self.lock.withLock {
         switch self.state {
         case let .active(outstandingRPCs):
           XCTAssertGreaterThan(outstandingRPCs, 0)
@@ -475,7 +475,7 @@ extension ClientQuiescingTests {
     }
 
     internal func willRequestGracefulShutdown() {
-      self.lock.withLockVoid {
+      self.lock.withLock {
         switch self.state {
         case let .active(outstandingRPCs):
           self.state = .shutdownRequested(outstandingRPCs)

--- a/Tests/GRPCTests/ConnectionPool/GRPCChannelPoolTests.swift
+++ b/Tests/GRPCTests/ConnectionPool/GRPCChannelPoolTests.swift
@@ -312,7 +312,7 @@ final class GRPCChannelPoolTests: GRPCTestCase {
       $0.connectionPool.maxWaitTime = .hours(1)
     }
 
-    let lock = Lock()
+    let lock = NIOLock()
     var order = 0
 
     // We need a connection to be up and running to avoid hitting the waiter limit when creating a
@@ -341,15 +341,15 @@ final class GRPCChannelPoolTests: GRPCTestCase {
     }
 
     // Still zero: the first RPC is still active.
-    lock.withLockVoid { XCTAssertEqual(order, 0) }
+    lock.withLock { XCTAssertEqual(order, 0) }
     // End the first RPC.
     XCTAssertNoThrow(try rpcs.first!.sendEnd().wait())
     XCTAssertNoThrow(try rpcs.first!.status.wait())
-    lock.withLockVoid { XCTAssertEqual(order, 1) }
+    lock.withLock { XCTAssertEqual(order, 1) }
     // End the last RPC.
     XCTAssertNoThrow(try rpcs.last!.sendEnd().wait())
     XCTAssertNoThrow(try rpcs.last!.status.wait())
-    lock.withLockVoid { XCTAssertEqual(order, 2) }
+    lock.withLock { XCTAssertEqual(order, 2) }
 
     // End the rest.
     for rpc in rpcs.dropFirst().dropLast() {

--- a/Tests/GRPCTests/ConnectionPool/PoolManagerStateMachineTests.swift
+++ b/Tests/GRPCTests/ConnectionPool/PoolManagerStateMachineTests.swift
@@ -330,7 +330,7 @@ extension PoolManagerStateMachine.ShutdownAction {
 private final class EmbeddedEventLoopGroup: EventLoopGroup {
   internal let loops: [EmbeddedEventLoop]
 
-  internal let lock = Lock()
+  internal let lock = NIOLock()
   internal var index = 0
 
   internal init(loops: Int) {

--- a/Tests/GRPCTests/ErrorRecordingDelegate.swift
+++ b/Tests/GRPCTests/ErrorRecordingDelegate.swift
@@ -24,7 +24,7 @@ extension ErrorRecordingDelegate: @unchecked Sendable {}
 #endif // compiler(>=5.6)
 
 final class ErrorRecordingDelegate: ClientErrorDelegate {
-  private let lock: Lock
+  private let lock: NIOLock
   private var _errors: [Error] = []
 
   internal var errors: [Error] {
@@ -37,11 +37,11 @@ final class ErrorRecordingDelegate: ClientErrorDelegate {
 
   init(expectation: XCTestExpectation) {
     self.expectation = expectation
-    self.lock = Lock()
+    self.lock = NIOLock()
   }
 
   func didCatchError(_ error: Error, logger: Logger, file: StaticString, line: Int) {
-    self.lock.withLockVoid {
+    self.lock.withLock {
       self._errors.append(error)
     }
     self.expectation.fulfill()

--- a/Tests/GRPCTests/StreamResponseHandlerRetainCycleTests.swift
+++ b/Tests/GRPCTests/StreamResponseHandlerRetainCycleTests.swift
@@ -57,11 +57,11 @@ final class StreamResponseHandlerRetainCycleTests: GRPCTestCase {
 
   func testHandlerClosureIsReleasedOnceStreamEnds() {
     final class Counter {
-      private let lock = Lock()
+      private let lock = NIOLock()
       private var _value = 0
 
       func increment() {
-        self.lock.withLockVoid {
+        self.lock.withLock {
           self._value += 1
         }
       }

--- a/scripts/alloc-limits.sh
+++ b/scripts/alloc-limits.sh
@@ -28,6 +28,7 @@
 #   MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request=64000
 
 grep 'test_.*\.total_allocations: ' \
+  | sed 's/^[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}T[0-9]\{2\}:[0-9]\{2\}:[0-9]\{2\}.[0-9]*Z //' \
   | sed 's/^test_/MAX_ALLOCS_ALLOWED_/' \
   | sed 's/.total_allocations://' \
   | awk '{ print "              " $1 ": " ((int($2 / 1000) + 1) * 1000) }' \


### PR DESCRIPTION
## Motivation
This change updates the allocation limits for `grpc-swift` allocation tests. This is necessary because we’ve increased the number of allocations in the new version of `swift-nio` for some of the code paths the tests hit. This change also fixes some warnings as a result of the NIO update.

## Modifications
* Updated max allocation values for allocation tests
* Updated the `alloc-limits.sh` script to work with the output of the GitHub CI logs, which include timestamps. Output from running the script locally doesn’t contain timestamps (and still works).
* Modified the allocation tests to use `Echo_EchoNIOClient` instead of the now deprecated `Echo_EchoClient`
* Fixed warnings related to NIO's `Lock` being deprecated.

## Result
`swift-nio` has been updated to 2.42.0, allocation tests have updated allocation counts, and warnings related to the update fixed.