### PR TITLE
Expose closeFuture in server interceptor context

### DIFF
--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncServerHandler.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncServerHandler.swift
@@ -283,6 +283,7 @@ internal final class AsyncServerHandler<
       callType: callType,
       remoteAddress: context.remoteAddress,
       userInfoRef: self.userInfoRef,
+      closeFuture: context.closeFuture,
       interceptors: interceptors,
       onRequestPart: self.receiveInterceptedPart(_:),
       onResponsePart: self.sendInterceptedPart(_:promise:)

--- a/Sources/GRPC/CallHandlers/BidirectionalStreamingServerHandler.swift
+++ b/Sources/GRPC/CallHandlers/BidirectionalStreamingServerHandler.swift
@@ -92,6 +92,7 @@ public final class BidirectionalStreamingServerHandler<
       callType: .bidirectionalStreaming,
       remoteAddress: context.remoteAddress,
       userInfoRef: userInfoRef,
+      closeFuture: context.closeFuture,
       interceptors: interceptors,
       onRequestPart: self.receiveInterceptedPart(_:),
       onResponsePart: self.sendInterceptedPart(_:promise:)

--- a/Sources/GRPC/CallHandlers/ClientStreamingServerHandler.swift
+++ b/Sources/GRPC/CallHandlers/ClientStreamingServerHandler.swift
@@ -93,6 +93,7 @@ public final class ClientStreamingServerHandler<
       callType: .clientStreaming,
       remoteAddress: context.remoteAddress,
       userInfoRef: userInfoRef,
+      closeFuture: context.closeFuture,
       interceptors: interceptors,
       onRequestPart: self.receiveInterceptedPart(_:),
       onResponsePart: self.sendInterceptedPart(_:promise:)

--- a/Sources/GRPC/CallHandlers/ServerStreamingServerHandler.swift
+++ b/Sources/GRPC/CallHandlers/ServerStreamingServerHandler.swift
@@ -89,6 +89,7 @@ public final class ServerStreamingServerHandler<
       callType: .serverStreaming,
       remoteAddress: context.remoteAddress,
       userInfoRef: userInfoRef,
+      closeFuture: context.closeFuture,
       interceptors: interceptors,
       onRequestPart: self.receiveInterceptedPart(_:),
       onResponsePart: self.sendInterceptedPart(_:promise:)

--- a/Sources/GRPC/CallHandlers/UnaryServerHandler.swift
+++ b/Sources/GRPC/CallHandlers/UnaryServerHandler.swift
@@ -87,6 +87,7 @@ public final class UnaryServerHandler<
       callType: .unary,
       remoteAddress: context.remoteAddress,
       userInfoRef: userInfoRef,
+      closeFuture: context.closeFuture,
       interceptors: interceptors,
       onRequestPart: self.receiveInterceptedPart(_:),
       onResponsePart: self.sendInterceptedPart(_:promise:)

--- a/Sources/GRPC/Interceptor/ServerInterceptorContext.swift
+++ b/Sources/GRPC/Interceptor/ServerInterceptorContext.swift
@@ -54,6 +54,12 @@ public struct ServerInterceptorContext<Request, Response> {
     return self._pipeline.remoteAddress
   }
 
+  /// A future which completes when the call closes. This may be used to register callbacks which
+  /// free up resources used by the interceptor.
+  public var closeFuture: EventLoopFuture<Void> {
+    return self._pipeline.closeFuture
+  }
+
   /// A 'UserInfo' dictionary.
   ///
   /// - Important: While `UserInfo` has value-semantics, this property retrieves from, and sets a

--- a/Sources/GRPC/Interceptor/ServerInterceptorPipeline.swift
+++ b/Sources/GRPC/Interceptor/ServerInterceptorPipeline.swift
@@ -42,6 +42,11 @@ internal final class ServerInterceptorPipeline<Request, Response> {
   @usableFromInline
   internal let userInfoRef: Ref<UserInfo>
 
+  /// A future which completes when the call closes. This may be used to register callbacks which
+  /// free up resources used by the interceptor.
+  @usableFromInline
+  internal let closeFuture: EventLoopFuture<Void>
+
   /// Called when a response part has traversed the interceptor pipeline.
   @usableFromInline
   internal let _onResponsePart: (GRPCServerResponsePart<Response>, EventLoopPromise<Void>?) -> Void
@@ -99,6 +104,7 @@ internal final class ServerInterceptorPipeline<Request, Response> {
     callType: GRPCCallType,
     remoteAddress: SocketAddress?,
     userInfoRef: Ref<UserInfo>,
+    closeFuture: EventLoopFuture<Void>,
     interceptors: [ServerInterceptor<Request, Response>],
     onRequestPart: @escaping (GRPCServerRequestPart<Request>) -> Void,
     onResponsePart: @escaping (GRPCServerResponsePart<Response>, EventLoopPromise<Void>?) -> Void
@@ -109,6 +115,7 @@ internal final class ServerInterceptorPipeline<Request, Response> {
     self.type = callType
     self.remoteAddress = remoteAddress
     self.userInfoRef = userInfoRef
+    self.closeFuture = closeFuture
 
     self._onResponsePart = onResponsePart
     self._onRequestPart = onRequestPart

--- a/Tests/GRPCTests/ServerInterceptorPipelineTests.swift
+++ b/Tests/GRPCTests/ServerInterceptorPipelineTests.swift
@@ -43,6 +43,7 @@ class ServerInterceptorPipelineTests: GRPCTestCase {
       callType: callType,
       remoteAddress: nil,
       userInfoRef: Ref(UserInfo()),
+      closeFuture: self.embeddedEventLoop.makeSucceededVoidFuture(),
       interceptors: interceptors,
       onRequestPart: onRequestPart,
       onResponsePart: onResponsePart


### PR DESCRIPTION
Motivation:

Server calls expose a `closeFuture` where users can register callbacks to tear things down when the RPC ends. Interceptors don't have this capability and must rely on observing an `.end`.

Modifications:

Expose the `closeFuture` from `ServerCallContext` to the `ServerInterceptorContext`.

Result:

- Users can be notified in interceptors when the call ends.
- Resolves #1552