### PR TITLE
Handle non-200 status codes more gracefully

### DIFF
--- a/Sources/GRPC/GRPCClientChannelHandler.swift
+++ b/Sources/GRPC/GRPCClientChannelHandler.swift
@@ -374,8 +374,6 @@ extension GRPCClientChannelHandler: ChannelInboundHandler {
             return GRPCError.InvalidContentType(contentType).captureContext()
           case let .invalidHTTPStatus(status):
             return GRPCError.InvalidHTTPStatus(status).captureContext()
-          case let .invalidHTTPStatusWithGRPCStatus(status):
-            return GRPCError.InvalidHTTPStatusWithGRPCStatus(status).captureContext()
           case .invalidState:
             return GRPCError.InvalidState("parsing end-of-stream trailers").captureContext()
           }

--- a/Tests/GRPCTests/GRPCClientStateMachineTests.swift
+++ b/Tests/GRPCTests/GRPCClientStateMachineTests.swift
@@ -1097,14 +1097,8 @@ extension GRPCClientStateMachineTests {
       ":status": "418",
       "grpc-status": "5",
     ]
-    stateMachine.receiveEndOfResponseStream(trailers).assertFailure { error in
-      XCTAssertEqual(
-        error,
-        .invalidHTTPStatusWithGRPCStatus(GRPCStatus(
-          code: GRPCStatus.Code(rawValue: 5)!,
-          message: nil
-        ))
-      )
+    stateMachine.receiveEndOfResponseStream(trailers).assertSuccess { status in
+      XCTAssertEqual(status.code.rawValue, 5)
     }
   }
 
@@ -1115,8 +1109,8 @@ extension GRPCClientStateMachineTests {
     ))
 
     let trailers: HPACKHeaders = [":status": "418"]
-    stateMachine.receiveEndOfResponseStream(trailers).assertFailure { error in
-      XCTAssertEqual(error, .invalidHTTPStatus("418"))
+    stateMachine.receiveEndOfResponseStream(trailers).assertSuccess { status in
+      XCTAssertEqual(status.code, .unknown)
     }
   }
 }


### PR DESCRIPTION
Motivation:

Accepted RPCs should have a 200 HTTP response status code. gRPC knows how to handle some non-200 status codes and can synthesize a gRPC status from them. At the moment they are treated as errors and later converted to a gRPC status. However this means that only the gRPC status sees the error as a status: other response parts (e.g. the response stream) see an error relating to invalid HTTP response codes rather than the synthesized status.

Modifications:

- Handle non-200 HTTP status codes more gracefully by turning them into a gRPC status where possible.

Results:

- Non-200 status codes are more readily converted to a gRPC status.