### PR TITLE
Revert "Fix HelloWorld Samples (#1505)"

### DIFF
--- a/Sources/Examples/HelloWorld/Client/main.swift
+++ b/Sources/Examples/HelloWorld/Client/main.swift
@@ -20,7 +20,6 @@ import HelloWorldModel
 import NIOCore
 import NIOPosix
 
-@main
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 struct HelloWorld: AsyncParsableCommand {
   @Option(help: "The port to connect to")

--- a/Sources/Examples/HelloWorld/Server/main.swift
+++ b/Sources/Examples/HelloWorld/Server/main.swift
@@ -20,7 +20,6 @@ import HelloWorldModel
 import NIOCore
 import NIOPosix
 
-@main
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 struct HelloWorld: AsyncParsableCommand {
   @Option(help: "The port to listen on for new connections")


### PR DESCRIPTION
This reverts commit 4915076adf40d907559b8464511769a66f85980b.

This breaks the build on 5.5 and shouldn't have been merged over that CI failure.