### PR TITLE
Do not check source of logs in tests

### DIFF
--- a/Tests/GRPCTests/GRPCTestCase.swift
+++ b/Tests/GRPCTests/GRPCTestCase.swift
@@ -36,21 +36,10 @@ class GRPCTestCase: XCTestCase {
   }
 
   override func tearDown() {
-    let logs = self.capturedLogs()
-
-    // The default source emitted by swift-log is the directory containing the '#filePath' in which the
-    // log was emitted. It's meant to represent the system which emitted the log, typically the
-    // module name. In most cases it's right but in a few places, i.e. where the source lives in
-    // child directories below 'GRPC', it isn't. We'll use this as a sanity check.
-    //
-    // See also: https://github.com/apple/swift-log/issues/145
-    for log in logs {
-      XCTAssertEqual(log.source, "GRPC", "Incorrect log source in \(log.file) on line \(log.line)")
-    }
-
     // Only print logs when there's a failure and we're *not* always logging (when we are always
     // logging, logs will be printed as they're caught).
     if !GRPCTestCase.alwaysLog, (self.testRun.map { $0.totalFailureCount > 0 } ?? false) {
+      let logs = self.capturedLogs()
       self.printCapturedLogs(logs)
     }
 


### PR DESCRIPTION
Motivation:

swift-log captures the 'source' of a log, which is usually the defining module. In older Swift versions this was done by parsing `#file` and was not always correct as it would just take the directory containing the file rather than the source module: we added a check after each test in gRPC to make sure the source was always "GRPC".

This is no longer necessary as swift-log now does the right thing.

Modifications:

- Remove the check

Result:

Tests are slightly faster.