### PR TITLE
Add protoc-gen-grpc-swift to Swift Package Index documentation

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,4 +1,4 @@
 version: 1
 builder:
   configs:
-    - documentation_targets: [GRPC]
+    - documentation_targets: [GRPC, protoc-gen-grpc-swift]


### PR DESCRIPTION
Motivation:

This project also contains useful documentation which should be exposed to users.

Modifications:

Add the project to the list in .spi.yml

Result:

Swift Package Index will publish extra documentation.