### PR TITLE
Connect EmbeddedChannel when FuzzTesting

### DIFF
--- a/FuzzTesting/Sources/ServerFuzzerLib/ServerFuzzer.swift
+++ b/FuzzTesting/Sources/ServerFuzzerLib/ServerFuzzer.swift
@@ -22,6 +22,8 @@ public func test(_ start: UnsafeRawPointer, _ count: Int) -> CInt {
   let bytes = UnsafeRawBufferPointer(start: start, count: count)
 
   let channel = EmbeddedChannel()
+  try! channel.connect(to: try! SocketAddress(ipAddress: "127.0.0.1", port: 0)).wait()
+
   defer {
     _ = try? channel.finish()
   }

--- a/Tests/GRPCTests/ServerFuzzingRegressionTests.swift
+++ b/Tests/GRPCTests/ServerFuzzingRegressionTests.swift
@@ -31,6 +31,7 @@ final class ServerFuzzingRegressionTests: GRPCTestCase {
 
   private func runTest(withInput buffer: ByteBuffer) {
     let channel = EmbeddedChannel()
+    try! channel.connect(to: try! SocketAddress(ipAddress: "127.0.0.1", port: 0)).wait()
     defer {
       _ = try? channel.finish()
     }


### PR DESCRIPTION
Motivation:

FuzzTesting uses EmbeddedChannel but never called connect meaning that channel active was never fired. HTTP/2 recently added activity state checking and complains that we fire inactive without having activated.

Modifications:

- call connect on the EmbeddedChannel in fuzzing and in tests
- if the connection manager is closed while connecting it waits for the connect to resolve before closing the channel, however the channel future is completed before channel active is fired so defer closing it until the next loop tick.

Result:

Channel active is more frequently fired at the right time.