### PR TITLE
Adopt h2handler multiplexer

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,7 @@ jobs:
         include:
           - image: swiftlang/swift:nightly-focal
             env:
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 347000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 246000
               MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 167000
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 109000
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 64000
@@ -67,7 +67,7 @@ jobs:
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 136000
           - image: swift:5.8-jammy
             env:
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 347000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 246000
               MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 167000
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 109000
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 64000
@@ -77,7 +77,7 @@ jobs:
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 136000
           - image: swift:5.7-jammy
             env:
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 347000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 246000
               MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 167000
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 109000
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 64000
@@ -87,7 +87,7 @@ jobs:
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 136000
           - image: swift:5.6-focal
             env:
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 348000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 247000
               MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 168000
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 109000
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 64000

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,41 +58,41 @@ jobs:
           - image: swiftlang/swift:nightly-focal
             env:
               MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 246000
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 167000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 138000
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 109000
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 64000
               MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 60000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 169000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 129000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 136000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 136000
           - image: swift:5.8-jammy
             env:
               MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 246000
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 167000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 138000
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 109000
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 64000
               MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 60000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 169000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 129000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 136000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 136000
           - image: swift:5.7-jammy
             env:
               MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 246000
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 167000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 138000
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 109000
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 64000
               MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 60000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 169000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 129000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 136000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 136000
           - image: swift:5.6-focal
             env:
               MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 247000
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 168000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 139000
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 109000
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 64000
               MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 60000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 170000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 130000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 137000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 137000
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,8 +63,8 @@ jobs:
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 64000
               MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 60000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 169000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 176000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 176000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 136000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 136000
           - image: swift:5.8-jammy
             env:
               MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 347000
@@ -73,8 +73,8 @@ jobs:
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 64000
               MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 60000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 169000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 176000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 176000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 136000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 136000
           - image: swift:5.7-jammy
             env:
               MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 347000
@@ -83,8 +83,8 @@ jobs:
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 64000
               MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 60000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 169000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 176000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 176000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 136000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 136000
           - image: swift:5.6-focal
             env:
               MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 348000
@@ -93,8 +93,8 @@ jobs:
               MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 64000
               MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 60000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 170000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 177000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 177000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 137000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 137000
 
     name: Performance Tests on ${{ matrix.image }}
     runs-on: ubuntu-latest

--- a/NOTICES.txt
+++ b/NOTICES.txt
@@ -27,7 +27,7 @@ framework: 'test_01_allocation_counts.sh', 'run-nio-alloc-counter-tests.sh' and
     * https://github.com/apple/swift-nio
 
 This product contains a simplified derivation of SwiftNIO HTTP/2's
-`HTTP2FrameEncoder` for testing purposes.
+'HTTP2FrameEncoder' for testing purposes.
 
   * LICENSE (Apache License 2.0):
     * https://github.com/apple/swift-nio-http2/blob/main/LICENSE.txt

--- a/NOTICES.txt
+++ b/NOTICES.txt
@@ -25,3 +25,11 @@ framework: 'test_01_allocation_counts.sh', 'run-nio-alloc-counter-tests.sh' and
     * https://github.com/apple/swift-nio/blob/main/LICENSE.txt
   * HOMEPAGE:
     * https://github.com/apple/swift-nio
+
+This product contains a simplified derivation of SwiftNIO HTTP/2's
+`HTTP2FrameEncoder` for testing purposes.
+
+  * LICENSE (Apache License 2.0):
+    * https://github.com/apple/swift-nio-http2/blob/main/LICENSE.txt
+  * HOMEPAGE:
+    * https://github.com/apple/swift-nio-http2

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let packageDependencies: [Package.Dependency] = [
   ),
   .package(
     url: "https://github.com/apple/swift-nio-http2.git",
-    branch: "main" //TODO: replace with a version number before merging
+    branch: "main" // TODO: replace with a version number before merging
   ),
   .package(
     url: "https://github.com/apple/swift-nio-transport-services.git",

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let packageDependencies: [Package.Dependency] = [
   ),
   .package(
     url: "https://github.com/apple/swift-nio-http2.git",
-    from: "1.24.1"
+    branch: "main" //TODO: replace with a version number before merging
   ),
   .package(
     url: "https://github.com/apple/swift-nio-transport-services.git",

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let packageDependencies: [Package.Dependency] = [
   ),
   .package(
     url: "https://github.com/apple/swift-nio-http2.git",
-    branch: "main" // TODO: replace with a version number before merging
+    from: "1.26.0"
   ),
   .package(
     url: "https://github.com/apple/swift-nio-transport-services.git",

--- a/Sources/GRPC/ClientConnection.swift
+++ b/Sources/GRPC/ClientConnection.swift
@@ -603,7 +603,6 @@ extension ChannelPipeline.SynchronousOperations {
       HTTP2Setting(parameter: .initialWindowSize, value: httpTargetWindowSize),
     ]
 
-
     let grpcIdleHandler = GRPCIdleHandler(
       connectionManager: connectionManager,
       idleTimeout: connectionIdleTimeout,
@@ -644,7 +643,11 @@ extension Channel {
     errorDelegate: ClientErrorDelegate?,
     logger: Logger
   ) -> EventLoopFuture<Void> {
-    return self.configureHTTP2Pipeline(mode: .client, connectionConfiguration: .init(), streamConfiguration: .init()) { channel in
+    return self.configureHTTP2Pipeline(
+      mode: .client,
+      connectionConfiguration: .init(),
+      streamConfiguration: .init()
+    ) { channel in
       channel.eventLoop.makeSucceededVoidFuture()
     }.flatMap { _ in
       self.pipeline.addHandler(DelegatingErrorHandler(logger: logger, delegate: errorDelegate))

--- a/Sources/GRPC/ConnectionManager.swift
+++ b/Sources/GRPC/ConnectionManager.swift
@@ -47,7 +47,11 @@ internal final class ConnectionManager: @unchecked Sendable {
     var multiplexer: NIOHTTP2Handler.StreamMultiplexer
     var error: Error?
 
-    init(from state: ConnectingState, candidate: Channel, multiplexer: NIOHTTP2Handler.StreamMultiplexer) {
+    init(
+      from state: ConnectingState,
+      candidate: Channel,
+      multiplexer: NIOHTTP2Handler.StreamMultiplexer
+    ) {
       self.backoffIterator = state.backoffIterator
       self.reconnect = state.reconnect
       self.candidate = candidate
@@ -421,7 +425,8 @@ internal final class ConnectionManager: @unchecked Sendable {
   /// attempt, or if the state is 'idle' returns the future for the next connection attempt.
   ///
   /// Note: if the state is 'transientFailure' or 'shutdown' then a failed future will be returned.
-  private func getHTTP2MultiplexerOptimistic() -> EventLoopFuture<NIOHTTP2Handler.StreamMultiplexer> {
+  private func getHTTP2MultiplexerOptimistic()
+    -> EventLoopFuture<NIOHTTP2Handler.StreamMultiplexer> {
     // `getHTTP2Multiplexer` makes sure we're on the event loop but let's just be sure.
     self.eventLoop.preconditionInEventLoop()
 

--- a/Sources/GRPC/ConnectionManager.swift
+++ b/Sources/GRPC/ConnectionManager.swift
@@ -35,19 +35,19 @@ internal final class ConnectionManager: @unchecked Sendable {
     var reconnect: Reconnect
 
     var candidate: EventLoopFuture<Channel>
-    var readyChannelMuxPromise: EventLoopPromise<HTTP2StreamMultiplexer>
-    var candidateMuxPromise: EventLoopPromise<HTTP2StreamMultiplexer>
+    var readyChannelMuxPromise: EventLoopPromise<NIOHTTP2Handler.StreamMultiplexer>
+    var candidateMuxPromise: EventLoopPromise<NIOHTTP2Handler.StreamMultiplexer>
   }
 
   internal struct ConnectedState {
     var backoffIterator: ConnectionBackoffIterator?
     var reconnect: Reconnect
     var candidate: Channel
-    var readyChannelMuxPromise: EventLoopPromise<HTTP2StreamMultiplexer>
-    var multiplexer: HTTP2StreamMultiplexer
+    var readyChannelMuxPromise: EventLoopPromise<NIOHTTP2Handler.StreamMultiplexer>
+    var multiplexer: NIOHTTP2Handler.StreamMultiplexer
     var error: Error?
 
-    init(from state: ConnectingState, candidate: Channel, multiplexer: HTTP2StreamMultiplexer) {
+    init(from state: ConnectingState, candidate: Channel, multiplexer: NIOHTTP2Handler.StreamMultiplexer) {
       self.backoffIterator = state.backoffIterator
       self.reconnect = state.reconnect
       self.candidate = candidate
@@ -58,7 +58,7 @@ internal final class ConnectionManager: @unchecked Sendable {
 
   internal struct ReadyState {
     var channel: Channel
-    var multiplexer: HTTP2StreamMultiplexer
+    var multiplexer: NIOHTTP2Handler.StreamMultiplexer
     var error: Error?
 
     init(from state: ConnectedState) {
@@ -69,7 +69,7 @@ internal final class ConnectionManager: @unchecked Sendable {
 
   internal struct TransientFailureState {
     var backoffIterator: ConnectionBackoffIterator?
-    var readyChannelMuxPromise: EventLoopPromise<HTTP2StreamMultiplexer>
+    var readyChannelMuxPromise: EventLoopPromise<NIOHTTP2Handler.StreamMultiplexer>
     var scheduled: Scheduled<Void>
     var reason: Error
 
@@ -252,8 +252,8 @@ internal final class ConnectionManager: @unchecked Sendable {
     }
   }
 
-  /// Returns the `HTTP2StreamMultiplexer` from the 'ready' state or `nil` if it is not available.
-  private var multiplexer: HTTP2StreamMultiplexer? {
+  /// Returns the `NIOHTTP2Handler.StreamMultiplexer` from the 'ready' state or `nil` if it is not available.
+  private var multiplexer: NIOHTTP2Handler.StreamMultiplexer? {
     self.eventLoop.assertInEventLoop()
     switch self.state {
     case let .ready(state):
@@ -361,8 +361,8 @@ internal final class ConnectionManager: @unchecked Sendable {
   /// Get the multiplexer from the underlying channel handling gRPC calls.
   /// if the `ConnectionManager` was configured to be `fastFailure` this will have
   /// one chance to connect - if not reconnections are managed here.
-  internal func getHTTP2Multiplexer() -> EventLoopFuture<HTTP2StreamMultiplexer> {
-    func getHTTP2Multiplexer0() -> EventLoopFuture<HTTP2StreamMultiplexer> {
+  internal func getHTTP2Multiplexer() -> EventLoopFuture<NIOHTTP2Handler.StreamMultiplexer> {
+    func getHTTP2Multiplexer0() -> EventLoopFuture<NIOHTTP2Handler.StreamMultiplexer> {
       switch self.callStartBehavior {
       case .waitsForConnectivity:
         return self.getHTTP2MultiplexerPatient()
@@ -382,8 +382,8 @@ internal final class ConnectionManager: @unchecked Sendable {
 
   /// Returns a future for the multiplexer which succeeded when the channel is connected.
   /// Reconnects are handled if necessary.
-  private func getHTTP2MultiplexerPatient() -> EventLoopFuture<HTTP2StreamMultiplexer> {
-    let multiplexer: EventLoopFuture<HTTP2StreamMultiplexer>
+  private func getHTTP2MultiplexerPatient() -> EventLoopFuture<NIOHTTP2Handler.StreamMultiplexer> {
+    let multiplexer: EventLoopFuture<NIOHTTP2Handler.StreamMultiplexer>
 
     switch self.state {
     case .idle:
@@ -421,11 +421,11 @@ internal final class ConnectionManager: @unchecked Sendable {
   /// attempt, or if the state is 'idle' returns the future for the next connection attempt.
   ///
   /// Note: if the state is 'transientFailure' or 'shutdown' then a failed future will be returned.
-  private func getHTTP2MultiplexerOptimistic() -> EventLoopFuture<HTTP2StreamMultiplexer> {
+  private func getHTTP2MultiplexerOptimistic() -> EventLoopFuture<NIOHTTP2Handler.StreamMultiplexer> {
     // `getHTTP2Multiplexer` makes sure we're on the event loop but let's just be sure.
     self.eventLoop.preconditionInEventLoop()
 
-    let muxFuture: EventLoopFuture<HTTP2StreamMultiplexer> = { () in
+    let muxFuture: EventLoopFuture<NIOHTTP2Handler.StreamMultiplexer> = { () in
       switch self.state {
       case .idle:
         self.startConnecting()
@@ -656,7 +656,7 @@ internal final class ConnectionManager: @unchecked Sendable {
   }
 
   /// The connecting channel became `active`. Must be called on the `EventLoop`.
-  internal func channelActive(channel: Channel, multiplexer: HTTP2StreamMultiplexer) {
+  internal func channelActive(channel: Channel, multiplexer: NIOHTTP2Handler.StreamMultiplexer) {
     self.eventLoop.preconditionInEventLoop()
     self.logger.debug("activating connection", metadata: [
       "connectivity_state": "\(self.state.label)",
@@ -973,7 +973,7 @@ extension ConnectionManager {
 
   private func startConnecting(
     backoffIterator: ConnectionBackoffIterator?,
-    muxPromise: EventLoopPromise<HTTP2StreamMultiplexer>
+    muxPromise: EventLoopPromise<NIOHTTP2Handler.StreamMultiplexer>
   ) {
     let timeoutAndBackoff = backoffIterator?.next()
 
@@ -1060,7 +1060,7 @@ extension ConnectionManager {
 
     /// Returns the `multiplexer` from a connection in the `ready` state or `nil` if it is any
     /// other state.
-    internal var multiplexer: HTTP2StreamMultiplexer? {
+    internal var multiplexer: NIOHTTP2Handler.StreamMultiplexer? {
       return self.manager.multiplexer
     }
 

--- a/Sources/GRPC/ConnectionPool/ConnectionPool+PerConnectionState.swift
+++ b/Sources/GRPC/ConnectionPool/ConnectionPool+PerConnectionState.swift
@@ -53,7 +53,7 @@ extension ConnectionPool {
       }
 
       @usableFromInline
-      var multiplexer: HTTP2StreamMultiplexer
+      var multiplexer: NIOHTTP2Handler.StreamMultiplexer
       /// Maximum number of available streams.
       @usableFromInline
       var maxAvailable: Int
@@ -73,7 +73,7 @@ extension ConnectionPool {
 
       /// Increment the reserved streams and return the multiplexer.
       @usableFromInline
-      mutating func reserve() -> HTTP2StreamMultiplexer {
+      mutating func reserve() -> NIOHTTP2Handler.StreamMultiplexer {
         assert(!self.isQuiescing)
         self.reserved += 1
         return self.multiplexer
@@ -127,7 +127,7 @@ extension ConnectionPool {
     ///
     /// The result may be safely unwrapped if `self.availableStreams > 0` when reserving a stream.
     @usableFromInline
-    internal mutating func reserveStream() -> HTTP2StreamMultiplexer? {
+    internal mutating func reserveStream() -> NIOHTTP2Handler.StreamMultiplexer? {
       return self._availability?.reserve()
     }
 

--- a/Sources/GRPC/ConnectionPool/ConnectionPool+Waiter.swift
+++ b/Sources/GRPC/ConnectionPool/ConnectionPool+Waiter.swift
@@ -30,7 +30,7 @@ extension ConnectionPool {
 
     /// The channel initializer.
     @usableFromInline
-    internal let _channelInitializer: (Channel) -> EventLoopFuture<Void>
+    internal let _channelInitializer: @Sendable (Channel) -> EventLoopFuture<Void>
 
     /// The deadline at which the timeout is scheduled.
     @usableFromInline
@@ -51,7 +51,7 @@ extension ConnectionPool {
     internal init(
       deadline: NIODeadline,
       promise: EventLoopPromise<Channel>,
-      channelInitializer: @escaping (Channel) -> EventLoopFuture<Void>
+      channelInitializer: @escaping @Sendable (Channel) -> EventLoopFuture<Void>
     ) {
       self._deadline = deadline
       self._promise = promise
@@ -83,7 +83,7 @@ extension ConnectionPool {
 
     /// Succeed the waiter with the given multiplexer.
     @usableFromInline
-    internal func succeed(with multiplexer: HTTP2StreamMultiplexer) {
+    internal func succeed(with multiplexer: NIOHTTP2Handler.StreamMultiplexer) {
       self._scheduledTimeout?.cancel()
       self._scheduledTimeout = nil
       multiplexer.createStreamChannel(promise: self._promise, self._channelInitializer)

--- a/Sources/GRPC/ConnectionPool/PoolManager.swift
+++ b/Sources/GRPC/ConnectionPool/PoolManager.swift
@@ -278,7 +278,7 @@ internal final class PoolManager {
     preferredEventLoop: EventLoop?,
     deadline: NIODeadline,
     logger: GRPCLogger,
-    streamInitializer initializer: @escaping (Channel) -> EventLoopFuture<Void>
+    streamInitializer initializer: @escaping @Sendable (Channel) -> EventLoopFuture<Void>
   ) -> PooledStreamChannel {
     let preferredEventLoopID = preferredEventLoop.map { EventLoopID($0) }
     let reservedPool = self.lock.withLock {

--- a/Sources/GRPC/GRPCClientChannelHandler.swift
+++ b/Sources/GRPC/GRPCClientChannelHandler.swift
@@ -270,10 +270,10 @@ public enum GRPCCallType: Hashable, Sendable {
 /// This handler relies heavily on the `GRPCClientStateMachine` to manage the state of the request
 /// and response streams, which share a single HTTP/2 stream for transport.
 ///
-/// Typical usage of this handler is with a `HTTP2StreamMultiplexer` from SwiftNIO HTTP2:
+/// Typical usage of this handler is with a `NIOHTTP2Handler.StreamMultiplexer` from SwiftNIO HTTP2:
 ///
 /// ```
-/// let multiplexer: HTTP2StreamMultiplexer = // ...
+/// let multiplexer: NIOHTTP2Handler.StreamMultiplexer = // ...
 /// multiplexer.createStreamChannel(promise: nil) { (channel, streamID) in
 ///   let clientChannelHandler = GRPCClientChannelHandler<Request, Response>(
 ///     streamID: streamID,

--- a/Sources/GRPC/GRPCIdleHandler.swift
+++ b/Sources/GRPC/GRPCIdleHandler.swift
@@ -49,7 +49,7 @@ internal final class GRPCIdleHandler: ChannelInboundHandler {
 
     mutating func setMultiplexer(_ multiplexer: NIOHTTP2Handler.StreamMultiplexer) {
       switch self {
-      case .partial(let connectionManager):
+      case let .partial(connectionManager):
         self = .complete(connectionManager, multiplexer)
       case .complete:
         preconditionFailure("Setting the multiplexer twice is not supported.")
@@ -65,7 +65,7 @@ internal final class GRPCIdleHandler: ChannelInboundHandler {
 
     mutating func setMultiplexer(_ multiplexer: NIOHTTP2Handler.StreamMultiplexer) {
       switch self {
-      case .client(var clientConfigurationState):
+      case var .client(clientConfigurationState):
         clientConfigurationState.setMultiplexer(multiplexer)
         self = .client(clientConfigurationState)
       case .server:
@@ -75,11 +75,11 @@ internal final class GRPCIdleHandler: ChannelInboundHandler {
 
     var connectionManager: ConnectionManager? {
       switch self {
-      case .client(let configurationState):
+      case let .client(configurationState):
         switch configurationState {
-        case .complete(let connectionManager, _):
+        case let .complete(connectionManager, _):
           return connectionManager
-        case .partial(let connectionManager):
+        case let .partial(connectionManager):
           return connectionManager
         }
       case .server:
@@ -305,9 +305,9 @@ internal final class GRPCIdleHandler: ChannelInboundHandler {
 
     // No state machine action here.
     switch self.mode {
-    case .client(let configurationState):
+    case let .client(configurationState):
       switch configurationState {
-      case .complete(let connectionManager, let multiplexer):
+      case let .complete(connectionManager, multiplexer):
         connectionManager.channelActive(channel: context.channel, multiplexer: multiplexer)
       case .partial:
         preconditionFailure("not yet initialised")

--- a/Sources/GRPC/GRPCIdleHandler.swift
+++ b/Sources/GRPC/GRPCIdleHandler.swift
@@ -55,7 +55,9 @@ internal final class GRPCIdleHandler: ChannelInboundHandler {
       case .complete:
         preconditionFailure("Setting the multiplexer twice is not supported.")
       case .deinitialized:
-        preconditionFailure("Setting the multiplexer after removing from a channel is not supported.")
+        preconditionFailure(
+          "Setting the multiplexer after removing from a channel is not supported."
+        )
       }
     }
   }

--- a/Sources/GRPC/GRPCServerPipelineConfigurator.swift
+++ b/Sources/GRPC/GRPCServerPipelineConfigurator.swift
@@ -80,7 +80,7 @@ final class GRPCServerPipelineConfigurator: ChannelInboundHandler, RemovableChan
   /// Makes an HTTP/2 handler.
   private func makeHTTP2Handler(
     for channel: Channel,
-    streamDelegate: NIOHTTP2StreamDelegate? = nil
+    streamDelegate: NIOHTTP2StreamDelegate?
   ) -> NIOHTTP2Handler {
     var connectionConfiguration = NIOHTTP2Handler.ConnectionConfiguration()
     connectionConfiguration.initialSettings = [

--- a/Sources/GRPC/GRPCServerPipelineConfigurator.swift
+++ b/Sources/GRPC/GRPCServerPipelineConfigurator.swift
@@ -78,7 +78,10 @@ final class GRPCServerPipelineConfigurator: ChannelInboundHandler, RemovableChan
   }
 
   /// Makes an HTTP/2 handler.
-  private func makeHTTP2Handler(for channel: Channel, streamDelegate: NIOHTTP2StreamDelegate? = nil) -> NIOHTTP2Handler {
+  private func makeHTTP2Handler(
+    for channel: Channel,
+    streamDelegate: NIOHTTP2StreamDelegate? = nil
+  ) -> NIOHTTP2Handler {
     var connectionConfiguration = NIOHTTP2Handler.ConnectionConfiguration()
     connectionConfiguration.initialSettings = [
       HTTP2Setting(

--- a/Sources/GRPC/GRPCServerPipelineConfigurator.swift
+++ b/Sources/GRPC/GRPCServerPipelineConfigurator.swift
@@ -78,38 +78,36 @@ final class GRPCServerPipelineConfigurator: ChannelInboundHandler, RemovableChan
   }
 
   /// Makes an HTTP/2 handler.
-  private func makeHTTP2Handler() -> NIOHTTP2Handler {
-    return .init(
-      mode: .server,
-      initialSettings: [
-        HTTP2Setting(
-          parameter: .maxConcurrentStreams,
-          value: self.configuration.httpMaxConcurrentStreams
-        ),
-        HTTP2Setting(
-          parameter: .maxHeaderListSize,
-          value: HPACKDecoder.defaultMaxHeaderListSize
-        ),
-        HTTP2Setting(
-          parameter: .maxFrameSize,
-          value: self.configuration.httpMaxFrameSize
-        ),
-        HTTP2Setting(
-          parameter: .initialWindowSize,
-          value: self.configuration.httpTargetWindowSize
-        ),
-      ]
-    )
-  }
+  private func makeHTTP2Handler(for channel: Channel, streamDelegate: NIOHTTP2StreamDelegate? = nil) -> NIOHTTP2Handler {
+    var connectionConfiguration = NIOHTTP2Handler.ConnectionConfiguration()
+    connectionConfiguration.initialSettings = [
+      HTTP2Setting(
+        parameter: .maxConcurrentStreams,
+        value: self.configuration.httpMaxConcurrentStreams
+      ),
+      HTTP2Setting(
+        parameter: .maxHeaderListSize,
+        value: HPACKDecoder.defaultMaxHeaderListSize
+      ),
+      HTTP2Setting(
+        parameter: .maxFrameSize,
+        value: self.configuration.httpMaxFrameSize
+      ),
+      HTTP2Setting(
+        parameter: .initialWindowSize,
+        value: self.configuration.httpTargetWindowSize
+      ),
+    ]
 
-  /// Makes an HTTP/2 multiplexer suitable handling gRPC requests.
-  private func makeHTTP2Multiplexer(for channel: Channel) -> HTTP2StreamMultiplexer {
-    var logger = self.configuration.logger
+    var streamConfiguration = NIOHTTP2Handler.StreamConfiguration()
+    streamConfiguration.targetWindowSize = self.configuration.httpTargetWindowSize
 
     return .init(
       mode: .server,
-      channel: channel,
-      targetWindowSize: self.configuration.httpTargetWindowSize
+      eventLoop: channel.eventLoop,
+      connectionConfiguration: connectionConfiguration,
+      streamConfiguration: streamConfiguration,
+      streamDelegate: streamDelegate
     ) { stream in
       // Sync options were added to the HTTP/2 stream channel in 1.17.0 (we require at least this)
       // so this shouldn't be `nil`, but it's not a problem if it is.
@@ -118,6 +116,7 @@ final class GRPCServerPipelineConfigurator: ChannelInboundHandler, RemovableChan
         return String(Int(streamID))
       } ?? "<unknown>"
 
+      var logger = self.configuration.logger
       logger[metadataKey: MetadataKey.h2StreamID] = "\(streamID)"
 
       do {
@@ -165,13 +164,14 @@ final class GRPCServerPipelineConfigurator: ChannelInboundHandler, RemovableChan
     // to then insert our keepalive and idle handlers between. We can just add everything together.
     let result: Result<Void, Error>
 
+    let idleHandler = self.makeIdleHandler()
     do {
       // This is only ever called as a result of reading a user inbound event or reading inbound so
       // we'll be on the right event loop and sync operations are fine.
       let sync = context.pipeline.syncOperations
-      try sync.addHandler(self.makeHTTP2Handler())
-      try sync.addHandler(self.makeIdleHandler())
-      try sync.addHandler(self.makeHTTP2Multiplexer(for: context.channel))
+      try sync.addHandler(self.makeHTTP2Handler(for: context.channel, streamDelegate: idleHandler))
+      // Here we intentionally don't associate the multiplexer with the idleHandler in the server case
+      try sync.addHandler(idleHandler)
       result = .success(())
     } catch {
       result = .failure(error)

--- a/Sources/GRPC/Server.swift
+++ b/Sources/GRPC/Server.swift
@@ -54,10 +54,6 @@ import Network
 ///    `GRPCServerPipelineConfigurator`. In the case of HTTP/2:
 ///
 ///                           ┌─────────────────────────────────┐
-///                           │      HTTP2StreamMultiplexer     │
-///                           └─▲─────────────────────────────┬─┘
-///                   HTTP2Frame│                             │HTTP2Frame
-///                           ┌─┴─────────────────────────────▼─┐
 ///                           │           HTTP2Handler          │
 ///                           └─▲─────────────────────────────┬─┘
 ///                   ByteBuffer│                             │ByteBuffer
@@ -67,7 +63,7 @@ import Network
 ///                   ByteBuffer│                             │ByteBuffer
 ///                             │                             ▼
 ///
-///    The `HTTP2StreamMultiplexer` provides one `Channel` for each HTTP/2 stream (and thus each
+///    The `NIOHTTP2Handler.StreamMultiplexer` provides one `Channel` for each HTTP/2 stream (and thus each
 ///    RPC).
 ///
 /// 3. The frames for each stream channel are routed by the `HTTP2ToRawGRPCServerCodec` handler to

--- a/Tests/GRPCTests/ConnectionManagerTests.swift
+++ b/Tests/GRPCTests/ConnectionManagerTests.swift
@@ -255,8 +255,8 @@ extension ConnectionManagerTests {
 
     var seenAnInactive = false
     public func channelInactive(context: ChannelHandlerContext) {
-      if !seenAnInactive {
-        seenAnInactive = true
+      if !self.seenAnInactive {
+        self.seenAnInactive = true
         context.fireChannelInactive()
       }
     }
@@ -520,15 +520,16 @@ extension ConnectionManagerTests {
       return next
     }
 
-    let readyChannelMux: EventLoopFuture<NIOHTTP2Handler.StreamMultiplexer> = self.waitForStateChanges([
-      Change(from: .idle, to: .connecting),
-      Change(from: .connecting, to: .transientFailure),
-    ]) {
-      // Get a HTTP/2 stream multiplexer.
-      let readyChannelMux = manager.getHTTP2Multiplexer()
-      self.loop.run()
-      return readyChannelMux
-    }
+    let readyChannelMux: EventLoopFuture<NIOHTTP2Handler.StreamMultiplexer> = self
+      .waitForStateChanges([
+        Change(from: .idle, to: .connecting),
+        Change(from: .connecting, to: .transientFailure),
+      ]) {
+        // Get a HTTP/2 stream multiplexer.
+        let readyChannelMux = manager.getHTTP2Multiplexer()
+        self.loop.run()
+        return readyChannelMux
+      }
 
     // Get a HTTP/2 stream mux from the manager - it is a future for the one we made earlier.
     let anotherReadyChannelMux = manager.getHTTP2Multiplexer()
@@ -624,15 +625,16 @@ extension ConnectionManagerTests {
       self.loop.makeFailedFuture(DoomedChannelError())
     }
 
-    let readyChannelMux: EventLoopFuture<NIOHTTP2Handler.StreamMultiplexer> = self.waitForStateChanges([
-      Change(from: .idle, to: .connecting),
-      Change(from: .connecting, to: .transientFailure),
-    ]) {
-      // Get a HTTP/2 stream multiplexer.
-      let readyChannelMux = manager.getHTTP2Multiplexer()
-      self.loop.run()
-      return readyChannelMux
-    }
+    let readyChannelMux: EventLoopFuture<NIOHTTP2Handler.StreamMultiplexer> = self
+      .waitForStateChanges([
+        Change(from: .idle, to: .connecting),
+        Change(from: .connecting, to: .transientFailure),
+      ]) {
+        // Get a HTTP/2 stream multiplexer.
+        let readyChannelMux = manager.getHTTP2Multiplexer()
+        self.loop.run()
+        return readyChannelMux
+      }
 
     // Now shutdown.
     try self.waitForStateChange(from: .transientFailure, to: .shutdown) {
@@ -1058,14 +1060,15 @@ extension ConnectionManagerTests {
     }
 
     // Start the connection.
-    let readyChannelMux: EventLoopFuture<NIOHTTP2Handler.StreamMultiplexer> = self.waitForStateChange(
-      from: .idle,
-      to: .connecting
-    ) {
-      let readyChannelMux = manager.getHTTP2Multiplexer()
-      self.loop.run()
-      return readyChannelMux
-    }
+    let readyChannelMux: EventLoopFuture<NIOHTTP2Handler.StreamMultiplexer> = self
+      .waitForStateChange(
+        from: .idle,
+        to: .connecting
+      ) {
+        let readyChannelMux = manager.getHTTP2Multiplexer()
+        self.loop.run()
+        return readyChannelMux
+      }
 
     // Setup the real channel and activate it.
     let channel = EmbeddedChannel(loop: self.loop)
@@ -1207,7 +1210,7 @@ extension ConnectionManagerTests {
 
     let http2 = HTTP2Delegate()
 
-    var streamDelegate: NIOHTTP2StreamDelegate? = nil
+    var streamDelegate: NIOHTTP2StreamDelegate?
     let manager = ConnectionManager(
       eventLoop: self.loop,
       channelProvider: HookedChannelProvider { manager, eventLoop -> EventLoopFuture<Channel> in
@@ -1222,7 +1225,7 @@ extension ConnectionManagerTests {
           eventLoop: channel.eventLoop,
           streamDelegate: idleHandler
         ) { channel in
-            channel.eventLoop.makeSucceededVoidFuture()
+          channel.eventLoop.makeSucceededVoidFuture()
         }
         try! channel.pipeline.syncOperations.addHandler(h2Handler)
         idleHandler.setMultiplexer(try! h2Handler.syncMultiplexer())

--- a/Tests/GRPCTests/ConnectionManagerTests.swift
+++ b/Tests/GRPCTests/ConnectionManagerTests.swift
@@ -116,7 +116,7 @@ extension ConnectionManagerTests {
       return channelPromise.futureResult
     }
 
-    let multiplexer: EventLoopFuture<HTTP2StreamMultiplexer> = self
+    let multiplexer: EventLoopFuture<NIOHTTP2Handler.StreamMultiplexer> = self
       .waitForStateChange(from: .idle, to: .connecting) {
         let channel = manager.getHTTP2Multiplexer()
         self.loop.run()
@@ -146,20 +146,22 @@ extension ConnectionManagerTests {
 
     // Setup the real channel and activate it.
     let channel = EmbeddedChannel(loop: self.loop)
-    let h2mux = HTTP2StreamMultiplexer(
-      mode: .client,
-      channel: channel,
-      inboundStreamInitializer: nil
+    let idleHandler = GRPCIdleHandler(
+      connectionManager: manager,
+      idleTimeout: .minutes(5),
+      keepalive: .init(),
+      logger: self.logger
     )
-    try channel.pipeline.addHandler(
-      GRPCIdleHandler(
-        connectionManager: manager,
-        multiplexer: h2mux,
-        idleTimeout: .minutes(5),
-        keepalive: .init(),
-        logger: self.logger
-      )
-    ).wait()
+    let h2handler = NIOHTTP2Handler(
+      mode: .client,
+      eventLoop: channel.eventLoop,
+      streamDelegate: idleHandler
+    ) { channel in
+      channel.eventLoop.makeSucceededVoidFuture()
+    }
+    try channel.pipeline.addHandler(h2handler).wait()
+    idleHandler.setMultiplexer(try h2handler.syncMultiplexer())
+    try channel.pipeline.addHandler(idleHandler).wait()
     channelPromise.succeed(channel)
     XCTAssertNoThrow(
       try channel.connect(to: SocketAddress(unixDomainSocketPath: "/ignored"))
@@ -169,7 +171,7 @@ extension ConnectionManagerTests {
     // Write a settings frame on the root stream; this'll make the channel 'ready'.
     try self.waitForStateChange(from: .connecting, to: .ready) {
       let frame = HTTP2Frame(streamID: .rootStream, payload: .settings(.settings([])))
-      XCTAssertNoThrow(try channel.writeInbound(frame))
+      XCTAssertNoThrow(try channel.writeInbound(frame.encode()))
     }
 
     // Close the channel.
@@ -188,7 +190,7 @@ extension ConnectionManagerTests {
     }
 
     // Start the connection.
-    let readyChannelMux: EventLoopFuture<HTTP2StreamMultiplexer> = self
+    let readyChannelMux: EventLoopFuture<NIOHTTP2Handler.StreamMultiplexer> = self
       .waitForStateChange(from: .idle, to: .connecting) {
         let readyChannelMux = manager.getHTTP2Multiplexer()
         self.loop.run()
@@ -197,20 +199,23 @@ extension ConnectionManagerTests {
 
     // Setup the channel.
     let channel = EmbeddedChannel(loop: self.loop)
-    let h2mux = HTTP2StreamMultiplexer(
-      mode: .client,
-      channel: channel,
-      inboundStreamInitializer: nil
+    let idleHandler = GRPCIdleHandler(
+      connectionManager: manager,
+      idleTimeout: .minutes(5),
+      keepalive: .init(),
+      logger: self.logger
     )
-    try channel.pipeline.addHandler(
-      GRPCIdleHandler(
-        connectionManager: manager,
-        multiplexer: h2mux,
-        idleTimeout: .minutes(5),
-        keepalive: .init(),
-        logger: self.logger
-      )
-    ).wait()
+
+    let h2handler = NIOHTTP2Handler(
+      mode: .client,
+      eventLoop: channel.eventLoop,
+      streamDelegate: idleHandler
+    ) { channel in
+      channel.eventLoop.makeSucceededVoidFuture()
+    }
+    try channel.pipeline.addHandler(h2handler).wait()
+    idleHandler.setMultiplexer(try h2handler.syncMultiplexer())
+    try channel.pipeline.addHandler(idleHandler).wait()
     channelPromise.succeed(channel)
     XCTAssertNoThrow(
       try channel.connect(to: SocketAddress(unixDomainSocketPath: "/ignored"))
@@ -220,7 +225,7 @@ extension ConnectionManagerTests {
     // Write a settings frame on the root stream; this'll make the channel 'ready'.
     try self.waitForStateChange(from: .connecting, to: .ready) {
       let frame = HTTP2Frame(streamID: .rootStream, payload: .settings(.settings([])))
-      XCTAssertNoThrow(try channel.writeInbound(frame))
+      XCTAssertNoThrow(try channel.writeInbound(frame.encode()))
       // Wait for the multiplexer, it _must_ be ready now.
       XCTAssertNoThrow(try readyChannelMux.wait())
     }
@@ -239,6 +244,24 @@ extension ConnectionManagerTests {
     }
   }
 
+  /// Forwards only the first `channelInactive` call
+  ///
+  /// This is useful in tests where we intentionally mis-use the channels
+  /// and call `fireChannelInactive` manually during the test but don't want
+  /// teardown to cause precondition failures due to this unexpected behavior.
+  class SwallowSecondInactiveHandler: ChannelInboundHandler {
+    typealias InboundIn = HTTP2Frame
+    typealias OutboundOut = HTTP2Frame
+
+    var seenAnInactive = false
+    public func channelInactive(context: ChannelHandlerContext) {
+      if !seenAnInactive {
+        seenAnInactive = true
+        context.fireChannelInactive()
+      }
+    }
+  }
+
   func testChannelInactiveBeforeActiveWithNoReconnect() throws {
     let channel = EmbeddedChannel(loop: self.loop)
     let channelPromise = self.loop.makePromise(of: Channel.self)
@@ -253,27 +276,29 @@ extension ConnectionManagerTests {
       _ = manager.getHTTP2Multiplexer()
       self.loop.run()
     }
-
-    try channel.pipeline.syncOperations.addHandler(
-      GRPCIdleHandler(
-        connectionManager: manager,
-        multiplexer: HTTP2StreamMultiplexer(
-          mode: .client,
-          channel: channel,
-          inboundStreamInitializer: nil
-        ),
-        idleTimeout: .minutes(5),
-        keepalive: .init(),
-        logger: self.logger
-      )
+    let idleHandler = GRPCIdleHandler(
+      connectionManager: manager,
+      idleTimeout: .minutes(5),
+      keepalive: .init(),
+      logger: self.logger
     )
-    channelPromise.succeed(channel)
-    // Oops: wrong way around. We should tolerate this.
-    self.waitForStateChange(from: .connecting, to: .shutdown) {
-      channel.pipeline.fireChannelInactive()
-    }
 
-    // Should be ignored.
+    let h2handler = NIOHTTP2Handler(
+      mode: .client,
+      eventLoop: channel.eventLoop,
+      streamDelegate: idleHandler
+    ) { channel in
+      channel.eventLoop.makeSucceededVoidFuture()
+    }
+    try channel.pipeline.syncOperations.addHandler(SwallowSecondInactiveHandler())
+    try channel.pipeline.syncOperations.addHandler(h2handler)
+    idleHandler.setMultiplexer(try h2handler.syncMultiplexer())
+    try channel.pipeline.syncOperations.addHandler(idleHandler)
+    try channel.pipeline.syncOperations.addHandler(NIOCloseOnErrorHandler())
+    channelPromise.succeed(channel)
+
+    // Oops: wrong way around. We should tolerate this - just don't crash.
+    channel.pipeline.fireChannelInactive()
     channel.pipeline.fireChannelActive()
   }
 
@@ -300,55 +325,59 @@ extension ConnectionManagerTests {
     // Setup the channel.
     let channel1 = channels.removeLast()
     let channel1Promise = channelPromises.removeLast()
-
-    try channel1.pipeline.syncOperations.addHandler(
-      GRPCIdleHandler(
-        connectionManager: manager,
-        multiplexer: HTTP2StreamMultiplexer(
-          mode: .client,
-          channel: channel1,
-          inboundStreamInitializer: nil
-        ),
-        idleTimeout: .minutes(5),
-        keepalive: .init(),
-        logger: self.logger
-      )
+    let idleHandler1 = GRPCIdleHandler(
+      connectionManager: manager,
+      idleTimeout: .minutes(5),
+      keepalive: .init(),
+      logger: self.logger
     )
+    let h2handler1 = NIOHTTP2Handler(
+      mode: .client,
+      eventLoop: channel1.eventLoop,
+      streamDelegate: idleHandler1
+    ) { channel in
+      channel.eventLoop.makeSucceededVoidFuture()
+    }
+    try channel1.pipeline.syncOperations.addHandler(SwallowSecondInactiveHandler())
+    try channel1.pipeline.syncOperations.addHandler(h2handler1)
+    idleHandler1.setMultiplexer(try h2handler1.syncMultiplexer())
+    try channel1.pipeline.syncOperations.addHandler(idleHandler1)
+    try channel1.pipeline.syncOperations.addHandler(NIOCloseOnErrorHandler())
     channel1Promise.succeed(channel1)
     // Oops: wrong way around. We should tolerate this.
-    self.waitForStateChange(from: .connecting, to: .transientFailure) {
-      channel1.pipeline.fireChannelInactive()
-    }
-
+    channel1.pipeline.fireChannelInactive()
     channel1.pipeline.fireChannelActive()
 
     // Start the next attempt.
-    self.waitForStateChange(from: .transientFailure, to: .connecting) {
-      self.loop.advanceTime(by: .seconds(1))
-    }
+    self.loop.advanceTime(by: .seconds(1))
 
     let channel2 = channels.removeLast()
     let channel2Promise = channelPromises.removeLast()
-    try channel2.pipeline.syncOperations.addHandler(
-      GRPCIdleHandler(
-        connectionManager: manager,
-        multiplexer: HTTP2StreamMultiplexer(
-          mode: .client,
-          channel: channel1,
-          inboundStreamInitializer: nil
-        ),
-        idleTimeout: .minutes(5),
-        keepalive: .init(),
-        logger: self.logger
-      )
+    let idleHandler2 = GRPCIdleHandler(
+      connectionManager: manager,
+      idleTimeout: .minutes(5),
+      keepalive: .init(),
+      logger: self.logger
     )
+    let h2handler2 = NIOHTTP2Handler(
+      mode: .client,
+      eventLoop: channel2.eventLoop,
+      streamDelegate: idleHandler2
+    ) { channel in
+      channel.eventLoop.makeSucceededVoidFuture()
+    }
 
+    try channel2.pipeline.syncOperations.addHandler(SwallowSecondInactiveHandler())
+    try channel2.pipeline.syncOperations.addHandler(h2handler2)
+    idleHandler2.setMultiplexer(try h2handler2.syncMultiplexer())
+    try channel2.pipeline.syncOperations.addHandler(idleHandler2)
+    try channel2.pipeline.syncOperations.addHandler(NIOCloseOnErrorHandler())
     channel2Promise.succeed(channel2)
 
     try self.waitForStateChange(from: .connecting, to: .ready) {
       channel2.pipeline.fireChannelActive()
       let frame = HTTP2Frame(streamID: .rootStream, payload: .settings(.settings([])))
-      XCTAssertNoThrow(try channel2.writeInbound(frame))
+      XCTAssertNoThrow(try channel2.writeInbound(frame.encode()))
     }
   }
 
@@ -359,7 +388,7 @@ extension ConnectionManagerTests {
     }
 
     // Start the connection.
-    let readyChannelMux: EventLoopFuture<HTTP2StreamMultiplexer> = self
+    let readyChannelMux: EventLoopFuture<NIOHTTP2Handler.StreamMultiplexer> = self
       .waitForStateChange(from: .idle, to: .connecting) {
         let readyChannelMux = manager.getHTTP2Multiplexer()
         self.loop.run()
@@ -368,20 +397,23 @@ extension ConnectionManagerTests {
 
     // Setup the channel.
     let channel = EmbeddedChannel(loop: self.loop)
-    let h2mux = HTTP2StreamMultiplexer(
-      mode: .client,
-      channel: channel,
-      inboundStreamInitializer: nil
+    let idleHandler = GRPCIdleHandler(
+      connectionManager: manager,
+      idleTimeout: .minutes(5),
+      keepalive: .init(),
+      logger: self.logger
     )
-    try channel.pipeline.addHandler(
-      GRPCIdleHandler(
-        connectionManager: manager,
-        multiplexer: h2mux,
-        idleTimeout: .minutes(5),
-        keepalive: .init(),
-        logger: self.logger
-      )
-    ).wait()
+
+    let h2handler = NIOHTTP2Handler(
+      mode: .client,
+      eventLoop: channel.eventLoop,
+      streamDelegate: idleHandler
+    ) { channel in
+      channel.eventLoop.makeSucceededVoidFuture()
+    }
+    try channel.pipeline.addHandler(h2handler).wait()
+    idleHandler.setMultiplexer(try h2handler.syncMultiplexer())
+    try channel.pipeline.addHandler(idleHandler).wait()
 
     channelPromise.succeed(channel)
     XCTAssertNoThrow(
@@ -392,18 +424,13 @@ extension ConnectionManagerTests {
     // Write a settings frame on the root stream; this'll make the channel 'ready'.
     try self.waitForStateChange(from: .connecting, to: .ready) {
       let frame = HTTP2Frame(streamID: .rootStream, payload: .settings(.settings([])))
-      XCTAssertNoThrow(try channel.writeInbound(frame))
+      XCTAssertNoThrow(try channel.writeInbound(frame.encode()))
       // Wait for the HTTP/2 stream multiplexer, it _must_ be ready now.
       XCTAssertNoThrow(try readyChannelMux.wait())
     }
 
     // "create" a stream; the details don't matter here.
-    let streamCreated = NIOHTTP2StreamCreatedEvent(
-      streamID: 1,
-      localInitialWindowSize: nil,
-      remoteInitialWindowSize: nil
-    )
-    channel.pipeline.fireUserInboundEventTriggered(streamCreated)
+    idleHandler.streamCreated(1, channel: channel)
 
     // Wait for the idle timeout: this should _not_ cause the channel to idle.
     self.loop.advanceTime(by: .minutes(5))
@@ -411,8 +438,7 @@ extension ConnectionManagerTests {
     // Now we're going to close the stream and wait for an idle timeout and then shutdown.
     self.waitForStateChange(from: .ready, to: .idle) {
       // Close the stream.
-      let streamClosed = StreamClosedEvent(streamID: 1, reason: nil)
-      channel.pipeline.fireUserInboundEventTriggered(streamClosed)
+      idleHandler.streamClosed(1, channel: channel)
       // ... wait for the idle timeout,
       self.loop.advanceTime(by: .minutes(5))
     }
@@ -431,7 +457,7 @@ extension ConnectionManagerTests {
       return channelPromise.futureResult
     }
 
-    let readyChannelMux: EventLoopFuture<HTTP2StreamMultiplexer> = self
+    let readyChannelMux: EventLoopFuture<NIOHTTP2Handler.StreamMultiplexer> = self
       .waitForStateChange(from: .idle, to: .connecting) {
         let readyChannelMux = manager.getHTTP2Multiplexer()
         self.loop.run()
@@ -440,20 +466,23 @@ extension ConnectionManagerTests {
 
     // Setup the channel.
     let channel = EmbeddedChannel(loop: self.loop)
-    let h2mux = HTTP2StreamMultiplexer(
-      mode: .client,
-      channel: channel,
-      inboundStreamInitializer: nil
+    let idleHandler = GRPCIdleHandler(
+      connectionManager: manager,
+      idleTimeout: .minutes(5),
+      keepalive: .init(),
+      logger: self.logger
     )
-    try channel.pipeline.addHandler(
-      GRPCIdleHandler(
-        connectionManager: manager,
-        multiplexer: h2mux,
-        idleTimeout: .minutes(5),
-        keepalive: .init(),
-        logger: self.logger
-      )
-    ).wait()
+
+    let h2handler = NIOHTTP2Handler(
+      mode: .client,
+      eventLoop: channel.eventLoop,
+      streamDelegate: idleHandler
+    ) { channel in
+      channel.eventLoop.makeSucceededVoidFuture()
+    }
+    try channel.pipeline.addHandler(h2handler).wait()
+    idleHandler.setMultiplexer(try h2handler.syncMultiplexer())
+    try channel.pipeline.addHandler(idleHandler).wait()
     channelPromise.succeed(channel)
     XCTAssertNoThrow(
       try channel.connect(to: SocketAddress(unixDomainSocketPath: "/ignored"))
@@ -491,7 +520,7 @@ extension ConnectionManagerTests {
       return next
     }
 
-    let readyChannelMux: EventLoopFuture<HTTP2StreamMultiplexer> = self.waitForStateChanges([
+    let readyChannelMux: EventLoopFuture<NIOHTTP2Handler.StreamMultiplexer> = self.waitForStateChanges([
       Change(from: .idle, to: .connecting),
       Change(from: .connecting, to: .transientFailure),
     ]) {
@@ -512,20 +541,23 @@ extension ConnectionManagerTests {
 
     // Setup the actual channel and complete the promise.
     let channel = EmbeddedChannel(loop: self.loop)
-    let h2mux = HTTP2StreamMultiplexer(
-      mode: .client,
-      channel: channel,
-      inboundStreamInitializer: nil
+    let idleHandler = GRPCIdleHandler(
+      connectionManager: manager,
+      idleTimeout: .minutes(5),
+      keepalive: .init(),
+      logger: self.logger
     )
-    try channel.pipeline.addHandler(
-      GRPCIdleHandler(
-        connectionManager: manager,
-        multiplexer: h2mux,
-        idleTimeout: .minutes(5),
-        keepalive: .init(),
-        logger: self.logger
-      )
-    ).wait()
+
+    let h2handler = NIOHTTP2Handler(
+      mode: .client,
+      eventLoop: channel.eventLoop,
+      streamDelegate: idleHandler
+    ) { channel in
+      channel.eventLoop.makeSucceededVoidFuture()
+    }
+    try channel.pipeline.addHandler(h2handler).wait()
+    idleHandler.setMultiplexer(try h2handler.syncMultiplexer())
+    try channel.pipeline.addHandler(idleHandler).wait()
     channelPromise.succeed(channel)
     XCTAssertNoThrow(
       try channel.connect(to: SocketAddress(unixDomainSocketPath: "/ignored"))
@@ -535,7 +567,7 @@ extension ConnectionManagerTests {
     // Write a SETTINGS frame on the root stream.
     try self.waitForStateChange(from: .connecting, to: .ready) {
       let frame = HTTP2Frame(streamID: .rootStream, payload: .settings(.settings([])))
-      XCTAssertNoThrow(try channel.writeInbound(frame))
+      XCTAssertNoThrow(try channel.writeInbound(frame.encode()))
     }
 
     // Wait for the HTTP/2 stream multiplexer, it _must_ be ready now.
@@ -556,7 +588,7 @@ extension ConnectionManagerTests {
       return channelPromise.futureResult
     }
 
-    let readyChannelMux: EventLoopFuture<HTTP2StreamMultiplexer> = self
+    let readyChannelMux: EventLoopFuture<NIOHTTP2Handler.StreamMultiplexer> = self
       .waitForStateChange(from: .idle, to: .connecting) {
         let readyChannelMux = manager.getHTTP2Multiplexer()
         self.loop.run()
@@ -592,7 +624,7 @@ extension ConnectionManagerTests {
       self.loop.makeFailedFuture(DoomedChannelError())
     }
 
-    let readyChannelMux: EventLoopFuture<HTTP2StreamMultiplexer> = self.waitForStateChanges([
+    let readyChannelMux: EventLoopFuture<NIOHTTP2Handler.StreamMultiplexer> = self.waitForStateChanges([
       Change(from: .idle, to: .connecting),
       Change(from: .connecting, to: .transientFailure),
     ]) {
@@ -619,7 +651,7 @@ extension ConnectionManagerTests {
       return channelPromise.futureResult
     }
 
-    let readyChannelMux: EventLoopFuture<HTTP2StreamMultiplexer> = self
+    let readyChannelMux: EventLoopFuture<NIOHTTP2Handler.StreamMultiplexer> = self
       .waitForStateChange(from: .idle, to: .connecting) {
         let readyChannelMux = manager.getHTTP2Multiplexer()
         self.loop.run()
@@ -628,20 +660,23 @@ extension ConnectionManagerTests {
 
     // Prepare the channel
     let channel = EmbeddedChannel(loop: self.loop)
-    let h2mux = HTTP2StreamMultiplexer(
-      mode: .client,
-      channel: channel,
-      inboundStreamInitializer: nil
+    let idleHandler = GRPCIdleHandler(
+      connectionManager: manager,
+      idleTimeout: .minutes(5),
+      keepalive: .init(),
+      logger: self.logger
     )
-    try channel.pipeline.addHandler(
-      GRPCIdleHandler(
-        connectionManager: manager,
-        multiplexer: h2mux,
-        idleTimeout: .minutes(5),
-        keepalive: .init(),
-        logger: self.logger
-      )
-    ).wait()
+
+    let h2handler = NIOHTTP2Handler(
+      mode: .client,
+      eventLoop: channel.eventLoop,
+      streamDelegate: idleHandler
+    ) { channel in
+      channel.eventLoop.makeSucceededVoidFuture()
+    }
+    try channel.pipeline.addHandler(h2handler).wait()
+    idleHandler.setMultiplexer(try h2handler.syncMultiplexer())
+    try channel.pipeline.addHandler(idleHandler).wait()
     channelPromise.succeed(channel)
     XCTAssertNoThrow(
       try channel.connect(to: SocketAddress(unixDomainSocketPath: "/ignored"))
@@ -694,7 +729,7 @@ extension ConnectionManagerTests {
       return next
     }
 
-    let readyChannelMux: EventLoopFuture<HTTP2StreamMultiplexer> = self
+    let readyChannelMux: EventLoopFuture<NIOHTTP2Handler.StreamMultiplexer> = self
       .waitForStateChange(from: .idle, to: .connecting) {
         let readyChannelMux = manager.getHTTP2Multiplexer()
         self.loop.run()
@@ -703,20 +738,23 @@ extension ConnectionManagerTests {
 
     // Prepare the channel
     let firstChannel = EmbeddedChannel(loop: self.loop)
-    let h2mux = HTTP2StreamMultiplexer(
-      mode: .client,
-      channel: firstChannel,
-      inboundStreamInitializer: nil
+    let idleHandler = GRPCIdleHandler(
+      connectionManager: manager,
+      idleTimeout: .minutes(5),
+      keepalive: .init(),
+      logger: self.logger
     )
-    try firstChannel.pipeline.addHandler(
-      GRPCIdleHandler(
-        connectionManager: manager,
-        multiplexer: h2mux,
-        idleTimeout: .minutes(5),
-        keepalive: .init(),
-        logger: self.logger
-      )
-    ).wait()
+
+    let h2handler = NIOHTTP2Handler(
+      mode: .client,
+      eventLoop: firstChannel.eventLoop,
+      streamDelegate: idleHandler
+    ) { channel in
+      channel.eventLoop.makeSucceededVoidFuture()
+    }
+    try firstChannel.pipeline.addHandler(h2handler).wait()
+    idleHandler.setMultiplexer(try h2handler.syncMultiplexer())
+    try firstChannel.pipeline.addHandler(idleHandler).wait()
 
     channelPromise.succeed(firstChannel)
     XCTAssertNoThrow(
@@ -770,7 +808,7 @@ extension ConnectionManagerTests {
       return next
     }
 
-    let readyChannelMux: EventLoopFuture<HTTP2StreamMultiplexer> = self
+    let readyChannelMux: EventLoopFuture<NIOHTTP2Handler.StreamMultiplexer> = self
       .waitForStateChange(from: .idle, to: .connecting) {
         let readyChannelMux = manager.getHTTP2Multiplexer()
         self.loop.run()
@@ -779,20 +817,22 @@ extension ConnectionManagerTests {
 
     // Prepare the first channel
     let firstChannel = EmbeddedChannel(loop: self.loop)
-    let firstH2mux = HTTP2StreamMultiplexer(
-      mode: .client,
-      channel: firstChannel,
-      inboundStreamInitializer: nil
+    let firstIdleHandler = GRPCIdleHandler(
+      connectionManager: manager,
+      idleTimeout: .minutes(5),
+      keepalive: .init(),
+      logger: self.logger
     )
-    try firstChannel.pipeline.addHandler(
-      GRPCIdleHandler(
-        connectionManager: manager,
-        multiplexer: firstH2mux,
-        idleTimeout: .minutes(5),
-        keepalive: .init(),
-        logger: self.logger
-      )
-    ).wait()
+    let firstH2handler = NIOHTTP2Handler(
+      mode: .client,
+      eventLoop: firstChannel.eventLoop,
+      streamDelegate: firstIdleHandler
+    ) { channel in
+      channel.eventLoop.makeSucceededVoidFuture()
+    }
+    try firstChannel.pipeline.addHandler(firstH2handler).wait()
+    firstIdleHandler.setMultiplexer(try firstH2handler.syncMultiplexer())
+    try firstChannel.pipeline.addHandler(firstIdleHandler).wait()
     firstChannelPromise.succeed(firstChannel)
     XCTAssertNoThrow(
       try firstChannel.connect(to: SocketAddress(unixDomainSocketPath: "/ignored"))
@@ -802,19 +842,14 @@ extension ConnectionManagerTests {
     // Write a SETTINGS frame on the root stream.
     try self.waitForStateChange(from: .connecting, to: .ready) {
       let frame = HTTP2Frame(streamID: .rootStream, payload: .settings(.settings([])))
-      XCTAssertNoThrow(try firstChannel.writeInbound(frame))
+      XCTAssertNoThrow(try firstChannel.writeInbound(frame.encode()))
     }
 
     // Channel should now be ready.
     XCTAssertNoThrow(try readyChannelMux.wait())
 
     // Kill the first channel. But first ensure there's an active RPC, otherwise we'll idle.
-    let streamCreated = NIOHTTP2StreamCreatedEvent(
-      streamID: 1,
-      localInitialWindowSize: nil,
-      remoteInitialWindowSize: nil
-    )
-    firstChannel.pipeline.fireUserInboundEventTriggered(streamCreated)
+    firstIdleHandler.streamCreated(1, channel: firstChannel)
 
     try self.waitForStateChange(from: .ready, to: .transientFailure) {
       XCTAssertNoThrow(try firstChannel.close().wait())
@@ -827,20 +862,22 @@ extension ConnectionManagerTests {
 
     // Prepare the second channel
     let secondChannel = EmbeddedChannel(loop: self.loop)
-    let secondH2mux = HTTP2StreamMultiplexer(
-      mode: .client,
-      channel: secondChannel,
-      inboundStreamInitializer: nil
+    let secondIdleHandler = GRPCIdleHandler(
+      connectionManager: manager,
+      idleTimeout: .minutes(5),
+      keepalive: .init(),
+      logger: self.logger
     )
-    try secondChannel.pipeline.addHandler(
-      GRPCIdleHandler(
-        connectionManager: manager,
-        multiplexer: secondH2mux,
-        idleTimeout: .minutes(5),
-        keepalive: .init(),
-        logger: self.logger
-      )
-    ).wait()
+    let secondH2handler = NIOHTTP2Handler(
+      mode: .client,
+      eventLoop: secondChannel.eventLoop,
+      streamDelegate: secondIdleHandler
+    ) { channel in
+      channel.eventLoop.makeSucceededVoidFuture()
+    }
+    try secondChannel.pipeline.addHandler(secondH2handler).wait()
+    secondIdleHandler.setMultiplexer(try secondH2handler.syncMultiplexer())
+    try secondChannel.pipeline.addHandler(secondIdleHandler).wait()
     secondChannelPromise.succeed(secondChannel)
     XCTAssertNoThrow(
       try secondChannel.connect(to: SocketAddress(unixDomainSocketPath: "/ignored"))
@@ -850,7 +887,7 @@ extension ConnectionManagerTests {
     // Write a SETTINGS frame on the root stream.
     try self.waitForStateChange(from: .connecting, to: .ready) {
       let frame = HTTP2Frame(streamID: .rootStream, payload: .settings(.settings([])))
-      XCTAssertNoThrow(try secondChannel.writeInbound(frame))
+      XCTAssertNoThrow(try secondChannel.writeInbound(frame.encode()))
     }
 
     // Now shutdown
@@ -867,7 +904,7 @@ extension ConnectionManagerTests {
       return channelPromise.futureResult
     }
 
-    let readyChannelMux: EventLoopFuture<HTTP2StreamMultiplexer> = self
+    let readyChannelMux: EventLoopFuture<NIOHTTP2Handler.StreamMultiplexer> = self
       .waitForStateChange(from: .idle, to: .connecting) {
         let readyChannelMux = manager.getHTTP2Multiplexer()
         self.loop.run()
@@ -876,20 +913,23 @@ extension ConnectionManagerTests {
 
     // Setup the channel.
     let channel = EmbeddedChannel(loop: self.loop)
-    let h2mux = HTTP2StreamMultiplexer(
-      mode: .client,
-      channel: channel,
-      inboundStreamInitializer: nil
+    let idleHandler = GRPCIdleHandler(
+      connectionManager: manager,
+      idleTimeout: .minutes(5),
+      keepalive: .init(),
+      logger: self.logger
     )
-    try channel.pipeline.addHandler(
-      GRPCIdleHandler(
-        connectionManager: manager,
-        multiplexer: h2mux,
-        idleTimeout: .minutes(5),
-        keepalive: .init(),
-        logger: self.logger
-      )
-    ).wait()
+
+    let h2handler = NIOHTTP2Handler(
+      mode: .client,
+      eventLoop: channel.eventLoop,
+      streamDelegate: idleHandler
+    ) { channel in
+      channel.eventLoop.makeSucceededVoidFuture()
+    }
+    try channel.pipeline.addHandler(h2handler).wait()
+    idleHandler.setMultiplexer(try h2handler.syncMultiplexer())
+    try channel.pipeline.addHandler(idleHandler).wait()
     channelPromise.succeed(channel)
     XCTAssertNoThrow(
       try channel.connect(to: SocketAddress(unixDomainSocketPath: "/ignored"))
@@ -899,7 +939,7 @@ extension ConnectionManagerTests {
     try self.waitForStateChange(from: .connecting, to: .ready) {
       // Write a SETTINGS frame on the root stream.
       let frame = HTTP2Frame(streamID: .rootStream, payload: .settings(.settings([])))
-      XCTAssertNoThrow(try channel.writeInbound(frame))
+      XCTAssertNoThrow(try channel.writeInbound(frame.encode()))
     }
 
     // Wait for the HTTP/2 stream multiplexer, it _must_ be ready now.
@@ -912,7 +952,7 @@ extension ConnectionManagerTests {
         streamID: .rootStream,
         payload: .goAway(lastStreamID: 1, errorCode: .noError, opaqueData: nil)
       )
-      XCTAssertNoThrow(try channel.writeInbound(goAway))
+      XCTAssertNoThrow(try channel.writeInbound(goAway.encode()))
       self.loop.run()
     }
 
@@ -1018,7 +1058,7 @@ extension ConnectionManagerTests {
     }
 
     // Start the connection.
-    let readyChannelMux: EventLoopFuture<HTTP2StreamMultiplexer> = self.waitForStateChange(
+    let readyChannelMux: EventLoopFuture<NIOHTTP2Handler.StreamMultiplexer> = self.waitForStateChange(
       from: .idle,
       to: .connecting
     ) {
@@ -1029,20 +1069,22 @@ extension ConnectionManagerTests {
 
     // Setup the real channel and activate it.
     let channel = EmbeddedChannel(loop: self.loop)
-    let h2mux = HTTP2StreamMultiplexer(
-      mode: .client,
-      channel: channel,
-      inboundStreamInitializer: nil
+    let idleHandler = GRPCIdleHandler(
+      connectionManager: manager,
+      idleTimeout: .minutes(5),
+      keepalive: .init(),
+      logger: self.logger
     )
-    XCTAssertNoThrow(try channel.pipeline.addHandlers([
-      GRPCIdleHandler(
-        connectionManager: manager,
-        multiplexer: h2mux,
-        idleTimeout: .minutes(5),
-        keepalive: .init(),
-        logger: self.logger
-      ),
-    ]).wait())
+    let h2handler = NIOHTTP2Handler(
+      mode: .client,
+      eventLoop: channel.eventLoop,
+      streamDelegate: idleHandler
+    ) { channel in
+      channel.eventLoop.makeSucceededVoidFuture()
+    }
+    try channel.pipeline.addHandler(h2handler).wait()
+    idleHandler.setMultiplexer(try h2handler.syncMultiplexer())
+    XCTAssertNoThrow(try channel.pipeline.addHandler(idleHandler).wait())
     channelPromise.succeed(channel)
     self.loop.run()
 
@@ -1052,7 +1094,7 @@ extension ConnectionManagerTests {
     // Write a SETTINGS frame on the root stream.
     try self.waitForStateChange(from: .connecting, to: .ready) {
       let frame = HTTP2Frame(streamID: .rootStream, payload: .settings(.settings([])))
-      XCTAssertNoThrow(try channel.writeInbound(frame))
+      XCTAssertNoThrow(try channel.writeInbound(frame.encode()))
     }
 
     // The channel should now be ready.
@@ -1076,7 +1118,7 @@ extension ConnectionManagerTests {
     let readyChannelMux = self.waitForStateChange(
       from: .idle,
       to: .connecting
-    ) { () -> EventLoopFuture<HTTP2StreamMultiplexer> in
+    ) { () -> EventLoopFuture<NIOHTTP2Handler.StreamMultiplexer> in
       let readyChannelMux = manager.getHTTP2Multiplexer()
       self.loop.run()
       return readyChannelMux
@@ -1084,20 +1126,22 @@ extension ConnectionManagerTests {
 
     // Setup the actual channel and activate it.
     let channel = EmbeddedChannel(loop: self.loop)
-    let h2mux = HTTP2StreamMultiplexer(
-      mode: .client,
-      channel: channel,
-      inboundStreamInitializer: nil
+    let idleHandler = GRPCIdleHandler(
+      connectionManager: manager,
+      idleTimeout: .minutes(5),
+      keepalive: .init(),
+      logger: self.logger
     )
-    XCTAssertNoThrow(try channel.pipeline.addHandlers([
-      GRPCIdleHandler(
-        connectionManager: manager,
-        multiplexer: h2mux,
-        idleTimeout: .minutes(5),
-        keepalive: .init(),
-        logger: self.logger
-      ),
-    ]).wait())
+    let h2handler = NIOHTTP2Handler(
+      mode: .client,
+      eventLoop: channel.eventLoop,
+      streamDelegate: idleHandler
+    ) { channel in
+      channel.eventLoop.makeSucceededVoidFuture()
+    }
+    try channel.pipeline.addHandler(h2handler).wait()
+    idleHandler.setMultiplexer(try h2handler.syncMultiplexer())
+    XCTAssertNoThrow(try channel.pipeline.addHandler(idleHandler).wait())
     channelPromise.succeed(channel)
     self.loop.run()
 
@@ -1107,7 +1151,7 @@ extension ConnectionManagerTests {
     // "ready" the connection.
     try self.waitForStateChange(from: .connecting, to: .ready) {
       let frame = HTTP2Frame(streamID: .rootStream, payload: .settings(.settings([])))
-      XCTAssertNoThrow(try channel.writeInbound(frame))
+      XCTAssertNoThrow(try channel.writeInbound(frame.encode()))
     }
 
     // The HTTP/2 stream multiplexer should now be ready.
@@ -1140,12 +1184,6 @@ extension ConnectionManagerTests {
       XCTAssertNoThrow(try channel.finish())
     }
 
-    let multiplexer = HTTP2StreamMultiplexer(
-      mode: .client,
-      channel: channel,
-      inboundStreamInitializer: nil
-    )
-
     class HTTP2Delegate: ConnectionManagerHTTP2Delegate {
       var streamsOpened = 0
       var streamsClosed = 0
@@ -1169,16 +1207,26 @@ extension ConnectionManagerTests {
 
     let http2 = HTTP2Delegate()
 
+    var streamDelegate: NIOHTTP2StreamDelegate? = nil
     let manager = ConnectionManager(
       eventLoop: self.loop,
       channelProvider: HookedChannelProvider { manager, eventLoop -> EventLoopFuture<Channel> in
         let idleHandler = GRPCIdleHandler(
           connectionManager: manager,
-          multiplexer: multiplexer,
           idleTimeout: .minutes(5),
           keepalive: ClientConnectionKeepalive(),
           logger: self.logger
         )
+        let h2Handler = NIOHTTP2Handler(
+          mode: .client,
+          eventLoop: channel.eventLoop,
+          streamDelegate: idleHandler
+        ) { channel in
+            channel.eventLoop.makeSucceededVoidFuture()
+        }
+        try! channel.pipeline.syncOperations.addHandler(h2Handler)
+        idleHandler.setMultiplexer(try! h2Handler.syncMultiplexer())
+        streamDelegate = idleHandler
 
         // We're going to cheat a bit by not putting the multiplexer in the channel. This allows
         // us to just fire stream created/closed events into the channel.
@@ -1210,30 +1258,24 @@ extension ConnectionManagerTests {
       let settings = [HTTP2Setting(parameter: .maxConcurrentStreams, value: maxConcurrentStreams)]
       return HTTP2Frame(streamID: .rootStream, payload: .settings(.settings(settings)))
     }
-    XCTAssertNoThrow(try channel.writeInbound(makeSettingsFrame(maxConcurrentStreams: 42)))
+    XCTAssertNoThrow(try channel.writeInbound(makeSettingsFrame(maxConcurrentStreams: 42).encode()))
 
     // We're ready now so the future multiplexer will resolve and we'll have seen an update to
     // max concurrent streams.
     XCTAssertNoThrow(try futureMultiplexer.wait())
     XCTAssertEqual(http2.maxConcurrentStreams, 42)
 
-    XCTAssertNoThrow(try channel.writeInbound(makeSettingsFrame(maxConcurrentStreams: 13)))
+    XCTAssertNoThrow(try channel.writeInbound(makeSettingsFrame(maxConcurrentStreams: 13).encode()))
     XCTAssertEqual(http2.maxConcurrentStreams, 13)
 
     // Open some streams.
     for streamID in stride(from: HTTP2StreamID(1), to: HTTP2StreamID(9), by: 2) {
-      let streamCreated = NIOHTTP2StreamCreatedEvent(
-        streamID: streamID,
-        localInitialWindowSize: nil,
-        remoteInitialWindowSize: nil
-      )
-      channel.pipeline.fireUserInboundEventTriggered(streamCreated)
+      streamDelegate!.streamCreated(streamID, channel: channel)
     }
 
     // ... and then close them.
     for streamID in stride(from: HTTP2StreamID(1), to: HTTP2StreamID(9), by: 2) {
-      let streamClosed = StreamClosedEvent(streamID: streamID, reason: nil)
-      channel.pipeline.fireUserInboundEventTriggered(streamClosed)
+      streamDelegate!.streamClosed(streamID, channel: channel)
     }
 
     XCTAssertEqual(http2.streamsOpened, 4)
@@ -1246,7 +1288,7 @@ extension ConnectionManagerTests {
       return channelPromise.futureResult
     }
 
-    let multiplexer: EventLoopFuture<HTTP2StreamMultiplexer> = self.waitForStateChange(
+    let multiplexer: EventLoopFuture<NIOHTTP2Handler.StreamMultiplexer> = self.waitForStateChange(
       from: .idle,
       to: .connecting
     ) {

--- a/Tests/GRPCTests/ConnectionManagerTests.swift
+++ b/Tests/GRPCTests/ConnectionManagerTests.swift
@@ -300,6 +300,9 @@ extension ConnectionManagerTests {
     // Oops: wrong way around. We should tolerate this - just don't crash.
     channel.pipeline.fireChannelInactive()
     channel.pipeline.fireChannelActive()
+
+    channel.embeddedEventLoop.run()
+    try manager.shutdown(mode: .forceful).wait()
   }
 
   func testChannelInactiveBeforeActiveWillReconnect() throws {

--- a/Tests/GRPCTests/ConnectionManagerTests.swift
+++ b/Tests/GRPCTests/ConnectionManagerTests.swift
@@ -521,8 +521,8 @@ extension ConnectionManagerTests {
     }
 
     let readyChannelMux = self.waitForStateChanges([
-        Change(from: .idle, to: .connecting),
-        Change(from: .connecting, to: .transientFailure),
+      Change(from: .idle, to: .connecting),
+      Change(from: .connecting, to: .transientFailure),
     ]) { () -> EventLoopFuture<NIOHTTP2Handler.StreamMultiplexer> in
       // Get a HTTP/2 stream multiplexer.
       let readyChannelMux = manager.getHTTP2Multiplexer()
@@ -625,8 +625,8 @@ extension ConnectionManagerTests {
     }
 
     let readyChannelMux = self.waitForStateChanges([
-        Change(from: .idle, to: .connecting),
-        Change(from: .connecting, to: .transientFailure),
+      Change(from: .idle, to: .connecting),
+      Change(from: .connecting, to: .transientFailure),
     ]) { () -> EventLoopFuture<NIOHTTP2Handler.StreamMultiplexer> in
       // Get a HTTP/2 stream multiplexer.
       let readyChannelMux = manager.getHTTP2Multiplexer()

--- a/Tests/GRPCTests/ConnectionPool/ConnectionPoolDelegates.swift
+++ b/Tests/GRPCTests/ConnectionPool/ConnectionPoolDelegates.swift
@@ -13,11 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Dispatch
 import GRPC
 import NIOConcurrencyHelpers
 import NIOCore
-import XCTest
 
 final class IsConnectingDelegate: GRPCConnectionPoolDelegate {
   private let lock = NIOLock()

--- a/Tests/GRPCTests/ConnectionPool/ConnectionPoolDelegates.swift
+++ b/Tests/GRPCTests/ConnectionPool/ConnectionPoolDelegates.swift
@@ -195,7 +195,11 @@ extension EventRecordingConnectionPoolDelegate: @unchecked Sendable {}
 final class AsyncEventStreamConnectionPoolDelegate: GRPCConnectionPoolDelegate {
   private let continuation: AsyncStream<EventRecordingConnectionPoolDelegate.Event>.Continuation
 
-  static func makeDelegateAndAsyncStream() -> (AsyncEventStreamConnectionPoolDelegate, AsyncStream<EventRecordingConnectionPoolDelegate.Event>) {
+  static func makeDelegateAndAsyncStream()
+    -> (
+      AsyncEventStreamConnectionPoolDelegate,
+      AsyncStream<EventRecordingConnectionPoolDelegate.Event>
+    ) {
     var continuation: AsyncStream<EventRecordingConnectionPoolDelegate.Event>.Continuation!
     let asyncStream = AsyncStream(EventRecordingConnectionPoolDelegate.Event.self) {
       continuation = $0

--- a/Tests/GRPCTests/ConnectionPool/ConnectionPoolDelegates.swift
+++ b/Tests/GRPCTests/ConnectionPool/ConnectionPoolDelegates.swift
@@ -13,9 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import Dispatch
 import GRPC
 import NIOConcurrencyHelpers
 import NIOCore
+import XCTest
 
 final class IsConnectingDelegate: GRPCConnectionPoolDelegate {
   private let lock = NIOLock()
@@ -189,3 +191,51 @@ final class EventRecordingConnectionPoolDelegate: GRPCConnectionPoolDelegate {
 }
 
 extension EventRecordingConnectionPoolDelegate: @unchecked Sendable {}
+
+final class AsyncEventStreamConnectionPoolDelegate: GRPCConnectionPoolDelegate {
+  private let continuation: AsyncStream<EventRecordingConnectionPoolDelegate.Event>.Continuation
+
+  static func makeDelegateAndAsyncStream() -> (AsyncEventStreamConnectionPoolDelegate, AsyncStream<EventRecordingConnectionPoolDelegate.Event>) {
+    var continuation: AsyncStream<EventRecordingConnectionPoolDelegate.Event>.Continuation!
+    let asyncStream = AsyncStream(EventRecordingConnectionPoolDelegate.Event.self) {
+      continuation = $0
+    }
+    return (Self(continuation: continuation), asyncStream)
+  }
+
+  init(continuation: AsyncStream<EventRecordingConnectionPoolDelegate.Event>.Continuation) {
+    self.continuation = continuation
+  }
+
+  func connectionAdded(id: GRPCConnectionID) {
+    self.continuation.yield(.connectionAdded(id))
+  }
+
+  func startedConnecting(id: GRPCConnectionID) {
+    self.continuation.yield(.startedConnecting(id))
+  }
+
+  func connectFailed(id: GRPCConnectionID, error: Error) {
+    self.continuation.yield(.connectFailed(id))
+  }
+
+  func connectSucceeded(id: GRPCConnectionID, streamCapacity: Int) {
+    self.continuation.yield(.connectSucceeded(id, streamCapacity))
+  }
+
+  func connectionClosed(id: GRPCConnectionID, error: Error?) {
+    self.continuation.yield(.connectionClosed(id))
+  }
+
+  func connectionUtilizationChanged(id: GRPCConnectionID, streamsUsed: Int, streamCapacity: Int) {
+    self.continuation.yield(.connectionUtilizationChanged(id, streamsUsed, streamCapacity))
+  }
+
+  func connectionQuiescing(id: GRPCConnectionID) {
+    self.continuation.yield(.connectionQuiescing(id))
+  }
+
+  func connectionRemoved(id: GRPCConnectionID) {
+    self.continuation.yield(.connectionRemoved(id))
+  }
+}

--- a/Tests/GRPCTests/ConnectionPool/ConnectionPoolTests.swift
+++ b/Tests/GRPCTests/ConnectionPool/ConnectionPoolTests.swift
@@ -17,7 +17,7 @@
 import Logging
 import NIOCore
 import NIOEmbedded
-@testable import NIOHTTP2
+import NIOHTTP2
 import XCTest
 
 final class ConnectionPoolTests: GRPCTestCase {
@@ -1024,12 +1024,10 @@ internal final class ChannelController {
   }
 
   internal func finish() {
-    while let channel = self.channels.popLast() {
-      if !channel.isActive {
-        continue
+    while let state = self.channels.popLast() {
+      if state.isActive {
+        _ = try? state.channel.finish()
       }
-      // We're okay with this throwing: some channels are left in a bad state (i.e. with errors).
-      _ = try? channel.channel.finish()
     }
   }
 
@@ -1216,12 +1214,138 @@ extension Optional where Wrapped == ConnectionPoolError {
   }
 }
 
-extension HTTP2Frame {
+// Simplified version of the frame encoder found in SwiftNIO HTTP/2
+struct HTTP2FrameEncoder {
+  mutating func encode(frame: HTTP2Frame, to buf: inout ByteBuffer) throws -> IOData? {
+    // note our starting point
+    let start = buf.writerIndex
+
+    //      +-----------------------------------------------+
+    //      |                 Length (24)                   |
+    //      +---------------+---------------+---------------+
+    //      |   Type (8)    |   Flags (8)   |
+    //      +-+-------------+---------------+-------------------------------+
+    //      |R|                 Stream Identifier (31)                      |
+    //      +=+=============================================================+
+    //      |                   Frame Payload (0...)                      ...
+    //      +---------------------------------------------------------------+
+
+    // skip 24-bit length for now, we'll fill that in later
+    buf.moveWriterIndex(forwardBy: 3)
+
+    // 8-bit type
+    buf.writeInteger(frame.code())
+
+    // skip the 8 bit flags for now, we'll fill it in later as well.
+    let flagsIndex = buf.writerIndex
+    var flags = FrameFlags()
+    buf.moveWriterIndex(forwardBy: 1)
+
+    // 32-bit stream identifier -- ensuring the top bit is empty
+    buf.writeInteger(Int32(frame.streamID))
+
+    // frame payload follows, which depends on the frame type itself
+    let payloadStart = buf.writerIndex
+    let extraFrameData: IOData?
+    let payloadSize: Int
+
+    switch frame.payload {
+
+    case .settings(.settings(let settings)):
+      for setting in settings {
+        buf.writeInteger(setting.parameter.networkRepresentation())
+        buf.writeInteger(UInt32(setting.value))
+      }
+
+      payloadSize = settings.count * 6
+      extraFrameData = nil
+
+    case .settings(.ack):
+      payloadSize = 0
+      extraFrameData = nil
+      flags.insert(.ack)
+
+    case .goAway(let lastStreamID, let errorCode, let opaqueData):
+      let streamVal: UInt32 = UInt32(Int(lastStreamID)) & ~0x8000_0000
+      buf.writeInteger(streamVal)
+      buf.writeInteger(UInt32(errorCode.networkCode))
+
+      if let data = opaqueData {
+        payloadSize = data.readableBytes + 8
+        extraFrameData = .byteBuffer(data)
+      } else {
+        payloadSize = 8
+        extraFrameData = nil
+      }
+
+    case .data, .headers, .priority,
+        .rstStream, .pushPromise, .ping,
+        .windowUpdate, .alternativeService, .origin:
+      preconditionFailure("Frame type not supported: \(frame.payload)")
+    }
+
+    // Write the frame data. This is the payload size and the flags byte.
+    buf.writePayloadSize(payloadSize, at: start)
+    buf.setInteger(flags.rawValue, at: flagsIndex)
+
+    // all bytes to write are in the provided buffer now
+    return extraFrameData
+  }
+
+  struct FrameFlags: OptionSet {
+    internal private(set) var rawValue: UInt8
+
+    internal init(rawValue: UInt8) {
+      self.rawValue = rawValue
+    }
+
+    /// ACK flag. Valid on SETTINGS and PING frames.
+    internal static let ack = FrameFlags(rawValue: 0x01)
+  }
+}
+
+internal extension HTTP2SettingsParameter {
+  func networkRepresentation() -> UInt16 {
+    switch self {
+    case HTTP2SettingsParameter.headerTableSize:
+      return UInt16(1)
+    case HTTP2SettingsParameter.enablePush:
+      return UInt16(2)
+    case HTTP2SettingsParameter.maxConcurrentStreams:
+      return UInt16(3)
+    case HTTP2SettingsParameter.initialWindowSize:
+      return UInt16(4)
+    case HTTP2SettingsParameter.maxFrameSize:
+      return UInt16(5)
+    case HTTP2SettingsParameter.maxHeaderListSize:
+      return UInt16(6)
+    case HTTP2SettingsParameter.enableConnectProtocol:
+      return UInt16(8)
+    default:
+      preconditionFailure("Unknown settings parameter.")
+    }
+  }
+}
+
+extension ByteBuffer {
+  fileprivate mutating func writePayloadSize(_ size: Int, at location: Int) {
+    // Yes, this performs better than running a UInt8 through the generic write(integer:) three times.
+    var bytes: (UInt8, UInt8, UInt8)
+    bytes.0 = UInt8((size & 0xff_00_00) >> 16)
+    bytes.1 = UInt8((size & 0x00_ff_00) >>  8)
+    bytes.2 = UInt8( size & 0x00_00_ff)
+    withUnsafeBytes(of: bytes) { ptr in
+      _ = self.setBytes(ptr, at: location)
+    }
+  }
+}
+
+internal extension HTTP2Frame {
   func encode() throws -> ByteBuffer {
     let allocator = ByteBufferAllocator()
     var buffer = allocator.buffer(capacity: 1024)
 
-    var frameEncoder = HTTP2FrameEncoder(allocator: allocator)
+    var frameEncoder = HTTP2FrameEncoder()
     let extraData = try frameEncoder.encode(frame: self, to: &buffer)
     if let extraData = extraData {
       switch extraData {
@@ -1232,5 +1356,22 @@ extension HTTP2Frame {
       }
     }
     return buffer
+  }
+
+  /// The one-byte identifier used to indicate the type of a frame on the wire.
+  func code() -> UInt8 {
+    switch self.payload {
+    case .data:                 return 0x0
+    case .headers:              return 0x1
+    case .priority:             return 0x2
+    case .rstStream:            return 0x3
+    case .settings:             return 0x4
+    case .pushPromise:          return 0x5
+    case .ping:                 return 0x6
+    case .goAway:               return 0x7
+    case .windowUpdate:         return 0x8
+    case .alternativeService:   return 0xa
+    case .origin:               return 0xc
+    }
   }
 }

--- a/Tests/GRPCTests/ConnectionPool/GRPCChannelPoolTests.swift
+++ b/Tests/GRPCTests/ConnectionPool/GRPCChannelPoolTests.swift
@@ -441,54 +441,75 @@ final class GRPCChannelPoolTests: GRPCTestCase {
     }
   }
 
-  func testConnectionPoolDelegateSingleConnection() throws {
-    let recorder = EventRecordingConnectionPoolDelegate()
+  func testConnectionPoolDelegateSingleConnection() async throws {
+    let (delegate, stream) = AsyncEventStreamConnectionPoolDelegate.makeDelegateAndAsyncStream()
     self.setUpClientAndServer(withTLS: false, threads: 1) {
-      $0.delegate = recorder
+      $0.delegate = delegate
     }
 
     let warmup = self.echo.get(.with { $0.text = "" })
     XCTAssertNoThrow(try warmup.status.wait())
 
-    let id = try XCTUnwrap(recorder.first?.id)
-    XCTAssertEqual(recorder.popFirst(), .connectionAdded(id))
-    XCTAssertEqual(recorder.popFirst(), .startedConnecting(id))
-    XCTAssertEqual(recorder.popFirst(), .connectSucceeded(id, 100))
-    XCTAssertEqual(recorder.popFirst(), .connectionUtilizationChanged(id, 1, 100))
-    XCTAssertEqual(recorder.popFirst(), .connectionUtilizationChanged(id, 0, 100))
+    var iterator = stream.makeAsyncIterator()
+
+    var event = await iterator.next()
+    let id = try XCTUnwrap(event?.id)
+    XCTAssertEqual(event, .connectionAdded(id))
+    event = await iterator.next()
+    XCTAssertEqual(event, .startedConnecting(id))
+    event = await iterator.next()
+    XCTAssertEqual(event, .connectSucceeded(id, 100))
+    event = await iterator.next()
+    XCTAssertEqual(event, .connectionUtilizationChanged(id, 1, 100))
+    event = await iterator.next()
+    XCTAssertEqual(event, .connectionUtilizationChanged(id, 0, 100))
 
     let rpcs: [ClientStreamingCall<Echo_EchoRequest, Echo_EchoResponse>] = try (1 ... 10).map { i in
       let rpc = self.echo.collect()
       XCTAssertNoThrow(try rpc.sendMessage(.with { $0.text = "foo" }).wait())
-      XCTAssertEqual(recorder.popFirst(), .connectionUtilizationChanged(id, i, 100))
       return rpc
+    }
+
+    for (i, _) in rpcs.enumerated() {
+      let event = await iterator.next()
+      XCTAssertEqual(event, .connectionUtilizationChanged(id, i + 1, 100))
     }
 
     for (i, rpc) in rpcs.enumerated() {
       XCTAssertNoThrow(try rpc.sendEnd().wait())
       XCTAssertNoThrow(try rpc.status.wait())
-      XCTAssertEqual(recorder.popFirst(), .connectionUtilizationChanged(id, 10 - (i + 1), 100))
+      let event = await iterator.next()
+      XCTAssertEqual(event, .connectionUtilizationChanged(id, 10 - (i + 1), 100))
     }
 
     XCTAssertNoThrow(try self.channel?.close().wait())
-    XCTAssertEqual(recorder.popFirst(), .connectionClosed(id))
-    XCTAssertEqual(recorder.popFirst(), .connectionRemoved(id))
-    XCTAssert(recorder.isEmpty)
+    event = await iterator.next()
+    XCTAssertEqual(event, .connectionClosed(id))
+    event = await iterator.next()
+    XCTAssertEqual(event, .connectionRemoved(id))
   }
 
-  func testConnectionPoolDelegateQuiescing() throws {
-    let recorder = EventRecordingConnectionPoolDelegate()
+  func testConnectionPoolDelegateQuiescing() async throws {
+    let (delegate, stream) = AsyncEventStreamConnectionPoolDelegate.makeDelegateAndAsyncStream()
     self.setUpClientAndServer(withTLS: false, threads: 1) {
-      $0.delegate = recorder
+      $0.delegate = delegate
     }
 
     XCTAssertNoThrow(try self.echo.get(.with { $0.text = "foo" }).status.wait())
-    let id1 = try XCTUnwrap(recorder.first?.id)
-    XCTAssertEqual(recorder.popFirst(), .connectionAdded(id1))
-    XCTAssertEqual(recorder.popFirst(), .startedConnecting(id1))
-    XCTAssertEqual(recorder.popFirst(), .connectSucceeded(id1, 100))
-    XCTAssertEqual(recorder.popFirst(), .connectionUtilizationChanged(id1, 1, 100))
-    XCTAssertEqual(recorder.popFirst(), .connectionUtilizationChanged(id1, 0, 100))
+
+    var iterator = stream.makeAsyncIterator()
+
+    var event = await iterator.next()
+    let id1 = try XCTUnwrap(event?.id)
+    XCTAssertEqual(event, .connectionAdded(id1))
+    event = await iterator.next()
+    XCTAssertEqual(event, .startedConnecting(id1))
+    event = await iterator.next()
+    XCTAssertEqual(event, .connectSucceeded(id1, 100))
+    event = await iterator.next()
+    XCTAssertEqual(event, .connectionUtilizationChanged(id1, 1, 100))
+    event = await iterator.next()
+    XCTAssertEqual(event, .connectionUtilizationChanged(id1, 0, 100))
 
     // Start an RPC.
     let rpc = self.echo.collect()
@@ -496,9 +517,12 @@ final class GRPCChannelPoolTests: GRPCTestCase {
     // Complete another one to make sure the previous one is known by the server.
     XCTAssertNoThrow(try self.echo.get(.with { $0.text = "foo" }).status.wait())
 
-    XCTAssertEqual(recorder.popFirst(), .connectionUtilizationChanged(id1, 1, 100))
-    XCTAssertEqual(recorder.popFirst(), .connectionUtilizationChanged(id1, 2, 100))
-    XCTAssertEqual(recorder.popFirst(), .connectionUtilizationChanged(id1, 1, 100))
+    event = await iterator.next()
+    XCTAssertEqual(event, .connectionUtilizationChanged(id1, 1, 100))
+    event = await iterator.next()
+    XCTAssertEqual(event, .connectionUtilizationChanged(id1, 2, 100))
+    event = await iterator.next()
+    XCTAssertEqual(event, .connectionUtilizationChanged(id1, 1, 100))
 
     // Start shutting the server down.
     let didShutdown = self.server!.initiateGracefulShutdown()
@@ -507,7 +531,8 @@ final class GRPCChannelPoolTests: GRPCTestCase {
     // Pause a moment so we know the client received the GOAWAY.
     let sleep = self.group.any().scheduleTask(in: .milliseconds(50)) {}
     XCTAssertNoThrow(try sleep.futureResult.wait())
-    XCTAssertEqual(recorder.popFirst(), .connectionQuiescing(id1))
+    event = await iterator.next()
+    XCTAssertEqual(event, .connectionQuiescing(id1))
 
     // Finish the RPC.
     XCTAssertNoThrow(try rpc.sendEnd().wait())

--- a/Tests/GRPCTests/ConnectionPool/GRPCChannelPoolTests.swift
+++ b/Tests/GRPCTests/ConnectionPool/GRPCChannelPoolTests.swift
@@ -464,7 +464,7 @@ final class GRPCChannelPoolTests: GRPCTestCase {
     event = await iterator.next()
     XCTAssertEqual(event, .connectionUtilizationChanged(id, 0, 100))
 
-    let rpcs: [ClientStreamingCall<Echo_EchoRequest, Echo_EchoResponse>] = try (1 ... 10).map { i in
+    let rpcs: [ClientStreamingCall<Echo_EchoRequest, Echo_EchoResponse>] = try (1 ... 10).map { _ in
       let rpc = self.echo.collect()
       XCTAssertNoThrow(try rpc.sendMessage(.with { $0.text = "foo" }).wait())
       return rpc


### PR DESCRIPTION
Motivation:

Switch from `HTTP2StreamMultiplexer` to `HTTP2Handler.StreamMultiplexer` to benefit from improved performance due to reduced allocations.

Modifications:

- Replace all references to  `HTTP2StreamMultiplexer` with `HTTP2Handler.StreamMultiplexer`.
- `GRPCIdleHandler` is now a `NIOHTTP2StreamDelegate` to allow it to receive notifications when a stream is created or closed rather than using `UserInboundEvent`s.
- `GRPCIdleHandler` now has two states of configuration in the client case. This is required to break a cycle of dependencies which would otherwise exist at `init` because the `GRPCIdleHandler` holds a reference to the `HTTP2Handler.StreamMultiplexer` (which is a member of the `HTTP2Handler` itself) and the `HTTP2Handler` holds a reference back to the `GRPCIdleHandler` as its stream delegate.
- Several tests now insert `HTTP2Handler` into the pipeline where they used to use `HTTP2StreamMultiplexer`. This causes a few changes in behavior often around different assertions. This required some small supporting changes.
- Introduce test infrastructure `AsyncEventStreamConnectionPoolDelegate` to eliminate observed racey behavior in `EventRecordingConnectionPoolDelegate`.

Result:

Performance increase without overall behavior changes.