### PR TITLE
Allow to write a sequence of requests/responses

### DIFF
--- a/Tests/GRPCTests/GRPCAsyncClientCallTests.swift
+++ b/Tests/GRPCTests/GRPCAsyncClientCallTests.swift
@@ -132,14 +132,17 @@ class GRPCAsyncClientCallTests: GRPCTestCase {
         callOptions: .init()
       )
 
-    for word in ["boyle", "jeffers", "holt"] {
-      try await update.requestStream.send(.with { $0.text = word })
+    let requests = ["boyle", "jeffers", "holt"]
+      .map { word in Echo_EchoRequest.with { $0.text = word } }
+    for request in requests {
+      try await update.requestStream.send(request)
     }
+    try await update.requestStream.send(requests)
     try await update.requestStream.finish()
 
     let numResponses = try await update.responseStream.map { _ in 1 }.reduce(0, +)
 
-    await assertThat(numResponses, .is(.equalTo(3)))
+    await assertThat(numResponses, .is(.equalTo(6)))
     await assertThat(try await update.trailingMetadata, .is(.equalTo(Self.OKTrailingMetadata)))
     await assertThat(await update.status, .hasCode(.ok))
   }


### PR DESCRIPTION
# Motivation
We recently adopted the `NIOAsyncWriter` to back the `GRPCAsyncRequestStreamWriter` and the `GRPCAsyncResponseStreamWriter`; however, we did not expose the functionality to write a sequence of the elements that the `NIOAsyncWriter` offers. This can be useful in cases where you want to write a batch of requests/responses since it reduces the amount of locks and thread hops.

# Modification
Expose new methods on the `GRPCAsyncRequestStreamWriter` and the `GRPCAsyncResponseStreamWriter` to enable to write a sequence. I also fixed up the comments for the `GRPCAsyncRequestStreamWriter` since they were outdated.

# Result
Users can write a batch of requests/responses.