### PR TITLE
Use iterator when checking encoding headers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,8 +16,8 @@ jobs:
       run: |
         SWIFTFORMAT_VERSION=0.49.4
         git clone --depth 1 --branch "$SWIFTFORMAT_VERSION" "https://github.com/nicklockwood/SwiftFormat" "$HOME/SwiftFormat"
-        swift build --package-path "$HOME/SwiftFormat" --product swiftformat
-        export PATH=$PATH:"$(swift build --package-path "$HOME/SwiftFormat" --show-bin-path)"
+        swift build -c release --package-path "$HOME/SwiftFormat" --product swiftformat
+        export PATH=$PATH:"$(swift build -c release --package-path "$HOME/SwiftFormat" --show-bin-path)"
         ./scripts/sanity.sh
   unit-tests:
     strategy:

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let packageDependencies: [Package.Dependency] = [
   ),
   .package(
     url: "https://github.com/apple/swift-nio-http2.git",
-    from: "1.22.0"
+    from: "1.24.1"
   ),
   .package(
     url: "https://github.com/apple/swift-nio-transport-services.git",


### PR DESCRIPTION
Motivation:

SwiftNIO HTTP/2 1.24.0 added a method for retrieving a sequence of header values rather than directly returning an array of values. We can use it when checking the encoding header as there should only be at most one value.

Modifications:

- Update HTTP/2 to be min 1.24.1
- Use the iterator API

Result:

Fewer allocations.