### PR TITLE
Relax AsyncSequence.collect availability check

### DIFF
--- a/Tests/GRPCTests/AsyncAwaitSupport/AsyncSequence+Helpers.swift
+++ b/Tests/GRPCTests/AsyncAwaitSupport/AsyncSequence+Helpers.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncSequence {
   internal func collect() async throws -> [Element] {
     return try await self.reduce(into: []) { accumulated, next in


### PR DESCRIPTION
Motivation:

Tests currently fail with:
> grpc-swift/Tests/GRPCTests/GRPCAsyncClientCallTests.swift:374:61:
error: 'collect()' is only available in macOS 12 or newer

Modifications:

Relax the availability check on the `AsyncSequence` extension. It seems to arise from the constraint on `AsyncSequence.reduce(into: Result)` which only requires 10.15, not 12.

Result:

Tests should pass.