### PR TITLE
Fix stream accounting bug when stream close leads to connection close

### DIFF
--- a/Sources/GRPC/ConnectionPool/ConnectionPool+PerConnectionState.swift
+++ b/Sources/GRPC/ConnectionPool/ConnectionPool+PerConnectionState.swift
@@ -27,6 +27,11 @@ extension ConnectionPool {
     internal var _availability: StreamAvailability?
 
     @usableFromInline
+    internal var isAvailable: Bool {
+      return self._availability != nil
+    }
+
+    @usableFromInline
     internal var isQuiescing: Bool {
       get {
         return self._availability?.isQuiescing ?? false

--- a/Sources/GRPC/ConnectionPool/ConnectionPool.swift
+++ b/Sources/GRPC/ConnectionPool/ConnectionPool.swift
@@ -701,9 +701,9 @@ extension ConnectionPool: ConnectionManagerHTTP2Delegate {
       )
     }
 
-    // Don't return the stream to the pool manager if the connection is quiescing, they were returned
-    // when the connection started quiescing.
-    if !self._connections.values[index].isQuiescing {
+    // Return the stream to the pool manager if the connection is available and not quiescing. For
+    // quiescing connections streams were returned when the connection started quiescing.
+    if self._connections.values[index].isAvailable, !self._connections.values[index].isQuiescing {
       self.streamLender.returnStreams(1, to: self)
 
       // A stream was returned: we may be able to service a waiter now.


### PR DESCRIPTION
Motivation:

The connection pool manager manages a pool of connections per event-loop. It spreads load across these pools by tracking how many streams a pool has capacity for and how many streams are in use. To facilitate this each pool reports back to the pool manager when streams have been reserved and when they have been returned.

If connections are closed unexpectedly (due to an error, for example) then the pool reports this in bulk. However when the streams are closed they are also reported back to the pool manager. This means the manager can end up thinking a pool has a negative number of reserved streams which results in an assertion failure.

Modifications:

- Check if the connection a stream is being returned to is available before reporting stream closures to the pool manager.

Result:

- Better stream accounting.
- Resolved #1598