### PR TITLE
Bump version number to 1.19.0

### DIFF
--- a/Sources/GRPC/Version.swift
+++ b/Sources/GRPC/Version.swift
@@ -19,7 +19,7 @@ internal enum Version {
   internal static let major = 1
 
   /// The minor version.
-  internal static let minor = 18
+  internal static let minor = 19
 
   /// The patch version.
   internal static let patch = 0


### PR DESCRIPTION
Motivation:

We plan on tagging a release soon.

Modifications:

- Bump the version to 1.19.0

Result:

The version in the default user-agent string will match the released version.