### PR TITLE
Ignore 'NoSuchStream' errors

### DIFF
--- a/Tests/GRPCTests/LengthPrefixedMessageWriterTests.swift
+++ b/Tests/GRPCTests/LengthPrefixedMessageWriterTests.swift
@@ -79,7 +79,6 @@ class LengthPrefixedMessageWriterTests: GRPCTestCase {
 
   func testLargeCompressedPayloadEmitsOneBuffer() throws {
     var writer = LengthPrefixedMessageWriter(compression: .gzip)
-    let allocator = ByteBufferAllocator()
     let message = ByteBuffer(repeating: 0, count: 16 * 1024 * 1024)
 
     var (lengthPrefixed, other) = try writer.write(buffer: message)
@@ -91,7 +90,6 @@ class LengthPrefixedMessageWriterTests: GRPCTestCase {
 
   func testLargeUncompressedPayloadEmitsTwoBuffers() throws {
     var writer = LengthPrefixedMessageWriter(compression: .none)
-    let allocator = ByteBufferAllocator()
     let message = ByteBuffer(repeating: 0, count: 16 * 1024 * 1024)
 
     var (header, payload) = try writer.write(buffer: message)


### PR DESCRIPTION
Motivation:

If NIOHTTP2 emits a WINDOW_UPDATE frame from a stream and the connection is not writable then the WINDOW_UPDATE frame will not be processed immediately. If the stream is closed before the frame is processed then a NoSuchStream error is emitted. gRPC will close the connection if the error is not handled, bringing down any healthy streams in the process.

Modifications:

- Ignore NoSuchStream errors

Result:

Connections aren't closed on NoSuchStream errors.