### PR TITLE
Increase cancellation support for async calls

### DIFF
--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncBidirectionalStreamingCall.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncBidirectionalStreamingCall.swift
@@ -52,6 +52,12 @@ public struct GRPCAsyncBidirectionalStreamingCall<Request: Sendable, Response: S
 
   // MARK: - Response Parts
 
+  private func withRPCCancellation<R: Sendable>(_ fn: () async throws -> R) async rethrows -> R {
+    return try await withTaskCancellationHandler(operation: fn) {
+      self.cancel()
+    }
+  }
+
   /// The initial metadata returned from the server.
   ///
   /// - Important: The initial metadata will only be available when the first response has been
@@ -59,7 +65,9 @@ public struct GRPCAsyncBidirectionalStreamingCall<Request: Sendable, Response: S
   /// this property.
   public var initialMetadata: HPACKHeaders {
     get async throws {
-      try await self.responseParts.initialMetadata.get()
+      try await self.withRPCCancellation {
+        try await self.responseParts.initialMetadata.get()
+      }
     }
   }
 
@@ -68,7 +76,9 @@ public struct GRPCAsyncBidirectionalStreamingCall<Request: Sendable, Response: S
   /// - Important: Awaiting this property will suspend until the responses have been consumed.
   public var trailingMetadata: HPACKHeaders {
     get async throws {
-      try await self.responseParts.trailingMetadata.get()
+      try await self.withRPCCancellation {
+        try await self.responseParts.trailingMetadata.get()
+      }
     }
   }
 
@@ -78,7 +88,9 @@ public struct GRPCAsyncBidirectionalStreamingCall<Request: Sendable, Response: S
   public var status: GRPCStatus {
     get async {
       // force-try acceptable because any error is encapsulated in a successful GRPCStatus future.
-      try! await self.responseParts.status.get()
+      await self.withRPCCancellation {
+        try! await self.responseParts.status.get()
+      }
     }
   }
 

--- a/Tests/GRPCTests/AsyncAwaitSupport/XCTest+AsyncAwait.swift
+++ b/Tests/GRPCTests/AsyncAwaitSupport/XCTest+AsyncAwait.swift
@@ -30,6 +30,19 @@ internal func XCTAssertThrowsError<T>(
   }
 }
 
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+internal func XCTAssertNoThrowAsync<T>(
+  _ expression: @autoclosure () async throws -> T,
+  file: StaticString = #filePath,
+  line: UInt = #line
+) async {
+  do {
+    _ = try await expression()
+  } catch {
+    XCTFail("Expression throw error '\(error)'", file: file, line: line)
+  }
+}
+
 private enum TaskResult<Result> {
   case operation(Result)
   case cancellation

--- a/Tests/GRPCTests/InterceptedRPCCancellationTests.swift
+++ b/Tests/GRPCTests/InterceptedRPCCancellationTests.swift
@@ -33,7 +33,7 @@ final class InterceptedRPCCancellationTests: GRPCTestCase {
     }
 
     // Interceptor checks that a "magic" header is present.
-    let serverInterceptors = EchoServerInterceptors(MagicRequiredServerInterceptor.init)
+    let serverInterceptors = EchoServerInterceptors({ MagicRequiredServerInterceptor() })
     let server = try Server.insecure(group: group)
       .withLogger(self.serverLogger)
       .withServiceProviders([EchoProvider(interceptors: serverInterceptors)])


### PR DESCRIPTION
Motivation:

The async client calls have limiteed support for cancellation: they support it for the "wrapped" calls and request/response streams but not for metadata/status on the lower level call objects.

Modifications:

- Add support for Task cancellation on the async call types

Result:

Better cancellation support