### PR TITLE
Use #fileID/#filePath instead of #file

### DIFF
--- a/Sources/Examples/RouteGuide/Client/RouteGuideClient.swift
+++ b/Sources/Examples/RouteGuide/Client/RouteGuideClient.swift
@@ -23,7 +23,7 @@ import RouteGuideModel
 
 /// Loads the features from `route_guide_db.json`, assumed to be in the directory above this file.
 func loadFeatures() throws -> [Routeguide_Feature] {
-  let url = URL(fileURLWithPath: #fileID)
+  let url = URL(fileURLWithPath: #filePath)
     .deletingLastPathComponent() // main.swift
     .deletingLastPathComponent() // Client/
     .appendingPathComponent("route_guide_db.json")

--- a/Sources/Examples/RouteGuide/Client/RouteGuideClient.swift
+++ b/Sources/Examples/RouteGuide/Client/RouteGuideClient.swift
@@ -23,7 +23,7 @@ import RouteGuideModel
 
 /// Loads the features from `route_guide_db.json`, assumed to be in the directory above this file.
 func loadFeatures() throws -> [Routeguide_Feature] {
-  let url = URL(fileURLWithPath: #file)
+  let url = URL(fileURLWithPath: #fileID)
     .deletingLastPathComponent() // main.swift
     .deletingLastPathComponent() // Client/
     .appendingPathComponent("route_guide_db.json")

--- a/Sources/Examples/RouteGuide/Server/RouteGuideServer.swift
+++ b/Sources/Examples/RouteGuide/Server/RouteGuideServer.swift
@@ -24,7 +24,7 @@ import RouteGuideModel
 
 /// Loads the features from `route_guide_db.json`, assumed to be in the directory above this file.
 func loadFeatures() throws -> [Routeguide_Feature] {
-  let url = URL(fileURLWithPath: #fileID)
+  let url = URL(fileURLWithPath: #filePath)
     .deletingLastPathComponent() // main.swift
     .deletingLastPathComponent() // Server/
     .appendingPathComponent("route_guide_db.json")

--- a/Sources/Examples/RouteGuide/Server/RouteGuideServer.swift
+++ b/Sources/Examples/RouteGuide/Server/RouteGuideServer.swift
@@ -24,7 +24,7 @@ import RouteGuideModel
 
 /// Loads the features from `route_guide_db.json`, assumed to be in the directory above this file.
 func loadFeatures() throws -> [Routeguide_Feature] {
-  let url = URL(fileURLWithPath: #file)
+  let url = URL(fileURLWithPath: #fileID)
     .deletingLastPathComponent() // main.swift
     .deletingLastPathComponent() // Server/
     .appendingPathComponent("route_guide_db.json")

--- a/Sources/GRPC/ConnectionManager.swift
+++ b/Sources/GRPC/ConnectionManager.swift
@@ -1063,7 +1063,7 @@ extension ConnectionManager {
 extension ConnectionManager {
   private func invalidState(
     function: StaticString = #function,
-    file: StaticString = #file,
+    file: StaticString = #fileID,
     line: UInt = #line
   ) -> Never {
     preconditionFailure("Invalid state \(self.state) for \(function)", file: file, line: line)

--- a/Sources/GRPC/GRPCError.swift
+++ b/Sources/GRPC/GRPCError.swift
@@ -309,7 +309,7 @@ extension GRPCError {
 
     init(
       _ error: GRPCStatusTransformable,
-      file: StaticString = #file,
+      file: StaticString = #fileID,
       line: Int = #line,
       function: StaticString = #function
     ) {
@@ -331,7 +331,7 @@ public protocol GRPCErrorProtocol: GRPCStatusTransformable, Equatable, CustomStr
 extension GRPCErrorProtocol {
   /// Creates a `GRPCError.WithContext` containing a `GRPCError` and the location of the call site.
   internal func captureContext(
-    file: StaticString = #file,
+    file: StaticString = #fileID,
     line: Int = #line,
     function: StaticString = #function
   ) -> GRPCError.WithContext {

--- a/Sources/GRPC/GRPCLogger.swift
+++ b/Sources/GRPC/GRPCLogger.swift
@@ -46,7 +46,7 @@ internal struct GRPCLogger {
   internal func trace(
     _ message: @autoclosure () -> Logger.Message,
     metadata: @autoclosure () -> Logger.Metadata? = nil,
-    file: String = #file,
+    file: String = #fileID,
     function: String = #function,
     line: UInt = #line
   ) {
@@ -64,7 +64,7 @@ internal struct GRPCLogger {
   internal func debug(
     _ message: @autoclosure () -> Logger.Message,
     metadata: @autoclosure () -> Logger.Metadata? = nil,
-    file: String = #file,
+    file: String = #fileID,
     function: String = #function,
     line: UInt = #line
   ) {
@@ -82,7 +82,7 @@ internal struct GRPCLogger {
   internal func notice(
     _ message: @autoclosure () -> Logger.Message,
     metadata: @autoclosure () -> Logger.Metadata? = nil,
-    file: String = #file,
+    file: String = #fileID,
     function: String = #function,
     line: UInt = #line
   ) {
@@ -100,7 +100,7 @@ internal struct GRPCLogger {
   internal func warning(
     _ message: @autoclosure () -> Logger.Message,
     metadata: @autoclosure () -> Logger.Metadata? = nil,
-    file: String = #file,
+    file: String = #fileID,
     function: String = #function,
     line: UInt = #line
   ) {

--- a/Sources/GRPC/PlatformSupport.swift
+++ b/Sources/GRPC/PlatformSupport.swift
@@ -416,7 +416,7 @@ extension EventLoopGroup {
 
   internal func preconditionCompatible(
     with tlsConfiguration: GRPCTLSConfiguration,
-    file: StaticString = #file,
+    file: StaticString = #fileID,
     line: UInt = #line
   ) {
     precondition(

--- a/Sources/GRPCInteroperabilityTestsImplementation/Assertions.swift
+++ b/Sources/GRPCInteroperabilityTestsImplementation/Assertions.swift
@@ -28,7 +28,7 @@ public struct AssertionError: Error {
 public func assertEqual<T: Equatable>(
   _ value1: T,
   _ value2: T,
-  file: StaticString = #file,
+  file: StaticString = #fileID,
   line: UInt = #line
 ) throws {
   guard value1 == value2 else {
@@ -43,7 +43,7 @@ public func assertEqual<T: Equatable>(
 public func waitAndAssertEqual<T: Equatable>(
   _ future: EventLoopFuture<T>,
   _ value: T,
-  file: StaticString = #file,
+  file: StaticString = #fileID,
   line: UInt = #line
 ) throws {
   try assertEqual(try future.wait(), value, file: file, line: line)
@@ -56,7 +56,7 @@ public func waitAndAssertEqual<T: Equatable>(
 public func waitAndAssertEqual<T: Equatable>(
   _ future1: EventLoopFuture<T>,
   _ future2: EventLoopFuture<T>,
-  file: StaticString = #file,
+  file: StaticString = #fileID,
   line: UInt = #line
 ) throws {
   try assertEqual(try future1.wait(), try future2.wait(), file: file, line: line)
@@ -64,7 +64,7 @@ public func waitAndAssertEqual<T: Equatable>(
 
 public func waitAndAssert<T>(
   _ future: EventLoopFuture<T>,
-  file: StaticString = #file,
+  file: StaticString = #fileID,
   line: UInt = #line,
   message: String = "",
   verify: (T) -> Bool

--- a/Tests/GRPCTests/AsyncAwaitSupport/XCTest+AsyncAwait.swift
+++ b/Tests/GRPCTests/AsyncAwaitSupport/XCTest+AsyncAwait.swift
@@ -20,7 +20,7 @@ import XCTest
 internal func XCTAssertThrowsError<T>(
   _ expression: @autoclosure () async throws -> T,
   verify: (Error) -> Void = { _ in },
-  file: StaticString = #file,
+  file: StaticString = #filePath,
   line: UInt = #line
 ) async {
   do {

--- a/Tests/GRPCTests/ClientTransportTests.swift
+++ b/Tests/GRPCTests/ClientTransportTests.swift
@@ -80,7 +80,7 @@ class ClientTransportTests: GRPCTestCase {
     self.transport.configure(body)
   }
 
-  private func connect(file: StaticString = #file, line: UInt = #line) throws {
+  private func connect(file: StaticString = #filePath, line: UInt = #line) throws {
     let address = try assertNoThrow(SocketAddress(unixDomainSocketPath: "/whatever"))
     assertThat(
       try self.channel.connect(to: address).wait(),
@@ -103,7 +103,7 @@ class ClientTransportTests: GRPCTestCase {
 
   private func sendResponse(
     _ part: _GRPCClientResponsePart<String>,
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
   ) throws {
     assertThat(try self.channel.writeInbound(part), .doesNotThrow(), file: file, line: line)

--- a/Tests/GRPCTests/ConnectionManagerTests.swift
+++ b/Tests/GRPCTests/ConnectionManagerTests.swift
@@ -66,7 +66,7 @@ class ConnectionManagerTests: GRPCTestCase {
     from: ConnectivityState,
     to: ConnectivityState,
     timeout: DispatchTimeInterval = .seconds(1),
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line,
     body: () throws -> Result
   ) rethrows -> Result {
@@ -81,7 +81,7 @@ class ConnectionManagerTests: GRPCTestCase {
   private func waitForStateChanges<Result>(
     _ changes: [Change],
     timeout: DispatchTimeInterval = .seconds(1),
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line,
     body: () throws -> Result
   ) rethrows -> Result {
@@ -1248,7 +1248,7 @@ internal class RecordingConnectivityDelegate: ConnectivityStateDelegate {
 
   func waitForExpectedChanges(
     timeout: DispatchTimeInterval,
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
   ) {
     let result = self.semaphore.wait(timeout: .now() + timeout)

--- a/Tests/GRPCTests/ConnectionPool/ConnectionPoolTests.swift
+++ b/Tests/GRPCTests/ConnectionPool/ConnectionPoolTests.swift
@@ -1026,7 +1026,7 @@ internal final class ChannelController {
 
   private func isValidIndex(
     _ index: Int,
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
   ) -> Bool {
     let isValid = self.channels.indices.contains(index)
@@ -1036,7 +1036,7 @@ internal final class ChannelController {
 
   internal func connectChannel(
     atIndex index: Int,
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
   ) {
     guard self.isValidIndex(index, file: file, line: line) else { return }
@@ -1050,7 +1050,7 @@ internal final class ChannelController {
 
   internal func fireChannelInactiveForChannel(
     atIndex index: Int,
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
   ) {
     guard self.isValidIndex(index, file: file, line: line) else { return }
@@ -1060,7 +1060,7 @@ internal final class ChannelController {
   internal func throwError(
     _ error: Error,
     inChannelAtIndex index: Int,
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
   ) {
     guard self.isValidIndex(index, file: file, line: line) else { return }
@@ -1070,7 +1070,7 @@ internal final class ChannelController {
   internal func sendSettingsToChannel(
     atIndex index: Int,
     maxConcurrentStreams: Int = 100,
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
   ) {
     guard self.isValidIndex(index, file: file, line: line) else { return }
@@ -1083,7 +1083,7 @@ internal final class ChannelController {
 
   internal func sendGoAwayToChannel(
     atIndex index: Int,
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
   ) {
     guard self.isValidIndex(index, file: file, line: line) else { return }
@@ -1098,7 +1098,7 @@ internal final class ChannelController {
 
   internal func openStreamInChannel(
     atIndex index: Int,
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
   ) {
     guard self.isValidIndex(index, file: file, line: line) else { return }
@@ -1115,7 +1115,7 @@ internal final class ChannelController {
 
   internal func closeStreamInChannel(
     atIndex index: Int,
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
   ) {
     guard self.isValidIndex(index, file: file, line: line) else { return }

--- a/Tests/GRPCTests/ConnectionPool/PoolManagerStateMachineTests.swift
+++ b/Tests/GRPCTests/ConnectionPool/PoolManagerStateMachineTests.swift
@@ -270,7 +270,7 @@ class PoolManagerStateMachineTests: GRPCTestCase {
 
 extension Result {
   internal func assertSuccess(
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line,
     verify: (Success) -> Void = { _ in }
   ) {
@@ -282,7 +282,7 @@ extension Result {
   }
 
   internal func assertFailure(
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line,
     verify: (Failure) -> Void = { _ in }
   ) {
@@ -296,7 +296,7 @@ extension Result {
 
 extension PoolManagerStateMachine.ShutdownAction {
   internal func assertShutdownPools(
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
   ) {
     if case .shutdownPools = self {
@@ -307,7 +307,7 @@ extension PoolManagerStateMachine.ShutdownAction {
   }
 
   internal func assertAlreadyShuttingDown(
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line,
     verify: (EventLoopFuture<Void>) -> Void = { _ in }
   ) {
@@ -318,7 +318,7 @@ extension PoolManagerStateMachine.ShutdownAction {
     }
   }
 
-  internal func assertAlreadyShutdown(file: StaticString = #file, line: UInt = #line) {
+  internal func assertAlreadyShutdown(file: StaticString = #filePath, line: UInt = #line) {
     if case .alreadyShutdown = self {
       ()
     } else {

--- a/Tests/GRPCTests/EventLoopFuture+Assertions.swift
+++ b/Tests/GRPCTests/EventLoopFuture+Assertions.swift
@@ -27,7 +27,7 @@ extension EventLoopFuture where Value: Equatable {
   func assertEqual(
     _ expected: Value,
     fulfill expectation: XCTestExpectation,
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
   ) {
     self.whenComplete { result in
@@ -59,7 +59,7 @@ extension EventLoopFuture {
   ///   - handler: A block to run additional verification on the error. Defaults to no-op.
   func assertError(
     fulfill expectation: XCTestExpectation,
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line,
     handler: @escaping (Error) -> Void = { _ in }
   ) {
@@ -84,7 +84,7 @@ extension EventLoopFuture {
   /// - Parameter expectation: The expectation to fulfill.
   func assertSuccess(
     fulfill expectation: XCTestExpectation,
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
   ) {
     self.whenSuccess { _ in

--- a/Tests/GRPCTests/FunctionalTests.swift
+++ b/Tests/GRPCTests/FunctionalTests.swift
@@ -40,7 +40,7 @@ class FunctionalTestsInsecureTransport: EchoTestCaseBase {
   func doTestUnary(
     request: Echo_EchoRequest,
     expect response: Echo_EchoResponse,
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
   ) {
     let responseExpectation = self.makeResponseExpectation()
@@ -53,7 +53,7 @@ class FunctionalTestsInsecureTransport: EchoTestCaseBase {
     self.wait(for: [responseExpectation, statusExpectation], timeout: self.defaultTestTimeout)
   }
 
-  func doTestUnary(message: String, file: StaticString = #file, line: UInt = #line) {
+  func doTestUnary(message: String, file: StaticString = #filePath, line: UInt = #line) {
     self.doTestUnary(
       request: Echo_EchoRequest(text: message),
       expect: Echo_EchoResponse(text: "Swift echo get: \(message)"),
@@ -130,7 +130,7 @@ class FunctionalTestsInsecureTransport: EchoTestCaseBase {
 
   func doTestClientStreaming(
     messages: [String],
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
   ) throws {
     let responseExpectation = self.makeResponseExpectation()

--- a/Tests/GRPCTests/GRPCNetworkFrameworkTests.swift
+++ b/Tests/GRPCTests/GRPCNetworkFrameworkTests.swift
@@ -37,7 +37,7 @@ final class GRPCNetworkFrameworkTests: GRPCTestCase {
   private var group: MultiThreadedEventLoopGroup!
   private let queue = DispatchQueue(label: "io.grpc.verify-handshake")
 
-  private static let p12bundleURL = URL(fileURLWithPath: #file)
+  private static let p12bundleURL = URL(fileURLWithPath: #filePath)
     .deletingLastPathComponent() // (this file)
     .deletingLastPathComponent() // GRPCTests
     .deletingLastPathComponent() // Tests

--- a/Tests/GRPCTests/GRPCTestCase.swift
+++ b/Tests/GRPCTests/GRPCTestCase.swift
@@ -38,7 +38,7 @@ class GRPCTestCase: XCTestCase {
   override func tearDown() {
     let logs = self.capturedLogs()
 
-    // The default source emitted by swift-log is the directory containing the '#file' in which the
+    // The default source emitted by swift-log is the directory containing the '#filePath' in which the
     // log was emitted. It's meant to represent the system which emitted the log, typically the
     // module name. In most cases it's right but in a few places, i.e. where the source lives in
     // child directories below 'GRPC', it isn't. We'll use this as a sanity check.

--- a/Tests/GRPCTests/GRPCWebToHTTP2StateMachineTests.swift
+++ b/Tests/GRPCTests/GRPCWebToHTTP2StateMachineTests.swift
@@ -516,7 +516,7 @@ final class GRPCWebToHTTP2StateMachineTests: GRPCTestCase {
 
 extension GRPCWebToHTTP2ServerCodec.StateMachine.Action {
   func assertRead(
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line,
     verify: (HTTP2Frame.FramePayload) -> Void = { _ in }
   ) {
@@ -528,7 +528,7 @@ extension GRPCWebToHTTP2ServerCodec.StateMachine.Action {
   }
 
   func assertWrite(
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line,
     verify: (Write) -> Void = { _ in }
   ) {
@@ -540,7 +540,7 @@ extension GRPCWebToHTTP2ServerCodec.StateMachine.Action {
   }
 
   func assertCompletePromise(
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line,
     verify: (Error?) -> Void = { _ in }
   ) {
@@ -557,7 +557,7 @@ extension GRPCWebToHTTP2ServerCodec.StateMachine.Action {
   }
 
   func assertNone(
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
   ) {
     if case .none = self {
@@ -570,7 +570,7 @@ extension GRPCWebToHTTP2ServerCodec.StateMachine.Action {
 
 extension HTTP2Frame.FramePayload {
   func assertHeaders(
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line,
     verify: (Headers) -> Void = { _ in }
   ) {
@@ -582,7 +582,7 @@ extension HTTP2Frame.FramePayload {
   }
 
   func assertData(
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line,
     verify: (Data) -> Void = { _ in }
   ) {
@@ -594,7 +594,7 @@ extension HTTP2Frame.FramePayload {
   }
 
   func assertEmptyDataWithEndStream(
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
   ) {
     self.assertData(file: file, line: line) {
@@ -608,7 +608,7 @@ extension HTTP2Frame.FramePayload {
 
 extension HTTPServerResponsePart {
   func assertHead(
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line,
     verify: (HTTPResponseHead) -> Void = { _ in }
   ) {
@@ -620,7 +620,7 @@ extension HTTPServerResponsePart {
   }
 
   func assertBody(
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line,
     verify: (ByteBuffer) -> Void = { _ in }
   ) {
@@ -632,7 +632,7 @@ extension HTTPServerResponsePart {
   }
 
   func assertEnd(
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line,
     verify: (HTTPHeaders?) -> Void = { _ in }
   ) {
@@ -646,7 +646,7 @@ extension HTTPServerResponsePart {
 
 extension IOData {
   func assertByteBuffer(
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line,
     verify: (ByteBuffer) -> Void = { _ in }
   ) {
@@ -660,7 +660,7 @@ extension IOData {
 
 extension Optional {
   func assertSome(
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line,
     verify: (Wrapped) -> Void = { _ in }
   ) {

--- a/Tests/GRPCTests/HeaderNormalizationTests.swift
+++ b/Tests/GRPCTests/HeaderNormalizationTests.swift
@@ -119,7 +119,7 @@ class HeaderNormalizationTests: GRPCTestCase {
   private func assertCustomMetadataIsLowercased(
     _ headers: EventLoopFuture<HPACKHeaders>,
     expectation: XCTestExpectation,
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
   ) {
     // Header lookup is case-insensitive so we need to pull out the values we know the server sent

--- a/Tests/GRPCTests/SampleCertificate+Assertions.swift
+++ b/Tests/GRPCTests/SampleCertificate+Assertions.swift
@@ -19,7 +19,7 @@ import GRPCSampleData
 import XCTest
 
 extension SampleCertificate {
-  func assertNotExpired(file: StaticString = #file, line: UInt = #line) {
+  func assertNotExpired(file: StaticString = #filePath, line: UInt = #line) {
     XCTAssertFalse(
       self.isExpired,
       "Certificate expired at \(self.notAfter)",

--- a/Tests/GRPCTests/ServerFuzzingRegressionTests.swift
+++ b/Tests/GRPCTests/ServerFuzzingRegressionTests.swift
@@ -22,7 +22,7 @@ import NIOEmbedded
 import XCTest
 
 final class ServerFuzzingRegressionTests: GRPCTestCase {
-  private static let failCasesURL = URL(fileURLWithPath: #file)
+  private static let failCasesURL = URL(fileURLWithPath: #filePath)
     .deletingLastPathComponent() // ServerFuzzingRegressionTests.swift
     .deletingLastPathComponent() // GRPCTests
     .deletingLastPathComponent() // Tests

--- a/Tests/GRPCTests/XCTestHelpers.swift
+++ b/Tests/GRPCTests/XCTestHelpers.swift
@@ -26,7 +26,7 @@ struct UnwrapError: Error {}
 func assertNotNil<Value>(
   _ expression: @autoclosure () throws -> Value?,
   message: @autoclosure () -> String = "Optional value was nil",
-  file: StaticString = #file,
+  file: StaticString = #filePath,
   line: UInt = #line
 ) throws -> Value {
   guard let value = try expression() else {
@@ -39,7 +39,7 @@ func assertNotNil<Value>(
 func assertNoThrow<Value>(
   _ expression: @autoclosure () throws -> Value,
   message: @autoclosure () -> String = "Unexpected error thrown",
-  file: StaticString = #file,
+  file: StaticString = #filePath,
   line: UInt = #line
 ) throws -> Value {
   do {
@@ -59,7 +59,7 @@ func assertNoThrow<Value>(
 func assertThat<Value>(
   _ expression: @autoclosure @escaping () throws -> Value,
   _ matcher: Matcher<Value>,
-  file: StaticString = #file,
+  file: StaticString = #filePath,
   line: UInt = #line
 ) {
   // For value matchers we'll assert that we don't throw by default.
@@ -69,7 +69,7 @@ func assertThat<Value>(
 func assertThat<Value>(
   _ expression: @autoclosure @escaping () throws -> Value,
   _ matcher: ExpressionMatcher<Value>,
-  file: StaticString = #file,
+  file: StaticString = #filePath,
   line: UInt = #line
 ) {
   switch matcher.evaluate(expression) {
@@ -666,7 +666,7 @@ struct ExpressionMatcher<Value> {
 func assertThat<Value>(
   _ expression: @autoclosure @escaping () async throws -> Value,
   _ matcher: Matcher<Value>,
-  file: StaticString = #file,
+  file: StaticString = #filePath,
   line: UInt = #line
 ) async {
   // For value matchers we'll assert that we don't throw by default.
@@ -677,7 +677,7 @@ func assertThat<Value>(
 func assertThat<Value>(
   _ expression: @autoclosure @escaping () async throws -> Value,
   _ matcher: ExpressionMatcher<Value>,
-  file: StaticString = #file,
+  file: StaticString = #filePath,
   line: UInt = #line
 ) async {
   // Create a shim here from async-await world...


### PR DESCRIPTION
Motivation:

#fileID introduced in Swift 5.3, so no longer need to use #file anywhere                                  

Modifications:

Changed #file to #filePath or #fileID depending on the situation
