### PR TITLE
add concurrency avail guard to AsyncSequenceOfOne

### DIFF
--- a/Sources/GRPCCore/Stream/AsyncSequenceOfOne.swift
+++ b/Sources/GRPCCore/Stream/AsyncSequenceOfOne.swift
@@ -30,6 +30,7 @@ extension RPCAsyncSequence {
 }
 
 /// An `AsyncSequence` of a single value.
+@available(macOS 10.15, iOS 13.0, tvOS 13, watchOS 6, *)
 private struct AsyncSequenceOfOne<Element: Sendable, Failure: Error>: AsyncSequence {
   private let result: Result<Element, Failure>
 


### PR DESCRIPTION
Motivation:

Building fails with
```
error: concurrency is only available in macOS 10.15.0 or newer
```

Modifications:

Add an availability guard to `AsyncSequenceOfOne`

Result:

Code will build.