### PR TITLE
Bump version number to 1.14.2

### DIFF
--- a/Sources/GRPC/Version.swift
+++ b/Sources/GRPC/Version.swift
@@ -22,7 +22,7 @@ internal enum Version {
   internal static let minor = 14
 
   /// The patch version.
-  internal static let patch = 1
+  internal static let patch = 2
 
   /// The version string.
   internal static let versionString = "\(major).\(minor).\(patch)"


### PR DESCRIPTION
Motivation:

We plan on tagging a release soon.

Modifications:

- Bump the version to 1.14.2

Result:

The version in the default user-agent string will match the released version.