### PR TITLE
Fix gRPC Web trailers encoding

### DIFF
--- a/Tests/GRPCTests/ServerWebTests.swift
+++ b/Tests/GRPCTests/ServerWebTests.swift
@@ -41,9 +41,9 @@ class ServerWebTests: EchoTestCaseBase {
   private func gRPCWebTrailers(status: Int = 0, message: String? = nil) -> Data {
     var data: Data
     if let message = message {
-      data = "grpc-status: \(status)\r\ngrpc-message: \(message)".data(using: .utf8)!
+      data = "grpc-status: \(status)\r\ngrpc-message: \(message)\r\n".data(using: .utf8)!
     } else {
-      data = "grpc-status: \(status)".data(using: .utf8)!
+      data = "grpc-status: \(status)\r\n".data(using: .utf8)!
     }
 
     // Add the gRPC prefix with the compression byte and the 4 length bytes.


### PR DESCRIPTION
Motivation:

In gRPC Web HTTP trailers are encoded as a 'regular' gRPC message; that is a length prefixed message. For grpc-web we sent trailers back as regular trailers.

Modifications:

- Send trailers back as a length prefixed body part.
- Update tests.

Result:

Resolves #1580