### PR TITLE
Drop Swift 5.6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,13 +27,13 @@ jobs:
           - image: swiftlang/swift:nightly-focal
             # No TSAN because of: https://github.com/apple/swift/issues/59068
             # swift-test-flags: "--sanitize=thread"
+          - image: swift:5.9-focal
+            # No TSAN because of: https://github.com/apple/swift/issues/59068
+            # swift-test-flags: "--sanitize=thread"
           - image: swift:5.8-jammy
             # No TSAN because of: https://github.com/apple/swift/issues/59068
             # swift-test-flags: "--sanitize=thread"
           - image: swift:5.7-jammy
-            # No TSAN because of: https://github.com/apple/swift/issues/59068
-            # swift-test-flags: "--sanitize=thread"
-          - image: swift:5.6-focal
             # No TSAN because of: https://github.com/apple/swift/issues/59068
             # swift-test-flags: "--sanitize=thread"
     name: Build and Test on ${{ matrix.image }}
@@ -46,8 +46,6 @@ jobs:
       run: swift build ${{ matrix.swift-build-flags }}
       timeout-minutes: 20
     - name: 🧪 Test
-      # Skip tests on 5.6: https://bugs.swift.org/browse/SR-15955
-      if: ${{ matrix.image != 'swift:5.6-focal' }}
       run: swift test ${{ matrix.swift-test-flags }}
       timeout-minutes: 20
   performance-tests:
@@ -65,6 +63,16 @@ jobs:
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 163000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 170000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 170000
+          - image: swift:5.9-focal
+            env:
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 323000
+              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 161000
+              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 110000
+              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 65000
+              MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 61000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 163000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 170000
+              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 170000
           - image: swift:5.8-jammy
             env:
               MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 323000
@@ -85,16 +93,6 @@ jobs:
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 163000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 170000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 170000
-          - image: swift:5.6-focal
-            env:
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 324000
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 162000
-              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 110000
-              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 65000
-              MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 61000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 164000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 171000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 171000
     name: Performance Tests on ${{ matrix.image }}
     runs-on: ubuntu-latest
     container:
@@ -111,9 +109,9 @@ jobs:
       matrix:
         include:
           - image: swiftlang/swift:nightly-focal
+          - image: swift:5.9-focal
           - image: swift:5.8-jammy
           - image: swift:5.7-jammy
-          - image: swift:5.6-focal
     name: Integration Tests on ${{ matrix.image }}
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,16 +24,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: swiftlang/swift:nightly-focal
+          - image: swiftlang/swift:nightly-jammy
             # No TSAN because of: https://github.com/apple/swift/issues/59068
             # swift-test-flags: "--sanitize=thread"
-          - image: swift:5.9-focal
+          - image: swift:5.9-jammy
             # No TSAN because of: https://github.com/apple/swift/issues/59068
             # swift-test-flags: "--sanitize=thread"
-          - image: swift:5.8-jammy
+          - image: swift:5.8-focal
             # No TSAN because of: https://github.com/apple/swift/issues/59068
             # swift-test-flags: "--sanitize=thread"
-          - image: swift:5.7-jammy
+          - image: swift:5.7-focal
             # No TSAN because of: https://github.com/apple/swift/issues/59068
             # swift-test-flags: "--sanitize=thread"
     name: Build and Test on ${{ matrix.image }}
@@ -53,7 +53,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: swiftlang/swift:nightly-focal
+          - image: swiftlang/swift:nightly-jammy
             env:
               MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 323000
               MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 161000
@@ -63,7 +63,7 @@ jobs:
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 163000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 170000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 170000
-          - image: swift:5.9-focal
+          - image: swift:5.9-jammy
             env:
               MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 323000
               MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 161000
@@ -73,7 +73,7 @@ jobs:
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 163000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 170000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 170000
-          - image: swift:5.8-jammy
+          - image: swift:5.8-focal
             env:
               MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 323000
               MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 161000
@@ -83,7 +83,7 @@ jobs:
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 163000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 170000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 170000
-          - image: swift:5.7-jammy
+          - image: swift:5.7-focal
             env:
               MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 323000
               MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 161000
@@ -108,10 +108,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: swiftlang/swift:nightly-focal
-          - image: swift:5.9-focal
-          - image: swift:5.8-jammy
-          - image: swift:5.7-jammy
+          - image: swiftlang/swift:nightly-jammy
+          - image: swift:5.9-jammy
+          - image: swift:5.8-focal
+          - image: swift:5.7-focal
     name: Integration Tests on ${{ matrix.image }}
     runs-on: ubuntu-latest
     container:

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.7
 /*
  * Copyright 2017, gRPC Authors All rights reserved.
  *

--- a/Performance/QPSBenchmark/Package.swift
+++ b/Performance/QPSBenchmark/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.7
 /*
  * Copyright 2020, gRPC Authors All rights reserved.
  *

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ gRPC Swift Version | Earliest Swift Version
 `1.0.0 ..< 1.8.0`  | 5.2
 `1.8.0 ..< 1.11.0` | 5.4
 `1.11.0..< 1.16.0`.| 5.5
-`1.16.0...`        | 5.6
+`1.16.0..< 1.20.0` | 5.6
+`1.20.0...`        | 5.7
 
 Versions of clients and services which are use Swift's Concurrency support
 are available from gRPC Swift 1.8.0 and require Swift 5.6 and newer.

--- a/Sources/GRPC/Docs.docc/index.md
+++ b/Sources/GRPC/Docs.docc/index.md
@@ -27,7 +27,8 @@ gRPC Swift Version | Earliest Swift Version
 `1.0.0 ..< 1.8.0`  | 5.2
 `1.8.0 ..< 1.11.0` | 5.4
 `1.11.0..< 1.16.0`.| 5.5
-`1.16.0...`        | 5.6
+`1.16.0..< 1.20.0` | 5.6
+`1.20.0...`        | 5.7
 
 Versions of clients and services which are use Swift's Concurrency support
 are available from gRPC Swift 1.8.0 and require Swift 5.6 and newer.

--- a/Sources/GRPC/PlatformSupport.swift
+++ b/Sources/GRPC/PlatformSupport.swift
@@ -123,12 +123,8 @@ public protocol ClientBootstrapProtocol {
   func connectTimeout(_ timeout: TimeAmount) -> Self
   func channelOption<T>(_ option: T, value: T.Value) -> Self where T: ChannelOption
 
-  #if swift(>=5.7)
   @preconcurrency
   func channelInitializer(_ handler: @escaping @Sendable (Channel) -> EventLoopFuture<Void>) -> Self
-  #else
-  func channelInitializer(_ handler: @escaping (Channel) -> EventLoopFuture<Void>) -> Self
-  #endif
 }
 
 extension ClientBootstrapProtocol {
@@ -161,24 +157,16 @@ public protocol ServerBootstrapProtocol {
   func withBoundSocket(_ connectedSocket: NIOBSDSocket.Handle) -> EventLoopFuture<Channel>
   func bind(to vsockAddress: VsockAddress) -> EventLoopFuture<Channel>
 
-  #if swift(>=5.7)
   @preconcurrency
   func serverChannelInitializer(
     _ handler: @escaping @Sendable (Channel) -> EventLoopFuture<Void>
   ) -> Self
-  #else
-  func serverChannelInitializer(_ handler: @escaping (Channel) -> EventLoopFuture<Void>) -> Self
-  #endif
 
   func serverChannelOption<T>(_ option: T, value: T.Value) -> Self where T: ChannelOption
 
-  #if swift(>=5.7)
   @preconcurrency
   func childChannelInitializer(_ handler: @escaping @Sendable (Channel) -> EventLoopFuture<Void>)
     -> Self
-  #else
-  func childChannelInitializer(_ handler: @escaping (Channel) -> EventLoopFuture<Void>) -> Self
-  #endif
 
   func childChannelOption<T>(_ option: T, value: T.Value) -> Self where T: ChannelOption
 }

--- a/Sources/GRPC/Server.swift
+++ b/Sources/GRPC/Server.swift
@@ -569,11 +569,7 @@ extension Server.Configuration.CORS.AllowedOrigins {
   struct AnyCustomCORSAllowedOrigin: GRPCCustomCORSAllowedOrigin {
     private var checkOrigin: @Sendable (String) -> String?
     private let hashInto: @Sendable (inout Hasher) -> Void
-    #if swift(>=5.7)
     private let isEqualTo: @Sendable (any GRPCCustomCORSAllowedOrigin) -> Bool
-    #else
-    private let isEqualTo: @Sendable (Any) -> Bool
-    #endif
 
     init<W: GRPCCustomCORSAllowedOrigin>(_ wrap: W) {
       self.checkOrigin = { wrap.check(origin: $0) }


### PR DESCRIPTION
Motivation:

Now that Swift 5.9 has been released we can drop support for Swift 5.6.

Modifications:

- Update CI
- Update minimum tools version
- Remove code conditioned on Swift version
- Update README

Result:

Swift 5.7 is the minimum supported Swift version