### PR TITLE
Update perf test precondition

### DIFF
--- a/Sources/GRPCPerformanceTests/Benchmarks/EmbeddedClientThroughput.swift
+++ b/Sources/GRPCPerformanceTests/Benchmarks/EmbeddedClientThroughput.swift
@@ -108,7 +108,12 @@ class EmbeddedClientThroughput: Benchmark {
       while let _ = try channel.readOutbound(as: HTTP2Frame.FramePayload.self) {
         requestFrames += 1
       }
-      precondition(requestFrames == 3) // headers, data, empty data (end-stream)
+      // headers, data, empty data (end-stream). If the request is large there may be
+      // two DATA frames.
+      precondition(
+        requestFrames == 3 || requestFrames == 4,
+        "Expected 3/4 HTTP/2 frames but got \(requestFrames)"
+      )
 
       // Okay, let's build a response.
 


### PR DESCRIPTION
Motivation:

A change made in #1529 allowed multiple DATA frames to be emitted for a single message. One of the perf tests preconditions on there being exactly one DATA frame per message which is no longer the case.

Modifications:

- Update the precondition

Result:

Perf test does not crash.