### PR TITLE
Adopt the coalescing writer for clients

### DIFF
--- a/Sources/GRPC/LengthPrefixedMessageWriter.swift
+++ b/Sources/GRPC/LengthPrefixedMessageWriter.swift
@@ -15,6 +15,7 @@
  */
 import Foundation
 import NIOCore
+import NIOHPACK
 
 internal struct LengthPrefixedMessageWriter {
   static let metadataLength = 5

--- a/Tests/GRPCTests/GRPCClientStateMachineTests.swift
+++ b/Tests/GRPCTests/GRPCClientStateMachineTests.swift
@@ -154,14 +154,7 @@ extension GRPCClientStateMachineTests {
     stateMachine.sendRequest(
       ByteBuffer(string: request),
       compressed: false
-    ).assertSuccess { buffers in
-      var buffer = buffers.0
-      XCTAssertNil(buffers.1)
-      // Remove the length and compression flag prefix.
-      buffer.moveReaderIndex(forwardBy: 5)
-      let data = buffer.readString(length: buffer.readableBytes)!
-      XCTAssertEqual(request, data)
-    }
+    ).assertSuccess()
   }
 
   func testSendRequestFromIdle() {
@@ -1299,10 +1292,18 @@ extension PendingWriteState {
 
 extension WriteState {
   static func one() -> WriteState {
-    return .writing(.one, .protobuf, LengthPrefixedMessageWriter(compression: .none))
+    return .init(
+      arity: .one,
+      contentType: .protobuf,
+      writer: .init(compression: .none, allocator: .init())
+    )
   }
 
   static func many() -> WriteState {
-    return .writing(.many, .protobuf, LengthPrefixedMessageWriter(compression: .none))
+    return .init(
+      arity: .many,
+      contentType: .protobuf,
+      writer: .init(compression: .none, allocator: .init())
+    )
   }
 }


### PR DESCRIPTION
Motivation:

In #1357 we introduced a message frames which coalesces writes into a single buffer in a write-flush cycle to reduce the number of emitted DATA frames. This PR adopts those changes for the client.

Modifications:

- Adjust the client state machine to use the coalescing writer

Results:

Small messages are coalesced in a flush cycle within a stream.