### PR TITLE
Avoid copies of large payloads

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,7 @@ jobs:
         include:
           - image: swiftlang/swift:nightly-focal
             env:
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 428000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 392000
               MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 176000
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 112000
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 67000
@@ -66,7 +66,7 @@ jobs:
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 181000
           - image: swift:5.7-jammy
             env:
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 428000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 392000
               MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 176000
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 112000
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 67000
@@ -76,7 +76,7 @@ jobs:
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 181000
           - image: swift:5.6-focal
             env:
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 429000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 393000
               MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 177000
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 112000
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 67000
@@ -86,7 +86,7 @@ jobs:
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 182000
           - image: swift:5.5-focal
             env:
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 459000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 423000
               MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 189000
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 112000
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 67000

--- a/Sources/GRPC/GRPCClientChannelHandler.swift
+++ b/Sources/GRPC/GRPCClientChannelHandler.swift
@@ -541,7 +541,7 @@ extension GRPCClientChannelHandler: ChannelOutboundHandler {
         let promise1 = maybeBuffer == nil ? promise : nil
         context.write(self.wrapOutboundOut(frame1), promise: promise1)
 
-        if let maybeBuffer = maybeBuffer {
+        if let actuallyBuffer = maybeBuffer {
           let frame2 = HTTP2Frame.FramePayload.data(.init(data: .byteBuffer(maybeBuffer)))
           self.logger.trace("writing HTTP2 frame", metadata: [
             MetadataKey.h2Payload: "DATA",

--- a/Sources/GRPC/GRPCClientChannelHandler.swift
+++ b/Sources/GRPC/GRPCClientChannelHandler.swift
@@ -502,7 +502,10 @@ extension GRPCClientChannelHandler: ChannelOutboundHandler {
     switch self.unwrapOutboundIn(data) {
     case let .head(requestHead):
       // Feed the request into the state machine:
-      switch self.stateMachine.sendRequestHeaders(requestHead: requestHead) {
+      switch self.stateMachine.sendRequestHeaders(
+        requestHead: requestHead,
+        allocator: context.channel.allocator
+      ) {
       case let .success(headers):
         // We're clear to write some headers. Create an appropriate frame and write it.
         let framePayload = HTTP2Frame.FramePayload.headers(.init(headers: headers))
@@ -526,8 +529,7 @@ extension GRPCClientChannelHandler: ChannelOutboundHandler {
       // Feed the request message into the state machine:
       let result = self.stateMachine.sendRequest(
         request.message,
-        compressed: request.compressed,
-        allocator: context.channel.allocator
+        compressed: request.compressed
       )
       switch result {
       case let .success((buffer, maybeBuffer)):

--- a/Sources/GRPC/GRPCClientChannelHandler.swift
+++ b/Sources/GRPC/GRPCClientChannelHandler.swift
@@ -542,10 +542,10 @@ extension GRPCClientChannelHandler: ChannelOutboundHandler {
         context.write(self.wrapOutboundOut(frame1), promise: promise1)
 
         if let actuallyBuffer = maybeBuffer {
-          let frame2 = HTTP2Frame.FramePayload.data(.init(data: .byteBuffer(maybeBuffer)))
+          let frame2 = HTTP2Frame.FramePayload.data(.init(data: .byteBuffer(actuallyBuffer)))
           self.logger.trace("writing HTTP2 frame", metadata: [
             MetadataKey.h2Payload: "DATA",
-            MetadataKey.h2DataBytes: "\(maybeBuffer.readableBytes)",
+            MetadataKey.h2DataBytes: "\(actuallyBuffer.readableBytes)",
             MetadataKey.h2EndStream: "false",
           ])
           context.write(self.wrapOutboundOut(frame2), promise: promise)

--- a/Sources/GRPC/GRPCClientStateMachine.swift
+++ b/Sources/GRPC/GRPCClientStateMachine.swift
@@ -197,7 +197,7 @@ struct GRPCClientStateMachine {
     _ message: ByteBuffer,
     compressed: Bool,
     allocator: ByteBufferAllocator
-  ) -> Result<ByteBuffer, MessageWriteError> {
+  ) -> Result<(ByteBuffer, ByteBuffer?), MessageWriteError> {
     return self.withStateAvoidingCoWs { state in
       state.sendRequest(message, compressed: compressed, allocator: allocator)
     }
@@ -392,8 +392,8 @@ extension GRPCClientStateMachine.State {
     _ message: ByteBuffer,
     compressed: Bool,
     allocator: ByteBufferAllocator
-  ) -> Result<ByteBuffer, MessageWriteError> {
-    let result: Result<ByteBuffer, MessageWriteError>
+  ) -> Result<(ByteBuffer, ByteBuffer?), MessageWriteError> {
+    let result: Result<(ByteBuffer, ByteBuffer?), MessageWriteError>
 
     switch self {
     case .clientActiveServerIdle(var writeState, let pendingReadState):

--- a/Sources/GRPC/GRPCClientStateMachine.swift
+++ b/Sources/GRPC/GRPCClientStateMachine.swift
@@ -165,10 +165,11 @@ struct GRPCClientStateMachine {
   ///
   /// - Parameter requestHead: The client request head for the RPC.
   mutating func sendRequestHeaders(
-    requestHead: _GRPCRequestHead
+    requestHead: _GRPCRequestHead,
+    allocator: ByteBufferAllocator
   ) -> Result<HPACKHeaders, SendRequestHeadersError> {
     return self.withStateAvoidingCoWs { state in
-      state.sendRequestHeaders(requestHead: requestHead)
+      state.sendRequestHeaders(requestHead: requestHead, allocator: allocator)
     }
   }
 
@@ -195,11 +196,10 @@ struct GRPCClientStateMachine {
   ///     request will be written.
   mutating func sendRequest(
     _ message: ByteBuffer,
-    compressed: Bool,
-    allocator: ByteBufferAllocator
+    compressed: Bool
   ) -> Result<(ByteBuffer, ByteBuffer?), MessageWriteError> {
     return self.withStateAvoidingCoWs { state in
-      state.sendRequest(message, compressed: compressed, allocator: allocator)
+      state.sendRequest(message, compressed: compressed)
     }
   }
 
@@ -351,7 +351,8 @@ struct GRPCClientStateMachine {
 extension GRPCClientStateMachine.State {
   /// See `GRPCClientStateMachine.sendRequestHeaders(requestHead:)`.
   mutating func sendRequestHeaders(
-    requestHead: _GRPCRequestHead
+    requestHead: _GRPCRequestHead,
+    allocator: ByteBufferAllocator
   ) -> Result<HPACKHeaders, SendRequestHeadersError> {
     let result: Result<HPACKHeaders, SendRequestHeadersError>
 
@@ -369,7 +370,10 @@ extension GRPCClientStateMachine.State {
       result = .success(headers)
 
       self = .clientActiveServerIdle(
-        writeState: pendingWriteState.makeWriteState(messageEncoding: requestHead.encoding),
+        writeState: pendingWriteState.makeWriteState(
+          messageEncoding: requestHead.encoding,
+          allocator: allocator
+        ),
         pendingReadState: .init(arity: responseArity, messageEncoding: requestHead.encoding)
       )
 
@@ -390,18 +394,17 @@ extension GRPCClientStateMachine.State {
   /// See `GRPCClientStateMachine.sendRequest(_:allocator:)`.
   mutating func sendRequest(
     _ message: ByteBuffer,
-    compressed: Bool,
-    allocator: ByteBufferAllocator
+    compressed: Bool
   ) -> Result<(ByteBuffer, ByteBuffer?), MessageWriteError> {
     let result: Result<(ByteBuffer, ByteBuffer?), MessageWriteError>
 
     switch self {
     case .clientActiveServerIdle(var writeState, let pendingReadState):
-      result = writeState.write(message, compressed: compressed, allocator: allocator)
+      result = writeState.write(message, compressed: compressed)
       self = .clientActiveServerIdle(writeState: writeState, pendingReadState: pendingReadState)
 
     case .clientActiveServerActive(var writeState, let readState):
-      result = writeState.write(message, compressed: compressed, allocator: allocator)
+      result = writeState.write(message, compressed: compressed)
       self = .clientActiveServerActive(writeState: writeState, readState: readState)
 
     case .clientClosedServerIdle,

--- a/Sources/GRPC/HTTP2ToRawGRPCServerCodec.swift
+++ b/Sources/GRPC/HTTP2ToRawGRPCServerCodec.swift
@@ -296,7 +296,7 @@ internal final class HTTP2ToRawGRPCServerCodec: ChannelInboundHandler, GRPCServe
 
     switch writeBuffer {
     case let .success((buffer, maybeBuffer)):
-      if let maybeBuffer = maybeBuffer {
+      if let actuallyBuffer = maybeBuffer {
         let payload1 = HTTP2Frame.FramePayload.data(.init(data: .byteBuffer(buffer)))
         self.context.write(self.wrapOutboundOut(payload1), promise: nil)
         let payload2 = HTTP2Frame.FramePayload.data(.init(data: .byteBuffer(maybeBuffer)))

--- a/Sources/GRPC/HTTP2ToRawGRPCServerCodec.swift
+++ b/Sources/GRPC/HTTP2ToRawGRPCServerCodec.swift
@@ -299,7 +299,7 @@ internal final class HTTP2ToRawGRPCServerCodec: ChannelInboundHandler, GRPCServe
       if let actuallyBuffer = maybeBuffer {
         let payload1 = HTTP2Frame.FramePayload.data(.init(data: .byteBuffer(buffer)))
         self.context.write(self.wrapOutboundOut(payload1), promise: nil)
-        let payload2 = HTTP2Frame.FramePayload.data(.init(data: .byteBuffer(maybeBuffer)))
+        let payload2 = HTTP2Frame.FramePayload.data(.init(data: .byteBuffer(actuallyBuffer)))
         self.context.write(self.wrapOutboundOut(payload2), promise: promise)
       } else {
         let payload = HTTP2Frame.FramePayload.data(.init(data: .byteBuffer(buffer)))

--- a/Sources/GRPC/HTTP2ToRawGRPCServerCodec.swift
+++ b/Sources/GRPC/HTTP2ToRawGRPCServerCodec.swift
@@ -295,9 +295,16 @@ internal final class HTTP2ToRawGRPCServerCodec: ChannelInboundHandler, GRPCServe
     )
 
     switch writeBuffer {
-    case let .success(buffer):
-      let payload = HTTP2Frame.FramePayload.data(.init(data: .byteBuffer(buffer)))
-      self.context.write(self.wrapOutboundOut(payload), promise: promise)
+    case let .success((buffer, maybeBuffer)):
+      if let maybeBuffer = maybeBuffer {
+        let payload1 = HTTP2Frame.FramePayload.data(.init(data: .byteBuffer(buffer)))
+        self.context.write(self.wrapOutboundOut(payload1), promise: nil)
+        let payload2 = HTTP2Frame.FramePayload.data(.init(data: .byteBuffer(maybeBuffer)))
+        self.context.write(self.wrapOutboundOut(payload2), promise: promise)
+      } else {
+        let payload = HTTP2Frame.FramePayload.data(.init(data: .byteBuffer(buffer)))
+        self.context.write(self.wrapOutboundOut(payload), promise: promise)
+      }
       if metadata.flush {
         self.markFlushPoint()
       }

--- a/Sources/GRPC/HTTP2ToRawGRPCStateMachine.swift
+++ b/Sources/GRPC/HTTP2ToRawGRPCStateMachine.swift
@@ -303,7 +303,11 @@ extension HTTP2ToRawGRPCStateMachine.State {
     }
 
     // Figure out which encoding we should use for responses.
-    let (writer, responseEncoding) = self.extractResponseEncoding(from: headers, encoding: encoding)
+    let (writer, responseEncoding) = self.extractResponseEncoding(
+      from: headers,
+      encoding: encoding,
+      allocator: allocator
+    )
 
     // Parse the path, and create a call handler.
     guard let path = headers.first(name: ":path") else {
@@ -516,7 +520,8 @@ extension HTTP2ToRawGRPCStateMachine.State {
   /// - Returns: A message writer and the response encoding header to send back to the client.
   private func extractResponseEncoding(
     from headers: HPACKHeaders,
-    encoding: ServerMessageEncoding
+    encoding: ServerMessageEncoding,
+    allocator: ByteBufferAllocator
   ) -> (LengthPrefixedMessageWriter, String?) {
     let writer: LengthPrefixedMessageWriter
     let responseEncoding: String?
@@ -534,12 +539,12 @@ extension HTTP2ToRawGRPCStateMachine.State {
         configuration.enabledAlgorithms.contains($0)
       }
 
-      writer = LengthPrefixedMessageWriter(compression: algorithm)
+      writer = LengthPrefixedMessageWriter(compression: algorithm, allocator: allocator)
       responseEncoding = algorithm?.name
 
     case .disabled:
       // The server doesn't have compression enabled.
-      writer = LengthPrefixedMessageWriter(compression: .none)
+      writer = LengthPrefixedMessageWriter(compression: .none, allocator: allocator)
       responseEncoding = nil
     }
 
@@ -642,11 +647,10 @@ extension HTTP2ToRawGRPCStateMachine {
   static func writeGRPCFramedMessage(
     _ buffer: ByteBuffer,
     compress: Bool,
-    allocator: ByteBufferAllocator,
-    writer: LengthPrefixedMessageWriter
+    writer: inout LengthPrefixedMessageWriter
   ) -> Result<(ByteBuffer, ByteBuffer?), Error> {
     do {
-      let buffers = try writer.write(buffer: buffer, allocator: allocator, compressed: compress)
+      let buffers = try writer.write(buffer: buffer, compressed: compress)
       return .success(buffers)
     } catch {
       return .failure(error)
@@ -655,31 +659,27 @@ extension HTTP2ToRawGRPCStateMachine {
 }
 
 extension HTTP2ToRawGRPCStateMachine.RequestOpenResponseOpenState {
-  func send(
+  mutating func send(
     buffer: ByteBuffer,
-    allocator: ByteBufferAllocator,
     compress: Bool
   ) -> Result<(ByteBuffer, ByteBuffer?), Error> {
     return HTTP2ToRawGRPCStateMachine.writeGRPCFramedMessage(
       buffer,
       compress: compress,
-      allocator: allocator,
-      writer: self.writer
+      writer: &self.writer
     )
   }
 }
 
 extension HTTP2ToRawGRPCStateMachine.RequestClosedResponseOpenState {
-  func send(
+  mutating func send(
     buffer: ByteBuffer,
-    allocator: ByteBufferAllocator,
     compress: Bool
   ) -> Result<(ByteBuffer, ByteBuffer?), Error> {
     return HTTP2ToRawGRPCStateMachine.writeGRPCFramedMessage(
       buffer,
       compress: compress,
-      allocator: allocator,
-      writer: self.writer
+      writer: &self.writer
     )
   }
 }
@@ -903,12 +903,14 @@ extension HTTP2ToRawGRPCStateMachine {
   }
 
   /// Send a response buffer.
-  func send(
+  mutating func send(
     buffer: ByteBuffer,
     allocator: ByteBufferAllocator,
     compress: Bool
   ) -> Result<(ByteBuffer, ByteBuffer?), Error> {
-    return self.state.send(buffer: buffer, allocator: allocator, compress: compress)
+    return self.withStateAvoidingCoWs { state in
+      state.send(buffer: buffer, allocator: allocator, compress: compress)
+    }
   }
 
   /// Send status and trailers.
@@ -1115,7 +1117,7 @@ extension HTTP2ToRawGRPCStateMachine.State {
     }
   }
 
-  func send(
+  mutating func send(
     buffer: ByteBuffer,
     allocator: ByteBufferAllocator,
     compress: Bool
@@ -1129,19 +1131,21 @@ extension HTTP2ToRawGRPCStateMachine.State {
       let error = GRPCError.InvalidState("Response headers must be sent before response message")
       return .failure(error)
 
-    case let .requestOpenResponseOpen(state):
-      return state.send(
+    case var .requestOpenResponseOpen(state):
+      let result = state.send(
         buffer: buffer,
-        allocator: allocator,
         compress: compress
       )
+      self = .requestOpenResponseOpen(state)
+      return result
 
-    case let .requestClosedResponseOpen(state):
-      return state.send(
+    case var .requestClosedResponseOpen(state):
+      let result = state.send(
         buffer: buffer,
-        allocator: allocator,
         compress: compress
       )
+      self = .requestClosedResponseOpen(state)
+      return result
 
     case .requestOpenResponseClosed,
          .requestClosedResponseClosed:

--- a/Sources/GRPC/HTTP2ToRawGRPCStateMachine.swift
+++ b/Sources/GRPC/HTTP2ToRawGRPCStateMachine.swift
@@ -644,10 +644,10 @@ extension HTTP2ToRawGRPCStateMachine {
     compress: Bool,
     allocator: ByteBufferAllocator,
     writer: LengthPrefixedMessageWriter
-  ) -> Result<ByteBuffer, Error> {
+  ) -> Result<(ByteBuffer, ByteBuffer?), Error> {
     do {
-      let prefixed = try writer.write(buffer: buffer, allocator: allocator, compressed: compress)
-      return .success(prefixed)
+      let buffers = try writer.write(buffer: buffer, allocator: allocator, compressed: compress)
+      return .success(buffers)
     } catch {
       return .failure(error)
     }
@@ -659,7 +659,7 @@ extension HTTP2ToRawGRPCStateMachine.RequestOpenResponseOpenState {
     buffer: ByteBuffer,
     allocator: ByteBufferAllocator,
     compress: Bool
-  ) -> Result<ByteBuffer, Error> {
+  ) -> Result<(ByteBuffer, ByteBuffer?), Error> {
     return HTTP2ToRawGRPCStateMachine.writeGRPCFramedMessage(
       buffer,
       compress: compress,
@@ -674,7 +674,7 @@ extension HTTP2ToRawGRPCStateMachine.RequestClosedResponseOpenState {
     buffer: ByteBuffer,
     allocator: ByteBufferAllocator,
     compress: Bool
-  ) -> Result<ByteBuffer, Error> {
+  ) -> Result<(ByteBuffer, ByteBuffer?), Error> {
     return HTTP2ToRawGRPCStateMachine.writeGRPCFramedMessage(
       buffer,
       compress: compress,
@@ -907,7 +907,7 @@ extension HTTP2ToRawGRPCStateMachine {
     buffer: ByteBuffer,
     allocator: ByteBufferAllocator,
     compress: Bool
-  ) -> Result<ByteBuffer, Error> {
+  ) -> Result<(ByteBuffer, ByteBuffer?), Error> {
     return self.state.send(buffer: buffer, allocator: allocator, compress: compress)
   }
 
@@ -1119,7 +1119,7 @@ extension HTTP2ToRawGRPCStateMachine.State {
     buffer: ByteBuffer,
     allocator: ByteBufferAllocator,
     compress: Bool
-  ) -> Result<ByteBuffer, Error> {
+  ) -> Result<(ByteBuffer, ByteBuffer?), Error> {
     switch self {
     case .requestIdleResponseIdle:
       preconditionFailure("Invalid state: the request stream is still closed")

--- a/Sources/GRPC/LengthPrefixedMessageWriter.swift
+++ b/Sources/GRPC/LengthPrefixedMessageWriter.swift
@@ -86,99 +86,42 @@ internal struct LengthPrefixedMessageWriter {
     buffer: ByteBuffer,
     allocator: ByteBufferAllocator,
     compressed: Bool = true
-  ) throws -> ByteBuffer {
+  ) throws -> (ByteBuffer, ByteBuffer?) {
     if compressed, let compressor = self.compressor {
-      return try self.compress(buffer: buffer, using: compressor, allocator: allocator)
-    } else if buffer.readerIndex >= 5 {
-      // We're not compressing and we have enough bytes before the reader index that we can write
-      // over with the compression byte and length.
-      var buffer = buffer
-
-      // Get the size of the message.
-      let messageSize = buffer.readableBytes
-
-      // Move the reader index back 5 bytes. This is okay: we validated the `readerIndex` above.
-      buffer.moveReaderIndex(to: buffer.readerIndex - 5)
-
-      // Fill in the compression byte and message length.
-      buffer.setInteger(UInt8(0), at: buffer.readerIndex)
-      buffer.setInteger(UInt32(messageSize), at: buffer.readerIndex + 1)
-
-      // The message bytes are already in place, we're done.
-      return buffer
+      let compressedAndFramedPayload = try self.compress(
+        buffer: buffer,
+        using: compressor,
+        allocator: allocator
+      )
+      return (compressedAndFramedPayload, nil)
+    } else if buffer.readableBytes > Self.singleBufferSizeLimit {
+      // Buffer is larger than the limit for emitting a single buffer: create a second buffer
+      // containing just the message header.
+      var prefixed = allocator.buffer(capacity: 5)
+      prefixed.writeMultipleIntegers(UInt8(0), UInt32(buffer.readableBytes))
+      return (prefixed, buffer)
     } else {
-      // We're not compressing and we don't have enough space before the message bytes passed in.
-      // We need a new buffer.
-      var lengthPrefixed = allocator.buffer(capacity: 5 + buffer.readableBytes)
-
-      // Write the compression byte.
-      lengthPrefixed.writeInteger(UInt8(0))
-
-      // Write the message length.
-      lengthPrefixed.writeInteger(UInt32(buffer.readableBytes))
-
+      // We're not compressing and the message is within our single buffer size limit.
+      var lengthPrefixed = allocator.buffer(capacity: 5 &+ buffer.readableBytes)
+      // Write the compression byte and message length.
+      lengthPrefixed.writeMultipleIntegers(UInt8(0), UInt32(buffer.readableBytes))
       // Write the message.
-      var buffer = buffer
-      lengthPrefixed.writeBuffer(&buffer)
-
-      return lengthPrefixed
+      lengthPrefixed.writeImmutableBuffer(buffer)
+      return (lengthPrefixed, nil)
     }
   }
 
-  /// Writes the data into a `ByteBuffer` as a gRPC length-prefixed message.
+  /// Message size above which we emit two buffers: one containing the header and one with the
+  /// actual message bytes. At or below the limit we copy the message into a new buffer containing
+  /// both the header and the message.
   ///
-  /// - Parameters:
-  ///   - payload: The payload to serialize and write.
-  ///   - buffer: The buffer to write the message into.
-  /// - Returns: A `ByteBuffer` containing a gRPC length-prefixed message.
-  /// - Precondition: `compression.supported` is `true`.
-  /// - Note: See `LengthPrefixedMessageReader` for more details on the format.
-  func write(
-    _ payload: GRPCPayload,
-    into buffer: inout ByteBuffer,
-    compressed: Bool = true
-  ) throws {
-    buffer.reserveCapacity(buffer.writerIndex + LengthPrefixedMessageWriter.metadataLength)
-
-    if compressed, let compressor = self.compressor {
-      // Set the compression byte.
-      buffer.writeInteger(UInt8(1))
-
-      // Leave a gap for the length, we'll set it in a moment.
-      let payloadSizeIndex = buffer.writerIndex
-      buffer.moveWriterIndex(forwardBy: MemoryLayout<UInt32>.size)
-
-      var messageBuf = ByteBufferAllocator().buffer(capacity: 0)
-      try payload.serialize(into: &messageBuf)
-
-      // Compress the message.
-      let bytesWritten = try compressor.deflate(&messageBuf, into: &buffer)
-
-      // Now fill in the message length.
-      buffer.writePayloadLength(UInt32(bytesWritten), at: payloadSizeIndex)
-
-      // Finally, the compression context should be reset between messages.
-      compressor.reset()
-    } else {
-      // We could be using 'identity' compression, but since the result is the same we'll just
-      // say it isn't compressed.
-      buffer.writeInteger(UInt8(0))
-
-      // Leave a gap for the length, we'll set it in a moment.
-      let payloadSizeIndex = buffer.writerIndex
-      buffer.moveWriterIndex(forwardBy: MemoryLayout<UInt32>.size)
-
-      let payloadPrefixedBytes = buffer.readableBytes
-      // Writes the payload into the buffer
-      try payload.serialize(into: &buffer)
-
-      // Calculates the Written bytes with respect to the prefixed ones
-      let bytesWritten = buffer.readableBytes - payloadPrefixedBytes
-
-      // Write the message length.
-      buffer.writePayloadLength(UInt32(bytesWritten), at: payloadSizeIndex)
-    }
-  }
+  /// Using two buffers avoids expensive copies of large messages. For smaller messages the copy
+  /// is cheaper than the additional allocations and overhead required to send an extra HTTP/2 DATA
+  /// frame.
+  ///
+  /// The value of 8192 was chosen empirically. We subtract the length of the message header
+  /// as `ByteBuffer` reserve capacity in powers of two and want to avoid overallocating.
+  private static let singleBufferSizeLimit = 8192 - 5
 }
 
 extension ByteBuffer {

--- a/Sources/GRPC/ReadWriteStates.swift
+++ b/Sources/GRPC/ReadWriteStates.swift
@@ -30,7 +30,10 @@ struct PendingWriteState {
   /// The 'content-type' being written.
   var contentType: ContentType
 
-  func makeWriteState(messageEncoding: ClientMessageEncoding) -> WriteState {
+  func makeWriteState(
+    messageEncoding: ClientMessageEncoding,
+    allocator: ByteBufferAllocator
+  ) -> WriteState {
     let compression: CompressionAlgorithm?
     switch messageEncoding {
     case let .enabled(configuration):
@@ -39,7 +42,7 @@ struct PendingWriteState {
       compression = nil
     }
 
-    let writer = LengthPrefixedMessageWriter(compression: compression)
+    let writer = LengthPrefixedMessageWriter(compression: compression, allocator: allocator)
     return .writing(self.arity, self.contentType, writer)
   }
 }
@@ -53,25 +56,23 @@ enum WriteState {
   /// more messages to be written.
   case notWriting
 
-  /// Writes a message into a buffer using the `writer` and `allocator`.
+  /// Writes a message into a buffer using the `writer`.
   ///
   /// - Parameter message: The `Message` to write.
-  /// - Parameter allocator: An allocator to provide a `ByteBuffer` into which the message will be
-  ///     written.
   mutating func write(
     _ message: ByteBuffer,
-    compressed: Bool,
-    allocator: ByteBufferAllocator
+    compressed: Bool
   ) -> Result<(ByteBuffer, ByteBuffer?), MessageWriteError> {
     switch self {
     case .notWriting:
       return .failure(.cardinalityViolation)
 
-    case let .writing(writeArity, contentType, writer):
+    case .writing(let writeArity, let contentType, var writer):
+      self = .notWriting
       let buffers: (ByteBuffer, ByteBuffer?)
 
       do {
-        buffers = try writer.write(buffer: message, allocator: allocator, compressed: compressed)
+        buffers = try writer.write(buffer: message, compressed: compressed)
       } catch {
         self = .notWriting
         return .failure(.serializationFailed)

--- a/Sources/GRPC/ReadWriteStates.swift
+++ b/Sources/GRPC/ReadWriteStates.swift
@@ -62,16 +62,16 @@ enum WriteState {
     _ message: ByteBuffer,
     compressed: Bool,
     allocator: ByteBufferAllocator
-  ) -> Result<ByteBuffer, MessageWriteError> {
+  ) -> Result<(ByteBuffer, ByteBuffer?), MessageWriteError> {
     switch self {
     case .notWriting:
       return .failure(.cardinalityViolation)
 
     case let .writing(writeArity, contentType, writer):
-      let buffer: ByteBuffer
+      let buffers: (ByteBuffer, ByteBuffer?)
 
       do {
-        buffer = try writer.write(buffer: message, allocator: allocator, compressed: compressed)
+        buffers = try writer.write(buffer: message, allocator: allocator, compressed: compressed)
       } catch {
         self = .notWriting
         return .failure(.serializationFailed)
@@ -84,7 +84,7 @@ enum WriteState {
         self = .writing(writeArity, contentType, writer)
       }
 
-      return .success(buffer)
+      return .success(buffers)
     }
   }
 }

--- a/Tests/GRPCTests/HTTP2ToRawGRPCStateMachineTests.swift
+++ b/Tests/GRPCTests/HTTP2ToRawGRPCStateMachineTests.swift
@@ -616,7 +616,7 @@ class HTTP2ToRawGRPCStateMachineTests: GRPCTestCase {
 
   func testSendData() {
     for startingState in [DesiredState.requestOpenResponseOpen, .requestClosedResponseOpen] {
-      let machine = self.makeStateMachine(state: startingState)
+      var machine = self.makeStateMachine(state: startingState)
       let buffer = ByteBuffer(repeating: 0, count: 1024)
 
       // We should be able to do this multiple times.
@@ -656,7 +656,7 @@ class HTTP2ToRawGRPCStateMachineTests: GRPCTestCase {
   }
 
   func testSendDataBeforeMetadata() {
-    let machine = self.makeStateMachine(state: .requestClosedResponseIdle(pipelineConfigured: true))
+    var machine = self.makeStateMachine(state: .requestClosedResponseIdle(pipelineConfigured: true))
 
     // Response stream is still idle, so this should fail.
     let buffer = ByteBuffer(repeating: 0, count: 1024)

--- a/Tests/GRPCTests/LengthPrefixedMessageWriterTests.swift
+++ b/Tests/GRPCTests/LengthPrefixedMessageWriterTests.swift
@@ -19,11 +19,11 @@ import XCTest
 
 class LengthPrefixedMessageWriterTests: GRPCTestCase {
   func testWriteBytesWithNoLeadingSpaceOrCompression() throws {
-    let writer = LengthPrefixedMessageWriter()
+    var writer = LengthPrefixedMessageWriter()
     let allocator = ByteBufferAllocator()
     let buffer = allocator.buffer(bytes: [1, 2, 3])
 
-    var (prefixed, other) = try writer.write(buffer: buffer, allocator: allocator)
+    var (prefixed, other) = try writer.write(buffer: buffer)
     XCTAssertNil(other)
     XCTAssertEqual(prefixed.readInteger(as: UInt8.self), 0)
     XCTAssertEqual(prefixed.readInteger(as: UInt32.self), 3)
@@ -32,13 +32,13 @@ class LengthPrefixedMessageWriterTests: GRPCTestCase {
   }
 
   func testWriteBytesWithLeadingSpaceAndNoCompression() throws {
-    let writer = LengthPrefixedMessageWriter()
+    var writer = LengthPrefixedMessageWriter()
     let allocator = ByteBufferAllocator()
 
     var buffer = allocator.buffer(bytes: Array(repeating: 0, count: 5) + [1, 2, 3])
     buffer.moveReaderIndex(forwardBy: 5)
 
-    var (prefixed, other) = try writer.write(buffer: buffer, allocator: allocator)
+    var (prefixed, other) = try writer.write(buffer: buffer)
     XCTAssertNil(other)
     XCTAssertEqual(prefixed.readInteger(as: UInt8.self), 0)
     XCTAssertEqual(prefixed.readInteger(as: UInt32.self), 3)
@@ -47,11 +47,11 @@ class LengthPrefixedMessageWriterTests: GRPCTestCase {
   }
 
   func testWriteBytesWithNoLeadingSpaceAndCompression() throws {
-    let writer = LengthPrefixedMessageWriter(compression: .gzip)
+    var writer = LengthPrefixedMessageWriter(compression: .gzip)
     let allocator = ByteBufferAllocator()
 
     let buffer = allocator.buffer(bytes: [1, 2, 3])
-    var (prefixed, other) = try writer.write(buffer: buffer, allocator: allocator)
+    var (prefixed, other) = try writer.write(buffer: buffer)
     XCTAssertNil(other)
 
     XCTAssertEqual(prefixed.readInteger(as: UInt8.self), 1)
@@ -62,12 +62,12 @@ class LengthPrefixedMessageWriterTests: GRPCTestCase {
   }
 
   func testWriteBytesWithLeadingSpaceAndCompression() throws {
-    let writer = LengthPrefixedMessageWriter(compression: .gzip)
+    var writer = LengthPrefixedMessageWriter(compression: .gzip)
     let allocator = ByteBufferAllocator()
 
     var buffer = allocator.buffer(bytes: Array(repeating: 0, count: 5) + [1, 2, 3])
     buffer.moveReaderIndex(forwardBy: 5)
-    var (prefixed, other) = try writer.write(buffer: buffer, allocator: allocator)
+    var (prefixed, other) = try writer.write(buffer: buffer)
     XCTAssertNil(other)
 
     XCTAssertEqual(prefixed.readInteger(as: UInt8.self), 1)
@@ -78,11 +78,11 @@ class LengthPrefixedMessageWriterTests: GRPCTestCase {
   }
 
   func testLargeCompressedPayloadEmitsOneBuffer() throws {
-    let writer = LengthPrefixedMessageWriter(compression: .gzip)
+    var writer = LengthPrefixedMessageWriter(compression: .gzip)
     let allocator = ByteBufferAllocator()
     let message = ByteBuffer(repeating: 0, count: 16 * 1024 * 1024)
 
-    var (lengthPrefixed, other) = try writer.write(buffer: message, allocator: allocator)
+    var (lengthPrefixed, other) = try writer.write(buffer: message)
     XCTAssertNil(other)
     XCTAssertEqual(lengthPrefixed.readInteger(as: UInt8.self), 1)
     let length = lengthPrefixed.readInteger(as: UInt32.self)
@@ -90,14 +90,20 @@ class LengthPrefixedMessageWriterTests: GRPCTestCase {
   }
 
   func testLargeUncompressedPayloadEmitsTwoBuffers() throws {
-    let writer = LengthPrefixedMessageWriter(compression: .none)
+    var writer = LengthPrefixedMessageWriter(compression: .none)
     let allocator = ByteBufferAllocator()
     let message = ByteBuffer(repeating: 0, count: 16 * 1024 * 1024)
 
-    var (header, payload) = try writer.write(buffer: message, allocator: allocator)
+    var (header, payload) = try writer.write(buffer: message)
     XCTAssertEqual(header.readInteger(as: UInt8.self), 0)
     XCTAssertEqual(header.readInteger(as: UInt32.self), UInt32(message.readableBytes))
     XCTAssertEqual(header.readableBytes, 0)
     XCTAssertEqual(payload, message)
+  }
+}
+
+extension LengthPrefixedMessageWriter {
+  init(compression: CompressionAlgorithm? = nil) {
+    self.init(compression: compression, allocator: .init())
   }
 }


### PR DESCRIPTION
Motivation:

Messages are prefixed with a 5-byte header. Currently messages of all sizes are written into a new buffer with their header. For smaller payloads this is good: we avoid the extra allocations associated with creating HTTP/2 frames. For large payloads the cost of the copy outweighs the cost of extra allocations.

Modifications:

- For messages larger than 8KB emit an extra HTTP/2 DATA frame containing just the message header.

Result:

Better performance for large payloads.