### PR TITLE
ClientRPCExecutionConfigurationTests only available on macOS 13...

### DIFF
--- a/Tests/GRPCCoreTests/Call/Client/ClientRPCExecutionConfigurationTests.swift
+++ b/Tests/GRPCCoreTests/Call/Client/ClientRPCExecutionConfigurationTests.swift
@@ -16,6 +16,7 @@
 import GRPCCore
 import XCTest
 
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 final class ClientRPCExecutionConfigurationTests: XCTestCase {
   func testRetryPolicyClampsMaxAttempts() {
     var policy = RetryPolicy(


### PR DESCRIPTION
ClientRPCExecutionConfigurationTests only available on macOS 13... due to dependency on `RetryPolicy` which has the same availability