### PR TITLE
Don't ack pings twice

### DIFF
--- a/Sources/GRPC/GRPCIdleHandler.swift
+++ b/Sources/GRPC/GRPCIdleHandler.swift
@@ -184,6 +184,10 @@ internal final class GRPCIdleHandler: ChannelInboundHandler {
     case .none:
       ()
 
+    case .ack:
+      // NIO's HTTP2 handler acks for us so this is a no-op.
+      ()
+
     case .cancelScheduledTimeout:
       self.scheduledClose?.cancel()
       self.scheduledClose = nil


### PR DESCRIPTION
Motivation:

gRPC Swift is emitting two acks per ping. NIOHTTP2 is emitting one and the keepalive handler is emitting the other.

Modifications:

- Don't emit ping acks from the keep alive handler; just let the H2 handler do it.

Result:

- No unnecessary ping acks are emitted.
- Resolves #1520