### PR TITLE
update swift-nio-ssl dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -67,7 +67,7 @@ let packageDependencies: [Package.Dependency] = [
 ].appending(
   .package(
     url: "https://github.com/apple/swift-nio-ssl.git",
-    from: "2.14.0"
+    from: "2.23.0"
   ),
   if: includeNIOSSL
 )


### PR DESCRIPTION
I needed to lift this version number to be able to build grpc-swift.