### PR TITLE
Server interceptors retain cycle

### DIFF
--- a/Sources/GRPC/CallHandlers/BidirectionalStreamingServerHandler.swift
+++ b/Sources/GRPC/CallHandlers/BidirectionalStreamingServerHandler.swift
@@ -137,6 +137,9 @@ public final class BidirectionalStreamingServerHandler<
     case let .creatingObserver(context),
          let .observing(_, context):
       context.statusPromise.fail(GRPCStatus(code: .unavailable, message: nil))
+      self.context.eventLoop.execute {
+        self.interceptors = nil
+      }
 
     case .completed:
       self.interceptors = nil

--- a/Sources/GRPC/CallHandlers/ClientStreamingServerHandler.swift
+++ b/Sources/GRPC/CallHandlers/ClientStreamingServerHandler.swift
@@ -138,6 +138,9 @@ public final class ClientStreamingServerHandler<
     case let .creatingObserver(context),
          let .observing(_, context):
       context.responsePromise.fail(GRPCStatus(code: .unavailable, message: nil))
+      self.context.eventLoop.execute {
+        self.interceptors = nil
+      }
 
     case .completed:
       self.interceptors = nil

--- a/Sources/GRPC/CallHandlers/ServerStreamingServerHandler.swift
+++ b/Sources/GRPC/CallHandlers/ServerStreamingServerHandler.swift
@@ -134,6 +134,9 @@ public final class ServerStreamingServerHandler<
     case let .createdContext(context),
          let .invokedFunction(context):
       context.statusPromise.fail(GRPCStatus(code: .unavailable, message: nil))
+      self.context.eventLoop.execute {
+        self.interceptors = nil
+      }
 
     case .completed:
       self.interceptors = nil

--- a/Sources/GRPC/CallHandlers/UnaryServerHandler.swift
+++ b/Sources/GRPC/CallHandlers/UnaryServerHandler.swift
@@ -132,6 +132,9 @@ public final class UnaryServerHandler<
     case let .createdContext(context),
          let .invokedFunction(context):
       context.responsePromise.fail(GRPCStatus(code: .unavailable, message: nil))
+      self.context.eventLoop.execute {
+        self.interceptors = nil
+      }
 
     case .completed:
       self.interceptors = nil


### PR DESCRIPTION
Motivation:

There's a code path through the ELF-based server handlers where the interceptor pipeline does not get `nil`'d out to break the reference cycle between the handler and the interceptors leading to a leak. This can happen if the RPC ends unexpectedtly.

Modifications:

- Break the retain cycle on the next event-loop tick; this gives any clean up code a chance to run first.
- Break the retain cycle from the interceptors when they send end.

Results:

Fewer leaks.