### PR TITLE
Avoid a CoW in the client read state

### DIFF
--- a/Sources/GRPC/ReadWriteStates.swift
+++ b/Sources/GRPC/ReadWriteStates.swift
@@ -150,6 +150,7 @@ enum ReadState {
       return .failure(.cardinalityViolation)
 
     case .reading(let readArity, var reader):
+      self = .notReading // Avoid CoWs
       reader.append(buffer: &buffer)
       var messages: [ByteBuffer] = []
 


### PR DESCRIPTION
Motivation:

In some Swift versions the reader is CoW'd when appending in one of the client state machines substates.

Modifications:

- Temporarily switch state before appending to the reader

Result:

Fewer CoWs