### PR TITLE
Use a C executable for fuzz testing

### DIFF
--- a/FuzzTesting/Package.swift
+++ b/FuzzTesting/Package.swift
@@ -26,6 +26,12 @@ let package = Package(
     .executableTarget(
       name: "ServerFuzzer",
       dependencies: [
+        .target(name: "ServerFuzzerLib"),
+      ]
+    ),
+    .target(
+      name: "ServerFuzzerLib",
+      dependencies: [
         .product(name: "GRPC", package: "grpc-swift"),
         .product(name: "NIO", package: "swift-nio"),
         .target(name: "EchoImplementation"),

--- a/FuzzTesting/Sources/ServerFuzzer/src/serverfuzzer.c
+++ b/FuzzTesting/Sources/ServerFuzzer/src/serverfuzzer.c
@@ -1,0 +1,9 @@
+#include <inttypes.h>
+#include <stddef.h>
+
+// Provided by ServerFuzzerLib.
+int ServerFuzzer(const uint8_t *Data, size_t Size);
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  return ServerFuzzer(data, size);
+}

--- a/FuzzTesting/Sources/ServerFuzzerLib/ServerFuzzer.swift
+++ b/FuzzTesting/Sources/ServerFuzzerLib/ServerFuzzer.swift
@@ -17,7 +17,7 @@ import EchoImplementation
 import GRPC
 import NIO
 
-@_cdecl("LLVMFuzzerTestOneInput")
+@_cdecl("ServerFuzzer")
 public func test(_ start: UnsafeRawPointer, _ count: Int) -> CInt {
   let bytes = UnsafeRawBufferPointer(start: start, count: count)
 


### PR DESCRIPTION
Motivation:

Fuzz testing was accidentally broken in https://github.com/grpc/grpc-swift/pull/1483.

Modifications:

- The compiler was looking for a 'ServerFuzzer_main' symbol which didn't exist ('ServerFuzzer' is an executable target).
- Add a 'ServerFuzzerLib' target containing the contents of the existing 'ServerFuzzer' target.
- Change the 'ServerFuzzer' target to be a C module calling the API exposed by 'ServerFuzzerLib'

Result:

Fuzzing builds again.