### PR TITLE
Update SwiftFormat version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: "Formatting and License Headers check"
       run: |
-        SWIFTFORMAT_VERSION=0.49.4
+        SWIFTFORMAT_VERSION=0.52.0
         git clone --depth 1 --branch "$SWIFTFORMAT_VERSION" "https://github.com/nicklockwood/SwiftFormat" "$HOME/SwiftFormat"
         swift build -c release --package-path "$HOME/SwiftFormat" --product swiftformat
         export PATH=$PATH:"$(swift build -c release --package-path "$HOME/SwiftFormat" --show-bin-path)"

--- a/.swiftformat
+++ b/.swiftformat
@@ -41,3 +41,20 @@
 
 # Put ACLs on declarations within an extension rather than the extension itself.
 --extensionacl on-declarations
+
+# Don't remove internal ACLs
+--disable redundantInternal
+
+# Don't remove redundant parenstheses, because no all of them are redundant.
+--disable redundantParens
+
+# Don't remove static Self
+--disable redundantStaticSelf
+
+# Hoisting try and await causes a bunch of issues (and churn) in 0.52.0. Disable
+# them for the time being.
+--disable hoistTry
+--disable hoistAwait
+
+# Disabled as enabling causes a lot of churn.
+--disable wrapSingleLineComments

--- a/Examples/Google/SpeechToText/Sources/Launch/AppDelegate.swift
+++ b/Examples/Google/SpeechToText/Sources/Launch/AppDelegate.swift
@@ -16,7 +16,7 @@
 
 import UIKit
 
-@UIApplicationMain
+@main
 class AppDelegate: UIResponder, UIApplicationDelegate {
   func application(
     _ application: UIApplication,

--- a/Examples/Google/SpeechToText/Sources/ViewController.swift
+++ b/Examples/Google/SpeechToText/Sources/ViewController.swift
@@ -27,7 +27,7 @@ final class ViewController: UIViewController {
     button.backgroundColor = .darkGray
     button.layer.cornerRadius = 15
     button.clipsToBounds = true
-    button.addTarget(self, action: #selector(recordTapped), for: .touchUpInside)
+    button.addTarget(self, action: #selector(self.recordTapped), for: .touchUpInside)
     return button
   }()
 
@@ -110,7 +110,7 @@ final class ViewController: UIViewController {
     self.textView.snp.makeConstraints { make in
       make.top.equalTo(view.safeAreaLayoutGuide.snp.topMargin)
       make.left.right.equalToSuperview()
-      make.bottom.equalTo(recordButton.snp.top)
+      make.bottom.equalTo(self.recordButton.snp.top)
     }
 
     self.recordButton.snp.makeConstraints { make in

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@
  */
 import PackageDescription
 // swiftformat puts the next import before the tools version.
-// swiftformat:disable:next sortedImports
+// swiftformat:disable:next sortImports
 import class Foundation.ProcessInfo
 
 let grpcPackageName = "grpc-swift"

--- a/Performance/QPSBenchmark/Sources/QPSBenchmark/Runtime/Async/AsyncPingPongRequestMaker.swift
+++ b/Performance/QPSBenchmark/Sources/QPSBenchmark/Runtime/Async/AsyncPingPongRequestMaker.swift
@@ -68,7 +68,7 @@ final class AsyncPingPongRequestMaker: AsyncRequestMaker, @unchecked Sendable {
     while !self.stopRequested.load(ordering: .relaxed),
           self.messagesPerStream == 0 || messagesSent < self.messagesPerStream {
       try await streamingCall.requestStream.send(self.requestMessage)
-      let _ = try await responseStream.next()
+      _ = try await responseStream.next()
       let endTime = grpcTimeNow()
       self.stats.add(latency: endTime - startTime)
       messagesSent += 1

--- a/Sources/GRPC/ServerCallContexts/StreamingResponseCallContext.swift
+++ b/Sources/GRPC/ServerCallContexts/StreamingResponseCallContext.swift
@@ -237,7 +237,9 @@ internal final class _StreamingResponseCallContext<Request, Response>:
 /// Concrete implementation of `StreamingResponseCallContext` used for testing.
 ///
 /// Simply records all sent messages.
-open class StreamingResponseCallContextTestStub<ResponsePayload>: StreamingResponseCallContext<ResponsePayload> {
+open class StreamingResponseCallContextTestStub<ResponsePayload>: StreamingResponseCallContext<
+  ResponsePayload
+> {
   open var recordedResponses: [ResponsePayload] = []
 
   override open func sendResponse(

--- a/Sources/GRPCPerformanceTests/Benchmarks/UnaryThroughput.swift
+++ b/Sources/GRPCPerformanceTests/Benchmarks/UnaryThroughput.swift
@@ -79,7 +79,7 @@ class Unary: ServerProvidingBenchmark {
       let upperBound = min(lowerBound + batchSize, self.requestCount)
 
       let requests = (lowerBound ..< upperBound).map { _ in
-        client.get(Echo_EchoRequest.with { $0.text = self.requestText }).response
+        self.client.get(Echo_EchoRequest.with { $0.text = self.requestText }).response
       }
 
       messages += requests.count

--- a/Tests/GRPCTests/ClientInterceptorPipelineTests.swift
+++ b/Tests/GRPCTests/ClientInterceptorPipelineTests.swift
@@ -159,7 +159,7 @@ class ClientInterceptorPipelineTests: GRPCTestCase {
         assertThat(cancelled, .is(false))
         cancelled = true
         // We don't expect a promise: this cancellation is fired by the pipeline.
-        assertThat(promise, .is(.nil()))
+        assertThat(promise, .is(.none()))
       },
       onRequestPart: { _, _ in
         XCTFail("Unexpected request part")
@@ -202,14 +202,14 @@ class ClientInterceptorPipelineTests: GRPCTestCase {
         assertThat(cancellations, .is(0))
         cancellations += 1
         // We don't expect a promise: this cancellation is fired by the pipeline.
-        assertThat(promise, .is(.nil()))
+        assertThat(promise, .is(.none()))
       },
       onRequestPart: { _, _ in
         XCTFail("Unexpected request part")
       },
       onResponsePart: { part in
         // We only expect the end.
-        assertThat(part.end, .is(.notNil()))
+        assertThat(part.end, .is(.some()))
       }
     )
 

--- a/Tests/GRPCTests/ConnectionPool/GRPCChannelPoolTests.swift
+++ b/Tests/GRPCTests/ConnectionPool/GRPCChannelPoolTests.swift
@@ -303,7 +303,7 @@ final class GRPCChannelPoolTests: GRPCTestCase {
 
     // If we express no event loop preference then we should not get the loaded loop.
     let indifferentLoopRPCs = (1 ... 10).map {
-      _ in echo.get(.with { $0.text = "" })
+      _ in self.echo.get(.with { $0.text = "" })
     }
 
     XCTAssert(indifferentLoopRPCs.map { $0.eventLoop }.allSatisfy { $0 !== loop })

--- a/Tests/GRPCTests/GRPCAsyncClientCallTests.swift
+++ b/Tests/GRPCTests/GRPCAsyncClientCallTests.swift
@@ -160,12 +160,12 @@ class GRPCAsyncClientCallTests: GRPCTestCase {
     var responseStreamIterator = update.responseStream.makeAsyncIterator()
     for word in ["boyle", "jeffers", "holt"] {
       try await update.requestStream.send(.with { $0.text = word })
-      await assertThat(try await responseStreamIterator.next(), .is(.notNil()))
+      await assertThat(try await responseStreamIterator.next(), .is(.some()))
     }
 
     update.requestStream.finish()
 
-    await assertThat(try await responseStreamIterator.next(), .is(.nil()))
+    await assertThat(try await responseStreamIterator.next(), .is(.none()))
 
     await assertThat(try await update.trailingMetadata, .is(.equalTo(Self.OKTrailingMetadata)))
     await assertThat(await update.status, .hasCode(.ok))

--- a/Tests/GRPCTests/GRPCPingHandlerTests.swift
+++ b/Tests/GRPCTests/GRPCPingHandlerTests.swift
@@ -387,7 +387,7 @@ extension PingHandler.Action: Equatable {
 extension GRPCPingHandlerTests {
   func testSingleAckIsEmittedOnPing() throws {
     let client = EmbeddedChannel()
-    let _ = try client.configureHTTP2Pipeline(mode: .client) { _ in
+    _ = try client.configureHTTP2Pipeline(mode: .client) { _ in
       fatalError("Unexpected inbound stream")
     }.wait()
 

--- a/Tests/GRPCTests/GRPCWebToHTTP2ServerCodecTests.swift
+++ b/Tests/GRPCTests/GRPCWebToHTTP2ServerCodecTests.swift
@@ -47,7 +47,7 @@ class GRPCWebToHTTP2ServerCodecTests: GRPCTestCase {
     )
     assertThat(try channel.writeInbound(HTTPServerRequestPart.head(head)), .doesNotThrow())
     let headersPayload = try channel.readInbound(as: HTTP2Frame.FramePayload.self)
-    assertThat(headersPayload, .notNil(.headers(.contains(":path", [path]))))
+    assertThat(headersPayload, .some(.headers(.contains(":path", [path]))))
   }
 
   private func receiveBytes(
@@ -59,14 +59,14 @@ class GRPCWebToHTTP2ServerCodecTests: GRPCTestCase {
 
     if let expectedBytes = expectedBytes {
       let dataPayload = try channel.readInbound(as: HTTP2Frame.FramePayload.self)
-      assertThat(dataPayload, .notNil(.data(buffer: ByteBuffer(bytes: expectedBytes))))
+      assertThat(dataPayload, .some(.data(buffer: ByteBuffer(bytes: expectedBytes))))
     }
   }
 
   private func receiveEnd(on channel: EmbeddedChannel) throws {
     assertThat(try channel.writeInbound(HTTPServerRequestPart.end(nil)), .doesNotThrow())
     let dataEndPayload = try channel.readInbound(as: HTTP2Frame.FramePayload.self)
-    assertThat(dataEndPayload, .notNil(.data(buffer: ByteBuffer(), endStream: true)))
+    assertThat(dataEndPayload, .some(.data(buffer: ByteBuffer(), endStream: true)))
   }
 
   private func sendResponseHeaders(on channel: EmbeddedChannel) throws {
@@ -74,7 +74,7 @@ class GRPCWebToHTTP2ServerCodecTests: GRPCTestCase {
     let headerPayload: HTTP2Frame.FramePayload = .headers(.init(headers: responseHeaders))
     assertThat(try channel.writeOutbound(headerPayload), .doesNotThrow())
     let responseHead = try channel.readOutbound(as: HTTPServerResponsePart.self)
-    assertThat(responseHead, .notNil(.head(status: .ok)))
+    assertThat(responseHead, .some(.head(status: .ok)))
   }
 
   private func sendTrailersOnlyResponse(on channel: EmbeddedChannel) throws {
@@ -83,9 +83,9 @@ class GRPCWebToHTTP2ServerCodecTests: GRPCTestCase {
 
     assertThat(try channel.writeOutbound(headerPayload), .doesNotThrow())
     let responseHead = try channel.readOutbound(as: HTTPServerResponsePart.self)
-    assertThat(responseHead, .notNil(.head(status: .ok)))
+    assertThat(responseHead, .some(.head(status: .ok)))
     let end = try channel.readOutbound(as: HTTPServerResponsePart.self)
-    assertThat(end, .notNil(.end()))
+    assertThat(end, .some(.end()))
   }
 
   private func sendBytes(
@@ -99,9 +99,9 @@ class GRPCWebToHTTP2ServerCodecTests: GRPCTestCase {
 
     if let expectedBytes = expectedBytes {
       let expectedBuffer = ByteBuffer(bytes: expectedBytes)
-      assertThat(try channel.readOutbound(), .notNil(.body(.is(expectedBuffer))))
+      assertThat(try channel.readOutbound(), .some(.body(.is(expectedBuffer))))
     } else {
-      assertThat(try channel.readOutbound(as: HTTPServerResponsePart.self), .doesNotThrow(.nil()))
+      assertThat(try channel.readOutbound(as: HTTPServerResponsePart.self), .doesNotThrow(.none()))
     }
   }
 
@@ -115,10 +115,10 @@ class GRPCWebToHTTP2ServerCodecTests: GRPCTestCase {
     assertThat(try channel.writeOutbound(headersPayload), .doesNotThrow())
 
     if let expectedBytes = expectedBytes {
-      assertThat(try channel.readOutbound(), .notNil(.body(.is(expectedBytes))))
+      assertThat(try channel.readOutbound(), .some(.body(.is(expectedBytes))))
     }
 
-    assertThat(try channel.readOutbound(), .notNil(.end()))
+    assertThat(try channel.readOutbound(), .some(.end()))
   }
 
   func testWebBinaryHappyPath() throws {

--- a/Tests/GRPCTests/ServerInterceptorPipelineTests.swift
+++ b/Tests/GRPCTests/ServerInterceptorPipelineTests.swift
@@ -60,7 +60,7 @@ class ServerInterceptorPipelineTests: GRPCTestCase {
       onRequestPart: { requestParts.append($0) },
       onResponsePart: { part, promise in
         responseParts.append(part)
-        assertThat(promise, .is(.nil()))
+        assertThat(promise, .is(.none()))
       }
     )
 
@@ -80,7 +80,7 @@ class ServerInterceptorPipelineTests: GRPCTestCase {
     assertThat(responseParts, .hasCount(3))
     assertThat(responseParts[0].metadata, .is([:]))
     assertThat(responseParts[1].message, .is("bar"))
-    assertThat(responseParts[2].end, .is(.notNil()))
+    assertThat(responseParts[2].end, .is(.some()))
 
     // Pipelines should now be closed. We can't send or receive.
     let p = self.embeddedEventLoop.makePromise(of: Void.self)
@@ -110,15 +110,15 @@ class ServerInterceptorPipelineTests: GRPCTestCase {
 
     // Check the request parts are there.
     assertThat(recorder.requestParts, .hasCount(3))
-    assertThat(recorder.requestParts[0].metadata, .is(.notNil()))
-    assertThat(recorder.requestParts[1].message, .is(.notNil()))
+    assertThat(recorder.requestParts[0].metadata, .is(.some()))
+    assertThat(recorder.requestParts[1].message, .is(.some()))
     assertThat(recorder.requestParts[2].isEnd, .is(true))
 
     // Check the response parts are there.
     assertThat(recorder.responseParts, .hasCount(3))
-    assertThat(recorder.responseParts[0].metadata, .is(.notNil()))
-    assertThat(recorder.responseParts[1].message, .is(.notNil()))
-    assertThat(recorder.responseParts[2].end, .is(.notNil()))
+    assertThat(recorder.responseParts[0].metadata, .is(.some()))
+    assertThat(recorder.responseParts[1].message, .is(.some()))
+    assertThat(recorder.responseParts[2].end, .is(.some()))
   }
 }
 

--- a/Tests/GRPCTests/ServerInterceptorTests.swift
+++ b/Tests/GRPCTests/ServerInterceptorTests.swift
@@ -98,9 +98,9 @@ class ServerInterceptorTests: GRPCTestCase {
     handler.receiveEnd()
 
     // Expect responses.
-    assertThat(self.recorder.metadata, .is(.notNil()))
+    assertThat(self.recorder.metadata, .is(.some()))
     assertThat(self.recorder.messages.count, .is(1))
-    assertThat(self.recorder.status, .is(.notNil()))
+    assertThat(self.recorder.status, .is(.some()))
 
     // We expect 2 request parts: the provider responds before it sees end, that's fine.
     assertThat(recordingInterceptor.requestParts, .hasCount(2))
@@ -123,9 +123,9 @@ class ServerInterceptorTests: GRPCTestCase {
     handler.receiveEnd()
 
     // Get the responses.
-    assertThat(self.recorder.metadata, .is(.notNil()))
+    assertThat(self.recorder.metadata, .is(.some()))
     assertThat(self.recorder.messages.count, .is(1))
-    assertThat(self.recorder.status, .is(.notNil()))
+    assertThat(self.recorder.status, .is(.some()))
   }
 
   func testClientStreamingFromInterceptor() throws {
@@ -140,9 +140,9 @@ class ServerInterceptorTests: GRPCTestCase {
     handler.receiveEnd()
 
     // Get the responses.
-    assertThat(self.recorder.metadata, .is(.notNil()))
+    assertThat(self.recorder.metadata, .is(.some()))
     assertThat(self.recorder.messages.count, .is(1))
-    assertThat(self.recorder.status, .is(.notNil()))
+    assertThat(self.recorder.status, .is(.some()))
   }
 
   func testServerStreamingFromInterceptor() throws {
@@ -155,9 +155,9 @@ class ServerInterceptorTests: GRPCTestCase {
     handler.receiveEnd()
 
     // Get the responses.
-    assertThat(self.recorder.metadata, .is(.notNil()))
+    assertThat(self.recorder.metadata, .is(.some()))
     assertThat(self.recorder.messages.count, .is(3))
-    assertThat(self.recorder.status, .is(.notNil()))
+    assertThat(self.recorder.status, .is(.some()))
   }
 
   func testBidirectionalStreamingFromInterceptor() throws {
@@ -172,9 +172,9 @@ class ServerInterceptorTests: GRPCTestCase {
     handler.receiveEnd()
 
     // Get the responses.
-    assertThat(self.recorder.metadata, .is(.notNil()))
+    assertThat(self.recorder.metadata, .is(.some()))
     assertThat(self.recorder.messages.count, .is(3))
-    assertThat(self.recorder.status, .is(.notNil()))
+    assertThat(self.recorder.status, .is(.some()))
   }
 }
 

--- a/Tests/GRPCTests/ServerThrowingTests.swift
+++ b/Tests/GRPCTests/ServerThrowingTests.swift
@@ -150,7 +150,7 @@ class ServerThrowingTests: EchoTestCaseBase {
       }
     }
     XCTAssertThrowsError(try call.response.wait()) {
-      XCTAssertEqual(expectedError, $0 as? GRPCStatus)
+      XCTAssertEqual(self.expectedError, $0 as? GRPCStatus)
     }
   }
 
@@ -170,7 +170,7 @@ class ServerThrowingTests: EchoTestCaseBase {
       // With `ErrorReturningEchoProvider` we actually _return_ a response, which means that the `response` future
       // will _not_ fail, so in that case this test doesn't apply.
       XCTAssertThrowsError(try call.response.wait()) {
-        XCTAssertEqual(expectedError, $0 as? GRPCStatus)
+        XCTAssertEqual(self.expectedError, $0 as? GRPCStatus)
       }
     }
   }

--- a/Tests/GRPCTests/ServerWebTests.swift
+++ b/Tests/GRPCTests/ServerWebTests.swift
@@ -157,7 +157,7 @@ extension ServerWebTests {
     var expectedData = Data()
     var index = 0
     message.split(separator: " ").forEach { component in
-      expectedData.append(gRPCEncodedEchoRequest("Swift echo expand (\(index)): \(component)"))
+      expectedData.append(self.gRPCEncodedEchoRequest("Swift echo expand (\(index)): \(component)"))
       index += 1
     }
     expectedData.append(self.gRPCWebTrailers())

--- a/Tests/GRPCTests/UnaryServerHandlerTests.swift
+++ b/Tests/GRPCTests/UnaryServerHandlerTests.swift
@@ -149,7 +149,7 @@ class UnaryServerHandlerTests: ServerHandlerTestCaseBase {
 
     assertThat(self.recorder.messages.first, .is(buffer))
     assertThat(self.recorder.messageMetadata.first?.compress, .is(false))
-    assertThat(self.recorder.status, .notNil(.hasCode(.ok)))
+    assertThat(self.recorder.status, .some(.hasCode(.ok)))
     assertThat(self.recorder.trailers, .is([:]))
   }
 
@@ -199,7 +199,7 @@ class UnaryServerHandlerTests: ServerHandlerTestCaseBase {
     handler.receiveMessage(buffer)
 
     assertThat(self.recorder.messages, .isEmpty())
-    assertThat(self.recorder.status, .notNil(.hasCode(.internalError)))
+    assertThat(self.recorder.status, .some(.hasCode(.internalError)))
   }
 
   func testThrowingSerializer() {
@@ -219,7 +219,7 @@ class UnaryServerHandlerTests: ServerHandlerTestCaseBase {
     handler.receiveEnd()
 
     assertThat(self.recorder.messages, .isEmpty())
-    assertThat(self.recorder.status, .notNil(.hasCode(.internalError)))
+    assertThat(self.recorder.status, .some(.hasCode(.internalError)))
   }
 
   func testUserFunctionReturnsFailedFuture() {
@@ -234,7 +234,7 @@ class UnaryServerHandlerTests: ServerHandlerTestCaseBase {
     handler.receiveMessage(buffer)
 
     assertThat(self.recorder.messages, .isEmpty())
-    assertThat(self.recorder.status, .notNil(.hasCode(.unavailable)))
+    assertThat(self.recorder.status, .some(.hasCode(.unavailable)))
     assertThat(self.recorder.status?.message, .is(":("))
   }
 
@@ -242,9 +242,9 @@ class UnaryServerHandlerTests: ServerHandlerTestCaseBase {
     let handler = self.makeHandler(function: self.neverCalled(_:context:))
 
     handler.receiveMessage(ByteBuffer(string: "foo"))
-    assertThat(self.recorder.metadata, .is(.nil()))
+    assertThat(self.recorder.metadata, .is(.none()))
     assertThat(self.recorder.messages, .isEmpty())
-    assertThat(self.recorder.status, .notNil(.hasCode(.internalError)))
+    assertThat(self.recorder.status, .some(.hasCode(.internalError)))
   }
 
   func testReceiveMultipleHeaders() {
@@ -255,7 +255,7 @@ class UnaryServerHandlerTests: ServerHandlerTestCaseBase {
 
     handler.receiveMetadata([:])
     assertThat(self.recorder.messages, .isEmpty())
-    assertThat(self.recorder.status, .notNil(.hasCode(.internalError)))
+    assertThat(self.recorder.status, .some(.hasCode(.internalError)))
   }
 
   func testReceiveMultipleMessages() {
@@ -271,17 +271,17 @@ class UnaryServerHandlerTests: ServerHandlerTestCaseBase {
     handler.receiveMessage(buffer)
 
     assertThat(self.recorder.messages, .isEmpty())
-    assertThat(self.recorder.status, .notNil(.hasCode(.internalError)))
+    assertThat(self.recorder.status, .some(.hasCode(.internalError)))
   }
 
   func testFinishBeforeStarting() {
     let handler = self.makeHandler(function: self.neverCalled(_:context:))
 
     handler.finish()
-    assertThat(self.recorder.metadata, .is(.nil()))
+    assertThat(self.recorder.metadata, .is(.none()))
     assertThat(self.recorder.messages, .isEmpty())
-    assertThat(self.recorder.status, .is(.nil()))
-    assertThat(self.recorder.trailers, .is(.nil()))
+    assertThat(self.recorder.status, .is(.none()))
+    assertThat(self.recorder.trailers, .is(.none()))
   }
 
   func testFinishAfterHeaders() {
@@ -292,7 +292,7 @@ class UnaryServerHandlerTests: ServerHandlerTestCaseBase {
     handler.finish()
 
     assertThat(self.recorder.messages, .isEmpty())
-    assertThat(self.recorder.status, .notNil(.hasCode(.unavailable)))
+    assertThat(self.recorder.status, .some(.hasCode(.unavailable)))
     assertThat(self.recorder.trailers, .is([:]))
   }
 
@@ -304,7 +304,7 @@ class UnaryServerHandlerTests: ServerHandlerTestCaseBase {
     handler.finish()
 
     assertThat(self.recorder.messages, .isEmpty())
-    assertThat(self.recorder.status, .notNil(.hasCode(.unavailable)))
+    assertThat(self.recorder.status, .some(.hasCode(.unavailable)))
     assertThat(self.recorder.trailers, .is([:]))
   }
 }
@@ -376,7 +376,7 @@ class ClientStreamingServerHandlerTests: ServerHandlerTestCaseBase {
 
     assertThat(self.recorder.messages.first, .is(ByteBuffer(string: "1 2 3")))
     assertThat(self.recorder.messageMetadata.first?.compress, .is(false))
-    assertThat(self.recorder.status, .notNil(.hasCode(.ok)))
+    assertThat(self.recorder.status, .some(.hasCode(.ok)))
     assertThat(self.recorder.trailers, .is([:]))
   }
 
@@ -430,7 +430,7 @@ class ClientStreamingServerHandlerTests: ServerHandlerTestCaseBase {
     handler.receiveMessage(buffer)
 
     assertThat(self.recorder.messages, .isEmpty())
-    assertThat(self.recorder.status, .notNil(.hasCode(.internalError)))
+    assertThat(self.recorder.status, .some(.hasCode(.internalError)))
   }
 
   func testThrowingSerializer() {
@@ -450,7 +450,7 @@ class ClientStreamingServerHandlerTests: ServerHandlerTestCaseBase {
     handler.receiveEnd()
 
     assertThat(self.recorder.messages, .isEmpty())
-    assertThat(self.recorder.status, .notNil(.hasCode(.internalError)))
+    assertThat(self.recorder.status, .some(.hasCode(.internalError)))
   }
 
   func testObserverFactoryReturnsFailedFuture() {
@@ -460,7 +460,7 @@ class ClientStreamingServerHandlerTests: ServerHandlerTestCaseBase {
 
     handler.receiveMetadata([:])
     assertThat(self.recorder.messages, .isEmpty())
-    assertThat(self.recorder.status, .notNil(.hasCode(.unavailable)))
+    assertThat(self.recorder.status, .some(.hasCode(.unavailable)))
     assertThat(self.recorder.status?.message, .is(":("))
   }
 
@@ -485,7 +485,7 @@ class ClientStreamingServerHandlerTests: ServerHandlerTestCaseBase {
     handler.receiveEnd()
 
     assertThat(self.recorder.messages.first, .is(ByteBuffer(string: "1 2 3 4 5")))
-    assertThat(self.recorder.status, .notNil(.hasCode(.ok)))
+    assertThat(self.recorder.status, .some(.hasCode(.ok)))
   }
 
   func testDelayedObserverFactoryAllMessagesBeforeSucceeding() {
@@ -506,16 +506,16 @@ class ClientStreamingServerHandlerTests: ServerHandlerTestCaseBase {
     promise.succeed(())
 
     assertThat(self.recorder.messages.first, .is(ByteBuffer(string: "1 2 3")))
-    assertThat(self.recorder.status, .notNil(.hasCode(.ok)))
+    assertThat(self.recorder.status, .some(.hasCode(.ok)))
   }
 
   func testReceiveMessageBeforeHeaders() {
     let handler = self.makeHandler(observerFactory: self.neverCalled(context:))
 
     handler.receiveMessage(ByteBuffer(string: "foo"))
-    assertThat(self.recorder.metadata, .is(.nil()))
+    assertThat(self.recorder.metadata, .is(.none()))
     assertThat(self.recorder.messages, .isEmpty())
-    assertThat(self.recorder.status, .notNil(.hasCode(.internalError)))
+    assertThat(self.recorder.status, .some(.hasCode(.internalError)))
   }
 
   func testReceiveMultipleHeaders() {
@@ -526,17 +526,17 @@ class ClientStreamingServerHandlerTests: ServerHandlerTestCaseBase {
 
     handler.receiveMetadata([:])
     assertThat(self.recorder.messages, .isEmpty())
-    assertThat(self.recorder.status, .notNil(.hasCode(.internalError)))
+    assertThat(self.recorder.status, .some(.hasCode(.internalError)))
   }
 
   func testFinishBeforeStarting() {
     let handler = self.makeHandler(observerFactory: self.neverCalled(context:))
 
     handler.finish()
-    assertThat(self.recorder.metadata, .is(.nil()))
+    assertThat(self.recorder.metadata, .is(.none()))
     assertThat(self.recorder.messages, .isEmpty())
-    assertThat(self.recorder.status, .is(.nil()))
-    assertThat(self.recorder.trailers, .is(.nil()))
+    assertThat(self.recorder.status, .is(.none()))
+    assertThat(self.recorder.trailers, .is(.none()))
   }
 
   func testFinishAfterHeaders() {
@@ -547,7 +547,7 @@ class ClientStreamingServerHandlerTests: ServerHandlerTestCaseBase {
     handler.finish()
 
     assertThat(self.recorder.messages, .isEmpty())
-    assertThat(self.recorder.status, .notNil(.hasCode(.unavailable)))
+    assertThat(self.recorder.status, .some(.hasCode(.unavailable)))
     assertThat(self.recorder.trailers, .is([:]))
   }
 
@@ -559,7 +559,7 @@ class ClientStreamingServerHandlerTests: ServerHandlerTestCaseBase {
     handler.finish()
 
     assertThat(self.recorder.messages, .isEmpty())
-    assertThat(self.recorder.status, .notNil(.hasCode(.unavailable)))
+    assertThat(self.recorder.status, .some(.hasCode(.unavailable)))
     assertThat(self.recorder.trailers, .is([:]))
   }
 }
@@ -620,7 +620,7 @@ class ServerStreamingServerHandlerTests: ServerHandlerTestCaseBase {
       .is([ByteBuffer(string: "a"), ByteBuffer(string: "b")])
     )
     assertThat(self.recorder.messageMetadata.map { $0.compress }, .is([false, false]))
-    assertThat(self.recorder.status, .notNil(.hasCode(.ok)))
+    assertThat(self.recorder.status, .some(.hasCode(.ok)))
     assertThat(self.recorder.trailers, .is([:]))
   }
 
@@ -670,7 +670,7 @@ class ServerStreamingServerHandlerTests: ServerHandlerTestCaseBase {
     handler.receiveMessage(buffer)
 
     assertThat(self.recorder.messages, .isEmpty())
-    assertThat(self.recorder.status, .notNil(.hasCode(.internalError)))
+    assertThat(self.recorder.status, .some(.hasCode(.internalError)))
   }
 
   func testThrowingSerializer() {
@@ -690,7 +690,7 @@ class ServerStreamingServerHandlerTests: ServerHandlerTestCaseBase {
     handler.receiveEnd()
 
     assertThat(self.recorder.messages, .isEmpty())
-    assertThat(self.recorder.status, .notNil(.hasCode(.internalError)))
+    assertThat(self.recorder.status, .some(.hasCode(.internalError)))
   }
 
   func testUserFunctionReturnsFailedFuture() {
@@ -705,7 +705,7 @@ class ServerStreamingServerHandlerTests: ServerHandlerTestCaseBase {
     handler.receiveMessage(buffer)
 
     assertThat(self.recorder.messages, .isEmpty())
-    assertThat(self.recorder.status, .notNil(.hasCode(.unavailable)))
+    assertThat(self.recorder.status, .some(.hasCode(.unavailable)))
     assertThat(self.recorder.status?.message, .is(":("))
   }
 
@@ -713,9 +713,9 @@ class ServerStreamingServerHandlerTests: ServerHandlerTestCaseBase {
     let handler = self.makeHandler(userFunction: self.neverCalled(_:context:))
 
     handler.receiveMessage(ByteBuffer(string: "foo"))
-    assertThat(self.recorder.metadata, .is(.nil()))
+    assertThat(self.recorder.metadata, .is(.none()))
     assertThat(self.recorder.messages, .isEmpty())
-    assertThat(self.recorder.status, .notNil(.hasCode(.internalError)))
+    assertThat(self.recorder.status, .some(.hasCode(.internalError)))
   }
 
   func testReceiveMultipleHeaders() {
@@ -726,7 +726,7 @@ class ServerStreamingServerHandlerTests: ServerHandlerTestCaseBase {
 
     handler.receiveMetadata([:])
     assertThat(self.recorder.messages, .isEmpty())
-    assertThat(self.recorder.status, .notNil(.hasCode(.internalError)))
+    assertThat(self.recorder.status, .some(.hasCode(.internalError)))
   }
 
   func testReceiveMultipleMessages() {
@@ -742,17 +742,17 @@ class ServerStreamingServerHandlerTests: ServerHandlerTestCaseBase {
     handler.receiveMessage(buffer)
 
     assertThat(self.recorder.messages, .isEmpty())
-    assertThat(self.recorder.status, .notNil(.hasCode(.internalError)))
+    assertThat(self.recorder.status, .some(.hasCode(.internalError)))
   }
 
   func testFinishBeforeStarting() {
     let handler = self.makeHandler(userFunction: self.neverCalled(_:context:))
 
     handler.finish()
-    assertThat(self.recorder.metadata, .is(.nil()))
+    assertThat(self.recorder.metadata, .is(.none()))
     assertThat(self.recorder.messages, .isEmpty())
-    assertThat(self.recorder.status, .is(.nil()))
-    assertThat(self.recorder.trailers, .is(.nil()))
+    assertThat(self.recorder.status, .is(.none()))
+    assertThat(self.recorder.trailers, .is(.none()))
   }
 
   func testFinishAfterHeaders() {
@@ -763,7 +763,7 @@ class ServerStreamingServerHandlerTests: ServerHandlerTestCaseBase {
     handler.finish()
 
     assertThat(self.recorder.messages, .isEmpty())
-    assertThat(self.recorder.status, .notNil(.hasCode(.unavailable)))
+    assertThat(self.recorder.status, .some(.hasCode(.unavailable)))
     assertThat(self.recorder.trailers, .is([:]))
   }
 
@@ -775,7 +775,7 @@ class ServerStreamingServerHandlerTests: ServerHandlerTestCaseBase {
     handler.finish()
 
     assertThat(self.recorder.messages, .isEmpty())
-    assertThat(self.recorder.status, .notNil(.hasCode(.unavailable)))
+    assertThat(self.recorder.status, .some(.hasCode(.unavailable)))
     assertThat(self.recorder.trailers, .is([:]))
   }
 }
@@ -849,7 +849,7 @@ class BidirectionalStreamingServerHandlerTests: ServerHandlerTestCaseBase {
       .is([ByteBuffer(string: "1"), ByteBuffer(string: "2"), ByteBuffer(string: "3")])
     )
     assertThat(self.recorder.messageMetadata.map { $0.compress }, .is([false, false, false]))
-    assertThat(self.recorder.status, .notNil(.hasCode(.ok)))
+    assertThat(self.recorder.status, .some(.hasCode(.ok)))
     assertThat(self.recorder.trailers, .is([:]))
   }
 
@@ -909,7 +909,7 @@ class BidirectionalStreamingServerHandlerTests: ServerHandlerTestCaseBase {
     handler.receiveMessage(buffer)
 
     assertThat(self.recorder.messages, .isEmpty())
-    assertThat(self.recorder.status, .notNil(.hasCode(.internalError)))
+    assertThat(self.recorder.status, .some(.hasCode(.internalError)))
   }
 
   func testThrowingSerializer() {
@@ -929,7 +929,7 @@ class BidirectionalStreamingServerHandlerTests: ServerHandlerTestCaseBase {
     handler.receiveEnd()
 
     assertThat(self.recorder.messages, .isEmpty())
-    assertThat(self.recorder.status, .notNil(.hasCode(.internalError)))
+    assertThat(self.recorder.status, .some(.hasCode(.internalError)))
   }
 
   func testObserverFactoryReturnsFailedFuture() {
@@ -939,7 +939,7 @@ class BidirectionalStreamingServerHandlerTests: ServerHandlerTestCaseBase {
 
     handler.receiveMetadata([:])
     assertThat(self.recorder.messages, .isEmpty())
-    assertThat(self.recorder.status, .notNil(.hasCode(.unavailable)))
+    assertThat(self.recorder.status, .some(.hasCode(.unavailable)))
     assertThat(self.recorder.status?.message, .is(":("))
   }
 
@@ -964,7 +964,7 @@ class BidirectionalStreamingServerHandlerTests: ServerHandlerTestCaseBase {
       self.recorder.messages,
       .is([ByteBuffer(string: "1"), ByteBuffer(string: "2")])
     )
-    assertThat(self.recorder.status, .notNil(.hasCode(.ok)))
+    assertThat(self.recorder.status, .some(.hasCode(.ok)))
   }
 
   func testDelayedObserverFactoryAllMessagesBeforeSucceeding() {
@@ -987,16 +987,16 @@ class BidirectionalStreamingServerHandlerTests: ServerHandlerTestCaseBase {
       self.recorder.messages,
       .is([ByteBuffer(string: "1"), ByteBuffer(string: "2")])
     )
-    assertThat(self.recorder.status, .notNil(.hasCode(.ok)))
+    assertThat(self.recorder.status, .some(.hasCode(.ok)))
   }
 
   func testReceiveMessageBeforeHeaders() {
     let handler = self.makeHandler(observerFactory: self.neverCalled(context:))
 
     handler.receiveMessage(ByteBuffer(string: "foo"))
-    assertThat(self.recorder.metadata, .is(.nil()))
+    assertThat(self.recorder.metadata, .is(.none()))
     assertThat(self.recorder.messages, .isEmpty())
-    assertThat(self.recorder.status, .notNil(.hasCode(.internalError)))
+    assertThat(self.recorder.status, .some(.hasCode(.internalError)))
   }
 
   func testReceiveMultipleHeaders() {
@@ -1007,17 +1007,17 @@ class BidirectionalStreamingServerHandlerTests: ServerHandlerTestCaseBase {
 
     handler.receiveMetadata([:])
     assertThat(self.recorder.messages, .isEmpty())
-    assertThat(self.recorder.status, .notNil(.hasCode(.internalError)))
+    assertThat(self.recorder.status, .some(.hasCode(.internalError)))
   }
 
   func testFinishBeforeStarting() {
     let handler = self.makeHandler(observerFactory: self.neverCalled(context:))
 
     handler.finish()
-    assertThat(self.recorder.metadata, .is(.nil()))
+    assertThat(self.recorder.metadata, .is(.none()))
     assertThat(self.recorder.messages, .isEmpty())
-    assertThat(self.recorder.status, .is(.nil()))
-    assertThat(self.recorder.trailers, .is(.nil()))
+    assertThat(self.recorder.status, .is(.none()))
+    assertThat(self.recorder.trailers, .is(.none()))
   }
 
   func testFinishAfterHeaders() {
@@ -1028,7 +1028,7 @@ class BidirectionalStreamingServerHandlerTests: ServerHandlerTestCaseBase {
     handler.finish()
 
     assertThat(self.recorder.messages, .isEmpty())
-    assertThat(self.recorder.status, .notNil(.hasCode(.unavailable)))
+    assertThat(self.recorder.status, .some(.hasCode(.unavailable)))
     assertThat(self.recorder.trailers, .is([:]))
   }
 
@@ -1040,7 +1040,7 @@ class BidirectionalStreamingServerHandlerTests: ServerHandlerTestCaseBase {
     handler.finish()
 
     assertThat(self.recorder.messages.first, .is(ByteBuffer(string: "hello")))
-    assertThat(self.recorder.status, .notNil(.hasCode(.unavailable)))
+    assertThat(self.recorder.status, .some(.hasCode(.unavailable)))
     assertThat(self.recorder.trailers, .is([:]))
   }
 }

--- a/Tests/GRPCTests/UserInfoTests.swift
+++ b/Tests/GRPCTests/UserInfoTests.swift
@@ -26,10 +26,10 @@ class UserInfoTests: GRPCTestCase {
     assertThat(userInfo[BarKey.self], .is(42))
 
     userInfo[FooKey.self] = nil
-    assertThat(userInfo[FooKey.self], .is(.nil()))
+    assertThat(userInfo[FooKey.self], .is(.none()))
 
     userInfo[BarKey.self] = nil
-    assertThat(userInfo[BarKey.self], .is(.nil()))
+    assertThat(userInfo[BarKey.self], .is(.none()))
   }
 
   func testWithExtensions() {
@@ -42,10 +42,10 @@ class UserInfoTests: GRPCTestCase {
     assertThat(userInfo.bar, .is(42))
 
     userInfo.foo = nil
-    assertThat(userInfo.foo, .is(.nil()))
+    assertThat(userInfo.foo, .is(.none()))
 
     userInfo.bar = nil
-    assertThat(userInfo.bar, .is(.nil()))
+    assertThat(userInfo.bar, .is(.none()))
   }
 
   func testDescription() {

--- a/Tests/GRPCTests/XCTestHelpers.swift
+++ b/Tests/GRPCTests/XCTestHelpers.swift
@@ -133,7 +133,7 @@ struct Matcher<Value> {
   }
 
   /// Matches if the value is `nil`.
-  static func `nil`<V>() -> Matcher<V?> {
+  static func none<V>() -> Matcher<V?> {
     return .init { actual in
       actual == nil
         ? .match
@@ -142,7 +142,7 @@ struct Matcher<Value> {
   }
 
   /// Matches if the value is not `nil`.
-  static func notNil<V>(_ matcher: Matcher<V>? = nil) -> Matcher<V?> {
+  static func some<V>(_ matcher: Matcher<V>? = nil) -> Matcher<V?> {
     return .init { actual in
       if let actual = actual {
         return matcher?.evaluate(actual) ?? .match

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -22,7 +22,7 @@ SWIFTFORMAT_DIR="$HERE/.swiftformat-source"
 
 # Important: if this is changed then make sure to update the version
 # in the .github/workflows/ci.yaml as well!
-SWIFTFORMAT_VERSION=0.49.4
+SWIFTFORMAT_VERSION=0.52.0
 
 # Clone SwiftFormat if we don't already have it.
 if [ ! -d "$SWIFTFORMAT_DIR" ]; then


### PR DESCRIPTION
Motivation:

Some changes cause the formatter to throw an error while formatting.
This particular bug was fixed in 0.52.0.

Modifications:

- Update the formatter version to 0.52.0
- Update the rules applied to minimise the diff from updating
- Run the formatter

Results:

- Formatter is up-to-date.