### PR TITLE
Add `package` visibility modifier

### DIFF
--- a/Plugins/GRPCSwiftPlugin/plugin.swift
+++ b/Plugins/GRPCSwiftPlugin/plugin.swift
@@ -53,6 +53,8 @@ struct GRPCSwiftPlugin {
         case `internal`
         /// The generated files should have `public` access level.
         case `public`
+        /// The generated files should have `package` access level.
+        case `package`
       }
 
       /// An array of paths to `.proto` files for this invocation.

--- a/Sources/protoc-gen-grpc-swift/options.swift
+++ b/Sources/protoc-gen-grpc-swift/options.swift
@@ -40,6 +40,7 @@ final class GeneratorOptions {
   enum Visibility: String {
     case `internal` = "Internal"
     case `public` = "Public"
+    case `package` = "Package"
 
     var sourceSnippet: String {
       switch self {
@@ -47,6 +48,8 @@ final class GeneratorOptions {
         return "internal"
       case .public:
         return "public"
+      case .package:
+        return "package"
       }
     }
   }

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -27,7 +27,7 @@ when invoking `protoc`.
 
 The **Visibility** option determines the access control for generated code.
 
-- **Possible values:** Public, Internal
+- **Possible values:** Public, Internal, Package
 - **Default value:** Internal
 
 ### Server


### PR DESCRIPTION
## Motivation
We want to allow the new `package` visibility modifier to be used when generating code.

## Modifications
Add a new `package` Visibility modifier case to both the SPM and `protoc` plugins.

## Result
Code can now be generated with `package` visibility, and not just `internal` or `public`.