### PR TITLE
Allow custom verification callback to be configured for servers

### DIFF
--- a/Sources/GRPC/Server.swift
+++ b/Sources/GRPC/Server.swift
@@ -140,7 +140,17 @@ public final class Server {
           let sync = channel.pipeline.syncOperations
           #if canImport(NIOSSL)
           if let sslContext = try sslContext?.get() {
-            try sync.addHandler(NIOSSLServerHandler(context: sslContext))
+            let sslHandler: NIOSSLServerHandler
+            if let verify = configuration.tlsConfiguration?.nioSSLCustomVerificationCallback {
+              sslHandler = NIOSSLServerHandler(
+                context: sslContext,
+                customVerificationCallback: verify
+              )
+            } else {
+              sslHandler = NIOSSLServerHandler(context: sslContext)
+            }
+
+            try sync.addHandler(sslHandler)
           }
           #endif // canImport(NIOSSL)
 

--- a/Tests/GRPCTests/AsyncAwaitSupport/AsyncClientTests.swift
+++ b/Tests/GRPCTests/AsyncAwaitSupport/AsyncClientTests.swift
@@ -33,12 +33,12 @@ final class AsyncClientCancellationTests: GRPCTestCase {
 
   override func tearDown() async throws {
     if self.pool != nil {
-      try self.pool.close().wait()
+      try await self.pool.close().get()
       self.pool = nil
     }
 
     if self.server != nil {
-      try self.server.close().wait()
+      try await self.server.close().get()
       self.server = nil
     }
 

--- a/Tests/GRPCTests/ConnectionPool/ConnectionPoolTests.swift
+++ b/Tests/GRPCTests/ConnectionPool/ConnectionPoolTests.swift
@@ -1245,7 +1245,6 @@ struct HTTP2FrameEncoder {
     buf.writeInteger(Int32(frame.streamID))
 
     // frame payload follows, which depends on the frame type itself
-    let payloadStart = buf.writerIndex
     let extraFrameData: IOData?
     let payloadSize: Int
 


### PR DESCRIPTION
Motivation:

NIOSSL allows users to override its certificate verification logic by setting a verification callback. gRPC allows clients to configure this but not servers.

Modifications:

- Add extra API to `GRPCTLSConfiguration` to allow custom verification callbacks to be set for servers.

Result:

Users can override the certificate verification logic on the server.