### PR TITLE
Fix sendable warnings

### DIFF
--- a/Sources/GRPC/ConnectionPool/GRPCChannelPool.swift
+++ b/Sources/GRPC/ConnectionPool/GRPCChannelPool.swift
@@ -167,7 +167,12 @@ extension GRPCChannelPool {
     /// This may be used to add additional handlers to the pipeline and is intended for debugging.
     ///
     /// - Warning: The initializer closure may be invoked *multiple times*.
-    public var debugChannelInitializer: GRPCChannelInitializer?
+    #if compiler(>=5.6)
+    @preconcurrency
+    public var debugChannelInitializer: (@Sendable (Channel) -> EventLoopFuture<Void>)?
+    #else
+    public var debugChannelInitializer: ((Channel) -> EventLoopFuture<Void>)?
+    #endif
 
     /// An error delegate which is called when errors are caught.
     public var errorDelegate: ClientErrorDelegate?

--- a/Sources/GRPC/GRPCChannel/GRPCChannelBuilder.swift
+++ b/Sources/GRPC/GRPCChannel/GRPCChannelBuilder.swift
@@ -315,13 +315,24 @@ extension ClientConnection.Builder {
   /// used to add additional handlers to the pipeline and is intended for debugging.
   ///
   /// - Warning: The initializer closure may be invoked *multiple times*.
+  #if compiler(>=5.6)
   @discardableResult
+  @preconcurrency
   public func withDebugChannelInitializer(
-    _ debugChannelInitializer: @escaping GRPCChannelInitializer
+    _ debugChannelInitializer: @Sendable @escaping (Channel) -> EventLoopFuture<Void>
   ) -> Self {
     self.configuration.debugChannelInitializer = debugChannelInitializer
     return self
   }
+  #else
+  @discardableResult
+  public func withDebugChannelInitializer(
+    _ debugChannelInitializer: @escaping (Channel) -> EventLoopFuture<Void>
+  ) -> Self {
+    self.configuration.debugChannelInitializer = debugChannelInitializer
+    return self
+  }
+  #endif
 }
 
 extension Double {


### PR DESCRIPTION
Motivation:

Warnings were emitted for `debugChannelInitializer`s as they were not `Sendable` even though their definition via a typealias was.

Modifications:

Expand out typealiases and add appropriate `@Sendable` and `@preconcurrency` annotations.

Results:

No warnings.