### PR TITLE
Remove invalid command line args from the example

### DIFF
--- a/docs/basic-tutorial.md
+++ b/docs/basic-tutorial.md
@@ -167,7 +167,7 @@ $ protoc Sources/Examples/RouteGuide/Model/route_guide.proto \
     --swift_opt=Visibility=Public \
     --swift_out=Sources/Examples/RouteGuide/Model \
     --plugin=./.build/debug/protoc-gen-grpc-swift \
-    --grpc-swift_opt=Visibility=Public,AsyncClient=True,AsyncServer=True \
+    --grpc-swift_opt=Visibility=Public \
     --grpc-swift_out=Sources/Examples/RouteGuide/Model
 ```
 


### PR DESCRIPTION
These two args has been removed since 1.8 and is on by default. Passing in these two args will result in the grpc stub not being generated at all.