### PR TITLE
Add a connection pool delegate

### DIFF
--- a/Sources/GRPC/ConnectionManager+Delegates.swift
+++ b/Sources/GRPC/ConnectionManager+Delegates.swift
@@ -35,6 +35,12 @@ internal protocol ConnectionManagerConnectivityDelegate {
 }
 
 internal protocol ConnectionManagerHTTP2Delegate {
+  /// An HTTP/2 stream was opened.
+  ///
+  /// - Parameters:
+  ///   - connectionManager: The connection manager reporting the opened stream.
+  func streamOpened(_ connectionManager: ConnectionManager)
+
   /// An HTTP/2 stream was closed.
   ///
   /// - Parameters:

--- a/Sources/GRPC/ConnectionPool/ConnectionManagerID.swift
+++ b/Sources/GRPC/ConnectionPool/ConnectionManagerID.swift
@@ -15,7 +15,7 @@
  */
 
 @usableFromInline
-internal struct ConnectionManagerID: Hashable, CustomStringConvertible {
+internal struct ConnectionManagerID: Hashable, CustomStringConvertible, GRPCSendable {
   @usableFromInline
   internal let _id: ObjectIdentifier
 

--- a/Sources/GRPC/ConnectionPool/ConnectionPool.swift
+++ b/Sources/GRPC/ConnectionPool/ConnectionPool.swift
@@ -517,7 +517,7 @@ internal final class ConnectionPool {
       let connections = self._connections
       self._connections.removeAll()
 
-      let allShutdown = connections.values.map {
+      let allShutdown: [EventLoopFuture<Void>] = connections.values.map {
         let id = $0.manager.id
         let manager = $0.manager
 

--- a/Sources/GRPC/ConnectionPool/PoolManager.swift
+++ b/Sources/GRPC/ConnectionPool/PoolManager.swift
@@ -58,13 +58,17 @@ internal final class PoolManager {
     var channelProvider: DefaultChannelProvider
 
     @usableFromInline
+    var delegate: GRPCConnectionPoolDelegate?
+
+    @usableFromInline
     internal init(
       maxConnections: Int,
       maxWaiters: Int,
       loadThreshold: Double,
       assumedMaxConcurrentStreams: Int = 100,
       connectionBackoff: ConnectionBackoff,
-      channelProvider: DefaultChannelProvider
+      channelProvider: DefaultChannelProvider,
+      delegate: GRPCConnectionPoolDelegate?
     ) {
       self.maxConnections = maxConnections
       self.maxWaiters = maxWaiters
@@ -72,6 +76,7 @@ internal final class PoolManager {
       self.assumedMaxConcurrentStreams = assumedMaxConcurrentStreams
       self.connectionBackoff = connectionBackoff
       self.channelProvider = channelProvider
+      self.delegate = delegate
     }
   }
 
@@ -224,6 +229,7 @@ internal final class PoolManager {
         connectionBackoff: configuration.connectionBackoff,
         channelProvider: configuration.channelProvider,
         streamLender: self,
+        delegate: configuration.delegate,
         logger: logger
       )
     }

--- a/Sources/GRPC/ConnectionPool/PooledChannel.swift
+++ b/Sources/GRPC/ConnectionPool/PooledChannel.swift
@@ -98,7 +98,8 @@ internal final class PooledChannel: GRPCChannel {
         loadThreshold: configuration.connectionPool.reservationLoadThreshold,
         assumedMaxConcurrentStreams: 100,
         connectionBackoff: configuration.connectionBackoff,
-        channelProvider: provider
+        channelProvider: provider,
+        delegate: configuration.delegate
       ),
       logger: configuration.backgroundActivityLogger.wrapped
     )

--- a/Sources/GRPC/GRPCIdleHandler.swift
+++ b/Sources/GRPC/GRPCIdleHandler.swift
@@ -239,6 +239,7 @@ internal final class GRPCIdleHandler: ChannelInboundHandler {
     if let created = event as? NIOHTTP2StreamCreatedEvent {
       self.perform(operations: self.stateMachine.streamCreated(withID: created.streamID))
       self.handlePingAction(self.pingHandler.streamCreated())
+      self.mode.connectionManager?.streamOpened()
       context.fireUserInboundEventTriggered(event)
     } else if let closed = event as? StreamClosedEvent {
       self.perform(operations: self.stateMachine.streamClosed(withID: closed.streamID))

--- a/Tests/GRPCTests/ConnectionManagerTests.swift
+++ b/Tests/GRPCTests/ConnectionManagerTests.swift
@@ -1034,8 +1034,13 @@ extension ConnectionManagerTests {
     )
 
     class HTTP2Delegate: ConnectionManagerHTTP2Delegate {
+      var streamsOpened = 0
       var streamsClosed = 0
       var maxConcurrentStreams = 0
+
+      func streamOpened(_ connectionManager: ConnectionManager) {
+        self.streamsOpened += 1
+      }
 
       func streamClosed(_ connectionManager: ConnectionManager) {
         self.streamsClosed += 1
@@ -1118,6 +1123,7 @@ extension ConnectionManagerTests {
       channel.pipeline.fireUserInboundEventTriggered(streamClosed)
     }
 
+    XCTAssertEqual(http2.streamsOpened, 4)
     XCTAssertEqual(http2.streamsClosed, 4)
   }
 

--- a/Tests/GRPCTests/ConnectionPool/ConnectionPoolDelegates.swift
+++ b/Tests/GRPCTests/ConnectionPool/ConnectionPoolDelegates.swift
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2022, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import GRPC
+import NIOConcurrencyHelpers
+import NIOCore
+
+final class IsConnectingDelegate: GRPCConnectionPoolDelegate {
+  private let lock = NIOLock()
+  private var connecting = Set<GRPCConnectionID>()
+  private var active = Set<GRPCConnectionID>()
+
+  enum StateNotifacation: Hashable, GRPCSendable {
+    case connecting
+    case connected
+  }
+
+  #if swift(>=5.6)
+  private let onStateChange: @Sendable (StateNotifacation) -> Void
+  #else
+  private let onStateChange: (StateNotifacation) -> Void
+  #endif
+
+  #if swift(>=5.6)
+  init(onStateChange: @escaping @Sendable (StateNotifacation) -> Void) {
+    self.onStateChange = onStateChange
+  }
+  #else
+  init(onStateChange: @escaping (StateNotifacation) -> Void) {
+    self.onStateChange = onStateChange
+  }
+  #endif
+
+  func startedConnecting(id: GRPCConnectionID) {
+    let didStartConnecting: Bool = self.lock.withLock {
+      let (inserted, _) = self.connecting.insert(id)
+      // Only intereseted new connection attempts when there are no active connections.
+      return inserted && self.connecting.count == 1 && self.active.isEmpty
+    }
+
+    if didStartConnecting {
+      self.onStateChange(.connecting)
+    }
+  }
+
+  func connectSucceeded(id: GRPCConnectionID, streamCapacity: Int) {
+    let didStopConnecting: Bool = self.lock.withLock {
+      let removed = self.connecting.remove(id) != nil
+      let (inserted, _) = self.active.insert(id)
+      return removed && inserted && self.active.count == 1
+    }
+
+    if didStopConnecting {
+      self.onStateChange(.connected)
+    }
+  }
+
+  func connectionClosed(id: GRPCConnectionID, error: Error?) {
+    self.lock.withLock {
+      self.active.remove(id)
+      self.connecting.remove(id)
+    }
+  }
+
+  func connectionQuiescing(id: GRPCConnectionID) {
+    self.lock.withLock {
+      _ = self.active.remove(id)
+    }
+  }
+
+  // No-op.
+  func connectionAdded(id: GRPCConnectionID) {}
+
+  // No-op.
+  func connectionRemoved(id: GRPCConnectionID) {}
+
+  // Conection failures put the connection into a backing off state, we consider that to still
+  // be 'connecting' at this point.
+  func connectFailed(id: GRPCConnectionID, error: Error) {}
+
+  // No-op.
+  func connectionUtilizationChanged(id: GRPCConnectionID, streamsUsed: Int, streamCapacity: Int) {}
+}
+
+#if swift(>=5.6)
+extension IsConnectingDelegate: @unchecked Sendable {}
+#endif
+
+final class EventRecordingConnectionPoolDelegate: GRPCConnectionPoolDelegate {
+  struct UnexpectedEvent: Error {
+    var event: Event
+
+    init(_ event: Event) {
+      self.event = event
+    }
+  }
+
+  enum Event: Equatable {
+    case connectionAdded(GRPCConnectionID)
+    case startedConnecting(GRPCConnectionID)
+    case connectFailed(GRPCConnectionID)
+    case connectSucceeded(GRPCConnectionID, Int)
+    case connectionClosed(GRPCConnectionID)
+    case connectionUtilizationChanged(GRPCConnectionID, Int, Int)
+    case connectionQuiescing(GRPCConnectionID)
+    case connectionRemoved(GRPCConnectionID)
+
+    var id: GRPCConnectionID {
+      switch self {
+      case let .connectionAdded(id),
+           let .startedConnecting(id),
+           let .connectFailed(id),
+           let .connectSucceeded(id, _),
+           let .connectionClosed(id),
+           let .connectionUtilizationChanged(id, _, _),
+           let .connectionQuiescing(id),
+           let .connectionRemoved(id):
+        return id
+      }
+    }
+  }
+
+  private var events: CircularBuffer<Event> = []
+  private let lock = NIOLock()
+
+  var first: Event? {
+    return self.lock.withLock {
+      self.events.first
+    }
+  }
+
+  var isEmpty: Bool {
+    return self.lock.withLock { self.events.isEmpty }
+  }
+
+  func popFirst() -> Event? {
+    return self.lock.withLock {
+      self.events.popFirst()
+    }
+  }
+
+  func connectionAdded(id: GRPCConnectionID) {
+    self.lock.withLock {
+      self.events.append(.connectionAdded(id))
+    }
+  }
+
+  func startedConnecting(id: GRPCConnectionID) {
+    self.lock.withLock {
+      self.events.append(.startedConnecting(id))
+    }
+  }
+
+  func connectFailed(id: GRPCConnectionID, error: Error) {
+    self.lock.withLock {
+      self.events.append(.connectFailed(id))
+    }
+  }
+
+  func connectSucceeded(id: GRPCConnectionID, streamCapacity: Int) {
+    self.lock.withLock {
+      self.events.append(.connectSucceeded(id, streamCapacity))
+    }
+  }
+
+  func connectionClosed(id: GRPCConnectionID, error: Error?) {
+    self.lock.withLock {
+      self.events.append(.connectionClosed(id))
+    }
+  }
+
+  func connectionUtilizationChanged(id: GRPCConnectionID, streamsUsed: Int, streamCapacity: Int) {
+    self.lock.withLock {
+      self.events.append(.connectionUtilizationChanged(id, streamsUsed, streamCapacity))
+    }
+  }
+
+  func connectionQuiescing(id: GRPCConnectionID) {
+    self.lock.withLock {
+      self.events.append(.connectionQuiescing(id))
+    }
+  }
+
+  func connectionRemoved(id: GRPCConnectionID) {
+    self.lock.withLock {
+      self.events.append(.connectionRemoved(id))
+    }
+  }
+}
+
+#if swift(>=5.6)
+extension EventRecordingConnectionPoolDelegate: @unchecked Sendable {}
+#endif // swift(>=5.6)

--- a/Tests/GRPCTests/ConnectionPool/GRPCChannelPoolTests.swift
+++ b/Tests/GRPCTests/ConnectionPool/GRPCChannelPoolTests.swift
@@ -575,6 +575,7 @@ final class GRPCChannelPoolTests: GRPCTestCase {
     XCTAssertNoThrow(try EventLoopFuture.andAllSucceed(rpcs, on: self.group.any()).wait())
   }
 }
+#endif // canImport(NIOSSL)
 
 final class IsConnectingDelegate: GRPCConnectionPoolDelegate {
   private let lock = NIOLock()
@@ -652,7 +653,6 @@ final class IsConnectingDelegate: GRPCConnectionPoolDelegate {
   // No-op.
   func connectionUtilizationChanged(id: GRPCConnectionID, streamsUsed: Int, streamCapacity: Int) {}
 }
-#endif // canImport(NIOSSL)
 
 #if swift(>=5.6)
 extension IsConnectingDelegate: @unchecked Sendable {}

--- a/Tests/GRPCTests/ConnectionPool/GRPCChannelPoolTests.swift
+++ b/Tests/GRPCTests/ConnectionPool/GRPCChannelPoolTests.swift
@@ -490,17 +490,31 @@ final class GRPCChannelPoolTests: GRPCTestCase {
     XCTAssertEqual(recorder.popFirst(), .connectionUtilizationChanged(id1, 1, 100))
     XCTAssertEqual(recorder.popFirst(), .connectionUtilizationChanged(id1, 0, 100))
 
-    // Grab the port and shutdown the server gracefully.
-    let serverPort = try XCTUnwrap(self.serverPort)
-    XCTAssertNoThrow(try self.server?.initiateGracefulShutdown().wait())
+    // Start an RPC.
+    let rpc = self.echo.collect()
+    XCTAssertNoThrow(try rpc.sendMessage(.with { $0.text = "foo" }).wait())
+    // Complete another one to make sure the previous one is known by the server.
+    XCTAssertNoThrow(try self.echo.get(.with { $0.text = "foo" }).status.wait())
 
-    // Start the server again on the same port.
-    self.startServer(withTLS: false, port: serverPort)
+    XCTAssertEqual(recorder.popFirst(), .connectionUtilizationChanged(id1, 1, 100))
+    XCTAssertEqual(recorder.popFirst(), .connectionUtilizationChanged(id1, 2, 100))
+    XCTAssertEqual(recorder.popFirst(), .connectionUtilizationChanged(id1, 1, 100))
 
-    self.server = nil
-    self.startServer(withTLS: false)
+    // Start shutting the server down.
+    let didShutdown = self.server!.initiateGracefulShutdown()
+    self.server = nil // Avoid shutting down again in tearDown
 
-    XCTAssertEqual(recorder.popFirst(), .connectionClosed(id1))
+    // Pause a moment so we know the client received the GOAWAY.
+    let sleep = self.group.any().scheduleTask(in: .milliseconds(50)) {}
+    XCTAssertNoThrow(try sleep.futureResult.wait())
+    XCTAssertEqual(recorder.popFirst(), .connectionQuiescing(id1))
+
+    // Finish the RPC.
+    XCTAssertNoThrow(try rpc.sendEnd().wait())
+    XCTAssertNoThrow(try rpc.status.wait())
+
+    // Server should shutdown now.
+    XCTAssertNoThrow(try didShutdown.wait())
   }
 
   func testDelegateCanTellWhenFirstConnectionIsBeingEstablished() {
@@ -568,7 +582,7 @@ final class GRPCChannelPoolTests: GRPCTestCase {
 
     // We should be able to do a bunch of other RPCs without the state changing (we'll XCTFail if
     // a state change happens).
-    let rpcs = (0 ..< 20).map { i in
+    let rpcs: [EventLoopFuture<GRPCStatus>] = (0 ..< 20).map { i in
       let rpc = self.echo.get(.with { $0.text = "\(i)" })
       return rpc.status
     }
@@ -576,191 +590,3 @@ final class GRPCChannelPoolTests: GRPCTestCase {
   }
 }
 #endif // canImport(NIOSSL)
-
-final class IsConnectingDelegate: GRPCConnectionPoolDelegate {
-  private let lock = NIOLock()
-  private var connecting = Set<GRPCConnectionID>()
-  private var active = Set<GRPCConnectionID>()
-
-  enum StateNotifacation: Hashable, GRPCSendable {
-    case connecting
-    case connected
-  }
-
-  #if swift(>=5.6)
-  private let onStateChange: @Sendable (StateNotifacation) -> Void
-  #else
-  private let onStateChange: (StateNotifacation) -> Void
-  #endif
-
-  #if swift(>=5.6)
-  init(onStateChange: @escaping @Sendable (StateNotifacation) -> Void) {
-    self.onStateChange = onStateChange
-  }
-  #else
-  init(onStateChange: @escaping (StateNotifacation) -> Void) {
-    self.onStateChange = onStateChange
-  }
-  #endif
-
-  func startedConnecting(id: GRPCConnectionID) {
-    let didStartConnecting = self.lock.withLock {
-      let (inserted, _) = self.connecting.insert(id)
-      // Only intereseted new connection attempts when there are no active connections.
-      return inserted && self.connecting.count == 1 && self.active.isEmpty
-    }
-
-    if didStartConnecting {
-      self.onStateChange(.connecting)
-    }
-  }
-
-  func connectSucceeded(id: GRPCConnectionID, streamCapacity: Int) {
-    let didStopConnecting = self.lock.withLock {
-      let removed = self.connecting.remove(id) != nil
-      let (inserted, _) = self.active.insert(id)
-      return removed && inserted && self.active.count == 1
-    }
-
-    if didStopConnecting {
-      self.onStateChange(.connected)
-    }
-  }
-
-  func connectionClosed(id: GRPCConnectionID, error: Error?) {
-    self.lock.withLock {
-      self.active.remove(id)
-      self.connecting.remove(id)
-    }
-  }
-
-  func connectionQuiescing(id: GRPCConnectionID) {
-    self.lock.withLock {
-      _ = self.active.remove(id)
-    }
-  }
-
-  // No-op.
-  func connectionAdded(id: GRPCConnectionID) {}
-
-  // No-op.
-  func connectionRemoved(id: GRPCConnectionID) {}
-
-  // Conection failures put the connection into a backing off state, we consider that to still
-  // be 'connecting' at this point.
-  func connectFailed(id: GRPCConnectionID, error: Error) {}
-
-  // No-op.
-  func connectionUtilizationChanged(id: GRPCConnectionID, streamsUsed: Int, streamCapacity: Int) {}
-}
-
-#if swift(>=5.6)
-extension IsConnectingDelegate: @unchecked Sendable {}
-#endif
-
-final class EventRecordingConnectionPoolDelegate: GRPCConnectionPoolDelegate {
-  struct UnexpectedEvent: Error {
-    var event: Event
-
-    init(_ event: Event) {
-      self.event = event
-    }
-  }
-
-  enum Event: Equatable {
-    case connectionAdded(GRPCConnectionID)
-    case startedConnecting(GRPCConnectionID)
-    case connectFailed(GRPCConnectionID)
-    case connectSucceeded(GRPCConnectionID, Int)
-    case connectionClosed(GRPCConnectionID)
-    case connectionUtilizationChanged(GRPCConnectionID, Int, Int)
-    case connectionQuiescing(GRPCConnectionID)
-    case connectionRemoved(GRPCConnectionID)
-
-    var id: GRPCConnectionID {
-      switch self {
-      case let .connectionAdded(id),
-           let .startedConnecting(id),
-           let .connectFailed(id),
-           let .connectSucceeded(id, _),
-           let .connectionClosed(id),
-           let .connectionUtilizationChanged(id, _, _),
-           let .connectionQuiescing(id),
-           let .connectionRemoved(id):
-        return id
-      }
-    }
-  }
-
-  private var events: CircularBuffer<Event> = []
-  private let lock = NIOLock()
-
-  var first: Event? {
-    return self.lock.withLock {
-      self.events.first
-    }
-  }
-
-  var isEmpty: Bool {
-    return self.lock.withLock { self.events.isEmpty }
-  }
-
-  func popFirst() -> Event? {
-    return self.lock.withLock {
-      self.events.popFirst()
-    }
-  }
-
-  func connectionAdded(id: GRPCConnectionID) {
-    self.lock.withLock {
-      self.events.append(.connectionAdded(id))
-    }
-  }
-
-  func startedConnecting(id: GRPCConnectionID) {
-    self.lock.withLock {
-      self.events.append(.startedConnecting(id))
-    }
-  }
-
-  func connectFailed(id: GRPCConnectionID, error: Error) {
-    self.lock.withLock {
-      self.events.append(.connectFailed(id))
-    }
-  }
-
-  func connectSucceeded(id: GRPCConnectionID, streamCapacity: Int) {
-    self.lock.withLock {
-      self.events.append(.connectSucceeded(id, streamCapacity))
-    }
-  }
-
-  func connectionClosed(id: GRPCConnectionID, error: Error?) {
-    self.lock.withLock {
-      self.events.append(.connectionClosed(id))
-    }
-  }
-
-  func connectionUtilizationChanged(id: GRPCConnectionID, streamsUsed: Int, streamCapacity: Int) {
-    self.lock.withLock {
-      self.events.append(.connectionUtilizationChanged(id, streamsUsed, streamCapacity))
-    }
-  }
-
-  func connectionQuiescing(id: GRPCConnectionID) {
-    self.lock.withLock {
-      self.events.append(.connectionQuiescing(id))
-    }
-    print("quiescing...")
-  }
-
-  func connectionRemoved(id: GRPCConnectionID) {
-    self.lock.withLock {
-      self.events.append(.connectionRemoved(id))
-    }
-  }
-}
-
-#if swift(>=5.6)
-extension EventRecordingConnectionPoolDelegate: @unchecked Sendable {}
-#endif // swift(>=5.6)

--- a/Tests/GRPCTests/ConnectionPool/GRPCChannelPoolTests.swift
+++ b/Tests/GRPCTests/ConnectionPool/GRPCChannelPoolTests.swift
@@ -652,6 +652,7 @@ final class IsConnectingDelegate: GRPCConnectionPoolDelegate {
   // No-op.
   func connectionUtilizationChanged(id: GRPCConnectionID, streamsUsed: Int, streamCapacity: Int) {}
 }
+#endif // canImport(NIOSSL)
 
 #if swift(>=5.6)
 extension IsConnectingDelegate: @unchecked Sendable {}
@@ -763,5 +764,3 @@ final class EventRecordingConnectionPoolDelegate: GRPCConnectionPoolDelegate {
 #if swift(>=5.6)
 extension EventRecordingConnectionPoolDelegate: @unchecked Sendable {}
 #endif // swift(>=5.6)
-
-#endif // canImport(NIOSSL)

--- a/Tests/GRPCTests/ConnectionPool/GRPCChannelPoolTests.swift
+++ b/Tests/GRPCTests/ConnectionPool/GRPCChannelPoolTests.swift
@@ -457,7 +457,7 @@ final class GRPCChannelPoolTests: GRPCTestCase {
     XCTAssertEqual(recorder.popFirst(), .connectionUtilizationChanged(id, 1, 100))
     XCTAssertEqual(recorder.popFirst(), .connectionUtilizationChanged(id, 0, 100))
 
-    let rpcs = try (1 ... 10).map { i in
+    let rpcs: [ClientStreamingCall<Echo_EchoRequest, Echo_EchoResponse>] = try (1 ... 10).map { i in
       let rpc = self.echo.collect()
       XCTAssertNoThrow(try rpc.sendMessage(.with { $0.text = "foo" }).wait())
       XCTAssertEqual(recorder.popFirst(), .connectionUtilizationChanged(id, i, 100))

--- a/Tests/GRPCTests/ConnectionPool/PoolManagerStateMachineTests.swift
+++ b/Tests/GRPCTests/ConnectionPool/PoolManagerStateMachineTests.swift
@@ -39,6 +39,7 @@ class PoolManagerStateMachineTests: GRPCTestCase {
         onReturnStreams: { _ in },
         onUpdateMaxAvailableStreams: { _ in }
       ),
+      delegate: nil,
       logger: self.logger.wrapped
     )
   }


### PR DESCRIPTION
Motivation:

It can be useful to observe what the underlying connection pool is doing over time. This could, for example, be instrumenting it to understand how many streams are active at a given time or to understand when a connection is in the processing of being brought up.

Modifications:

Add new API:
- `GRPCConnectionPoolDelegate` which users can implement and configure on the `GRPCChannelPool` to receive notifications about the connection pool state.
- `GRPCConnectionID`, an opaque ID to distinguish between different connections in the pool.

Modify the connection pool:
- Per-EventLoop pools now hold on to quiescing connections and track additional state, including whether a connection is quiescing and how many streams are currently open on a connection. By contrast the pool manager (which manages a number of these per-EventLoop pools) tracks reserved streams (which are not necessarily open). The delegate tracks _opened_ streams rather than _reserved_ streams (as reserved streams are not allocated to a connection but to an any connection running on an appropriate event-loop).
- Wire through the new delegate and call out to it in appropriate places.
- Add a stream opened function to the internal H2 delegate
- Expose various pieces of state from the connection manager

Result:

- Users can instrument the underlying connection pool.
- Resolves #1400 