### PR TITLE
Add "--version" to protoc-gen-grpc-swift

### DIFF
--- a/Sources/protoc-gen-grpc-swift/Version.swift
+++ b/Sources/protoc-gen-grpc-swift/Version.swift
@@ -1,0 +1,1 @@
+../GRPC/Version.swift

--- a/Sources/protoc-gen-grpc-swift/main.swift
+++ b/Sources/protoc-gen-grpc-swift/main.swift
@@ -104,7 +104,18 @@ func uniqueOutputFileName(
   }
 }
 
-func main() throws {
+func printVersion(args: [String]) {
+  // Stip off the file path
+  let program = args.first?.split(separator: "/").last ?? "protoc-gen-grpc-swift"
+  print("\(program) \(Version.versionString)")
+}
+
+func main(args: [String]) throws {
+  if args.dropFirst().contains("--version") {
+    printVersion(args: args)
+    return
+  }
+
   // initialize responses
   var response = Google_Protobuf_Compiler_CodeGeneratorResponse(
     files: [],
@@ -147,7 +158,7 @@ func main() throws {
 }
 
 do {
-  try main()
+  try main(args: CommandLine.arguments)
 } catch {
   Log("ERROR: \(error)")
 }


### PR DESCRIPTION
Motivation:

It can be useful to know the version of the protoc plugin being used.

Modifications:

- Add a "--version" flag to protoc-gen-grpc-swift which prints the plugin name and version.

Result:

Resolves #1556