### PR TITLE
Adopt strict concurrency checking

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,9 +29,8 @@ jobs:
             # No TSAN because of: https://github.com/apple/swift/issues/59068
             swift-test-flags: "-Xswiftc -strict-concurrency=complete" # "--sanitize=thread"
           - image: swift:5.8-jammy
-            swift-build-flags: "-Xswiftc -strict-concurrency=complete"
             # No TSAN because of: https://github.com/apple/swift/issues/59068
-            swift-test-flags: "-Xswiftc -strict-concurrency=complete" # "--sanitize=thread"
+            # swift-test-flags: "--sanitize=thread"
           - image: swift:5.7-jammy
             # No TSAN because of: https://github.com/apple/swift/issues/59068
             # swift-test-flags: "--sanitize=thread"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,13 +25,13 @@ jobs:
       matrix:
         include:
           - image: swiftlang/swift:nightly-focal
-            swift-build-flags: "-Xswiftc strict-concurrency=complete"
+            swift-build-flags: "-Xswiftc -strict-concurrency=complete"
             # No TSAN because of: https://github.com/apple/swift/issues/59068
-            swift-test-flags: "-Xswiftc strict-concurrency=complete" # "--sanitize=thread"
+            swift-test-flags: "-Xswiftc -strict-concurrency=complete" # "--sanitize=thread"
           - image: swift:5.8-jammy
-            swift-build-flags: "-Xswiftc strict-concurrency=complete"
+            swift-build-flags: "-Xswiftc -strict-concurrency=complete"
             # No TSAN because of: https://github.com/apple/swift/issues/59068
-            swift-test-flags: "-Xswiftc strict-concurrency=complete" # "--sanitize=thread"
+            swift-test-flags: "-Xswiftc -strict-concurrency=complete" # "--sanitize=thread"
           - image: swift:5.7-jammy
             # No TSAN because of: https://github.com/apple/swift/issues/59068
             # swift-test-flags: "--sanitize=thread"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,11 +25,13 @@ jobs:
       matrix:
         include:
           - image: swiftlang/swift:nightly-focal
+            swift-build-flags: "-Xswiftc strict-concurrency=complete"
             # No TSAN because of: https://github.com/apple/swift/issues/59068
-            # swift-test-flags: "--sanitize=thread"
+            swift-test-flags: "-Xswiftc strict-concurrency=complete" # "--sanitize=thread"
           - image: swift:5.8-jammy
+            swift-build-flags: "-Xswiftc strict-concurrency=complete"
             # No TSAN because of: https://github.com/apple/swift/issues/59068
-            # swift-test-flags: "--sanitize=thread"
+            swift-test-flags: "-Xswiftc strict-concurrency=complete" # "--sanitize=thread"
           - image: swift:5.7-jammy
             # No TSAN because of: https://github.com/apple/swift/issues/59068
             # swift-test-flags: "--sanitize=thread"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,41 +59,41 @@ jobs:
         include:
           - image: swiftlang/swift:nightly-focal
             env:
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 246000
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 138000
-              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 110000
-              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 65000
-              MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 61000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 245000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 137000
+              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 107000
+              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 62000
+              MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 59000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 129000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 136000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 136000
           - image: swift:5.8-jammy
             env:
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 246000
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 138000
-              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 110000
-              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 65000
-              MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 61000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 245000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 137000
+              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 107000
+              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 62000
+              MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 59000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 129000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 136000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 136000
           - image: swift:5.7-jammy
             env:
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 246000
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 138000
-              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 110000
-              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 65000
-              MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 61000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 245000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 137000
+              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 107000
+              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 62000
+              MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 59000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 129000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 136000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 136000
           - image: swift:5.6-focal
             env:
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 247000
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 139000
-              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 110000
-              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 65000
-              MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 61000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 246000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 138000
+              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 107000
+              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 62000
+              MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 59000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 130000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 137000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 137000

--- a/Sources/Examples/Echo/Implementation/EchoProvider.swift
+++ b/Sources/Examples/Echo/Implementation/EchoProvider.swift
@@ -18,7 +18,7 @@ import GRPC
 import NIOCore
 import SwiftProtobuf
 
-public class EchoProvider: Echo_EchoProvider {
+public final class EchoProvider: Echo_EchoProvider {
   public let interceptors: Echo_EchoServerInterceptorFactoryProtocol?
 
   public init(interceptors: Echo_EchoServerInterceptorFactoryProtocol? = nil) {

--- a/Sources/Examples/Echo/Model/echo.grpc.swift
+++ b/Sources/Examples/Echo/Model/echo.grpc.swift
@@ -431,14 +431,14 @@ public final class Echo_EchoTestClient: Echo_EchoClientProtocol {
   ///
   /// - Parameter requestHandler: a handler for request parts sent by the RPC.
   public func makeGetResponseStream(
-    _ requestHandler: @escaping (FakeRequestPart<Echo_EchoRequest>) -> () = { _ in }
+    _ requestHandler: @escaping @Sendable (FakeRequestPart<Echo_EchoRequest>) -> () = { _ in }
   ) -> FakeUnaryResponse<Echo_EchoRequest, Echo_EchoResponse> {
     return self.fakeChannel.makeFakeUnaryResponse(path: Echo_EchoClientMetadata.Methods.get.path, requestHandler: requestHandler)
   }
 
   public func enqueueGetResponse(
     _ response: Echo_EchoResponse,
-    _ requestHandler: @escaping (FakeRequestPart<Echo_EchoRequest>) -> () = { _ in }
+    _ requestHandler: @escaping @Sendable (FakeRequestPart<Echo_EchoRequest>) -> () = { _ in }
   ) {
     let stream = self.makeGetResponseStream(requestHandler)
     // This is the only operation on the stream; try! is fine.
@@ -455,14 +455,14 @@ public final class Echo_EchoTestClient: Echo_EchoClientProtocol {
   ///
   /// - Parameter requestHandler: a handler for request parts sent by the RPC.
   public func makeExpandResponseStream(
-    _ requestHandler: @escaping (FakeRequestPart<Echo_EchoRequest>) -> () = { _ in }
+    _ requestHandler: @escaping @Sendable (FakeRequestPart<Echo_EchoRequest>) -> () = { _ in }
   ) -> FakeStreamingResponse<Echo_EchoRequest, Echo_EchoResponse> {
     return self.fakeChannel.makeFakeStreamingResponse(path: Echo_EchoClientMetadata.Methods.expand.path, requestHandler: requestHandler)
   }
 
   public func enqueueExpandResponses(
     _ responses: [Echo_EchoResponse],
-    _ requestHandler: @escaping (FakeRequestPart<Echo_EchoRequest>) -> () = { _ in }
+    _ requestHandler: @escaping @Sendable (FakeRequestPart<Echo_EchoRequest>) -> () = { _ in }
   ) {
     let stream = self.makeExpandResponseStream(requestHandler)
     // These are the only operation on the stream; try! is fine.
@@ -480,14 +480,14 @@ public final class Echo_EchoTestClient: Echo_EchoClientProtocol {
   ///
   /// - Parameter requestHandler: a handler for request parts sent by the RPC.
   public func makeCollectResponseStream(
-    _ requestHandler: @escaping (FakeRequestPart<Echo_EchoRequest>) -> () = { _ in }
+    _ requestHandler: @escaping @Sendable (FakeRequestPart<Echo_EchoRequest>) -> () = { _ in }
   ) -> FakeUnaryResponse<Echo_EchoRequest, Echo_EchoResponse> {
     return self.fakeChannel.makeFakeUnaryResponse(path: Echo_EchoClientMetadata.Methods.collect.path, requestHandler: requestHandler)
   }
 
   public func enqueueCollectResponse(
     _ response: Echo_EchoResponse,
-    _ requestHandler: @escaping (FakeRequestPart<Echo_EchoRequest>) -> () = { _ in }
+    _ requestHandler: @escaping @Sendable (FakeRequestPart<Echo_EchoRequest>) -> () = { _ in }
   ) {
     let stream = self.makeCollectResponseStream(requestHandler)
     // This is the only operation on the stream; try! is fine.
@@ -504,14 +504,14 @@ public final class Echo_EchoTestClient: Echo_EchoClientProtocol {
   ///
   /// - Parameter requestHandler: a handler for request parts sent by the RPC.
   public func makeUpdateResponseStream(
-    _ requestHandler: @escaping (FakeRequestPart<Echo_EchoRequest>) -> () = { _ in }
+    _ requestHandler: @escaping @Sendable (FakeRequestPart<Echo_EchoRequest>) -> () = { _ in }
   ) -> FakeStreamingResponse<Echo_EchoRequest, Echo_EchoResponse> {
     return self.fakeChannel.makeFakeStreamingResponse(path: Echo_EchoClientMetadata.Methods.update.path, requestHandler: requestHandler)
   }
 
   public func enqueueUpdateResponses(
     _ responses: [Echo_EchoResponse],
-    _ requestHandler: @escaping (FakeRequestPart<Echo_EchoRequest>) -> () = { _ in }
+    _ requestHandler: @escaping @Sendable (FakeRequestPart<Echo_EchoRequest>) -> () = { _ in }
   ) {
     let stream = self.makeUpdateResponseStream(requestHandler)
     // These are the only operation on the stream; try! is fine.
@@ -560,7 +560,7 @@ extension Echo_EchoProvider {
         requestDeserializer: ProtobufDeserializer<Echo_EchoRequest>(),
         responseSerializer: ProtobufSerializer<Echo_EchoResponse>(),
         interceptors: self.interceptors?.makeGetInterceptors() ?? [],
-        userFunction: self.get(request:context:)
+        userFunction: { self.get(request: $0, context: $1) }
       )
 
     case "Expand":
@@ -569,7 +569,7 @@ extension Echo_EchoProvider {
         requestDeserializer: ProtobufDeserializer<Echo_EchoRequest>(),
         responseSerializer: ProtobufSerializer<Echo_EchoResponse>(),
         interceptors: self.interceptors?.makeExpandInterceptors() ?? [],
-        userFunction: self.expand(request:context:)
+        userFunction: { self.expand(request: $0, context: $1) }
       )
 
     case "Collect":
@@ -578,7 +578,7 @@ extension Echo_EchoProvider {
         requestDeserializer: ProtobufDeserializer<Echo_EchoRequest>(),
         responseSerializer: ProtobufSerializer<Echo_EchoResponse>(),
         interceptors: self.interceptors?.makeCollectInterceptors() ?? [],
-        observerFactory: self.collect(context:)
+        observerFactory: { self.collect(context: $0) }
       )
 
     case "Update":
@@ -587,7 +587,7 @@ extension Echo_EchoProvider {
         requestDeserializer: ProtobufDeserializer<Echo_EchoRequest>(),
         responseSerializer: ProtobufSerializer<Echo_EchoResponse>(),
         interceptors: self.interceptors?.makeUpdateInterceptors() ?? [],
-        observerFactory: self.update(context:)
+        observerFactory: { self.update(context: $0) }
       )
 
     default:
@@ -693,19 +693,15 @@ extension Echo_EchoAsyncProvider {
 public protocol Echo_EchoServerInterceptorFactoryProtocol: Sendable {
 
   /// - Returns: Interceptors to use when handling 'get'.
-  ///   Defaults to calling `self.makeInterceptors()`.
   func makeGetInterceptors() -> [ServerInterceptor<Echo_EchoRequest, Echo_EchoResponse>]
 
   /// - Returns: Interceptors to use when handling 'expand'.
-  ///   Defaults to calling `self.makeInterceptors()`.
   func makeExpandInterceptors() -> [ServerInterceptor<Echo_EchoRequest, Echo_EchoResponse>]
 
   /// - Returns: Interceptors to use when handling 'collect'.
-  ///   Defaults to calling `self.makeInterceptors()`.
   func makeCollectInterceptors() -> [ServerInterceptor<Echo_EchoRequest, Echo_EchoResponse>]
 
   /// - Returns: Interceptors to use when handling 'update'.
-  ///   Defaults to calling `self.makeInterceptors()`.
   func makeUpdateInterceptors() -> [ServerInterceptor<Echo_EchoRequest, Echo_EchoResponse>]
 }
 

--- a/Sources/Examples/HelloWorld/Model/helloworld.grpc.swift
+++ b/Sources/Examples/HelloWorld/Model/helloworld.grpc.swift
@@ -224,7 +224,7 @@ extension Helloworld_GreeterProvider {
         requestDeserializer: ProtobufDeserializer<Helloworld_HelloRequest>(),
         responseSerializer: ProtobufSerializer<Helloworld_HelloReply>(),
         interceptors: self.interceptors?.makeSayHelloInterceptors() ?? [],
-        userFunction: self.sayHello(request:context:)
+        userFunction: { self.sayHello(request: $0, context: $1) }
       )
 
     default:
@@ -285,7 +285,6 @@ extension Helloworld_GreeterAsyncProvider {
 public protocol Helloworld_GreeterServerInterceptorFactoryProtocol: Sendable {
 
   /// - Returns: Interceptors to use when handling 'sayHello'.
-  ///   Defaults to calling `self.makeInterceptors()`.
   func makeSayHelloInterceptors() -> [ServerInterceptor<Helloworld_HelloRequest, Helloworld_HelloReply>]
 }
 

--- a/Sources/Examples/RouteGuide/Model/route_guide.grpc.swift
+++ b/Sources/Examples/RouteGuide/Model/route_guide.grpc.swift
@@ -475,7 +475,7 @@ extension Routeguide_RouteGuideProvider {
         requestDeserializer: ProtobufDeserializer<Routeguide_Point>(),
         responseSerializer: ProtobufSerializer<Routeguide_Feature>(),
         interceptors: self.interceptors?.makeGetFeatureInterceptors() ?? [],
-        userFunction: self.getFeature(request:context:)
+        userFunction: { self.getFeature(request: $0, context: $1) }
       )
 
     case "ListFeatures":
@@ -484,7 +484,7 @@ extension Routeguide_RouteGuideProvider {
         requestDeserializer: ProtobufDeserializer<Routeguide_Rectangle>(),
         responseSerializer: ProtobufSerializer<Routeguide_Feature>(),
         interceptors: self.interceptors?.makeListFeaturesInterceptors() ?? [],
-        userFunction: self.listFeatures(request:context:)
+        userFunction: { self.listFeatures(request: $0, context: $1) }
       )
 
     case "RecordRoute":
@@ -493,7 +493,7 @@ extension Routeguide_RouteGuideProvider {
         requestDeserializer: ProtobufDeserializer<Routeguide_Point>(),
         responseSerializer: ProtobufSerializer<Routeguide_RouteSummary>(),
         interceptors: self.interceptors?.makeRecordRouteInterceptors() ?? [],
-        observerFactory: self.recordRoute(context:)
+        observerFactory: { self.recordRoute(context: $0) }
       )
 
     case "RouteChat":
@@ -502,7 +502,7 @@ extension Routeguide_RouteGuideProvider {
         requestDeserializer: ProtobufDeserializer<Routeguide_RouteNote>(),
         responseSerializer: ProtobufSerializer<Routeguide_RouteNote>(),
         interceptors: self.interceptors?.makeRouteChatInterceptors() ?? [],
-        observerFactory: self.routeChat(context:)
+        observerFactory: { self.routeChat(context: $0) }
       )
 
     default:
@@ -626,19 +626,15 @@ extension Routeguide_RouteGuideAsyncProvider {
 public protocol Routeguide_RouteGuideServerInterceptorFactoryProtocol: Sendable {
 
   /// - Returns: Interceptors to use when handling 'getFeature'.
-  ///   Defaults to calling `self.makeInterceptors()`.
   func makeGetFeatureInterceptors() -> [ServerInterceptor<Routeguide_Point, Routeguide_Feature>]
 
   /// - Returns: Interceptors to use when handling 'listFeatures'.
-  ///   Defaults to calling `self.makeInterceptors()`.
   func makeListFeaturesInterceptors() -> [ServerInterceptor<Routeguide_Rectangle, Routeguide_Feature>]
 
   /// - Returns: Interceptors to use when handling 'recordRoute'.
-  ///   Defaults to calling `self.makeInterceptors()`.
   func makeRecordRouteInterceptors() -> [ServerInterceptor<Routeguide_Point, Routeguide_RouteSummary>]
 
   /// - Returns: Interceptors to use when handling 'routeChat'.
-  ///   Defaults to calling `self.makeInterceptors()`.
   func makeRouteChatInterceptors() -> [ServerInterceptor<Routeguide_RouteNote, Routeguide_RouteNote>]
 }
 

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncBidirectionalStreamingCall.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncBidirectionalStreamingCall.swift
@@ -152,7 +152,7 @@ internal enum AsyncCall {
     >.Source,
     requestStream: GRPCAsyncRequestStreamWriter<Request>?,
     requestType: Request.Type = Request.self
-  ) -> (GRPCClientResponsePart<Response>) -> Void {
+  ) -> @Sendable (GRPCClientResponsePart<Response>) -> Void {
     return { responsePart in
       // Handle the metadata, trailers and status.
       responseParts.handle(responsePart)
@@ -182,7 +182,7 @@ internal enum AsyncCall {
     requestStream: GRPCAsyncRequestStreamWriter<Request>?,
     requestType: Request.Type = Request.self,
     responseType: Response.Type = Response.self
-  ) -> (GRPCClientResponsePart<Response>) -> Void {
+  ) -> @Sendable (GRPCClientResponsePart<Response>) -> Void {
     return { responsePart in
       // Handle (most of) all parts.
       responseParts.handle(responsePart)

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncServerStreamingCall.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncServerStreamingCall.swift
@@ -19,7 +19,7 @@ import NIOHPACK
 
 /// Async-await variant of ``ServerStreamingCall``.
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-public struct GRPCAsyncServerStreamingCall<Request: Sendable, Response: Sendable> {
+public struct GRPCAsyncServerStreamingCall<Request: Sendable, Response: Sendable>: Sendable {
   private let call: Call<Request, Response>
   private let responseParts: StreamingResponseParts<Response>
   private let responseSource: NIOThrowingAsyncSequenceProducer<

--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncUnaryCall.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncUnaryCall.swift
@@ -102,8 +102,12 @@ public struct GRPCAsyncUnaryCall<Request: Sendable, Response: Sendable>: Sendabl
     self.call.invokeUnaryRequest(
       request,
       onStart: {},
-      onError: self.responseParts.handleError(_:),
-      onResponsePart: self.responseParts.handle(_:)
+      onError: { [responseParts = self.responseParts] in
+        responseParts.handleError($0)
+      },
+      onResponsePart: { [responseParts = self.responseParts] in
+        responseParts.handle($0)
+      }
     )
   }
 

--- a/Sources/GRPC/CallHandlers/ClientStreamingServerHandler.swift
+++ b/Sources/GRPC/CallHandlers/ClientStreamingServerHandler.swift
@@ -19,7 +19,7 @@ import NIOHPACK
 public final class ClientStreamingServerHandler<
   Serializer: MessageSerializer,
   Deserializer: MessageDeserializer
->: GRPCServerHandlerProtocol {
+>: GRPCServerHandlerProtocol, @unchecked Sendable {
   public typealias Request = Deserializer.Output
   public typealias Response = Serializer.Input
 
@@ -178,10 +178,10 @@ public final class ClientStreamingServerHandler<
       self.state = .creatingObserver(context)
 
       // Register a callback on the response future.
-      context.responsePromise.futureResult.whenComplete(self.userFunctionCompletedWithResult(_:))
+      context.responsePromise.futureResult.whenComplete { self.userFunctionCompletedWithResult($0) }
 
       // Make an observer block and register a completion block.
-      self.handlerFactory(context).whenComplete(self.userFunctionResolved(_:))
+      self.handlerFactory(context).whenComplete { self.userFunctionResolved($0) }
 
       // Send response headers back via the interceptors.
       self.interceptors.send(.metadata([:]), promise: nil)

--- a/Sources/GRPC/CallHandlers/ServerStreamingServerHandler.swift
+++ b/Sources/GRPC/CallHandlers/ServerStreamingServerHandler.swift
@@ -19,7 +19,7 @@ import NIOHPACK
 public final class ServerStreamingServerHandler<
   Serializer: MessageSerializer,
   Deserializer: MessageDeserializer
->: GRPCServerHandlerProtocol {
+>: GRPCServerHandlerProtocol, @unchecked Sendable {
   public typealias Request = Deserializer.Output
   public typealias Response = Serializer.Input
 
@@ -176,7 +176,7 @@ public final class ServerStreamingServerHandler<
       self.state = .createdContext(context)
 
       // Register a callback on the status future.
-      context.statusPromise.futureResult.whenComplete(self.userFunctionCompletedWithResult(_:))
+      context.statusPromise.futureResult.whenComplete { self.userFunctionCompletedWithResult($0) }
 
       // Send response headers back via the interceptors.
       self.interceptors.send(.metadata([:]), promise: nil)

--- a/Sources/GRPC/CallHandlers/UnaryServerHandler.swift
+++ b/Sources/GRPC/CallHandlers/UnaryServerHandler.swift
@@ -19,7 +19,7 @@ import NIOHPACK
 public final class UnaryServerHandler<
   Serializer: MessageSerializer,
   Deserializer: MessageDeserializer
->: GRPCServerHandlerProtocol {
+>: GRPCServerHandlerProtocol, @unchecked Sendable {
   public typealias Request = Deserializer.Output
   public typealias Response = Serializer.Input
 
@@ -172,7 +172,7 @@ public final class UnaryServerHandler<
       self.state = .createdContext(context)
 
       // Register a callback on the response future. The user function will complete this promise.
-      context.responsePromise.futureResult.whenComplete(self.userFunctionCompletedWithResult(_:))
+      context.responsePromise.futureResult.whenComplete { self.userFunctionCompletedWithResult($0) }
 
       // Send back response headers.
       self.interceptors.send(.metadata([:]), promise: nil)

--- a/Sources/GRPC/ClientCalls/ResponseContainers.swift
+++ b/Sources/GRPC/ClientCalls/ResponseContainers.swift
@@ -17,7 +17,7 @@ import NIOCore
 import NIOHPACK
 
 /// A bucket of promises for a unary-response RPC.
-internal class UnaryResponseParts<Response> {
+internal final class UnaryResponseParts<Response: Sendable>: @unchecked Sendable {
   /// The `EventLoop` we expect to receive these response parts on.
   private let eventLoop: EventLoop
 
@@ -93,7 +93,7 @@ internal class UnaryResponseParts<Response> {
 }
 
 /// A bucket of promises for a streaming-response RPC.
-internal class StreamingResponseParts<Response> {
+internal final class StreamingResponseParts<Response: Sendable>: @unchecked Sendable {
   /// The `EventLoop` we expect to receive these response parts on.
   private let eventLoop: EventLoop
 
@@ -168,8 +168,8 @@ internal class StreamingResponseParts<Response> {
 }
 
 extension EventLoop {
-  fileprivate func executeOrFlatSubmit<Result>(
-    _ body: @escaping () -> EventLoopFuture<Result>
+  fileprivate func executeOrFlatSubmit<Result: Sendable>(
+    _ body: @escaping @Sendable () -> EventLoopFuture<Result>
   ) -> EventLoopFuture<Result> {
     if self.inEventLoop {
       return body()
@@ -200,7 +200,3 @@ extension Error {
     }
   }
 }
-
-// @unchecked is ok: all mutable state is accessed/modified from an appropriate event loop.
-extension UnaryResponseParts: @unchecked Sendable where Response: Sendable {}
-extension StreamingResponseParts: @unchecked Sendable where Response: Sendable {}

--- a/Sources/GRPC/ClientCalls/ServerStreamingCall.swift
+++ b/Sources/GRPC/ClientCalls/ServerStreamingCall.swift
@@ -23,7 +23,10 @@ import NIOHTTP2
 ///
 /// Note: while this object is a `struct`, its implementation delegates to `Call`. It therefore
 /// has reference semantics.
-public struct ServerStreamingCall<RequestPayload, ResponsePayload>: ClientCall {
+public struct ServerStreamingCall<
+  RequestPayload: Sendable,
+  ResponsePayload: Sendable
+>: ClientCall, Sendable {
   private let call: Call<RequestPayload, ResponsePayload>
   private let responseParts: StreamingResponseParts<ResponsePayload>
 
@@ -81,8 +84,8 @@ public struct ServerStreamingCall<RequestPayload, ResponsePayload>: ClientCall {
     self.call.invokeUnaryRequest(
       request,
       onStart: {},
-      onError: self.responseParts.handleError(_:),
-      onResponsePart: self.responseParts.handle(_:)
+      onError: { self.responseParts.handleError($0) },
+      onResponsePart: { self.responseParts.handle($0) }
     )
   }
 }

--- a/Sources/GRPC/ClientCalls/UnaryCall.swift
+++ b/Sources/GRPC/ClientCalls/UnaryCall.swift
@@ -25,7 +25,10 @@ import SwiftProtobuf
 ///
 /// Note: while this object is a `struct`, its implementation delegates to ``Call``. It therefore
 /// has reference semantics.
-public struct UnaryCall<RequestPayload, ResponsePayload>: UnaryResponseClientCall {
+public struct UnaryCall<
+  RequestPayload: Sendable,
+  ResponsePayload: Sendable
+>: UnaryResponseClientCall, Sendable {
   private let call: Call<RequestPayload, ResponsePayload>
   private let responseParts: UnaryResponseParts<ResponsePayload>
 
@@ -85,8 +88,8 @@ public struct UnaryCall<RequestPayload, ResponsePayload>: UnaryResponseClientCal
     self.call.invokeUnaryRequest(
       request,
       onStart: {},
-      onError: self.responseParts.handleError(_:),
-      onResponsePart: self.responseParts.handle(_:)
+      onError: { self.responseParts.handleError($0) },
+      onResponsePart: { self.responseParts.handle($0) }
     )
   }
 }

--- a/Sources/GRPC/ClientConnectionConfiguration+NIOSSL.swift
+++ b/Sources/GRPC/ClientConnectionConfiguration+NIOSSL.swift
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #if canImport(NIOSSL)
+import NIOCore
 import NIOSSL
 
 extension ClientConnection.Configuration {
@@ -71,7 +72,10 @@ extension ClientConnection.Configuration {
     }
 
     /// A custom verification callback that allows completely overriding the certificate verification logic for this connection.
-    public var customVerificationCallback: NIOSSLCustomVerificationCallback?
+    public var customVerificationCallback: (@Sendable (
+      [NIOSSLCertificate],
+      EventLoopPromise<NIOSSLVerificationResult>
+    ) -> Void)?
 
     /// TLS Configuration with suitable defaults for clients.
     ///
@@ -96,7 +100,10 @@ extension ClientConnection.Configuration {
       trustRoots: NIOSSLTrustRoots = .default,
       certificateVerification: CertificateVerification = .fullVerification,
       hostnameOverride: String? = nil,
-      customVerificationCallback: NIOSSLCustomVerificationCallback? = nil
+      customVerificationCallback: (@Sendable (
+        [NIOSSLCertificate],
+        EventLoopPromise<NIOSSLVerificationResult>
+      ) -> Void)? = nil
     ) {
       var configuration = TLSConfiguration.makeClientConfiguration()
       configuration.minimumTLSVersion = .tlsv12

--- a/Sources/GRPC/Compression/MessageEncoding.swift
+++ b/Sources/GRPC/Compression/MessageEncoding.swift
@@ -116,7 +116,7 @@ extension ClientMessageEncoding {
 }
 
 /// Whether compression is enabled or disabled on the server.
-public enum ServerMessageEncoding {
+public enum ServerMessageEncoding: Sendable {
   /// Compression is supported with this configuration.
   case enabled(Configuration)
   /// Compression is not enabled. However, 'identity' compression is still supported.
@@ -134,7 +134,7 @@ public enum ServerMessageEncoding {
 }
 
 extension ServerMessageEncoding {
-  public struct Configuration {
+  public struct Configuration: Sendable {
     /// The set of compression algorithms advertised that we will accept from clients for requests.
     /// Note that clients may send us messages compressed with algorithms not included in this list;
     /// if we support it then we still accept the message.

--- a/Sources/GRPC/ConnectionKeepalive.swift
+++ b/Sources/GRPC/ConnectionKeepalive.swift
@@ -54,7 +54,7 @@ public struct ClientConnectionKeepalive: Hashable, Sendable {
   }
 }
 
-public struct ServerConnectionKeepalive: Hashable {
+public struct ServerConnectionKeepalive: Hashable, Sendable {
   /// The amount of time to wait before sending a keepalive ping.
   public var interval: TimeAmount
 

--- a/Sources/GRPC/ConnectionManagerChannelProvider.swift
+++ b/Sources/GRPC/ConnectionManagerChannelProvider.swift
@@ -39,9 +39,9 @@ internal protocol ConnectionManagerChannelProvider {
 }
 
 @usableFromInline
-internal struct DefaultChannelProvider: ConnectionManagerChannelProvider {
+internal struct DefaultChannelProvider: ConnectionManagerChannelProvider, Sendable {
   @usableFromInline
-  enum TLSMode {
+  enum TLSMode: Sendable {
     #if canImport(NIOSSL)
     case configureWithNIOSSL(Result<NIOSSLContext, Error>)
     #endif // canImport(NIOSSL)
@@ -69,7 +69,7 @@ internal struct DefaultChannelProvider: ConnectionManagerChannelProvider {
   @usableFromInline
   internal var errorDelegate: Optional<ClientErrorDelegate>
   @usableFromInline
-  internal var debugChannelInitializer: Optional<(Channel) -> EventLoopFuture<Void>>
+  internal var debugChannelInitializer: Optional< @Sendable (Channel) -> EventLoopFuture < Void>>
 
   @inlinable
   internal init(
@@ -81,7 +81,7 @@ internal struct DefaultChannelProvider: ConnectionManagerChannelProvider {
     httpTargetWindowSize: Int,
     httpMaxFrameSize: Int,
     errorDelegate: ClientErrorDelegate?,
-    debugChannelInitializer: ((Channel) -> EventLoopFuture<Void>)?
+    debugChannelInitializer: (@Sendable (Channel) -> EventLoopFuture<Void>)?
   ) {
     self.connectionTarget = connectionTarget
     self.connectionKeepalive = connectionKeepalive

--- a/Sources/GRPC/ConnectionManagerChannelProvider.swift
+++ b/Sources/GRPC/ConnectionManagerChannelProvider.swift
@@ -69,7 +69,7 @@ internal struct DefaultChannelProvider: ConnectionManagerChannelProvider, Sendab
   @usableFromInline
   internal var errorDelegate: Optional<ClientErrorDelegate>
   @usableFromInline
-  internal var debugChannelInitializer: Optional<@Sendable (Channel) -> EventLoopFuture <Void>>
+  internal var debugChannelInitializer: Optional< @Sendable (Channel) -> EventLoopFuture <Void>>
 
   @inlinable
   internal init(

--- a/Sources/GRPC/ConnectionManagerChannelProvider.swift
+++ b/Sources/GRPC/ConnectionManagerChannelProvider.swift
@@ -69,7 +69,7 @@ internal struct DefaultChannelProvider: ConnectionManagerChannelProvider, Sendab
   @usableFromInline
   internal var errorDelegate: Optional<ClientErrorDelegate>
   @usableFromInline
-  internal var debugChannelInitializer: Optional< @Sendable (Channel) -> EventLoopFuture < Void>>
+  internal var debugChannelInitializer: Optional<@Sendable (Channel) -> EventLoopFuture <Void>>
 
   @inlinable
   internal init(

--- a/Sources/GRPC/ConnectionPool/ConnectionPool+Waiter.swift
+++ b/Sources/GRPC/ConnectionPool/ConnectionPool+Waiter.swift
@@ -68,7 +68,7 @@ extension ConnectionPool {
     @usableFromInline
     internal func scheduleTimeout(
       on eventLoop: EventLoop,
-      execute body: @escaping () -> Void
+      execute body: @escaping @Sendable () -> Void
     ) {
       assert(self._scheduledTimeout == nil)
       self._scheduledTimeout = eventLoop.scheduleTask(deadline: self._deadline, body)

--- a/Sources/GRPC/ConnectionPool/PoolManager.swift
+++ b/Sources/GRPC/ConnectionPool/PoolManager.swift
@@ -21,7 +21,9 @@ import NIOCore
 extension PooledChannel: @unchecked Sendable {}
 
 @usableFromInline
-internal final class PoolManager {
+internal final class PoolManager: @unchecked Sendable {
+  // @unchecked as all mutable state is protected by a lock.
+
   /// Configuration used for each connection pool.
   @usableFromInline
   internal struct PerPoolConfiguration {

--- a/Sources/GRPC/FakeChannel.swift
+++ b/Sources/GRPC/FakeChannel.swift
@@ -52,9 +52,9 @@ public class FakeChannel: GRPCChannel {
 
   /// Make and store a fake unary response for the given path. Users should prefer making a response
   /// stream for their RPC directly via the appropriate method on their generated test client.
-  public func makeFakeUnaryResponse<Request, Response>(
+  public func makeFakeUnaryResponse<Request: Sendable, Response: Sendable>(
     path: String,
-    requestHandler: @escaping (FakeRequestPart<Request>) -> Void
+    requestHandler: @escaping @Sendable (FakeRequestPart<Request>) -> Void
   ) -> FakeUnaryResponse<Request, Response> {
     let proxy = FakeUnaryResponse<Request, Response>(requestHandler: requestHandler)
     self.responseStreams[path, default: []].append(proxy)
@@ -64,9 +64,9 @@ public class FakeChannel: GRPCChannel {
   /// Make and store a fake streaming response for the given path. Users should prefer making a
   /// response stream for their RPC directly via the appropriate method on their generated test
   /// client.
-  public func makeFakeStreamingResponse<Request, Response>(
+  public func makeFakeStreamingResponse<Request: Sendable, Response: Sendable>(
     path: String,
-    requestHandler: @escaping (FakeRequestPart<Request>) -> Void
+    requestHandler: @escaping @Sendable (FakeRequestPart<Request>) -> Void
   ) -> FakeStreamingResponse<Request, Response> {
     let proxy = FakeStreamingResponse<Request, Response>(requestHandler: requestHandler)
     self.responseStreams[path, default: []].append(proxy)

--- a/Sources/GRPC/GRPCChannel/ClientConnection+NIOSSL.swift
+++ b/Sources/GRPC/GRPCChannel/ClientConnection+NIOSSL.swift
@@ -89,7 +89,10 @@ extension ClientConnection.Builder.Secure {
   /// - Note: May only be used with the 'NIOSSL' TLS backend.
   @discardableResult
   public func withTLSCustomVerificationCallback(
-    _ callback: @escaping NIOSSLCustomVerificationCallback
+    _ callback: @escaping @Sendable (
+      [NIOSSLCertificate],
+      EventLoopPromise<NIOSSLVerificationResult>
+    ) -> Void
   ) -> Self {
     self.tls.updateNIOCustomVerificationCallback(to: callback)
     return self

--- a/Sources/GRPC/GRPCChannel/GRPCChannel.swift
+++ b/Sources/GRPC/GRPCChannel/GRPCChannel.swift
@@ -105,7 +105,7 @@ extension GRPCChannel {
   ///   - request: The request to send.
   ///   - callOptions: Options for the RPC.
   ///   - interceptors: A list of interceptors to intercept the request and response stream with.
-  public func makeUnaryCall<Request: Message, Response: Message>(
+  public func makeUnaryCall<Request: Message & Sendable, Response: Message & Sendable>(
     path: String,
     request: Request,
     callOptions: CallOptions,
@@ -154,7 +154,7 @@ extension GRPCChannel {
   ///   - path: Path of the RPC, e.g. "/echo.Echo/Get"
   ///   - callOptions: Options for the RPC.
   ///   - interceptors: A list of interceptors to intercept the request and response stream with.
-  public func makeClientStreamingCall<Request: Message, Response: Message>(
+  public func makeClientStreamingCall<Request: Message & Sendable, Response: Message & Sendable>(
     path: String,
     callOptions: CallOptions,
     interceptors: [ClientInterceptor<Request, Response>] = []
@@ -202,7 +202,7 @@ extension GRPCChannel {
   ///   - callOptions: Options for the RPC.
   ///   - interceptors: A list of interceptors to intercept the request and response stream with.
   ///   - handler: Response handler; called for every response received from the server.
-  public func makeServerStreamingCall<Request: Message, Response: Message>(
+  public func makeServerStreamingCall<Request: Message & Sendable, Response: Message & Sendable>(
     path: String,
     request: Request,
     callOptions: CallOptions,
@@ -257,7 +257,10 @@ extension GRPCChannel {
   ///   - callOptions: Options for the RPC.
   ///   - interceptors: A list of interceptors to intercept the request and response stream with.
   ///   - handler: Response handler; called for every response received from the server.
-  public func makeBidirectionalStreamingCall<Request: Message, Response: Message>(
+  public func makeBidirectionalStreamingCall<
+    Request: Message & Sendable,
+    Response: Message & Sendable
+  >(
     path: String,
     callOptions: CallOptions,
     interceptors: [ClientInterceptor<Request, Response>] = [],

--- a/Sources/GRPC/GRPCClient.swift
+++ b/Sources/GRPC/GRPCClient.swift
@@ -31,7 +31,10 @@ public protocol GRPCClient: GRPCPreconcurrencySendable {
 // MARK: Convenience methods
 
 extension GRPCClient {
-  public func makeUnaryCall<Request: SwiftProtobuf.Message, Response: SwiftProtobuf.Message>(
+  public func makeUnaryCall<
+    Request: SwiftProtobuf.Message & Sendable,
+    Response: SwiftProtobuf.Message & Sendable
+  >(
     path: String,
     request: Request,
     callOptions: CallOptions? = nil,
@@ -62,8 +65,8 @@ extension GRPCClient {
   }
 
   public func makeServerStreamingCall<
-    Request: SwiftProtobuf.Message,
-    Response: SwiftProtobuf.Message
+    Request: SwiftProtobuf.Message & Sendable,
+    Response: SwiftProtobuf.Message & Sendable
   >(
     path: String,
     request: Request,
@@ -99,8 +102,8 @@ extension GRPCClient {
   }
 
   public func makeClientStreamingCall<
-    Request: SwiftProtobuf.Message,
-    Response: SwiftProtobuf.Message
+    Request: SwiftProtobuf.Message & Sendable,
+    Response: SwiftProtobuf.Message & Sendable
   >(
     path: String,
     callOptions: CallOptions? = nil,
@@ -130,8 +133,8 @@ extension GRPCClient {
   }
 
   public func makeBidirectionalStreamingCall<
-    Request: SwiftProtobuf.Message,
-    Response: SwiftProtobuf.Message
+    Request: SwiftProtobuf.Message & Sendable,
+    Response: SwiftProtobuf.Message & Sendable
   >(
     path: String,
     callOptions: CallOptions? = nil,

--- a/Sources/GRPC/GRPCClientChannelHandler.swift
+++ b/Sources/GRPC/GRPCClientChannelHandler.swift
@@ -42,7 +42,7 @@ public typealias _RawGRPCClientRequestPart = _GRPCClientRequestPart<ByteBuffer>
 /// A gRPC client response message part.
 ///
 /// - Important: This is **NOT** part of the public API.
-public enum _GRPCClientResponsePart<Response> {
+public enum _GRPCClientResponsePart<Response: Sendable>: Sendable {
   /// Metadata received as the server acknowledges the RPC.
   case initialMetadata(HPACKHeaders)
 

--- a/Sources/GRPC/GRPCLogger.swift
+++ b/Sources/GRPC/GRPCLogger.swift
@@ -20,7 +20,7 @@ import NIOCore
 ///
 /// See https://github.com/apple/swift-log/issues/145 for rationale.
 @usableFromInline
-internal struct GRPCLogger {
+internal struct GRPCLogger: Sendable {
   @usableFromInline
   internal var logger: Logger
 

--- a/Sources/GRPC/GRPCPayload.swift
+++ b/Sources/GRPC/GRPCPayload.swift
@@ -17,7 +17,7 @@ import NIOCore
 
 /// A data type which may be serialized into and out from a `ByteBuffer` in order to be sent between
 /// gRPC peers.
-public protocol GRPCPayload {
+public protocol GRPCPayload: Sendable {
   /// Initializes a new payload by deserializing the bytes from the given `ByteBuffer`.
   ///
   /// - Parameter serializedByteBuffer: A buffer containing the serialized bytes of this payload.

--- a/Sources/GRPC/GRPCServerRequestRoutingHandler.swift
+++ b/Sources/GRPC/GRPCServerRequestRoutingHandler.swift
@@ -23,7 +23,7 @@ import SwiftProtobuf
 /// Provides ``GRPCServerHandlerProtocol`` objects for the methods on a particular service name.
 ///
 /// Implemented by the generated code.
-public protocol CallHandlerProvider: AnyObject {
+public protocol CallHandlerProvider: AnyObject, Sendable {
   /// The name of the service this object is providing methods for, including the package path.
   ///
   /// - Example: "io.grpc.Echo.EchoService"

--- a/Sources/GRPC/GRPCStatusAndMetadata.swift
+++ b/Sources/GRPC/GRPCStatusAndMetadata.swift
@@ -18,7 +18,7 @@ import NIOHTTP1
 
 /// A simple struct holding a ``GRPCStatus`` and optionally trailers in the form of
 /// `HPACKHeaders`.
-public struct GRPCStatusAndTrailers: Equatable {
+public struct GRPCStatusAndTrailers: Equatable, Sendable {
   /// The status.
   public var status: GRPCStatus
 

--- a/Sources/GRPC/Interceptor/ClientInterceptorContext.swift
+++ b/Sources/GRPC/Interceptor/ClientInterceptorContext.swift
@@ -16,7 +16,7 @@
 import Logging
 import NIOCore
 
-public struct ClientInterceptorContext<Request, Response> {
+public struct ClientInterceptorContext<Request: Sendable, Response: Sendable> {
   /// The interceptor this context is for.
   @usableFromInline
   internal let interceptor: ClientInterceptor<Request, Response>

--- a/Sources/GRPC/Interceptor/ClientInterceptorPipeline.swift
+++ b/Sources/GRPC/Interceptor/ClientInterceptorPipeline.swift
@@ -58,7 +58,12 @@ import NIOHTTP2
 /// │                       (a NIO.ChannelHandler)                      │
 /// ```
 @usableFromInline
-internal final class ClientInterceptorPipeline<Request, Response> {
+internal final class ClientInterceptorPipeline<
+  Request: Sendable,
+  Response: Sendable
+>: @unchecked Sendable {
+  // @unchecked as all state is synchronized on the event loop.
+
   /// A logger.
   @usableFromInline
   internal var logger: GRPCLogger
@@ -460,6 +465,7 @@ extension ClientInterceptorPipeline {
   /// Sets up a deadline for the pipeline.
   @inlinable
   internal func _setupDeadline() {
+    @Sendable
     func setup() {
       self.eventLoop.assertInEventLoop()
 

--- a/Sources/GRPC/Interceptor/ClientInterceptors.swift
+++ b/Sources/GRPC/Interceptor/ClientInterceptors.swift
@@ -48,7 +48,10 @@ import NIOCore
 /// require any extra attention. However, if work is done on a `DispatchQueue` or _other_
 /// `EventLoop` then implementers should ensure that they use `context` from the correct
 /// `EventLoop`.
-@preconcurrency open class ClientInterceptor<Request, Response>: @unchecked Sendable {
+@preconcurrency open class ClientInterceptor<
+  Request: Sendable,
+  Response: Sendable
+>: @unchecked Sendable {
   public init() {}
 
   /// Called when the interceptor has received a response part to handle.

--- a/Sources/GRPC/Interceptor/ClientTransport.swift
+++ b/Sources/GRPC/Interceptor/ClientTransport.swift
@@ -35,7 +35,9 @@ import NIOHTTP2
 ///
 /// This class is not thread safe. All methods **must** be executed on the transport's `callEventLoop`.
 @usableFromInline
-internal final class ClientTransport<Request, Response> {
+internal final class ClientTransport<Request: Sendable, Response: Sendable>: @unchecked Sendable {
+  // @unchecked because all state is accessed from the event loop.
+
   /// The `EventLoop` the call is running on. State must be accessed from this event loop.
   @usableFromInline
   internal let callEventLoop: EventLoop

--- a/Sources/GRPC/LoggingServerErrorDelegate.swift
+++ b/Sources/GRPC/LoggingServerErrorDelegate.swift
@@ -15,7 +15,7 @@
  */
 import Logging
 
-public class LoggingServerErrorDelegate: ServerErrorDelegate {
+public final class LoggingServerErrorDelegate: ServerErrorDelegate, Sendable {
   private let logger: Logger
 
   public init(logger: Logger) {

--- a/Sources/GRPC/LoopBound.swift
+++ b/Sources/GRPC/LoopBound.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, gRPC Authors All rights reserved.
+ * Copyright 2023, gRPC Authors All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import SwiftProtobuf
+import NIOCore
 
-/// An event that can occur on a client-streaming RPC. Provided to the event observer registered for that call.
-public enum StreamEvent<Message: Sendable>: Sendable {
-  case message(Message)
-  case end
-  //! FIXME: Also support errors in this type, to propagate them to the event handler.
+extension EventLoop {
+  @inlinable
+  func makeLoopBound<Value>(_ value: Value) -> NIOLoopBound<Value> {
+    return NIOLoopBound(value, eventLoop: self)
+  }
 }

--- a/Sources/GRPC/Serialization.swift
+++ b/Sources/GRPC/Serialization.swift
@@ -19,7 +19,7 @@ import NIOFoundationCompat
 import SwiftProtobuf
 
 public protocol MessageSerializer {
-  associatedtype Input
+  associatedtype Input: Sendable
 
   /// Serializes `input` into a `ByteBuffer` allocated using the provided `allocator`.
   ///
@@ -31,7 +31,7 @@ public protocol MessageSerializer {
 }
 
 public protocol MessageDeserializer {
-  associatedtype Output
+  associatedtype Output: Sendable
 
   /// Deserializes `byteBuffer` to produce a single `Output`.
   ///
@@ -42,7 +42,7 @@ public protocol MessageDeserializer {
 
 // MARK: Protobuf
 
-public struct ProtobufSerializer<Message: SwiftProtobuf.Message>: MessageSerializer {
+public struct ProtobufSerializer<Message: SwiftProtobuf.Message & Sendable>: MessageSerializer {
   @inlinable
   public init() {}
 
@@ -65,7 +65,7 @@ public struct ProtobufSerializer<Message: SwiftProtobuf.Message>: MessageSeriali
   }
 }
 
-public struct ProtobufDeserializer<Message: SwiftProtobuf.Message>: MessageDeserializer {
+public struct ProtobufDeserializer<Message: SwiftProtobuf.Message & Sendable>: MessageDeserializer {
   @inlinable
   public init() {}
 
@@ -129,7 +129,7 @@ public struct GRPCPayloadDeserializer<Message: GRPCPayload>: MessageDeserializer
 
 // MARK: - Any Serializer/Deserializer
 
-internal struct AnySerializer<Input>: MessageSerializer {
+internal struct AnySerializer<Input: Sendable>: MessageSerializer {
   private let _serialize: (Input, ByteBufferAllocator) throws -> ByteBuffer
 
   init<Serializer: MessageSerializer>(wrapping other: Serializer) where Serializer.Input == Input {
@@ -141,7 +141,7 @@ internal struct AnySerializer<Input>: MessageSerializer {
   }
 }
 
-internal struct AnyDeserializer<Output>: MessageDeserializer {
+internal struct AnyDeserializer<Output: Sendable>: MessageDeserializer {
   private let _deserialize: (ByteBuffer) throws -> Output
 
   init<Deserializer: MessageDeserializer>(

--- a/Sources/GRPC/Server.swift
+++ b/Sources/GRPC/Server.swift
@@ -268,7 +268,7 @@ public typealias BindTarget = ConnectionTarget
 
 extension Server {
   /// The configuration for a server.
-  public struct Configuration {
+  public struct Configuration: Sendable {
     /// The target to bind to.
     public var target: BindTarget
     /// The event loop group to run the connection on.
@@ -367,7 +367,7 @@ extension Server {
     ///
     /// - Warning: The initializer closure may be invoked *multiple times*. More precisely: it will
     ///   be invoked at most once per accepted connection.
-    public var debugChannelInitializer: ((Channel) -> EventLoopFuture<Void>)?
+    public var debugChannelInitializer: (@Sendable (Channel) -> EventLoopFuture<Void>)?
 
     /// A calculated private cache of the service providers by name.
     ///
@@ -408,7 +408,7 @@ extension Server {
       messageEncoding: ServerMessageEncoding = .disabled,
       httpTargetWindowSize: Int = 8 * 1024 * 1024,
       logger: Logger = Logger(label: "io.grpc", factory: { _ in SwiftLogNoOpLogHandler() }),
-      debugChannelInitializer: ((Channel) -> EventLoopFuture<Void>)? = nil
+      debugChannelInitializer: (@Sendable (Channel) -> EventLoopFuture<Void>)? = nil
     ) {
       self.target = target
       self.eventLoopGroup = eventLoopGroup

--- a/Sources/GRPC/ServerBuilder.swift
+++ b/Sources/GRPC/ServerBuilder.swift
@@ -201,7 +201,7 @@ extension Server.Builder {
   ///   be invoked at most once per accepted connection.
   @discardableResult
   public func withDebugChannelInitializer(
-    _ debugChannelInitializer: @escaping (Channel) -> EventLoopFuture<Void>
+    _ debugChannelInitializer: @escaping @Sendable (Channel) -> EventLoopFuture<Void>
   ) -> Self {
     self.configuration.debugChannelInitializer = debugChannelInitializer
     return self

--- a/Sources/GRPC/ServerCallContexts/ServerCallContext.swift
+++ b/Sources/GRPC/ServerCallContexts/ServerCallContext.swift
@@ -59,7 +59,7 @@ extension GRPCStatus {
 }
 
 /// Base class providing data provided to the framework user for all server calls.
-open class ServerCallContextBase: ServerCallContext {
+open class ServerCallContextBase: ServerCallContext, @unchecked Sendable {
   /// The event loop this call is served on.
   public let eventLoop: EventLoop
 

--- a/Sources/GRPC/ServerCallContexts/StreamingResponseCallContext.swift
+++ b/Sources/GRPC/ServerCallContexts/StreamingResponseCallContext.swift
@@ -147,7 +147,7 @@ open class StreamingResponseCallContext<ResponsePayload: Sendable>: ServerCallCo
 /// A concrete implementation of `StreamingResponseCallContext` used internally.
 @usableFromInline
 internal final class _StreamingResponseCallContext<Request: Sendable, Response: Sendable>:
-  StreamingResponseCallContext<Response>, @unchecked Sendable {
+  StreamingResponseCallContext<Response> {
   @usableFromInline
   internal let _sendResponse: (Response, MessageMetadata, EventLoopPromise<Void>?) -> Void
 
@@ -233,6 +233,11 @@ internal final class _StreamingResponseCallContext<Request: Sendable, Response: 
     }
   }
 }
+
+#if swift(>=5.7)
+// 5.6 errors because the base class is marked as Sendable.
+extension _StreamingResponseCallContext: @unchecked Sendable {}
+#endif
 
 /// Concrete implementation of `StreamingResponseCallContext` used for testing.
 ///

--- a/Sources/GRPC/ServerErrorDelegate.swift
+++ b/Sources/GRPC/ServerErrorDelegate.swift
@@ -18,7 +18,7 @@ import NIOCore
 import NIOHPACK
 import NIOHTTP1
 
-public protocol ServerErrorDelegate: AnyObject {
+public protocol ServerErrorDelegate: AnyObject, Sendable {
   //! FIXME: Provide more context about where the error was thrown, i.e. using `GRPCError`.
   /// Called when an error is thrown in the channel pipeline.
   func observeLibraryError(_ error: Error)

--- a/Sources/GRPC/WriteCapturingHandler.swift
+++ b/Sources/GRPC/WriteCapturingHandler.swift
@@ -19,9 +19,9 @@ import NIOCore
 /// all writes will be failed.
 ///
 /// This handler is intended for use with 'fake' response streams the 'FakeChannel'.
-internal final class WriteCapturingHandler<Request>: ChannelOutboundHandler {
+internal final class WriteCapturingHandler<Request: Sendable>: ChannelOutboundHandler {
   typealias OutboundIn = _GRPCClientRequestPart<Request>
-  typealias RequestHandler = (FakeRequestPart<Request>) -> Void
+  typealias RequestHandler = @Sendable (FakeRequestPart<Request>) -> Void
 
   private var state: State
   private enum State {

--- a/Sources/GRPC/_EmbeddedThroughput.swift
+++ b/Sources/GRPC/_EmbeddedThroughput.swift
@@ -22,7 +22,10 @@ extension EmbeddedChannel {
   /// Configures an `EmbeddedChannel` for the `EmbeddedClientThroughput` benchmark.
   ///
   /// - Important: This is **not** part of the public API.
-  public func _configureForEmbeddedThroughputTest<Request: Message, Response: Message>(
+  public func _configureForEmbeddedThroughputTest<
+    Request: Message & Sendable,
+    Response: Message & Sendable
+  >(
     callType: GRPCCallType,
     logger: Logger,
     requestType: Request.Type = Request.self,

--- a/Sources/GRPC/_FakeResponseStream.swift
+++ b/Sources/GRPC/_FakeResponseStream.swift
@@ -207,7 +207,7 @@ public class _FakeResponseStream<Request: Sendable, Response: Sendable>: @unchec
   }
 
   private func writeOrBuffer(_ event: StreamEvent) {
-    let write = self.state.withLockedValue {
+    let write: Bool = self.state.withLockedValue {
       switch $0.activeState {
       case .inactive:
         $0.responseBuffer.append(event)
@@ -256,7 +256,7 @@ public class _FakeResponseStream<Request: Sendable, Response: Sendable>: @unchec
 public final class FakeUnaryResponse<
   Request: Sendable,
   Response: Sendable
->: _FakeResponseStream<Request, Response>, Sendable {
+>: _FakeResponseStream<Request, Response> {
   override public init(
     requestHandler: @escaping @Sendable (FakeRequestPart<Request>) -> Void = { _ in
     }
@@ -296,6 +296,12 @@ public final class FakeUnaryResponse<
   }
 }
 
+#if swift(>=5.7)
+// 5.6 produces errors because the Sendable conformance is "redundant" because it inherits
+// from the base class.
+extension FakeUnaryResponse: Sendable {}
+#endif
+
 // MARK: - Streaming Response
 
 /// A fake streaming response to be used with a generated test client.
@@ -325,7 +331,7 @@ public final class FakeUnaryResponse<
 public final class FakeStreamingResponse<
   Request: Sendable,
   Response: Sendable
->: _FakeResponseStream<Request, Response>, Sendable {
+>: _FakeResponseStream<Request, Response> {
   override public init(
     requestHandler: @escaping @Sendable (FakeRequestPart<Request>) -> Void = { _ in
     }
@@ -378,3 +384,9 @@ public final class FakeStreamingResponse<
     try self._sendError(error)
   }
 }
+
+#if swift(>=5.7)
+// 5.6 produces errors because the Sendable conformance is "redundant" because it inherits
+// from the base class.
+extension FakeStreamingResponse: Sendable {}
+#endif

--- a/Sources/GRPC/_MessageContext.swift
+++ b/Sources/GRPC/_MessageContext.swift
@@ -17,7 +17,7 @@
 /// Provides a context for gRPC payloads.
 ///
 /// - Important: This is **NOT** part of the public API.
-public final class _MessageContext<Message> {
+public final class _MessageContext<Message: Sendable>: Sendable {
   /// The message being sent or received.
   let message: Message
 

--- a/Sources/GRPCInteroperabilityTestModels/Generated/test.grpc.swift
+++ b/Sources/GRPCInteroperabilityTestModels/Generated/test.grpc.swift
@@ -1168,7 +1168,7 @@ extension Grpc_Testing_TestServiceProvider {
         requestDeserializer: ProtobufDeserializer<Grpc_Testing_Empty>(),
         responseSerializer: ProtobufSerializer<Grpc_Testing_Empty>(),
         interceptors: self.interceptors?.makeEmptyCallInterceptors() ?? [],
-        userFunction: self.emptyCall(request:context:)
+        userFunction: { self.emptyCall(request: $0, context: $1) }
       )
 
     case "UnaryCall":
@@ -1177,7 +1177,7 @@ extension Grpc_Testing_TestServiceProvider {
         requestDeserializer: ProtobufDeserializer<Grpc_Testing_SimpleRequest>(),
         responseSerializer: ProtobufSerializer<Grpc_Testing_SimpleResponse>(),
         interceptors: self.interceptors?.makeUnaryCallInterceptors() ?? [],
-        userFunction: self.unaryCall(request:context:)
+        userFunction: { self.unaryCall(request: $0, context: $1) }
       )
 
     case "CacheableUnaryCall":
@@ -1186,7 +1186,7 @@ extension Grpc_Testing_TestServiceProvider {
         requestDeserializer: ProtobufDeserializer<Grpc_Testing_SimpleRequest>(),
         responseSerializer: ProtobufSerializer<Grpc_Testing_SimpleResponse>(),
         interceptors: self.interceptors?.makeCacheableUnaryCallInterceptors() ?? [],
-        userFunction: self.cacheableUnaryCall(request:context:)
+        userFunction: { self.cacheableUnaryCall(request: $0, context: $1) }
       )
 
     case "StreamingOutputCall":
@@ -1195,7 +1195,7 @@ extension Grpc_Testing_TestServiceProvider {
         requestDeserializer: ProtobufDeserializer<Grpc_Testing_StreamingOutputCallRequest>(),
         responseSerializer: ProtobufSerializer<Grpc_Testing_StreamingOutputCallResponse>(),
         interceptors: self.interceptors?.makeStreamingOutputCallInterceptors() ?? [],
-        userFunction: self.streamingOutputCall(request:context:)
+        userFunction: { self.streamingOutputCall(request: $0, context: $1) }
       )
 
     case "StreamingInputCall":
@@ -1204,7 +1204,7 @@ extension Grpc_Testing_TestServiceProvider {
         requestDeserializer: ProtobufDeserializer<Grpc_Testing_StreamingInputCallRequest>(),
         responseSerializer: ProtobufSerializer<Grpc_Testing_StreamingInputCallResponse>(),
         interceptors: self.interceptors?.makeStreamingInputCallInterceptors() ?? [],
-        observerFactory: self.streamingInputCall(context:)
+        observerFactory: { self.streamingInputCall(context: $0) }
       )
 
     case "FullDuplexCall":
@@ -1213,7 +1213,7 @@ extension Grpc_Testing_TestServiceProvider {
         requestDeserializer: ProtobufDeserializer<Grpc_Testing_StreamingOutputCallRequest>(),
         responseSerializer: ProtobufSerializer<Grpc_Testing_StreamingOutputCallResponse>(),
         interceptors: self.interceptors?.makeFullDuplexCallInterceptors() ?? [],
-        observerFactory: self.fullDuplexCall(context:)
+        observerFactory: { self.fullDuplexCall(context: $0) }
       )
 
     case "HalfDuplexCall":
@@ -1222,7 +1222,7 @@ extension Grpc_Testing_TestServiceProvider {
         requestDeserializer: ProtobufDeserializer<Grpc_Testing_StreamingOutputCallRequest>(),
         responseSerializer: ProtobufSerializer<Grpc_Testing_StreamingOutputCallResponse>(),
         interceptors: self.interceptors?.makeHalfDuplexCallInterceptors() ?? [],
-        observerFactory: self.halfDuplexCall(context:)
+        observerFactory: { self.halfDuplexCall(context: $0) }
       )
 
     default:
@@ -1386,35 +1386,27 @@ extension Grpc_Testing_TestServiceAsyncProvider {
 public protocol Grpc_Testing_TestServiceServerInterceptorFactoryProtocol: Sendable {
 
   /// - Returns: Interceptors to use when handling 'emptyCall'.
-  ///   Defaults to calling `self.makeInterceptors()`.
   func makeEmptyCallInterceptors() -> [ServerInterceptor<Grpc_Testing_Empty, Grpc_Testing_Empty>]
 
   /// - Returns: Interceptors to use when handling 'unaryCall'.
-  ///   Defaults to calling `self.makeInterceptors()`.
   func makeUnaryCallInterceptors() -> [ServerInterceptor<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse>]
 
   /// - Returns: Interceptors to use when handling 'cacheableUnaryCall'.
-  ///   Defaults to calling `self.makeInterceptors()`.
   func makeCacheableUnaryCallInterceptors() -> [ServerInterceptor<Grpc_Testing_SimpleRequest, Grpc_Testing_SimpleResponse>]
 
   /// - Returns: Interceptors to use when handling 'streamingOutputCall'.
-  ///   Defaults to calling `self.makeInterceptors()`.
   func makeStreamingOutputCallInterceptors() -> [ServerInterceptor<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>]
 
   /// - Returns: Interceptors to use when handling 'streamingInputCall'.
-  ///   Defaults to calling `self.makeInterceptors()`.
   func makeStreamingInputCallInterceptors() -> [ServerInterceptor<Grpc_Testing_StreamingInputCallRequest, Grpc_Testing_StreamingInputCallResponse>]
 
   /// - Returns: Interceptors to use when handling 'fullDuplexCall'.
-  ///   Defaults to calling `self.makeInterceptors()`.
   func makeFullDuplexCallInterceptors() -> [ServerInterceptor<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>]
 
   /// - Returns: Interceptors to use when handling 'halfDuplexCall'.
-  ///   Defaults to calling `self.makeInterceptors()`.
   func makeHalfDuplexCallInterceptors() -> [ServerInterceptor<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>]
 
   /// - Returns: Interceptors to use when handling 'unimplementedCall'.
-  ///   Defaults to calling `self.makeInterceptors()`.
   func makeUnimplementedCallInterceptors() -> [ServerInterceptor<Grpc_Testing_Empty, Grpc_Testing_Empty>]
 }
 
@@ -1513,7 +1505,7 @@ extension Grpc_Testing_UnimplementedServiceProvider {
         requestDeserializer: ProtobufDeserializer<Grpc_Testing_Empty>(),
         responseSerializer: ProtobufSerializer<Grpc_Testing_Empty>(),
         interceptors: self.interceptors?.makeUnimplementedCallInterceptors() ?? [],
-        userFunction: self.unimplementedCall(request:context:)
+        userFunction: { self.unimplementedCall(request: $0, context: $1) }
       )
 
     default:
@@ -1575,7 +1567,6 @@ extension Grpc_Testing_UnimplementedServiceAsyncProvider {
 public protocol Grpc_Testing_UnimplementedServiceServerInterceptorFactoryProtocol: Sendable {
 
   /// - Returns: Interceptors to use when handling 'unimplementedCall'.
-  ///   Defaults to calling `self.makeInterceptors()`.
   func makeUnimplementedCallInterceptors() -> [ServerInterceptor<Grpc_Testing_Empty, Grpc_Testing_Empty>]
 }
 
@@ -1625,7 +1616,7 @@ extension Grpc_Testing_ReconnectServiceProvider {
         requestDeserializer: ProtobufDeserializer<Grpc_Testing_ReconnectParams>(),
         responseSerializer: ProtobufSerializer<Grpc_Testing_Empty>(),
         interceptors: self.interceptors?.makeStartInterceptors() ?? [],
-        userFunction: self.start(request:context:)
+        userFunction: { self.start(request: $0, context: $1) }
       )
 
     case "Stop":
@@ -1634,7 +1625,7 @@ extension Grpc_Testing_ReconnectServiceProvider {
         requestDeserializer: ProtobufDeserializer<Grpc_Testing_Empty>(),
         responseSerializer: ProtobufSerializer<Grpc_Testing_ReconnectInfo>(),
         interceptors: self.interceptors?.makeStopInterceptors() ?? [],
-        userFunction: self.stop(request:context:)
+        userFunction: { self.stop(request: $0, context: $1) }
       )
 
     default:
@@ -1708,11 +1699,9 @@ extension Grpc_Testing_ReconnectServiceAsyncProvider {
 public protocol Grpc_Testing_ReconnectServiceServerInterceptorFactoryProtocol: Sendable {
 
   /// - Returns: Interceptors to use when handling 'start'.
-  ///   Defaults to calling `self.makeInterceptors()`.
   func makeStartInterceptors() -> [ServerInterceptor<Grpc_Testing_ReconnectParams, Grpc_Testing_Empty>]
 
   /// - Returns: Interceptors to use when handling 'stop'.
-  ///   Defaults to calling `self.makeInterceptors()`.
   func makeStopInterceptors() -> [ServerInterceptor<Grpc_Testing_Empty, Grpc_Testing_ReconnectInfo>]
 }
 

--- a/Sources/GRPCInteroperabilityTestsImplementation/InteroperabilityTestCases.swift
+++ b/Sources/GRPCInteroperabilityTestsImplementation/InteroperabilityTestCases.swift
@@ -744,7 +744,7 @@ class EmptyStream: InteroperabilityTest {
 ///   received in the initial metadata for calls in Procedure steps 1 and 2.
 /// - metadata with key "x-grpc-test-echo-trailing-bin" and value 0xababab is received in the
 ///   trailing metadata for calls in Procedure steps 1 and 2.
-class CustomMetadata: InteroperabilityTest {
+final class CustomMetadata: InteroperabilityTest, Sendable {
   let initialMetadataName = "x-grpc-test-echo-initial"
   let initialMetadataValue = "test_initial_metadata_value"
 

--- a/Sources/GRPCInteroperabilityTestsImplementation/TestServiceProvider.swift
+++ b/Sources/GRPCInteroperabilityTestsImplementation/TestServiceProvider.swift
@@ -21,8 +21,8 @@ import NIOCore
 /// A service provider for the gRPC interoperability test suite.
 ///
 /// See: https://github.com/grpc/grpc/blob/master/doc/interop-test-descriptions.md#server
-public class TestServiceProvider: Grpc_Testing_TestServiceProvider {
-  public var interceptors: Grpc_Testing_TestServiceServerInterceptorFactoryProtocol?
+public final class TestServiceProvider: Grpc_Testing_TestServiceProvider {
+  public let interceptors: Grpc_Testing_TestServiceServerInterceptorFactoryProtocol? = nil
 
   public init() {}
 

--- a/Sources/GRPCPerformanceTests/Benchmarks/MinimalEchoProvider.swift
+++ b/Sources/GRPCPerformanceTests/Benchmarks/MinimalEchoProvider.swift
@@ -18,7 +18,7 @@ import NIOCore
 
 /// The echo provider that comes with the example does some string processing, we'll avoid some of
 /// that here so we're looking at the right things.
-public class MinimalEchoProvider: Echo_EchoProvider {
+public final class MinimalEchoProvider: Echo_EchoProvider {
   public let interceptors: Echo_EchoServerInterceptorFactoryProtocol?
 
   public init(interceptors: Echo_EchoServerInterceptorFactoryProtocol? = nil) {

--- a/Sources/protoc-gen-grpc-swift/Generator-Client.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator-Client.swift
@@ -473,7 +473,7 @@ extension Generator {
       name: name,
       arguments: [
         responseArgAndType,
-        "_ requestHandler: @escaping (FakeRequestPart<\(self.methodInputName)>) -> () = { _ in }",
+        "_ requestHandler: @escaping @Sendable (FakeRequestPart<\(self.methodInputName)>) -> () = { _ in }",
       ],
       returnType: nil,
       access: self.access
@@ -504,7 +504,7 @@ extension Generator {
     self.printFunction(
       name: "make\(self.method.name)ResponseStream",
       arguments: [
-        "_ requestHandler: @escaping (FakeRequestPart<\(self.methodInputName)>) -> () = { _ in }",
+        "_ requestHandler: @escaping @Sendable (FakeRequestPart<\(self.methodInputName)>) -> () = { _ in }",
       ],
       returnType: "\(type)<\(self.methodInputName), \(self.methodOutputName)>",
       access: self.access

--- a/Sources/protoc-gen-grpc-swift/Generator-Server.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator-Server.swift
@@ -126,9 +126,12 @@ extension Generator {
               )
               switch streamingType(method) {
               case .unary, .serverStreaming:
-                self.println("userFunction: self.\(self.methodFunctionName)(request:context:)")
+                self
+                  .println(
+                    "userFunction: { self.\(self.methodFunctionName)(request: $0, context: $1) }"
+                  )
               case .clientStreaming, .bidirectionalStreaming:
-                self.println("observerFactory: self.\(self.methodFunctionName)(context:)")
+                self.println("observerFactory: { self.\(self.methodFunctionName)(context: $0) }")
               }
             }
             self.println(")")
@@ -157,7 +160,6 @@ extension Generator {
         self.println(
           "/// - Returns: Interceptors to use when handling '\(self.methodFunctionName)'."
         )
-        self.println("///   Defaults to calling `self.makeInterceptors()`.")
         // Skip the access, we're defining a protocol.
         self.printMethodInterceptorFactory(access: nil)
       }

--- a/Sources/protoc-gen-grpc-swift/main.swift
+++ b/Sources/protoc-gen-grpc-swift/main.swift
@@ -158,7 +158,7 @@ func main(args: [String]) throws {
 }
 
 do {
-  try main(args: CommandLine.arguments)
+  try main(args: ProcessInfo.processInfo.arguments)
 } catch {
   Log("ERROR: \(error)")
 }

--- a/Tests/GRPCTests/AsyncAwaitSupport/AsyncClientTests.swift
+++ b/Tests/GRPCTests/AsyncAwaitSupport/AsyncClientTests.swift
@@ -335,7 +335,7 @@ final class AsyncClientCancellationTests: GRPCTestCase {
   }
 
   private func testSendingRequestsSuspendsWhileStreamIsNotReady(
-    makeRPC: @escaping () -> RequestStreamingRPC
+    makeRPC: @escaping @Sendable () -> RequestStreamingRPC
   ) async throws {
     // The strategy for this test is to race two different tasks. The first will attempt to send a
     // message on a request stream on a connection which will never establish. The second will sleep

--- a/Tests/GRPCTests/AsyncAwaitSupport/XCTest+AsyncAwait.swift
+++ b/Tests/GRPCTests/AsyncAwaitSupport/XCTest+AsyncAwait.swift
@@ -43,13 +43,13 @@ internal func XCTAssertNoThrowAsync<T>(
   }
 }
 
-private enum TaskResult<Result> {
+private enum TaskResult<Result: Sendable>: Sendable {
   case operation(Result)
   case cancellation
 }
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-func withTaskCancelledAfter<Result>(
+func withTaskCancelledAfter<Result: Sendable>(
   nanoseconds: UInt64,
   operation: @escaping @Sendable () async -> Result
 ) async throws {

--- a/Tests/GRPCTests/CapturingLogHandler.swift
+++ b/Tests/GRPCTests/CapturingLogHandler.swift
@@ -13,7 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#if os(Linux)
+@preconcurrency import struct Foundation.Date
+#else
 import struct Foundation.Date
+#endif
 import class Foundation.DateFormatter
 import Logging
 import NIOConcurrencyHelpers

--- a/Tests/GRPCTests/CapturingLogHandler.swift
+++ b/Tests/GRPCTests/CapturingLogHandler.swift
@@ -19,7 +19,7 @@ import Logging
 import NIOConcurrencyHelpers
 
 /// A `LogHandler` factory which captures all logs emitted by the handlers it makes.
-internal class CapturingLogHandlerFactory {
+internal class CapturingLogHandlerFactory: @unchecked Sendable {
   private var lock = NIOLock()
   private var _logs: [CapturedLog] = []
 
@@ -58,7 +58,7 @@ internal class CapturingLogHandlerFactory {
 }
 
 /// A captured log.
-internal struct CapturedLog {
+internal struct CapturedLog: Sendable {
   var label: String
   var level: Logger.Level
   var message: Logger.Message
@@ -72,13 +72,13 @@ internal struct CapturedLog {
 
 /// A log handler which captures all logs it records.
 internal struct CapturingLogHandler: LogHandler {
-  private let capture: (CapturedLog) -> Void
+  private let capture: @Sendable (CapturedLog) -> Void
 
   internal let label: String
   internal var metadata: Logger.Metadata = [:]
   internal var logLevel: Logger.Level = .trace
 
-  fileprivate init(label: String, capture: @escaping (CapturedLog) -> Void) {
+  fileprivate init(label: String, capture: @escaping @Sendable (CapturedLog) -> Void) {
     self.label = label
     self.capture = capture
   }

--- a/Tests/GRPCTests/ClientCallTests.swift
+++ b/Tests/GRPCTests/ClientCallTests.swift
@@ -81,7 +81,7 @@ class ClientCallTests: GRPCTestCase {
   private func makeResponsePartHandler<Response>(
     for: Response.Type = Response.self,
     completing promise: EventLoopPromise<GRPCStatus>
-  ) -> (GRPCClientResponsePart<Response>) -> Void {
+  ) -> @Sendable (GRPCClientResponsePart<Response>) -> Void {
     return { part in
       switch part {
       case .metadata, .message:
@@ -99,7 +99,7 @@ class ClientCallTests: GRPCTestCase {
 
     let statusPromise = self.makeStatusPromise()
     get.invoke(
-      onError: statusPromise.fail(_:),
+      onError: { statusPromise.fail($0) },
       onResponsePart: self.makeResponsePartHandler(completing: statusPromise)
     )
 
@@ -123,7 +123,7 @@ class ClientCallTests: GRPCTestCase {
     get.invokeUnaryRequest(
       .with { $0.text = "get" },
       onStart: {},
-      onError: promise.fail(_:),
+      onError: { promise.fail($0) },
       onResponsePart: self.makeResponsePartHandler(completing: promise)
     )
 
@@ -136,7 +136,7 @@ class ClientCallTests: GRPCTestCase {
     let promise = self.makeStatusPromise()
     collect.invokeStreamingRequests(
       onStart: {},
-      onError: promise.fail(_:),
+      onError: { promise.fail($0) },
       onResponsePart: self.makeResponsePartHandler(completing: promise)
     )
     collect.send(
@@ -155,7 +155,7 @@ class ClientCallTests: GRPCTestCase {
     expand.invokeUnaryRequest(
       .with { $0.text = "expand" },
       onStart: {},
-      onError: promise.fail(_:),
+      onError: { promise.fail($0) },
       onResponsePart: self.makeResponsePartHandler(completing: promise)
     )
 
@@ -168,7 +168,7 @@ class ClientCallTests: GRPCTestCase {
     let promise = self.makeStatusPromise()
     update.invokeStreamingRequests(
       onStart: {},
-      onError: promise.fail(_:),
+      onError: { promise.fail($0) },
       onResponsePart: self.makeResponsePartHandler(completing: promise)
     )
     update.send(
@@ -194,7 +194,7 @@ class ClientCallTests: GRPCTestCase {
     let get = self.get()
     let promise = self.makeStatusPromise()
     get.invoke(
-      onError: promise.fail(_:),
+      onError: { promise.fail($0) },
       onResponsePart: self.makeResponsePartHandler(completing: promise)
     )
 

--- a/Tests/GRPCTests/ClientClosedChannelTests.swift
+++ b/Tests/GRPCTests/ClientClosedChannelTests.swift
@@ -25,8 +25,8 @@ class ClientClosedChannelTests: EchoTestCaseBase {
     let responseExpectation = self.makeResponseExpectation()
     let statusExpectation = self.makeStatusExpectation()
 
-    self.client.channel.close().map {
-      self.client.get(Echo_EchoRequest(text: "foo"))
+    self.client.channel.close().map { [client = self.client!] in
+      client.get(Echo_EchoRequest(text: "foo"))
     }.whenSuccess { get in
       get.initialMetadata.assertError(fulfill: initialMetadataExpectation)
       get.response.assertError(fulfill: responseExpectation)
@@ -44,8 +44,8 @@ class ClientClosedChannelTests: EchoTestCaseBase {
     let responseExpectation = self.makeResponseExpectation()
     let statusExpectation = self.makeStatusExpectation()
 
-    self.client.channel.close().map {
-      self.client.collect()
+    self.client.channel.close().map { [client = self.client!] in
+      client.collect()
     }.whenSuccess { collect in
       collect.initialMetadata.assertError(fulfill: initialMetadataExpectation)
       collect.response.assertError(fulfill: responseExpectation)
@@ -71,8 +71,8 @@ class ClientClosedChannelTests: EchoTestCaseBase {
       collect.sendMessage(Echo_EchoRequest(text: "bar"))
     }.peek {
       requestExpectation.fulfill()
-    }.flatMap {
-      self.client.channel.close()
+    }.flatMap { [client = self.client!] in
+      client.channel.close()
     }.peekError { error in
       XCTFail("Encountered error before or during closing the connection: \(error)")
     }.flatMap {
@@ -92,8 +92,8 @@ class ClientClosedChannelTests: EchoTestCaseBase {
     let initialMetadataExpectation = self.makeInitialMetadataExpectation()
     let statusExpectation = self.makeStatusExpectation()
 
-    self.client.channel.close().map {
-      self.client.expand(Echo_EchoRequest(text: "foo")) { response in
+    self.client.channel.close().map { [client = self.client!] in
+      client.expand(Echo_EchoRequest(text: "foo")) { response in
         XCTFail("No response expected but got: \(response)")
       }
     }.whenSuccess { expand in
@@ -111,8 +111,8 @@ class ClientClosedChannelTests: EchoTestCaseBase {
     let initialMetadataExpectation = self.makeInitialMetadataExpectation()
     let statusExpectation = self.makeStatusExpectation()
 
-    self.client.channel.close().map {
-      self.client.update { response in
+    self.client.channel.close().map { [client = self.client!] in
+      client.update { response in
         XCTFail("No response expected but got: \(response)")
       }
     }.whenSuccess { update in
@@ -140,8 +140,8 @@ class ClientClosedChannelTests: EchoTestCaseBase {
       update.sendMessage(Echo_EchoRequest(text: "bar"))
     }.peek {
       requestExpectation.fulfill()
-    }.flatMap {
-      self.client.channel.close()
+    }.flatMap { [client = self.client!] in
+      client.channel.close()
     }.peekError { error in
       XCTFail("Encountered error before or during closing the connection: \(error)")
     }.flatMap {
@@ -160,8 +160,8 @@ class ClientClosedChannelTests: EchoTestCaseBase {
       XCTFail("No response expected but got: \(response)")
     }
 
-    update.sendMessage(.with { $0.text = "0" }).flatMap {
-      self.client.channel.close()
+    update.sendMessage(.with { $0.text = "0" }).flatMap { [client = self.client!] in
+      client.channel.close()
     }.whenSuccess {
       update.sendMessage(.with { $0.text = "1" }, promise: nil)
     }

--- a/Tests/GRPCTests/ClientInterceptorPipelineTests.swift
+++ b/Tests/GRPCTests/ClientInterceptorPipelineTests.swift
@@ -134,7 +134,10 @@ class ClientInterceptorPipelineTests: GRPCTestCase {
     var cancelled = false
     var timedOut = false
 
-    class FailOnCancel<Request, Response>: ClientInterceptor<Request, Response> {
+    class FailOnCancel<
+      Request: Sendable,
+      Response: Sendable
+    >: ClientInterceptor<Request, Response> {
       override func cancel(
         promise: EventLoopPromise<Void>?,
         context: ClientInterceptorContext<Request, Response>
@@ -297,7 +300,10 @@ class ClientInterceptorPipelineTests: GRPCTestCase {
 // MARK: - Test Interceptors
 
 /// A simple interceptor which records and then forwards and request and response parts it sees.
-class RecordingInterceptor<Request, Response>: ClientInterceptor<Request, Response> {
+class RecordingInterceptor<
+  Request: Sendable,
+  Response: Sendable
+>: ClientInterceptor<Request, Response> {
   var requestParts: [GRPCClientRequestPart<Request>] = []
   var responseParts: [GRPCClientResponsePart<Response>] = []
 

--- a/Tests/GRPCTests/ClientQuiescingTests.swift
+++ b/Tests/GRPCTests/ClientQuiescingTests.swift
@@ -92,8 +92,8 @@ internal final class ClientQuiescingTests: GRPCTestCase {
     let collect = self.echo.collect(callOptions: self.callOptionsWithLogger)
 
     if withTracking {
-      collect.status.whenSuccess { status in
-        self.tracker.didFinishRPC()
+      collect.status.whenSuccess { [tracker = self.tracker] status in
+        tracker.didFinishRPC()
         XCTAssert(status.isOk)
       }
     }
@@ -121,8 +121,8 @@ internal final class ClientQuiescingTests: GRPCTestCase {
     self.channel.closeGracefully(deadline: deadline, promise: promise)
 
     if withTracking {
-      promise.futureResult.whenComplete { _ in
-        self.tracker.didShutdown()
+      promise.futureResult.whenComplete { [tracker = self.tracker] _ in
+        tracker.didShutdown()
       }
     }
     return promise.futureResult
@@ -411,7 +411,7 @@ extension ClientQuiescingTests {
 }
 
 extension ClientQuiescingTests {
-  private final class RPCTracker {
+  private final class RPCTracker: @unchecked Sendable {
     private enum _State {
       case active(Int)
       case shutdownRequested(Int)

--- a/Tests/GRPCTests/ClientTLSTests.swift
+++ b/Tests/GRPCTests/ClientTLSTests.swift
@@ -169,8 +169,12 @@ class ClientTLSHostnameOverrideTests: GRPCTestCase {
   }
 }
 
-private class AuthorityCheckingEcho: Echo_EchoProvider {
-  var interceptors: Echo_EchoServerInterceptorFactoryProtocol?
+private final class AuthorityCheckingEcho: Echo_EchoProvider, @unchecked Sendable {
+  let interceptors: Echo_EchoServerInterceptorFactoryProtocol?
+
+  init(interceptors: Echo_EchoServerInterceptorFactoryProtocol? = nil) {
+    self.interceptors = interceptors
+  }
 
   func get(
     request: Echo_EchoRequest,

--- a/Tests/GRPCTests/ClientTransportTests.swift
+++ b/Tests/GRPCTests/ClientTransportTests.swift
@@ -204,8 +204,8 @@ extension ClientTransportTests {
 
     // Chain a cancel from the first write promise.
     let cancelPromise = self.eventLoop.makePromise(of: Void.self)
-    writePromise1.futureResult.whenSuccess {
-      self.cancel(promise: cancelPromise)
+    writePromise1.futureResult.whenSuccess { [transport = self.transport] in
+      transport?.cancel(promise: cancelPromise)
     }
 
     // Enqueue a second write.
@@ -348,7 +348,7 @@ class WriteRecorder<Write>: ChannelOutboundHandler {
 
 private struct DummyError: Error {}
 
-internal struct StringSerializer: MessageSerializer {
+internal struct StringSerializer: MessageSerializer, Sendable {
   typealias Input = String
 
   func serialize(_ input: String, allocator: ByteBufferAllocator) throws -> ByteBuffer {
@@ -356,7 +356,7 @@ internal struct StringSerializer: MessageSerializer {
   }
 }
 
-internal struct StringDeserializer: MessageDeserializer {
+internal struct StringDeserializer: MessageDeserializer, Sendable {
   typealias Output = String
 
   func deserialize(byteBuffer: ByteBuffer) throws -> String {

--- a/Tests/GRPCTests/Codegen/Normalization/normalization.grpc.swift
+++ b/Tests/GRPCTests/Codegen/Normalization/normalization.grpc.swift
@@ -714,7 +714,7 @@ extension Normalization_NormalizationProvider {
         requestDeserializer: ProtobufDeserializer<SwiftProtobuf.Google_Protobuf_Empty>(),
         responseSerializer: ProtobufSerializer<Normalization_FunctionName>(),
         interceptors: self.interceptors?.makeUnaryInterceptors() ?? [],
-        userFunction: self.Unary(request:context:)
+        userFunction: { self.Unary(request: $0, context: $1) }
       )
 
     case "unary":
@@ -723,7 +723,7 @@ extension Normalization_NormalizationProvider {
         requestDeserializer: ProtobufDeserializer<SwiftProtobuf.Google_Protobuf_Empty>(),
         responseSerializer: ProtobufSerializer<Normalization_FunctionName>(),
         interceptors: self.interceptors?.makeunaryInterceptors() ?? [],
-        userFunction: self.unary(request:context:)
+        userFunction: { self.unary(request: $0, context: $1) }
       )
 
     case "ServerStreaming":
@@ -732,7 +732,7 @@ extension Normalization_NormalizationProvider {
         requestDeserializer: ProtobufDeserializer<SwiftProtobuf.Google_Protobuf_Empty>(),
         responseSerializer: ProtobufSerializer<Normalization_FunctionName>(),
         interceptors: self.interceptors?.makeServerStreamingInterceptors() ?? [],
-        userFunction: self.ServerStreaming(request:context:)
+        userFunction: { self.ServerStreaming(request: $0, context: $1) }
       )
 
     case "serverStreaming":
@@ -741,7 +741,7 @@ extension Normalization_NormalizationProvider {
         requestDeserializer: ProtobufDeserializer<SwiftProtobuf.Google_Protobuf_Empty>(),
         responseSerializer: ProtobufSerializer<Normalization_FunctionName>(),
         interceptors: self.interceptors?.makeserverStreamingInterceptors() ?? [],
-        userFunction: self.serverStreaming(request:context:)
+        userFunction: { self.serverStreaming(request: $0, context: $1) }
       )
 
     case "ClientStreaming":
@@ -750,7 +750,7 @@ extension Normalization_NormalizationProvider {
         requestDeserializer: ProtobufDeserializer<SwiftProtobuf.Google_Protobuf_Empty>(),
         responseSerializer: ProtobufSerializer<Normalization_FunctionName>(),
         interceptors: self.interceptors?.makeClientStreamingInterceptors() ?? [],
-        observerFactory: self.ClientStreaming(context:)
+        observerFactory: { self.ClientStreaming(context: $0) }
       )
 
     case "clientStreaming":
@@ -759,7 +759,7 @@ extension Normalization_NormalizationProvider {
         requestDeserializer: ProtobufDeserializer<SwiftProtobuf.Google_Protobuf_Empty>(),
         responseSerializer: ProtobufSerializer<Normalization_FunctionName>(),
         interceptors: self.interceptors?.makeclientStreamingInterceptors() ?? [],
-        observerFactory: self.clientStreaming(context:)
+        observerFactory: { self.clientStreaming(context: $0) }
       )
 
     case "BidirectionalStreaming":
@@ -768,7 +768,7 @@ extension Normalization_NormalizationProvider {
         requestDeserializer: ProtobufDeserializer<SwiftProtobuf.Google_Protobuf_Empty>(),
         responseSerializer: ProtobufSerializer<Normalization_FunctionName>(),
         interceptors: self.interceptors?.makeBidirectionalStreamingInterceptors() ?? [],
-        observerFactory: self.BidirectionalStreaming(context:)
+        observerFactory: { self.BidirectionalStreaming(context: $0) }
       )
 
     case "bidirectionalStreaming":
@@ -777,7 +777,7 @@ extension Normalization_NormalizationProvider {
         requestDeserializer: ProtobufDeserializer<SwiftProtobuf.Google_Protobuf_Empty>(),
         responseSerializer: ProtobufSerializer<Normalization_FunctionName>(),
         interceptors: self.interceptors?.makebidirectionalStreamingInterceptors() ?? [],
-        observerFactory: self.bidirectionalStreaming(context:)
+        observerFactory: { self.bidirectionalStreaming(context: $0) }
       )
 
     default:
@@ -937,35 +937,27 @@ extension Normalization_NormalizationAsyncProvider {
 internal protocol Normalization_NormalizationServerInterceptorFactoryProtocol: Sendable {
 
   /// - Returns: Interceptors to use when handling 'Unary'.
-  ///   Defaults to calling `self.makeInterceptors()`.
   func makeUnaryInterceptors() -> [ServerInterceptor<SwiftProtobuf.Google_Protobuf_Empty, Normalization_FunctionName>]
 
   /// - Returns: Interceptors to use when handling 'unary'.
-  ///   Defaults to calling `self.makeInterceptors()`.
   func makeunaryInterceptors() -> [ServerInterceptor<SwiftProtobuf.Google_Protobuf_Empty, Normalization_FunctionName>]
 
   /// - Returns: Interceptors to use when handling 'ServerStreaming'.
-  ///   Defaults to calling `self.makeInterceptors()`.
   func makeServerStreamingInterceptors() -> [ServerInterceptor<SwiftProtobuf.Google_Protobuf_Empty, Normalization_FunctionName>]
 
   /// - Returns: Interceptors to use when handling 'serverStreaming'.
-  ///   Defaults to calling `self.makeInterceptors()`.
   func makeserverStreamingInterceptors() -> [ServerInterceptor<SwiftProtobuf.Google_Protobuf_Empty, Normalization_FunctionName>]
 
   /// - Returns: Interceptors to use when handling 'ClientStreaming'.
-  ///   Defaults to calling `self.makeInterceptors()`.
   func makeClientStreamingInterceptors() -> [ServerInterceptor<SwiftProtobuf.Google_Protobuf_Empty, Normalization_FunctionName>]
 
   /// - Returns: Interceptors to use when handling 'clientStreaming'.
-  ///   Defaults to calling `self.makeInterceptors()`.
   func makeclientStreamingInterceptors() -> [ServerInterceptor<SwiftProtobuf.Google_Protobuf_Empty, Normalization_FunctionName>]
 
   /// - Returns: Interceptors to use when handling 'BidirectionalStreaming'.
-  ///   Defaults to calling `self.makeInterceptors()`.
   func makeBidirectionalStreamingInterceptors() -> [ServerInterceptor<SwiftProtobuf.Google_Protobuf_Empty, Normalization_FunctionName>]
 
   /// - Returns: Interceptors to use when handling 'bidirectionalStreaming'.
-  ///   Defaults to calling `self.makeInterceptors()`.
   func makebidirectionalStreamingInterceptors() -> [ServerInterceptor<SwiftProtobuf.Google_Protobuf_Empty, Normalization_FunctionName>]
 }
 

--- a/Tests/GRPCTests/ConnectionManagerTests.swift
+++ b/Tests/GRPCTests/ConnectionManagerTests.swift
@@ -1391,13 +1391,13 @@ internal class RecordingConnectivityDelegate: ConnectivityStateDelegate {
     }
   }
 
-  func expectChanges(_ count: Int, verify: @escaping ([Change]) -> Void) {
+  func expectChanges(_ count: Int, verify: @escaping @Sendable ([Change]) -> Void) {
     self.serialQueue.async {
       self.expectation = .some(count: count, recorded: [], verify)
     }
   }
 
-  func expectChange(verify: @escaping (Change) -> Void) {
+  func expectChange(verify: @Sendable @escaping (Change) -> Void) {
     self.serialQueue.async {
       self.expectation = .one(verify)
     }

--- a/Tests/GRPCTests/ConnectionPool/ConnectionPoolTests.swift
+++ b/Tests/GRPCTests/ConnectionPool/ConnectionPoolTests.swift
@@ -866,8 +866,9 @@ final class ConnectionPoolTests: GRPCTestCase {
 
     XCTAssertNil(waiter._scheduledTimeout)
 
+    let loopBoundWaiter = NIOLoopBound(waiter, eventLoop: self.eventLoop)
     waiter.scheduleTimeout(on: self.eventLoop) {
-      waiter.fail(ConnectionPoolError.deadlineExceeded(connectionError: nil))
+      loopBoundWaiter.value.fail(ConnectionPoolError.deadlineExceeded(connectionError: nil))
     }
 
     XCTAssertNotNil(waiter._scheduledTimeout)

--- a/Tests/GRPCTests/ConnectionPool/PoolManagerStateMachineTests.swift
+++ b/Tests/GRPCTests/ConnectionPool/PoolManagerStateMachineTests.swift
@@ -346,7 +346,7 @@ private final class EmbeddedEventLoopGroup: EventLoopGroup, Sendable {
     return EventLoopIterator(self.loops)
   }
 
-  internal func shutdownGracefully(
+  private func _shutdownGracefully(
     queue: DispatchQueue,
     _ callback: @escaping @Sendable (Error?) -> Void
   ) {
@@ -364,4 +364,20 @@ private final class EmbeddedEventLoopGroup: EventLoopGroup, Sendable {
       callback(lockedError.withLockedValue { $0 })
     }
   }
+
+  #if swift(>=5.7)
+  internal func shutdownGracefully(
+    queue: DispatchQueue,
+    _ callback: @escaping @Sendable (Error?) -> Void
+  ) {
+    self._shutdownGracefully(queue: queue) { callback($0) }
+  }
+  #else
+  internal func shutdownGracefully(
+    queue: DispatchQueue,
+    _ callback: @escaping (Error?) -> Void
+  ) {
+    self._shutdownGracefully(queue: queue) { callback($0) }
+  }
+  #endif
 }

--- a/Tests/GRPCTests/EchoHelpers/Providers/DelegatingOnCloseEchoProvider.swift
+++ b/Tests/GRPCTests/EchoHelpers/Providers/DelegatingOnCloseEchoProvider.swift
@@ -19,16 +19,16 @@ import NIOCore
 
 /// An `Echo_EchoProvider` which sets `onClose` for each RPC and then calls a delegate to provide
 /// the RPC implementation.
-class OnCloseEchoProvider: Echo_EchoProvider {
+final class OnCloseEchoProvider: Echo_EchoProvider {
   let interceptors: Echo_EchoServerInterceptorFactoryProtocol?
 
-  let onClose: (Result<Void, Error>) -> Void
+  let onClose: @Sendable (Result<Void, Error>) -> Void
   let delegate: Echo_EchoProvider
 
   init(
     delegate: Echo_EchoProvider,
     interceptors: Echo_EchoServerInterceptorFactoryProtocol? = nil,
-    onClose: @escaping (Result<Void, Error>) -> Void
+    onClose: @escaping @Sendable (Result<Void, Error>) -> Void
   ) {
     self.delegate = delegate
     self.onClose = onClose

--- a/Tests/GRPCTests/EchoHelpers/Providers/FailingEchoProvider.swift
+++ b/Tests/GRPCTests/EchoHelpers/Providers/FailingEchoProvider.swift
@@ -18,7 +18,7 @@ import GRPC
 import NIOCore
 
 /// An `Echo_EchoProvider` which always returns failed future for each RPC.
-class FailingEchoProvider: Echo_EchoProvider {
+final class FailingEchoProvider: Echo_EchoProvider {
   let interceptors: Echo_EchoServerInterceptorFactoryProtocol?
 
   init(interceptors: Echo_EchoServerInterceptorFactoryProtocol? = nil) {

--- a/Tests/GRPCTests/EchoHelpers/Providers/NeverResolvingEchoProvider.swift
+++ b/Tests/GRPCTests/EchoHelpers/Providers/NeverResolvingEchoProvider.swift
@@ -19,7 +19,7 @@ import NIOCore
 
 /// An `Echo_EchoProvider` which returns a failed future for each RPC which resolves in the distant
 /// future.
-class NeverResolvingEchoProvider: Echo_EchoProvider {
+final class NeverResolvingEchoProvider: Echo_EchoProvider {
   let interceptors: Echo_EchoServerInterceptorFactoryProtocol?
 
   init(interceptors: Echo_EchoServerInterceptorFactoryProtocol? = nil) {

--- a/Tests/GRPCTests/EchoTestClientTests.swift
+++ b/Tests/GRPCTests/EchoTestClientTests.swift
@@ -32,7 +32,7 @@ class EchoModel {
   }
 
   /// Call 'get' with the given word and call the `callback` with the result.
-  func getWord(_ text: String, _ callback: @escaping (Result<String, Error>) -> Void) {
+  func getWord(_ text: String, _ callback: @escaping @Sendable (Result<String, Error>) -> Void) {
     let get = self.client.get(.with { $0.text = text })
     get.response.whenComplete { result in
       switch result {
@@ -48,8 +48,8 @@ class EchoModel {
   /// the RPC has completed.
   func updateWords(
     _ words: [String],
-    onResponse: @escaping (String) -> Void,
-    onEnd: @escaping (GRPCStatus) -> Void
+    onResponse: @escaping @Sendable (String) -> Void,
+    onEnd: @escaping @Sendable (GRPCStatus) -> Void
   ) {
     let update = self.client.update { response in
       onResponse(response.text)

--- a/Tests/GRPCTests/ErrorRecordingDelegate.swift
+++ b/Tests/GRPCTests/ErrorRecordingDelegate.swift
@@ -46,16 +46,16 @@ final class ErrorRecordingDelegate: ClientErrorDelegate {
   }
 }
 
-class ServerErrorRecordingDelegate: ServerErrorDelegate {
-  var errors: [Error] = []
-  var expectation: XCTestExpectation
+final class ServerErrorRecordingDelegate: ServerErrorDelegate {
+  let errors = NIOLockedValueBox<[Error]>([])
+  let expectation: XCTestExpectation
 
   init(expectation: XCTestExpectation) {
     self.expectation = expectation
   }
 
   func observeLibraryError(_ error: Error) {
-    self.errors.append(error)
+    self.errors.withLockedValue { $0.append(error) }
     self.expectation.fulfill()
   }
 }

--- a/Tests/GRPCTests/EventLoopFuture+Assertions.swift
+++ b/Tests/GRPCTests/EventLoopFuture+Assertions.swift
@@ -17,7 +17,7 @@ import Foundation
 import NIOCore
 import XCTest
 
-extension EventLoopFuture where Value: Equatable {
+extension EventLoopFuture where Value: Equatable & Sendable {
   /// Registers a callback which asserts the value promised by this future is equal to
   /// the expected value. Causes a test failure if the future returns an error.
   ///
@@ -61,7 +61,7 @@ extension EventLoopFuture {
     fulfill expectation: XCTestExpectation,
     file: StaticString = #filePath,
     line: UInt = #line,
-    handler: @escaping (Error) -> Void = { _ in }
+    handler: @escaping @Sendable (Error) -> Void = { _ in }
   ) {
     self.whenComplete { result in
       defer {
@@ -95,13 +95,13 @@ extension EventLoopFuture {
 
 extension EventLoopFuture {
   // TODO: Replace with `always` once https://github.com/apple/swift-nio/pull/981 is released.
-  func peekError(callback: @escaping (Error) -> Void) -> EventLoopFuture<Value> {
+  func peekError(callback: @escaping @Sendable (Error) -> Void) -> EventLoopFuture<Value> {
     self.whenFailure(callback)
     return self
   }
 
   // TODO: Replace with `always` once https://github.com/apple/swift-nio/pull/981 is released.
-  func peek(callback: @escaping (Value) -> Void) -> EventLoopFuture<Value> {
+  func peek(callback: @escaping @Sendable (Value) -> Void) -> EventLoopFuture<Value> {
     self.whenSuccess(callback)
     return self
   }

--- a/Tests/GRPCTests/GRPCCustomPayloadTests.swift
+++ b/Tests/GRPCTests/GRPCCustomPayloadTests.swift
@@ -163,8 +163,8 @@ class GRPCCustomPayloadTests: GRPCTestCase {
 
 // MARK: Custom Payload Service
 
-private class CustomPayloadProvider: CallHandlerProvider {
-  var serviceName: Substring = "CustomPayload"
+private final class CustomPayloadProvider: CallHandlerProvider {
+  let serviceName: Substring = "CustomPayload"
 
   fileprivate func reverseString(
     request: StringPayload,
@@ -257,7 +257,7 @@ private class CustomPayloadProvider: CallHandlerProvider {
         requestDeserializer: GRPCPayloadDeserializer<CustomPayload>(),
         responseSerializer: GRPCPayloadSerializer<CustomPayload>(),
         interceptors: [],
-        observerFactory: self.addOneAndReverseMessage(context:)
+        observerFactory: { self.addOneAndReverseMessage(context: $0) }
       )
 
     default:

--- a/Tests/GRPCTests/HeaderNormalizationTests.swift
+++ b/Tests/GRPCTests/HeaderNormalizationTests.swift
@@ -22,7 +22,7 @@ import NIOHTTP1
 import NIOPosix
 import XCTest
 
-class EchoMetadataValidator: Echo_EchoProvider {
+final class EchoMetadataValidator: Echo_EchoProvider {
   let interceptors: Echo_EchoServerInterceptorFactoryProtocol? = nil
 
   private func assertCustomMetadataIsLowercased(

--- a/Tests/GRPCTests/ImmediateServerFailureTests.swift
+++ b/Tests/GRPCTests/ImmediateServerFailureTests.swift
@@ -19,7 +19,7 @@ import GRPC
 import NIOCore
 import XCTest
 
-class ImmediatelyFailingEchoProvider: Echo_EchoProvider {
+final class ImmediatelyFailingEchoProvider: Echo_EchoProvider {
   let interceptors: Echo_EchoServerInterceptorFactoryProtocol? = nil
 
   static let status: GRPCStatus = .init(code: .unavailable, message: nil)

--- a/Tests/GRPCTests/MutualTLSTests.swift
+++ b/Tests/GRPCTests/MutualTLSTests.swift
@@ -105,10 +105,12 @@ class MutualTLSTests: GRPCTestCase {
 
     if !expectServerHandshakeError {
       XCTAssert(
-        serverErrorDelegate.errors.isEmpty,
+        serverErrorDelegate.errors.withLockedValue { $0.isEmpty },
         "Unexpected server errors: \(serverErrorDelegate.errors)"
       )
-    } else if case .handshakeFailed = serverErrorDelegate.errors.first as? NIOSSLError {
+    } else if case .handshakeFailed = serverErrorDelegate.errors.withLockedValue({
+      $0.first as? NIOSSLError
+    }) {
       // This is the expected error.
     } else {
       XCTFail(

--- a/Tests/GRPCTests/ServerErrorDelegateTests.swift
+++ b/Tests/GRPCTests/ServerErrorDelegateTests.swift
@@ -24,10 +24,10 @@ import NIOHPACK
 import NIOHTTP2
 import XCTest
 
-private class ServerErrorDelegateMock: ServerErrorDelegate {
-  private let transformLibraryErrorHandler: (Error) -> (GRPCStatusAndTrailers?)
+private final class ServerErrorDelegateMock: ServerErrorDelegate {
+  private let transformLibraryErrorHandler: @Sendable (Error) -> (GRPCStatusAndTrailers?)
 
-  init(transformLibraryErrorHandler: @escaping ((Error) -> (GRPCStatusAndTrailers?))) {
+  init(transformLibraryErrorHandler: @escaping (@Sendable (Error) -> (GRPCStatusAndTrailers?))) {
     self.transformLibraryErrorHandler = transformLibraryErrorHandler
   }
 
@@ -147,7 +147,7 @@ class ServerErrorDelegateTests: GRPCTestCase {
   }
 
   private func setupChannelAndDelegate(
-    transformLibraryErrorHandler: @escaping (Error) -> GRPCStatusAndTrailers?
+    transformLibraryErrorHandler: @escaping @Sendable (Error) -> GRPCStatusAndTrailers?
   ) {
     let provider = EchoProvider()
     self.errorDelegate = ServerErrorDelegateMock(

--- a/Tests/GRPCTests/ServerInterceptorTests.swift
+++ b/Tests/GRPCTests/ServerInterceptorTests.swift
@@ -238,8 +238,8 @@ class ExtraRequestPartEmitter: ServerInterceptor<Echo_EchoRequest, Echo_EchoResp
   }
 }
 
-class EchoFromInterceptor: Echo_EchoProvider {
-  var interceptors: Echo_EchoServerInterceptorFactoryProtocol? = Interceptors()
+final class EchoFromInterceptor: Echo_EchoProvider {
+  let interceptors: Echo_EchoServerInterceptorFactoryProtocol? = Interceptors()
 
   func get(
     request: Echo_EchoRequest,

--- a/Tests/GRPCTests/ServerOnCloseTests.swift
+++ b/Tests/GRPCTests/ServerOnCloseTests.swift
@@ -63,7 +63,7 @@ final class ServerOnCloseTests: GRPCTestCase {
 
   private func startServer(
     echoDelegate: Echo_EchoProvider,
-    onClose: @escaping (Result<Void, Error>) -> Void
+    onClose: @escaping @Sendable (Result<Void, Error>) -> Void
   ) {
     let provider = OnCloseEchoProvider(delegate: echoDelegate, onClose: onClose)
     XCTAssertNoThrow(try self.setUp(provider: provider))

--- a/Tests/GRPCTests/ServerTLSErrorTests.swift
+++ b/Tests/GRPCTests/ServerTLSErrorTests.swift
@@ -117,7 +117,7 @@ class ServerTLSErrorTests: GRPCTestCase {
     self.wait(for: [errorExpectation], timeout: self.defaultTestTimeout)
     stateChangeDelegate.waitForExpectedChanges(timeout: .seconds(1))
 
-    if let nioSSLError = errorDelegate.errors.first as? NIOSSLError,
+    if let nioSSLError = errorDelegate.errors.withLockedValue({ $0.first as? NIOSSLError }),
        case .failedToLoadCertificate = nioSSLError {
       // Expected case.
     } else {

--- a/Tests/GRPCTests/ServerThrowingTests.swift
+++ b/Tests/GRPCTests/ServerThrowingTests.swift
@@ -31,7 +31,7 @@ let transformedMetadata = HPACKHeaders([("transformed", "header")])
 // client-streaming and bidi-streaming cases) to throw immediately, _before_ the corresponding handler has even added
 // to the channel. We want to test that case as well as the one where we throw only _after_ the handler has been added
 // to the channel.
-class ImmediateThrowingEchoProvider: Echo_EchoProvider {
+class ImmediateThrowingEchoProvider: Echo_EchoProvider, @unchecked Sendable {
   var interceptors: Echo_EchoServerInterceptorFactoryProtocol? { return nil }
 
   func get(
@@ -68,7 +68,7 @@ extension EventLoop {
 }
 
 /// See `ImmediateThrowingEchoProvider`.
-class DelayedThrowingEchoProvider: Echo_EchoProvider {
+final class DelayedThrowingEchoProvider: Echo_EchoProvider {
   let interceptors: Echo_EchoServerInterceptorFactoryProtocol? = nil
 
   func get(
@@ -97,7 +97,7 @@ class DelayedThrowingEchoProvider: Echo_EchoProvider {
 }
 
 /// Ensures that fulfilling the status promise (where possible) with an error yields the same result as failing the future.
-class ErrorReturningEchoProvider: ImmediateThrowingEchoProvider {
+final class ErrorReturningEchoProvider: ImmediateThrowingEchoProvider {
   // There's no status promise to fulfill for unary calls (only the response promise), so that case is omitted.
 
   override func expand(
@@ -123,7 +123,7 @@ class ErrorReturningEchoProvider: ImmediateThrowingEchoProvider {
   }
 }
 
-private class ErrorTransformingDelegate: ServerErrorDelegate {
+private final class ErrorTransformingDelegate: ServerErrorDelegate {
   func transformRequestHandlerError(
     _ error: Error,
     headers: HPACKHeaders

--- a/Tests/GRPCTests/UnaryServerHandlerTests.swift
+++ b/Tests/GRPCTests/UnaryServerHandlerTests.swift
@@ -114,11 +114,14 @@ class UnaryServerHandlerTests: ServerHandlerTestCaseBase {
     )
   }
 
-  private func echo(_ request: String, context: StatusOnlyCallContext) -> EventLoopFuture<String> {
+  private static func echo(
+    _ request: String,
+    context: StatusOnlyCallContext
+  ) -> EventLoopFuture<String> {
     return context.eventLoop.makeSucceededFuture(request)
   }
 
-  private func neverComplete(
+  private static func neverComplete(
     _ request: String,
     context: StatusOnlyCallContext
   ) -> EventLoopFuture<String> {
@@ -128,7 +131,7 @@ class UnaryServerHandlerTests: ServerHandlerTestCaseBase {
     return scheduled.futureResult
   }
 
-  private func neverCalled(
+  private static func neverCalled(
     _ request: String,
     context: StatusOnlyCallContext
   ) -> EventLoopFuture<String> {
@@ -137,7 +140,7 @@ class UnaryServerHandlerTests: ServerHandlerTestCaseBase {
   }
 
   func testHappyPath() {
-    let handler = self.makeHandler(function: self.echo(_:context:))
+    let handler = self.makeHandler(function: Self.echo(_:context:))
 
     handler.receiveMetadata([:])
     assertThat(self.recorder.metadata, .is([:]))
@@ -156,7 +159,7 @@ class UnaryServerHandlerTests: ServerHandlerTestCaseBase {
   func testHappyPathWithCompressionEnabled() {
     let handler = self.makeHandler(
       encoding: .enabled(.init(decompressionLimit: .absolute(.max))),
-      function: self.echo(_:context:)
+      function: Self.echo(_:context:)
     )
 
     handler.receiveMetadata([:])
@@ -172,7 +175,7 @@ class UnaryServerHandlerTests: ServerHandlerTestCaseBase {
       encoding: .enabled(.init(decompressionLimit: .absolute(.max)))
     ) { request, context in
       context.compressionEnabled = false
-      return self.echo(request, context: context)
+      return Self.echo(request, context: context)
     }
 
     handler.receiveMetadata([:])
@@ -189,7 +192,7 @@ class UnaryServerHandlerTests: ServerHandlerTestCaseBase {
       requestDeserializer: ThrowingStringDeserializer(),
       responseSerializer: StringSerializer(),
       interceptors: [],
-      userFunction: self.neverCalled(_:context:)
+      userFunction: Self.neverCalled(_:context:)
     )
 
     handler.receiveMetadata([:])
@@ -208,7 +211,7 @@ class UnaryServerHandlerTests: ServerHandlerTestCaseBase {
       requestDeserializer: StringDeserializer(),
       responseSerializer: ThrowingStringSerializer(),
       interceptors: [],
-      userFunction: self.echo(_:context:)
+      userFunction: Self.echo(_:context:)
     )
 
     handler.receiveMetadata([:])
@@ -239,7 +242,7 @@ class UnaryServerHandlerTests: ServerHandlerTestCaseBase {
   }
 
   func testReceiveMessageBeforeHeaders() {
-    let handler = self.makeHandler(function: self.neverCalled(_:context:))
+    let handler = self.makeHandler(function: Self.neverCalled(_:context:))
 
     handler.receiveMessage(ByteBuffer(string: "foo"))
     assertThat(self.recorder.metadata, .is(.none()))
@@ -248,7 +251,7 @@ class UnaryServerHandlerTests: ServerHandlerTestCaseBase {
   }
 
   func testReceiveMultipleHeaders() {
-    let handler = self.makeHandler(function: self.neverCalled(_:context:))
+    let handler = self.makeHandler(function: Self.neverCalled(_:context:))
 
     handler.receiveMetadata([:])
     assertThat(self.recorder.metadata, .is([:]))
@@ -259,7 +262,7 @@ class UnaryServerHandlerTests: ServerHandlerTestCaseBase {
   }
 
   func testReceiveMultipleMessages() {
-    let handler = self.makeHandler(function: self.neverComplete(_:context:))
+    let handler = self.makeHandler(function: Self.neverComplete(_:context:))
 
     handler.receiveMetadata([:])
     assertThat(self.recorder.metadata, .is([:]))
@@ -275,7 +278,7 @@ class UnaryServerHandlerTests: ServerHandlerTestCaseBase {
   }
 
   func testFinishBeforeStarting() {
-    let handler = self.makeHandler(function: self.neverCalled(_:context:))
+    let handler = self.makeHandler(function: Self.neverCalled(_:context:))
 
     handler.finish()
     assertThat(self.recorder.metadata, .is(.none()))
@@ -285,7 +288,7 @@ class UnaryServerHandlerTests: ServerHandlerTestCaseBase {
   }
 
   func testFinishAfterHeaders() {
-    let handler = self.makeHandler(function: self.neverCalled(_:context:))
+    let handler = self.makeHandler(function: Self.neverCalled(_:context:))
     handler.receiveMetadata([:])
     assertThat(self.recorder.metadata, .is([:]))
 
@@ -297,7 +300,7 @@ class UnaryServerHandlerTests: ServerHandlerTestCaseBase {
   }
 
   func testFinishAfterMessage() {
-    let handler = self.makeHandler(function: self.neverComplete(_:context:))
+    let handler = self.makeHandler(function: Self.neverComplete(_:context:))
 
     handler.receiveMetadata([:])
     handler.receiveMessage(ByteBuffer(string: "hello"))
@@ -326,7 +329,7 @@ class ClientStreamingServerHandlerTests: ServerHandlerTestCaseBase {
     )
   }
 
-  private func joinWithSpaces(
+  private static func joinWithSpaces(
     context: UnaryResponseCallContext<String>
   ) -> EventLoopFuture<(StreamEvent<String>) -> Void> {
     var messages: [String] = []
@@ -341,7 +344,7 @@ class ClientStreamingServerHandlerTests: ServerHandlerTestCaseBase {
     return context.eventLoop.makeSucceededFuture(onEvent(_:))
   }
 
-  private func neverReceivesMessage(
+  private static func neverReceivesMessage(
     context: UnaryResponseCallContext<String>
   ) -> EventLoopFuture<(StreamEvent<String>) -> Void> {
     func onEvent(_ event: StreamEvent<String>) {
@@ -355,7 +358,7 @@ class ClientStreamingServerHandlerTests: ServerHandlerTestCaseBase {
     return context.eventLoop.makeSucceededFuture(onEvent(_:))
   }
 
-  private func neverCalled(
+  private static func neverCalled(
     context: UnaryResponseCallContext<String>
   ) -> EventLoopFuture<(StreamEvent<String>) -> Void> {
     XCTFail("This observer factory should never be called")
@@ -363,7 +366,7 @@ class ClientStreamingServerHandlerTests: ServerHandlerTestCaseBase {
   }
 
   func testHappyPath() {
-    let handler = self.makeHandler(observerFactory: self.joinWithSpaces(context:))
+    let handler = self.makeHandler(observerFactory: Self.joinWithSpaces(context:))
 
     handler.receiveMetadata([:])
     assertThat(self.recorder.metadata, .is([:]))
@@ -383,7 +386,7 @@ class ClientStreamingServerHandlerTests: ServerHandlerTestCaseBase {
   func testHappyPathWithCompressionEnabled() {
     let handler = self.makeHandler(
       encoding: .enabled(.init(decompressionLimit: .absolute(.max))),
-      observerFactory: self.joinWithSpaces(context:)
+      observerFactory: Self.joinWithSpaces(context:)
     )
 
     handler.receiveMetadata([:])
@@ -401,7 +404,7 @@ class ClientStreamingServerHandlerTests: ServerHandlerTestCaseBase {
       encoding: .enabled(.init(decompressionLimit: .absolute(.max)))
     ) { context in
       context.compressionEnabled = false
-      return self.joinWithSpaces(context: context)
+      return Self.joinWithSpaces(context: context)
     }
 
     handler.receiveMetadata([:])
@@ -420,7 +423,7 @@ class ClientStreamingServerHandlerTests: ServerHandlerTestCaseBase {
       requestDeserializer: ThrowingStringDeserializer(),
       responseSerializer: StringSerializer(),
       interceptors: [],
-      observerFactory: self.neverReceivesMessage(context:)
+      observerFactory: Self.neverReceivesMessage(context:)
     )
 
     handler.receiveMetadata([:])
@@ -439,7 +442,7 @@ class ClientStreamingServerHandlerTests: ServerHandlerTestCaseBase {
       requestDeserializer: StringDeserializer(),
       responseSerializer: ThrowingStringSerializer(),
       interceptors: [],
-      observerFactory: self.joinWithSpaces(context:)
+      observerFactory: Self.joinWithSpaces(context:)
     )
 
     handler.receiveMetadata([:])
@@ -468,7 +471,7 @@ class ClientStreamingServerHandlerTests: ServerHandlerTestCaseBase {
     let promise = self.eventLoop.makePromise(of: Void.self)
     let handler = self.makeHandler { context in
       return promise.futureResult.flatMap {
-        self.joinWithSpaces(context: context)
+        Self.joinWithSpaces(context: context)
       }
     }
 
@@ -492,7 +495,7 @@ class ClientStreamingServerHandlerTests: ServerHandlerTestCaseBase {
     let promise = self.eventLoop.makePromise(of: Void.self)
     let handler = self.makeHandler { context in
       return promise.futureResult.flatMap {
-        self.joinWithSpaces(context: context)
+        Self.joinWithSpaces(context: context)
       }
     }
 
@@ -510,7 +513,7 @@ class ClientStreamingServerHandlerTests: ServerHandlerTestCaseBase {
   }
 
   func testReceiveMessageBeforeHeaders() {
-    let handler = self.makeHandler(observerFactory: self.neverCalled(context:))
+    let handler = self.makeHandler(observerFactory: Self.neverCalled(context:))
 
     handler.receiveMessage(ByteBuffer(string: "foo"))
     assertThat(self.recorder.metadata, .is(.none()))
@@ -519,7 +522,7 @@ class ClientStreamingServerHandlerTests: ServerHandlerTestCaseBase {
   }
 
   func testReceiveMultipleHeaders() {
-    let handler = self.makeHandler(observerFactory: self.neverReceivesMessage(context:))
+    let handler = self.makeHandler(observerFactory: Self.neverReceivesMessage(context:))
 
     handler.receiveMetadata([:])
     assertThat(self.recorder.metadata, .is([:]))
@@ -530,7 +533,7 @@ class ClientStreamingServerHandlerTests: ServerHandlerTestCaseBase {
   }
 
   func testFinishBeforeStarting() {
-    let handler = self.makeHandler(observerFactory: self.neverCalled(context:))
+    let handler = self.makeHandler(observerFactory: Self.neverCalled(context:))
 
     handler.finish()
     assertThat(self.recorder.metadata, .is(.none()))
@@ -540,7 +543,7 @@ class ClientStreamingServerHandlerTests: ServerHandlerTestCaseBase {
   }
 
   func testFinishAfterHeaders() {
-    let handler = self.makeHandler(observerFactory: self.joinWithSpaces(context:))
+    let handler = self.makeHandler(observerFactory: Self.joinWithSpaces(context:))
     handler.receiveMetadata([:])
     assertThat(self.recorder.metadata, .is([:]))
 
@@ -552,7 +555,7 @@ class ClientStreamingServerHandlerTests: ServerHandlerTestCaseBase {
   }
 
   func testFinishAfterMessage() {
-    let handler = self.makeHandler(observerFactory: self.joinWithSpaces(context:))
+    let handler = self.makeHandler(observerFactory: Self.joinWithSpaces(context:))
 
     handler.receiveMetadata([:])
     handler.receiveMessage(ByteBuffer(string: "hello"))
@@ -579,7 +582,7 @@ class ServerStreamingServerHandlerTests: ServerHandlerTestCaseBase {
     )
   }
 
-  private func breakOnSpaces(
+  private static func breakOnSpaces(
     _ request: String,
     context: StreamingResponseCallContext<String>
   ) -> EventLoopFuture<GRPCStatus> {
@@ -588,7 +591,7 @@ class ServerStreamingServerHandlerTests: ServerHandlerTestCaseBase {
     return context.eventLoop.makeSucceededFuture(.ok)
   }
 
-  private func neverCalled(
+  private static func neverCalled(
     _ request: String,
     context: StreamingResponseCallContext<String>
   ) -> EventLoopFuture<GRPCStatus> {
@@ -596,7 +599,7 @@ class ServerStreamingServerHandlerTests: ServerHandlerTestCaseBase {
     return context.eventLoop.makeSucceededFuture(.processingError)
   }
 
-  private func neverComplete(
+  private static func neverComplete(
     _ request: String,
     context: StreamingResponseCallContext<String>
   ) -> EventLoopFuture<GRPCStatus> {
@@ -606,7 +609,7 @@ class ServerStreamingServerHandlerTests: ServerHandlerTestCaseBase {
   }
 
   func testHappyPath() {
-    let handler = self.makeHandler(userFunction: self.breakOnSpaces(_:context:))
+    let handler = self.makeHandler(userFunction: Self.breakOnSpaces(_:context:))
 
     handler.receiveMetadata([:])
     assertThat(self.recorder.metadata, .is([:]))
@@ -627,7 +630,7 @@ class ServerStreamingServerHandlerTests: ServerHandlerTestCaseBase {
   func testHappyPathWithCompressionEnabled() {
     let handler = self.makeHandler(
       encoding: .enabled(.init(decompressionLimit: .absolute(.max))),
-      userFunction: self.breakOnSpaces(_:context:)
+      userFunction: Self.breakOnSpaces(_:context:)
     )
 
     handler.receiveMetadata([:])
@@ -643,7 +646,7 @@ class ServerStreamingServerHandlerTests: ServerHandlerTestCaseBase {
       encoding: .enabled(.init(decompressionLimit: .absolute(.max)))
     ) { request, context in
       context.compressionEnabled = false
-      return self.breakOnSpaces(request, context: context)
+      return Self.breakOnSpaces(request, context: context)
     }
 
     handler.receiveMetadata([:])
@@ -660,7 +663,7 @@ class ServerStreamingServerHandlerTests: ServerHandlerTestCaseBase {
       requestDeserializer: ThrowingStringDeserializer(),
       responseSerializer: StringSerializer(),
       interceptors: [],
-      userFunction: self.neverCalled(_:context:)
+      userFunction: Self.neverCalled(_:context:)
     )
 
     handler.receiveMetadata([:])
@@ -679,7 +682,7 @@ class ServerStreamingServerHandlerTests: ServerHandlerTestCaseBase {
       requestDeserializer: StringDeserializer(),
       responseSerializer: ThrowingStringSerializer(),
       interceptors: [],
-      userFunction: self.breakOnSpaces(_:context:)
+      userFunction: Self.breakOnSpaces(_:context:)
     )
 
     handler.receiveMetadata([:])
@@ -710,7 +713,7 @@ class ServerStreamingServerHandlerTests: ServerHandlerTestCaseBase {
   }
 
   func testReceiveMessageBeforeHeaders() {
-    let handler = self.makeHandler(userFunction: self.neverCalled(_:context:))
+    let handler = self.makeHandler(userFunction: Self.neverCalled(_:context:))
 
     handler.receiveMessage(ByteBuffer(string: "foo"))
     assertThat(self.recorder.metadata, .is(.none()))
@@ -719,7 +722,7 @@ class ServerStreamingServerHandlerTests: ServerHandlerTestCaseBase {
   }
 
   func testReceiveMultipleHeaders() {
-    let handler = self.makeHandler(userFunction: self.neverCalled(_:context:))
+    let handler = self.makeHandler(userFunction: Self.neverCalled(_:context:))
 
     handler.receiveMetadata([:])
     assertThat(self.recorder.metadata, .is([:]))
@@ -730,7 +733,7 @@ class ServerStreamingServerHandlerTests: ServerHandlerTestCaseBase {
   }
 
   func testReceiveMultipleMessages() {
-    let handler = self.makeHandler(userFunction: self.neverComplete(_:context:))
+    let handler = self.makeHandler(userFunction: Self.neverComplete(_:context:))
 
     handler.receiveMetadata([:])
     assertThat(self.recorder.metadata, .is([:]))
@@ -746,7 +749,7 @@ class ServerStreamingServerHandlerTests: ServerHandlerTestCaseBase {
   }
 
   func testFinishBeforeStarting() {
-    let handler = self.makeHandler(userFunction: self.neverCalled(_:context:))
+    let handler = self.makeHandler(userFunction: Self.neverCalled(_:context:))
 
     handler.finish()
     assertThat(self.recorder.metadata, .is(.none()))
@@ -756,7 +759,7 @@ class ServerStreamingServerHandlerTests: ServerHandlerTestCaseBase {
   }
 
   func testFinishAfterHeaders() {
-    let handler = self.makeHandler(userFunction: self.neverCalled(_:context:))
+    let handler = self.makeHandler(userFunction: Self.neverCalled(_:context:))
     handler.receiveMetadata([:])
     assertThat(self.recorder.metadata, .is([:]))
 
@@ -768,7 +771,7 @@ class ServerStreamingServerHandlerTests: ServerHandlerTestCaseBase {
   }
 
   func testFinishAfterMessage() {
-    let handler = self.makeHandler(userFunction: self.neverComplete(_:context:))
+    let handler = self.makeHandler(userFunction: Self.neverComplete(_:context:))
 
     handler.receiveMetadata([:])
     handler.receiveMessage(ByteBuffer(string: "hello"))
@@ -782,10 +785,10 @@ class ServerStreamingServerHandlerTests: ServerHandlerTestCaseBase {
 
 // MARK: - Bidirectional Streaming
 
-class BidirectionalStreamingServerHandlerTests: ServerHandlerTestCaseBase {
+final class BidirectionalStreamingServerHandlerTests: ServerHandlerTestCaseBase {
   private func makeHandler(
     encoding: ServerMessageEncoding = .disabled,
-    observerFactory: @escaping (StreamingResponseCallContext<String>)
+    observerFactory: @escaping @Sendable (StreamingResponseCallContext<String>)
       -> EventLoopFuture<(StreamEvent<String>) -> Void>
   ) -> BidirectionalStreamingServerHandler<StringSerializer, StringDeserializer> {
     return BidirectionalStreamingServerHandler(
@@ -797,7 +800,7 @@ class BidirectionalStreamingServerHandlerTests: ServerHandlerTestCaseBase {
     )
   }
 
-  private func echo(
+  private static func echo(
     context: StreamingResponseCallContext<String>
   ) -> EventLoopFuture<(StreamEvent<String>) -> Void> {
     func onEvent(_ event: StreamEvent<String>) {
@@ -811,7 +814,7 @@ class BidirectionalStreamingServerHandlerTests: ServerHandlerTestCaseBase {
     return context.eventLoop.makeSucceededFuture(onEvent(_:))
   }
 
-  private func neverReceivesMessage(
+  private static func neverReceivesMessage(
     context: StreamingResponseCallContext<String>
   ) -> EventLoopFuture<(StreamEvent<String>) -> Void> {
     func onEvent(_ event: StreamEvent<String>) {
@@ -825,7 +828,7 @@ class BidirectionalStreamingServerHandlerTests: ServerHandlerTestCaseBase {
     return context.eventLoop.makeSucceededFuture(onEvent(_:))
   }
 
-  private func neverCalled(
+  private static func neverCalled(
     context: StreamingResponseCallContext<String>
   ) -> EventLoopFuture<(StreamEvent<String>) -> Void> {
     XCTFail("This observer factory should never be called")
@@ -833,7 +836,7 @@ class BidirectionalStreamingServerHandlerTests: ServerHandlerTestCaseBase {
   }
 
   func testHappyPath() {
-    let handler = self.makeHandler(observerFactory: self.echo(context:))
+    let handler = self.makeHandler { Self.echo(context: $0) }
 
     handler.receiveMetadata([:])
     assertThat(self.recorder.metadata, .is([:]))
@@ -856,7 +859,7 @@ class BidirectionalStreamingServerHandlerTests: ServerHandlerTestCaseBase {
   func testHappyPathWithCompressionEnabled() {
     let handler = self.makeHandler(
       encoding: .enabled(.init(decompressionLimit: .absolute(.max))),
-      observerFactory: self.echo(context:)
+      observerFactory: { Self.echo(context: $0) }
     )
 
     handler.receiveMetadata([:])
@@ -877,7 +880,7 @@ class BidirectionalStreamingServerHandlerTests: ServerHandlerTestCaseBase {
       encoding: .enabled(.init(decompressionLimit: .absolute(.max)))
     ) { context in
       context.compressionEnabled = false
-      return self.echo(context: context)
+      return Self.echo(context: context)
     }
 
     handler.receiveMetadata([:])
@@ -899,7 +902,7 @@ class BidirectionalStreamingServerHandlerTests: ServerHandlerTestCaseBase {
       requestDeserializer: ThrowingStringDeserializer(),
       responseSerializer: StringSerializer(),
       interceptors: [],
-      observerFactory: self.neverReceivesMessage(context:)
+      observerFactory: { Self.neverReceivesMessage(context: $0) }
     )
 
     handler.receiveMetadata([:])
@@ -918,7 +921,7 @@ class BidirectionalStreamingServerHandlerTests: ServerHandlerTestCaseBase {
       requestDeserializer: StringDeserializer(),
       responseSerializer: ThrowingStringSerializer(),
       interceptors: [],
-      observerFactory: self.echo(context:)
+      observerFactory: { Self.echo(context: $0) }
     )
 
     handler.receiveMetadata([:])
@@ -947,7 +950,7 @@ class BidirectionalStreamingServerHandlerTests: ServerHandlerTestCaseBase {
     let promise = self.eventLoop.makePromise(of: Void.self)
     let handler = self.makeHandler { context in
       return promise.futureResult.flatMap {
-        self.echo(context: context)
+        Self.echo(context: context)
       }
     }
 
@@ -971,7 +974,7 @@ class BidirectionalStreamingServerHandlerTests: ServerHandlerTestCaseBase {
     let promise = self.eventLoop.makePromise(of: Void.self)
     let handler = self.makeHandler { context in
       return promise.futureResult.flatMap {
-        self.echo(context: context)
+        Self.echo(context: context)
       }
     }
 
@@ -991,7 +994,7 @@ class BidirectionalStreamingServerHandlerTests: ServerHandlerTestCaseBase {
   }
 
   func testReceiveMessageBeforeHeaders() {
-    let handler = self.makeHandler(observerFactory: self.neverCalled(context:))
+    let handler = self.makeHandler { Self.neverCalled(context: $0) }
 
     handler.receiveMessage(ByteBuffer(string: "foo"))
     assertThat(self.recorder.metadata, .is(.none()))
@@ -1000,7 +1003,7 @@ class BidirectionalStreamingServerHandlerTests: ServerHandlerTestCaseBase {
   }
 
   func testReceiveMultipleHeaders() {
-    let handler = self.makeHandler(observerFactory: self.neverReceivesMessage(context:))
+    let handler = self.makeHandler { Self.neverReceivesMessage(context: $0) }
 
     handler.receiveMetadata([:])
     assertThat(self.recorder.metadata, .is([:]))
@@ -1011,7 +1014,7 @@ class BidirectionalStreamingServerHandlerTests: ServerHandlerTestCaseBase {
   }
 
   func testFinishBeforeStarting() {
-    let handler = self.makeHandler(observerFactory: self.neverCalled(context:))
+    let handler = self.makeHandler { Self.neverCalled(context: $0) }
 
     handler.finish()
     assertThat(self.recorder.metadata, .is(.none()))
@@ -1021,7 +1024,7 @@ class BidirectionalStreamingServerHandlerTests: ServerHandlerTestCaseBase {
   }
 
   func testFinishAfterHeaders() {
-    let handler = self.makeHandler(observerFactory: self.echo(context:))
+    let handler = self.makeHandler { Self.echo(context: $0) }
     handler.receiveMetadata([:])
     assertThat(self.recorder.metadata, .is([:]))
 
@@ -1033,7 +1036,7 @@ class BidirectionalStreamingServerHandlerTests: ServerHandlerTestCaseBase {
   }
 
   func testFinishAfterMessage() {
-    let handler = self.makeHandler(observerFactory: self.echo(context:))
+    let handler = self.makeHandler { Self.echo(context: $0) }
 
     handler.receiveMetadata([:])
     handler.receiveMessage(ByteBuffer(string: "hello"))


### PR DESCRIPTION
Motivation:

In Swift 6 strict concurrency checking will be enabled by default. We can enable support now to flush out any concurrency bugs.

Modifications:

In the generator:
- Add `@Sendable` annotations to closures which were not annotated
- Wrap functions refs in closures
- Remove an incorrect comment from docs

In the runtime: various changes to internal types marking them as `Sendable` or `@unchecked Sendable`. A number or larger changes were also made:
- Require the `Request`/`Response` types `Sendable`. We didn't add this initially because we adopted `Sendable` before Swift Protobuf did. It's now been long enough since Swift Protobuf adopted `Sendable` that this is no longer an issue.
- As a result of the above, `GRPCPayload`, the serializer and deserializer are also now required to be `Sendable`. This bubbles up to quite a few functions in the public API.
- The fake transport is now `Sendable` (and still deprecated) and uses a lock to synchronize state.
- The connection pool uses loop-bound self in a number of places.

CI:
- Add strict concurrency checking to 5.8 and nightly

Result:

Passes strict concurrency checking.