### PR TITLE
Fix warnings from nightly Swift builds

### DIFF
--- a/Sources/GRPC/ClientConnection.swift
+++ b/Sources/GRPC/ClientConnection.swift
@@ -13,7 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#if os(Linux)
 @preconcurrency import Foundation
+#else
+import Foundation
+#endif
 
 import Logging
 import NIOCore

--- a/Sources/GRPC/Interceptor/ClientTransportFactory.swift
+++ b/Sources/GRPC/Interceptor/ClientTransportFactory.swift
@@ -21,10 +21,10 @@ import protocol SwiftProtobuf.Message
 @usableFromInline
 internal struct ClientTransportFactory<Request, Response> {
   /// The underlying transport factory.
-  private var factory: Factory<Request, Response>
+  private var factory: Factory
 
   @usableFromInline
-  internal enum Factory<Request, Response> {
+  internal enum Factory {
     case http2(HTTP2ClientTransportFactory<Request, Response>)
     case fake(FakeClientTransportFactory<Request, Response>)
   }
@@ -45,13 +45,13 @@ internal struct ClientTransportFactory<Request, Response> {
   ///   - errorDelegate: A client error delegate.
   /// - Returns: A factory for making and configuring HTTP/2 based transport.
   @usableFromInline
-  internal static func http2<Request: SwiftProtobuf.Message, Response: SwiftProtobuf.Message>(
+  internal static func http2(
     channel: EventLoopFuture<Channel>,
     authority: String,
     scheme: String,
     maximumReceiveMessageLength: Int,
     errorDelegate: ClientErrorDelegate?
-  ) -> ClientTransportFactory<Request, Response> {
+  ) -> ClientTransportFactory<Request, Response> where Request: SwiftProtobuf.Message, Response: SwiftProtobuf.Message {
     let http2 = HTTP2ClientTransportFactory<Request, Response>(
       streamChannel: channel,
       scheme: scheme,
@@ -72,13 +72,13 @@ internal struct ClientTransportFactory<Request, Response> {
   ///   - errorDelegate: A client error delegate.
   /// - Returns: A factory for making and configuring HTTP/2 based transport.
   @usableFromInline
-  internal static func http2<Request: GRPCPayload, Response: GRPCPayload>(
+  internal static func http2(
     channel: EventLoopFuture<Channel>,
     authority: String,
     scheme: String,
     maximumReceiveMessageLength: Int,
     errorDelegate: ClientErrorDelegate?
-  ) -> ClientTransportFactory<Request, Response> {
+  ) -> ClientTransportFactory<Request, Response> where Request: GRPCPayload, Response: GRPCPayload {
     let http2 = HTTP2ClientTransportFactory<Request, Response>(
       streamChannel: channel,
       scheme: scheme,
@@ -95,9 +95,9 @@ internal struct ClientTransportFactory<Request, Response> {
   /// - Parameter fakeResponse: The fake response stream.
   /// - Returns: A factory for making and configuring fake transport.
   @usableFromInline
-  internal static func fake<Request: SwiftProtobuf.Message, Response: SwiftProtobuf.Message>(
+  internal static func fake(
     _ fakeResponse: _FakeResponseStream<Request, Response>?
-  ) -> ClientTransportFactory<Request, Response> {
+  ) -> ClientTransportFactory<Request, Response> where Request: SwiftProtobuf.Message, Response: SwiftProtobuf.Message {
     let factory = FakeClientTransportFactory(
       fakeResponse,
       requestSerializer: ProtobufSerializer(),
@@ -112,9 +112,9 @@ internal struct ClientTransportFactory<Request, Response> {
   /// - Parameter fakeResponse: The fake response stream.
   /// - Returns: A factory for making and configuring fake transport.
   @usableFromInline
-  internal static func fake<Request: GRPCPayload, Response: GRPCPayload>(
+  internal static func fake(
     _ fakeResponse: _FakeResponseStream<Request, Response>?
-  ) -> ClientTransportFactory<Request, Response> {
+  ) -> ClientTransportFactory<Request, Response> where Request: GRPCPayload, Response: GRPCPayload {
     let factory = FakeClientTransportFactory(
       fakeResponse,
       requestSerializer: GRPCPayloadSerializer(),
@@ -239,7 +239,7 @@ internal struct HTTP2ClientTransportFactory<Request, Response> {
     )
   }
 
-  fileprivate func configure<Request, Response>(_ transport: ClientTransport<Request, Response>) {
+  fileprivate func configure(_ transport: ClientTransport<Request, Response>) {
     transport.configure { _ in
       self.streamChannel.flatMapThrowing { channel in
         // This initializer will always occur on the appropriate event loop, sync operations are
@@ -342,7 +342,7 @@ internal struct FakeClientTransportFactory<Request, Response> {
     )
   }
 
-  fileprivate func configure<Request, Response>(_ transport: ClientTransport<Request, Response>) {
+  fileprivate func configure(_ transport: ClientTransport<Request, Response>) {
     transport.configure { handler in
       if let fakeResponse = self.fakeResponseStream {
         return fakeResponse.channel.pipeline.addHandlers(self.codec, handler).always { result in

--- a/Sources/GRPC/Interceptor/ClientTransportFactory.swift
+++ b/Sources/GRPC/Interceptor/ClientTransportFactory.swift
@@ -51,7 +51,8 @@ internal struct ClientTransportFactory<Request, Response> {
     scheme: String,
     maximumReceiveMessageLength: Int,
     errorDelegate: ClientErrorDelegate?
-  ) -> ClientTransportFactory<Request, Response> where Request: SwiftProtobuf.Message, Response: SwiftProtobuf.Message {
+  ) -> ClientTransportFactory<Request, Response> where Request: SwiftProtobuf.Message,
+    Response: SwiftProtobuf.Message {
     let http2 = HTTP2ClientTransportFactory<Request, Response>(
       streamChannel: channel,
       scheme: scheme,
@@ -97,7 +98,8 @@ internal struct ClientTransportFactory<Request, Response> {
   @usableFromInline
   internal static func fake(
     _ fakeResponse: _FakeResponseStream<Request, Response>?
-  ) -> ClientTransportFactory<Request, Response> where Request: SwiftProtobuf.Message, Response: SwiftProtobuf.Message {
+  ) -> ClientTransportFactory<Request, Response> where Request: SwiftProtobuf.Message,
+    Response: SwiftProtobuf.Message {
     let factory = FakeClientTransportFactory(
       fakeResponse,
       requestSerializer: ProtobufSerializer(),

--- a/Sources/GRPCInteroperabilityTestsImplementation/GRPCTestingConvenienceMethods.swift
+++ b/Sources/GRPCInteroperabilityTestsImplementation/GRPCTestingConvenienceMethods.swift
@@ -21,9 +21,11 @@ import SwiftProtobuf
 // MARK: - Payload creation
 
 extension Grpc_Testing_Payload {
-  static func bytes<T>(of body: inout T) -> Grpc_Testing_Payload {
+  static func bytes(of value: UInt64) -> Grpc_Testing_Payload {
     return Grpc_Testing_Payload.with { payload in
-      payload.body = Data(bytes: &body, count: MemoryLayout.size(ofValue: body))
+      withUnsafeBytes(of: value) { bytes in
+        payload.body = Data(bytes)
+      }
     }
   }
 

--- a/Sources/GRPCInteroperabilityTestsImplementation/InteroperabilityTestCases.swift
+++ b/Sources/GRPCInteroperabilityTestsImplementation/InteroperabilityTestCases.swift
@@ -67,8 +67,8 @@ class CacheableUnary: InteroperabilityTest {
   func run(using connection: ClientConnection) throws {
     let client = Grpc_Testing_TestServiceNIOClient(channel: connection)
 
-    var timestamp = DispatchTime.now().rawValue
-    let request = Grpc_Testing_SimpleRequest.withPayload(of: .bytes(of: &timestamp))
+    let timestamp = DispatchTime.now().uptimeNanoseconds
+    let request = Grpc_Testing_SimpleRequest.withPayload(of: .bytes(of: timestamp))
 
     let headers: HPACKHeaders = ["x-user-ip": "1.2.3.4"]
     let callOptions = CallOptions(customMetadata: headers, cacheable: true)

--- a/Tests/GRPCTests/XCTestHelpers.swift
+++ b/Tests/GRPCTests/XCTestHelpers.swift
@@ -100,24 +100,24 @@ struct Matcher<Value> {
   // MARK: Sugar
 
   /// Just returns the provided matcher.
-  static func `is`<Value>(_ matcher: Matcher<Value>) -> Matcher<Value> {
+  static func `is`<V>(_ matcher: Matcher<V>) -> Matcher<V> {
     return matcher
   }
 
   /// Just returns the provided matcher.
-  static func and<Value>(_ matcher: Matcher<Value>) -> Matcher<Value> {
+  static func and<V>(_ matcher: Matcher<V>) -> Matcher<V> {
     return matcher
   }
 
   // MARK: Equality
 
   /// Checks the equality of the actual value against the provided value. See `equalTo(_:)`.
-  static func `is`<Value: Equatable>(_ value: Value) -> Matcher<Value> {
+  static func `is`<V: Equatable>(_ value: V) -> Matcher<V> {
     return .equalTo(value)
   }
 
   /// Checks the equality of the actual value against the provided value.
-  static func equalTo<Value: Equatable>(_ expected: Value) -> Matcher<Value> {
+  static func equalTo<V: Equatable>(_ expected: V) -> Matcher<V> {
     return .init { actual in
       actual == expected
         ? .match
@@ -133,7 +133,7 @@ struct Matcher<Value> {
   }
 
   /// Matches if the value is `nil`.
-  static func `nil`<Value>() -> Matcher<Value?> {
+  static func `nil`<V>() -> Matcher<V?> {
     return .init { actual in
       actual == nil
         ? .match
@@ -142,7 +142,7 @@ struct Matcher<Value> {
   }
 
   /// Matches if the value is not `nil`.
-  static func notNil<Value>(_ matcher: Matcher<Value>? = nil) -> Matcher<Value?> {
+  static func notNil<V>(_ matcher: Matcher<V>? = nil) -> Matcher<V?> {
     return .init { actual in
       if let actual = actual {
         return matcher?.evaluate(actual) ?? .match
@@ -154,7 +154,7 @@ struct Matcher<Value> {
 
   // MARK: Result
 
-  static func success<Value>(_ matcher: Matcher<Value>? = nil) -> Matcher<Result<Value, Error>> {
+  static func success<V>(_ matcher: Matcher<V>? = nil) -> Matcher<Result<V, Error>> {
     return .init { actual in
       switch actual {
       case let .success(value):
@@ -191,7 +191,7 @@ struct Matcher<Value> {
 
   // MARK: Utility
 
-  static func all<Value>(_ matchers: Matcher<Value>...) -> Matcher<Value> {
+  static func all<V>(_ matchers: Matcher<V>...) -> Matcher<V> {
     return .init { actual in
       for matcher in matchers {
         let result = matcher.evaluate(actual)
@@ -209,7 +209,7 @@ struct Matcher<Value> {
   // MARK: Type
 
   /// Checks that the actual value is an instance of the given type.
-  static func instanceOf<Value, Expected>(_: Expected.Type) -> Matcher<Value> {
+  static func instanceOf<V, Expected>(_: Expected.Type) -> Matcher<V> {
     return .init { actual in
       if actual is Expected {
         return .match
@@ -635,7 +635,7 @@ struct ExpressionMatcher<Value> {
 
   /// Asserts that the expression does not throw and error. Returns the result of any provided
   /// matcher on the result of the expression.
-  static func doesNotThrow<Value>(_ matcher: Matcher<Value>? = nil) -> ExpressionMatcher<Value> {
+  static func doesNotThrow<V>(_ matcher: Matcher<V>? = nil) -> ExpressionMatcher<V> {
     return .init { expression in
       do {
         let value = try expression()
@@ -648,7 +648,7 @@ struct ExpressionMatcher<Value> {
 
   /// Asserts that the expression throws and error. Returns the result of any provided matcher
   /// on the error thrown by the expression.
-  static func `throws`<Value>(_ matcher: Matcher<Error>? = nil) -> ExpressionMatcher<Value> {
+  static func `throws`<V>(_ matcher: Matcher<Error>? = nil) -> ExpressionMatcher<V> {
     return .init { expression in
       do {
         let value = try expression()


### PR DESCRIPTION
Motivation:

Nightly swift builds produce a few warnings: mostly around shadowing generics from an outer scope.

Modifications:

- Fix warnings.

Result:

Fewer warnings.