### PR TITLE
Change a stray GRPCSendable to Sendable

### DIFF
--- a/Sources/GRPC/Server.swift
+++ b/Sources/GRPC/Server.swift
@@ -453,7 +453,7 @@ extension Server {
 }
 
 extension Server.Configuration {
-  public struct CORS: Hashable, GRPCSendable {
+  public struct CORS: Hashable, Sendable {
     /// Determines which 'origin' header field values are permitted in a CORS request.
     public var allowedOrigins: AllowedOrigins
     /// Sets the headers which are permitted in a response to a CORS request.


### PR DESCRIPTION
Motivation:

Occurrences of GRPCSendable were replaced with Sendable in #1584 as we dropped support for 5.5. However, one was missed.

Modifications:

- Change last `GRPCSendable` to `Sendable`

Result:

Fewer warnings.