### PR TITLE
Improve Sendable checking for server code

### DIFF
--- a/Sources/Examples/HelloWorld/Model/helloworld.grpc.swift
+++ b/Sources/Examples/HelloWorld/Model/helloworld.grpc.swift
@@ -252,12 +252,12 @@ extension Helloworld_GreeterProvider {
 ///
 /// To implement a server, implement an object which conforms to this protocol.
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-public protocol Helloworld_GreeterAsyncProvider: CallHandlerProvider {
+public protocol Helloworld_GreeterAsyncProvider: CallHandlerProvider, Sendable {
   static var serviceDescriptor: GRPCServiceDescriptor { get }
   var interceptors: Helloworld_GreeterServerInterceptorFactoryProtocol? { get }
 
   /// Sends a greeting.
-  @Sendable func sayHello(
+  func sayHello(
     request: Helloworld_HelloRequest,
     context: GRPCAsyncServerCallContext
   ) async throws -> Helloworld_HelloReply
@@ -288,7 +288,7 @@ extension Helloworld_GreeterAsyncProvider {
         requestDeserializer: ProtobufDeserializer<Helloworld_HelloRequest>(),
         responseSerializer: ProtobufSerializer<Helloworld_HelloReply>(),
         interceptors: self.interceptors?.makeSayHelloInterceptors() ?? [],
-        wrapping: self.sayHello(request:context:)
+        wrapping: { try await self.sayHello(request: $0, context: $1) }
       )
 
     default:
@@ -297,7 +297,7 @@ extension Helloworld_GreeterAsyncProvider {
   }
 }
 
-public protocol Helloworld_GreeterServerInterceptorFactoryProtocol {
+public protocol Helloworld_GreeterServerInterceptorFactoryProtocol: Sendable {
 
   /// - Returns: Interceptors to use when handling 'sayHello'.
   ///   Defaults to calling `self.makeInterceptors()`.

--- a/Sources/GRPC/Interceptor/ServerInterceptors.swift
+++ b/Sources/GRPC/Interceptor/ServerInterceptors.swift
@@ -42,7 +42,7 @@ import NIOCore
 /// require any extra attention. However, if work is done on a `DispatchQueue` or _other_
 /// `EventLoop` then implementers should ensure that they use `context` from the correct
 /// `EventLoop`.
-open class ServerInterceptor<Request, Response> {
+open class ServerInterceptor<Request, Response>: @unchecked Sendable {
   public init() {}
 
   /// Called when the interceptor has received a request part to handle.

--- a/Sources/GRPCInteroperabilityTestsImplementation/TestServiceAsyncProvider.swift
+++ b/Sources/GRPCInteroperabilityTestsImplementation/TestServiceAsyncProvider.swift
@@ -22,8 +22,8 @@ import NIOCore
 ///
 /// See: https://github.com/grpc/grpc/blob/master/doc/interop-test-descriptions.md#server
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-public class TestServiceAsyncProvider: Grpc_Testing_TestServiceAsyncProvider {
-  public var interceptors: Grpc_Testing_TestServiceServerInterceptorFactoryProtocol?
+public final class TestServiceAsyncProvider: Grpc_Testing_TestServiceAsyncProvider {
+  public let interceptors: Grpc_Testing_TestServiceServerInterceptorFactoryProtocol? = nil
 
   public init() {}
 

--- a/Sources/protoc-gen-grpc-swift/Generator-Server.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator-Server.swift
@@ -148,7 +148,7 @@ extension Generator {
   }
 
   private func printServerInterceptorFactoryProtocol() {
-    self.println("\(self.access) protocol \(self.serverInterceptorProtocolName) {")
+    self.println("\(self.access) protocol \(self.serverInterceptorProtocolName): Sendable {")
     self.withIndentation {
       // Method specific interceptors.
       for method in service.methods {

--- a/Tests/GRPCTests/Codegen/Normalization/normalization.grpc.swift
+++ b/Tests/GRPCTests/Codegen/Normalization/normalization.grpc.swift
@@ -803,49 +803,49 @@ extension Normalization_NormalizationProvider {
 
 /// To implement a server, implement an object which conforms to this protocol.
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-internal protocol Normalization_NormalizationAsyncProvider: CallHandlerProvider {
+internal protocol Normalization_NormalizationAsyncProvider: CallHandlerProvider, Sendable {
   static var serviceDescriptor: GRPCServiceDescriptor { get }
   var interceptors: Normalization_NormalizationServerInterceptorFactoryProtocol? { get }
 
-  @Sendable func Unary(
+  func Unary(
     request: SwiftProtobuf.Google_Protobuf_Empty,
     context: GRPCAsyncServerCallContext
   ) async throws -> Normalization_FunctionName
 
-  @Sendable func unary(
+  func unary(
     request: SwiftProtobuf.Google_Protobuf_Empty,
     context: GRPCAsyncServerCallContext
   ) async throws -> Normalization_FunctionName
 
-  @Sendable func ServerStreaming(
-    request: SwiftProtobuf.Google_Protobuf_Empty,
-    responseStream: GRPCAsyncResponseStreamWriter<Normalization_FunctionName>,
-    context: GRPCAsyncServerCallContext
-  ) async throws
-
-  @Sendable func serverStreaming(
+  func ServerStreaming(
     request: SwiftProtobuf.Google_Protobuf_Empty,
     responseStream: GRPCAsyncResponseStreamWriter<Normalization_FunctionName>,
     context: GRPCAsyncServerCallContext
   ) async throws
 
-  @Sendable func ClientStreaming(
+  func serverStreaming(
+    request: SwiftProtobuf.Google_Protobuf_Empty,
+    responseStream: GRPCAsyncResponseStreamWriter<Normalization_FunctionName>,
+    context: GRPCAsyncServerCallContext
+  ) async throws
+
+  func ClientStreaming(
     requestStream: GRPCAsyncRequestStream<SwiftProtobuf.Google_Protobuf_Empty>,
     context: GRPCAsyncServerCallContext
   ) async throws -> Normalization_FunctionName
 
-  @Sendable func clientStreaming(
+  func clientStreaming(
     requestStream: GRPCAsyncRequestStream<SwiftProtobuf.Google_Protobuf_Empty>,
     context: GRPCAsyncServerCallContext
   ) async throws -> Normalization_FunctionName
 
-  @Sendable func BidirectionalStreaming(
+  func BidirectionalStreaming(
     requestStream: GRPCAsyncRequestStream<SwiftProtobuf.Google_Protobuf_Empty>,
     responseStream: GRPCAsyncResponseStreamWriter<Normalization_FunctionName>,
     context: GRPCAsyncServerCallContext
   ) async throws
 
-  @Sendable func bidirectionalStreaming(
+  func bidirectionalStreaming(
     requestStream: GRPCAsyncRequestStream<SwiftProtobuf.Google_Protobuf_Empty>,
     responseStream: GRPCAsyncResponseStreamWriter<Normalization_FunctionName>,
     context: GRPCAsyncServerCallContext
@@ -877,7 +877,7 @@ extension Normalization_NormalizationAsyncProvider {
         requestDeserializer: ProtobufDeserializer<SwiftProtobuf.Google_Protobuf_Empty>(),
         responseSerializer: ProtobufSerializer<Normalization_FunctionName>(),
         interceptors: self.interceptors?.makeUnaryInterceptors() ?? [],
-        wrapping: self.Unary(request:context:)
+        wrapping: { try await self.Unary(request: $0, context: $1) }
       )
 
     case "unary":
@@ -886,7 +886,7 @@ extension Normalization_NormalizationAsyncProvider {
         requestDeserializer: ProtobufDeserializer<SwiftProtobuf.Google_Protobuf_Empty>(),
         responseSerializer: ProtobufSerializer<Normalization_FunctionName>(),
         interceptors: self.interceptors?.makeunaryInterceptors() ?? [],
-        wrapping: self.unary(request:context:)
+        wrapping: { try await self.unary(request: $0, context: $1) }
       )
 
     case "ServerStreaming":
@@ -895,7 +895,7 @@ extension Normalization_NormalizationAsyncProvider {
         requestDeserializer: ProtobufDeserializer<SwiftProtobuf.Google_Protobuf_Empty>(),
         responseSerializer: ProtobufSerializer<Normalization_FunctionName>(),
         interceptors: self.interceptors?.makeServerStreamingInterceptors() ?? [],
-        wrapping: self.ServerStreaming(request:responseStream:context:)
+        wrapping: { try await self.ServerStreaming(request: $0, responseStream: $1, context: $2) }
       )
 
     case "serverStreaming":
@@ -904,7 +904,7 @@ extension Normalization_NormalizationAsyncProvider {
         requestDeserializer: ProtobufDeserializer<SwiftProtobuf.Google_Protobuf_Empty>(),
         responseSerializer: ProtobufSerializer<Normalization_FunctionName>(),
         interceptors: self.interceptors?.makeserverStreamingInterceptors() ?? [],
-        wrapping: self.serverStreaming(request:responseStream:context:)
+        wrapping: { try await self.serverStreaming(request: $0, responseStream: $1, context: $2) }
       )
 
     case "ClientStreaming":
@@ -913,7 +913,7 @@ extension Normalization_NormalizationAsyncProvider {
         requestDeserializer: ProtobufDeserializer<SwiftProtobuf.Google_Protobuf_Empty>(),
         responseSerializer: ProtobufSerializer<Normalization_FunctionName>(),
         interceptors: self.interceptors?.makeClientStreamingInterceptors() ?? [],
-        wrapping: self.ClientStreaming(requestStream:context:)
+        wrapping: { try await self.ClientStreaming(requestStream: $0, context: $1) }
       )
 
     case "clientStreaming":
@@ -922,7 +922,7 @@ extension Normalization_NormalizationAsyncProvider {
         requestDeserializer: ProtobufDeserializer<SwiftProtobuf.Google_Protobuf_Empty>(),
         responseSerializer: ProtobufSerializer<Normalization_FunctionName>(),
         interceptors: self.interceptors?.makeclientStreamingInterceptors() ?? [],
-        wrapping: self.clientStreaming(requestStream:context:)
+        wrapping: { try await self.clientStreaming(requestStream: $0, context: $1) }
       )
 
     case "BidirectionalStreaming":
@@ -931,7 +931,7 @@ extension Normalization_NormalizationAsyncProvider {
         requestDeserializer: ProtobufDeserializer<SwiftProtobuf.Google_Protobuf_Empty>(),
         responseSerializer: ProtobufSerializer<Normalization_FunctionName>(),
         interceptors: self.interceptors?.makeBidirectionalStreamingInterceptors() ?? [],
-        wrapping: self.BidirectionalStreaming(requestStream:responseStream:context:)
+        wrapping: { try await self.BidirectionalStreaming(requestStream: $0, responseStream: $1, context: $2) }
       )
 
     case "bidirectionalStreaming":
@@ -940,7 +940,7 @@ extension Normalization_NormalizationAsyncProvider {
         requestDeserializer: ProtobufDeserializer<SwiftProtobuf.Google_Protobuf_Empty>(),
         responseSerializer: ProtobufSerializer<Normalization_FunctionName>(),
         interceptors: self.interceptors?.makebidirectionalStreamingInterceptors() ?? [],
-        wrapping: self.bidirectionalStreaming(requestStream:responseStream:context:)
+        wrapping: { try await self.bidirectionalStreaming(requestStream: $0, responseStream: $1, context: $2) }
       )
 
     default:
@@ -949,7 +949,7 @@ extension Normalization_NormalizationAsyncProvider {
   }
 }
 
-internal protocol Normalization_NormalizationServerInterceptorFactoryProtocol {
+internal protocol Normalization_NormalizationServerInterceptorFactoryProtocol: Sendable {
 
   /// - Returns: Interceptors to use when handling 'Unary'.
   ///   Defaults to calling `self.makeInterceptors()`.

--- a/Tests/GRPCTests/EchoHelpers/Interceptors/EchoInterceptorFactories.swift
+++ b/Tests/GRPCTests/EchoHelpers/Interceptors/EchoInterceptorFactories.swift
@@ -19,8 +19,7 @@ import GRPC
 // MARK: - Client
 
 internal final class EchoClientInterceptors: Echo_EchoClientInterceptorFactoryProtocol {
-  internal typealias Factory = @Sendable ()
-    -> ClientInterceptor<Echo_EchoRequest, Echo_EchoResponse>
+  typealias Factory = @Sendable () -> ClientInterceptor<Echo_EchoRequest, Echo_EchoResponse>
   private let factories: [Factory]
 
   internal init(_ factories: Factory...) {
@@ -51,15 +50,11 @@ internal final class EchoClientInterceptors: Echo_EchoClientInterceptorFactoryPr
 // MARK: - Server
 
 internal final class EchoServerInterceptors: Echo_EchoServerInterceptorFactoryProtocol {
-  internal typealias Factory = () -> ServerInterceptor<Echo_EchoRequest, Echo_EchoResponse>
-  private var factories: [Factory] = []
+  typealias Factory = @Sendable () -> ServerInterceptor<Echo_EchoRequest, Echo_EchoResponse>
+  private let factories: [Factory]
 
   internal init(_ factories: Factory...) {
     self.factories = factories
-  }
-
-  internal func register(_ factory: @escaping Factory) {
-    self.factories.append(factory)
   }
 
   private func makeInterceptors() -> [ServerInterceptor<Echo_EchoRequest, Echo_EchoResponse>] {

--- a/Tests/GRPCTests/InterceptorsTests.swift
+++ b/Tests/GRPCTests/InterceptorsTests.swift
@@ -208,7 +208,7 @@ class NotReallyAuthServerInterceptor<Request: Message, Response: Message>:
   }
 }
 
-class HelloWorldServerInterceptorFactory: Helloworld_GreeterServerInterceptorFactoryProtocol {
+final class HelloWorldServerInterceptorFactory: Helloworld_GreeterServerInterceptorFactoryProtocol {
   func makeSayHelloInterceptors(
   ) -> [ServerInterceptor<Helloworld_HelloRequest, Helloworld_HelloReply>] {
     return [RemoteAddressExistsInterceptor(), NotReallyAuthServerInterceptor()]

--- a/Tests/GRPCTests/ServerInterceptorTests.swift
+++ b/Tests/GRPCTests/ServerInterceptorTests.swift
@@ -178,7 +178,7 @@ class ServerInterceptorTests: GRPCTestCase {
   }
 }
 
-class EchoInterceptorFactory: Echo_EchoServerInterceptorFactoryProtocol {
+final class EchoInterceptorFactory: Echo_EchoServerInterceptorFactoryProtocol {
   private let interceptor: ServerInterceptor<Echo_EchoRequest, Echo_EchoResponse>
 
   init(interceptor: ServerInterceptor<Echo_EchoRequest, Echo_EchoResponse>) {
@@ -271,7 +271,7 @@ class EchoFromInterceptor: Echo_EchoProvider {
     return context.eventLoop.makeFailedFuture(GRPCStatus.processingError)
   }
 
-  class Interceptors: Echo_EchoServerInterceptorFactoryProtocol {
+  final class Interceptors: Echo_EchoServerInterceptorFactoryProtocol {
     func makeGetInterceptors() -> [ServerInterceptor<Echo_EchoRequest, Echo_EchoResponse>] {
       return [Interceptor()]
     }


### PR DESCRIPTION
Motivation:

The server handler protocol must be Sendable so that any methods on the handler are also Sendable as annotating methods as `@Sendable` does not work as expected. It follows from this that generated server interceptor factories must also be Sendable (they already are for clients). This puts the `ServerInterceptor` class in an awkward position: it must be Sendable but is not inherently thread-safe (these restrictions are documented and existed before Sendable checking was introduced to Swift). The `ClientInterceptor` has the same restrictions and is `@unchecked Sendable` so we elect to do the same for the `ServerInterceptor`.

Modifications:

- Make generated server handlers and server interceptor factories Sendable
- Make `ServerInterceptor` `@unchecked Sendable`
- Regenerate
- Fix some warnings in test code

Result:

Better Sendable checking