### PR TITLE
Deploy plugins to `buf` registry

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ FuzzTesting
 Performance
 .github
 .build
+protoc-gen-*

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+docs
+dev
+Examples
+FuzzTesting
+Performance
+.github
+# .build

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,4 +4,4 @@ Examples
 FuzzTesting
 Performance
 .github
-# .build
+.build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,3 +25,46 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: protoc-grpc-swift-plugins-linux-x86_64-${{ env.RELEASE_VERSION }}.zip
+
+  buf:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: bufbuild/buf-setup-action@v1.9.0
+
+      - name: Extract release version
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - name: Login to Buf docker registry
+        uses: docker/login-action@v2
+        with:
+          registry: plugins.buf.build
+          username: ${{ secrets.BUF_ORG }}
+          password: ${{ secrets.BUF_API_KEY }}
+
+      - name: Build and push buf plugin for protoc-gen-grpc-swift
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: Dockerfile.plugin
+          push: true
+          tags: plugins.buf.build/${{ secrets.BUF_ORG }}/protoc-gen-grpc-swift:${{ env.RELEASE_VERSION }}
+          build-args: |
+            PLUGIN=protoc-gen-grpc-swift
+
+      - name: Build and push buf plugin for protoc-gen-swift
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: Dockerfile.plugin
+          push: true
+          tags: plugins.buf.build/${{ secrets.BUF_ORG }}/protoc-gen-swift:${{ env.RELEASE_VERSION }}
+          build-args: |
+            PLUGIN=protoc-gen-swift
+
+      - name: Push template version
+        run: |-
+          buf beta registry template version create buf.build/${{ secrets.BUF_ORG }}/templates/grpc-swift \
+            --name ${{ env.RELEASE_VERSION }} \
+            --config '{"version":"${{ env.RELEASE_VERSION }}","plugin_versions":[{"owner":"${{ secrets.BUF_ORG }}","name":"protoc-gen-swift","version":"${{ env.RELEASE_VERSION }}"},{"owner":"${{ secrets.BUF_ORG }}","name":"protoc-gen-grpc-swift","version":"${{ env.RELEASE_VERSION }}"}]}' 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: bufbuild/buf-setup-action@v1.9.0
 
       - name: Extract release version
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+        run: echo "RELEASE_VERSION=v${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
       - name: Login to Buf docker registry
         uses: docker/login-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,9 @@ jobs:
           username: ${{ secrets.BUF_ORG }}
           password: ${{ secrets.BUF_API_KEY }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Build and push buf plugin for protoc-gen-grpc-swift
         uses: docker/build-push-action@v3
         with:
@@ -62,9 +65,3 @@ jobs:
           tags: plugins.buf.build/${{ secrets.BUF_ORG }}/protoc-gen-swift:${{ env.RELEASE_VERSION }}
           build-args: |
             PLUGIN=protoc-gen-swift
-
-      - name: Push template version
-        run: |-
-          buf beta registry template version create buf.build/${{ secrets.BUF_ORG }}/templates/grpc-swift \
-            --name ${{ env.RELEASE_VERSION }} \
-            --config '{"version":"${{ env.RELEASE_VERSION }}","plugin_versions":[{"owner":"${{ secrets.BUF_ORG }}","name":"protoc-gen-swift","version":"${{ env.RELEASE_VERSION }}"},{"owner":"${{ secrets.BUF_ORG }}","name":"protoc-gen-grpc-swift","version":"${{ env.RELEASE_VERSION }}"}]}' 

--- a/Dockerfile.plugin
+++ b/Dockerfile.plugin
@@ -2,23 +2,19 @@ ARG SWIFT_VERSION=5.7
 ARG PLUGIN
 ARG TARGET_PLUGIN=./.build/release/${PLUGIN}
 
-FROM --platform=linux/amd64 swift:${SWIFT_VERSION} as builder
-
+FROM swift:${SWIFT_VERSION} as builder
+WORKDIR /dist
 RUN apt-get update && apt-get install -y build-essential
 COPY . .
-
 ARG PLUGIN
 ARG TARGET_PLUGIN
-
 RUN make ${TARGET_PLUGIN}
 
 FROM swift:${SWIFT_VERSION}-jammy-slim
-
 ARG PLUGIN
 ARG TARGET_PLUGIN
 ENV PLUGIN=${PLUGIN}
-
-COPY --from=builder /${TARGET_PLUGIN} /usr/local/bin/${PLUGIN}
+COPY --from=builder /dist/${TARGET_PLUGIN} /usr/local/bin/${PLUGIN}
 RUN chmod +x /usr/local/bin/${PLUGIN}
 
 ENTRYPOINT /usr/local/bin/$PLUGIN

--- a/Dockerfile.plugin
+++ b/Dockerfile.plugin
@@ -1,0 +1,24 @@
+ARG SWIFT_VERSION=5.7
+ARG PLUGIN
+ARG TARGET_PLUGIN=./.build/release/${PLUGIN}
+
+FROM --platform=linux/amd64 swift:${SWIFT_VERSION} as builder
+
+RUN apt-get update && apt-get install -y build-essential
+COPY . .
+
+ARG PLUGIN
+ARG TARGET_PLUGIN
+
+RUN make ${TARGET_PLUGIN}
+
+FROM swift:${SWIFT_VERSION}-jammy-slim
+
+ARG PLUGIN
+ARG TARGET_PLUGIN
+ENV PLUGIN=${PLUGIN}
+
+COPY --from=builder /${TARGET_PLUGIN} /usr/local/bin/${PLUGIN}
+RUN chmod +x /usr/local/bin/${PLUGIN}
+
+ENTRYPOINT /usr/local/bin/$PLUGIN


### PR DESCRIPTION
Still a draft, Github Actions job has been tested locally only yet.

- Adds a Dockerfile to package protoc plugins into a docker image so that they can be pushed to the buf registry.
- Adds CI steps to automatically push them to the BSR on new releases.

See buf documentation on [Remote generation](https://docs.buf.build/bsr/remote-generation/overview)