### PR TITLE
Pass through the right h2 configuration

### DIFF
--- a/Sources/GRPC/ConnectionPool/PooledChannel.swift
+++ b/Sources/GRPC/ConnectionPool/PooledChannel.swift
@@ -85,7 +85,7 @@ internal final class PooledChannel: GRPCChannel {
       tlsMode: tlsMode,
       tlsConfiguration: configuration.transportSecurity.tlsConfiguration,
       httpTargetWindowSize: configuration.http2.targetWindowSize,
-      httpMaxFrameSize: configuration.http2.targetWindowSize,
+      httpMaxFrameSize: configuration.http2.maxFrameSize,
       errorDelegate: configuration.errorDelegate,
       debugChannelInitializer: configuration.debugChannelInitializer
     )


### PR DESCRIPTION
Motivation:

The client passed the target window size through max frame size.

Modifications:

Pass through the right configuration.