### PR TITLE
Allow Swift Package Index to generate documentation

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,4 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets: [GRPC]


### PR DESCRIPTION
Motivation:

Having all swift documentation available in one place makes a better user experience.

Modifications:

Add a .spi.yml to describe what documentation to generate.

Result:

Swift Package Index will generate documentation.