### PR TITLE
Support all_extension_numbers_of_type reflection requests

### DIFF
--- a/Sources/GRPCReflectionService/Server/ReflectionService.swift
+++ b/Sources/GRPCReflectionService/Server/ReflectionService.swift
@@ -51,13 +51,21 @@ internal struct ReflectionServiceData: Sendable {
   internal var fileDescriptorDataByFilename: [String: FileDescriptorProtoData]
   internal var serviceNames: [String]
   internal var fileNameBySymbol: [String: String]
+<<<<<<< Updated upstream
   private var fileNameByExtensionDescriptor: [ExtensionDescriptor: String]
 
+=======
+  internal var fieldNumbersByType: [String: Set<Int32>]
+>>>>>>> Stashed changes
   internal init(fileDescriptors: [Google_Protobuf_FileDescriptorProto]) throws {
     self.serviceNames = []
     self.fileDescriptorDataByFilename = [:]
     self.fileNameBySymbol = [:]
+<<<<<<< Updated upstream
     self.fileNameByExtensionDescriptor = [:]
+=======
+    self.fieldNumbersByType = [:]
+>>>>>>> Stashed changes
 
     for fileDescriptorProto in fileDescriptors {
       let serializedFileDescriptorProto: Data
@@ -91,6 +99,7 @@ internal struct ReflectionServiceData: Sendable {
           )
         }
       }
+<<<<<<< Updated upstream
 
       // Populating the <extension descriptor, file name> dictionary.
       for `extension` in fileDescriptorProto.extension {
@@ -113,6 +122,15 @@ internal struct ReflectionServiceData: Sendable {
           )
         }
       }
+=======
+        
+         for `extension` in fileDescriptorProto.extension {
+            if self.fieldNumbersByType[`extension`.extendee] == nil {
+                self.fieldNumbersByType[`extension`.extendee] = Set<Int32>()
+            }
+            self.fieldNumbersByType[`extension`.extendee]?.insert(`extension`.number)
+        }
+>>>>>>> Stashed changes
     }
   }
 
@@ -149,6 +167,7 @@ internal struct ReflectionServiceData: Sendable {
   internal func nameOfFileContainingSymbol(named symbolName: String) -> String? {
     return self.fileNameBySymbol[symbolName]
   }
+<<<<<<< Updated upstream
 
   internal func nameOfFileContainingExtension(
     named extendeeName: String,
@@ -158,6 +177,13 @@ internal struct ReflectionServiceData: Sendable {
     return self.fileNameByExtensionDescriptor[key]
   }
 }
+=======
+    
+    internal func extensionsFieldNumbersOfType(named typeName: String) -> Set<Int32>? {
+        return self.fieldNumbersByType[typeName]
+    }
+ }
+>>>>>>> Stashed changes
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 internal final class ReflectionServiceProvider: Reflection_ServerReflectionAsyncProvider {
@@ -210,6 +236,7 @@ internal final class ReflectionServiceProvider: Reflection_ServerReflectionAsync
     return try self.findFileByFileName(fileName, request: request)
   }
 
+<<<<<<< Updated upstream
   internal func findFileByExtension(
     extensionRequest: Reflection_ExtensionRequest,
     request: Reflection_ServerReflectionRequest
@@ -228,6 +255,20 @@ internal final class ReflectionServiceProvider: Reflection_ServerReflectionAsync
     return try self.findFileByFileName(fileName, request: request)
   }
 
+=======
+    internal func findExtensionsFieldNumbersOfType(
+        named typeName: String,
+        request: Reflection_ServerReflectionRequest) throws -> Reflection_ServerReflectionResponse {
+            guard let fieldNumbers = self.protoRegistry.extensionsFieldNumbersOfType(named: typeName) else {
+                throw GRPCStatus(
+                  code: .notFound,
+                  message: "The provided symbol could not be found."
+                )
+            }
+            
+    }
+    
+>>>>>>> Stashed changes
   internal func serverReflectionInfo(
     requestStream: GRPCAsyncRequestStream<Reflection_ServerReflectionRequest>,
     responseStream: GRPCAsyncResponseStreamWriter<Reflection_ServerReflectionResponse>,
@@ -253,6 +294,7 @@ internal final class ReflectionServiceProvider: Reflection_ServerReflectionAsync
         )
         try await responseStream.send(response)
 
+<<<<<<< Updated upstream
       case let .fileContainingExtension(extensionRequest):
         let response = try self.findFileByExtension(
           extensionRequest: extensionRequest,
@@ -260,6 +302,15 @@ internal final class ReflectionServiceProvider: Reflection_ServerReflectionAsync
         )
         try await responseStream.send(response)
 
+=======
+      case let .allExtensionNumbersOfType(typeName):
+          let response = try self.findExtensionsFieldNumbersOfType(
+            named: typeName,
+            request: request
+          )
+          try await responseStream.send(response)
+          
+>>>>>>> Stashed changes
       default:
         throw GRPCStatus(code: .unimplemented)
       }

--- a/Sources/GRPCReflectionService/Server/ReflectionService.swift
+++ b/Sources/GRPCReflectionService/Server/ReflectionService.swift
@@ -98,7 +98,9 @@ internal struct ReflectionServiceData: Sendable {
 
       // Populating the <extension descriptor, file name> dictionary and the <typeName, [FieldNumber]> one.
       for `extension` in fileDescriptorProto.extension {
-        let typeName = ReflectionServiceData.extractTypeNameFrom(fullyQualifiedName: `extension`.extendee)
+        let typeName = ReflectionServiceData.extractTypeNameFrom(
+          fullyQualifiedName: `extension`.extendee
+        )
         let extensionDescriptor = ExtensionDescriptor(
           extendeeTypeName: typeName,
           fieldNumber: `extension`.number
@@ -133,14 +135,14 @@ internal struct ReflectionServiceData: Sendable {
     }
   }
 
-    internal static func extractTypeNameFrom(fullyQualifiedName name: String) -> String {
-        var nameCopy = name
-        if (nameCopy.first == ".") {
-            nameCopy.removeFirst()
-        }
-        return nameCopy
+  internal static func extractTypeNameFrom(fullyQualifiedName name: String) -> String {
+    var nameCopy = name
+    if nameCopy.first == "." {
+      nameCopy.removeFirst()
     }
-    
+    return nameCopy
+  }
+
   internal func serialisedFileDescriptorProtosForDependenciesOfFile(
     named fileName: String
   ) throws -> [Data] {

--- a/Sources/GRPCReflectionService/Server/ReflectionService.swift
+++ b/Sources/GRPCReflectionService/Server/ReflectionService.swift
@@ -51,21 +51,15 @@ internal struct ReflectionServiceData: Sendable {
   internal var fileDescriptorDataByFilename: [String: FileDescriptorProtoData]
   internal var serviceNames: [String]
   internal var fileNameBySymbol: [String: String]
-<<<<<<< Updated upstream
   private var fileNameByExtensionDescriptor: [ExtensionDescriptor: String]
-
-=======
   internal var fieldNumbersByType: [String: Set<Int32>]
->>>>>>> Stashed changes
+    
   internal init(fileDescriptors: [Google_Protobuf_FileDescriptorProto]) throws {
     self.serviceNames = []
     self.fileDescriptorDataByFilename = [:]
     self.fileNameBySymbol = [:]
-<<<<<<< Updated upstream
     self.fileNameByExtensionDescriptor = [:]
-=======
     self.fieldNumbersByType = [:]
->>>>>>> Stashed changes
 
     for fileDescriptorProto in fileDescriptors {
       let serializedFileDescriptorProto: Data
@@ -99,7 +93,6 @@ internal struct ReflectionServiceData: Sendable {
           )
         }
       }
-<<<<<<< Updated upstream
 
       // Populating the <extension descriptor, file name> dictionary.
       for `extension` in fileDescriptorProto.extension {
@@ -121,8 +114,8 @@ internal struct ReflectionServiceData: Sendable {
               """
           )
         }
-      }
-=======
+    }
+
         
          for `extension` in fileDescriptorProto.extension {
             if self.fieldNumbersByType[`extension`.extendee] == nil {
@@ -130,7 +123,6 @@ internal struct ReflectionServiceData: Sendable {
             }
             self.fieldNumbersByType[`extension`.extendee]?.insert(`extension`.number)
         }
->>>>>>> Stashed changes
     }
   }
 
@@ -167,7 +159,6 @@ internal struct ReflectionServiceData: Sendable {
   internal func nameOfFileContainingSymbol(named symbolName: String) -> String? {
     return self.fileNameBySymbol[symbolName]
   }
-<<<<<<< Updated upstream
 
   internal func nameOfFileContainingExtension(
     named extendeeName: String,
@@ -176,14 +167,11 @@ internal struct ReflectionServiceData: Sendable {
     let key = ExtensionDescriptor(extendeeTypeName: extendeeName, fieldNumber: number)
     return self.fileNameByExtensionDescriptor[key]
   }
-}
-=======
     
     internal func extensionsFieldNumbersOfType(named typeName: String) -> Set<Int32>? {
         return self.fieldNumbersByType[typeName]
     }
  }
->>>>>>> Stashed changes
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 internal final class ReflectionServiceProvider: Reflection_ServerReflectionAsyncProvider {
@@ -236,7 +224,6 @@ internal final class ReflectionServiceProvider: Reflection_ServerReflectionAsync
     return try self.findFileByFileName(fileName, request: request)
   }
 
-<<<<<<< Updated upstream
   internal func findFileByExtension(
     extensionRequest: Reflection_ExtensionRequest,
     request: Reflection_ServerReflectionRequest
@@ -255,7 +242,6 @@ internal final class ReflectionServiceProvider: Reflection_ServerReflectionAsync
     return try self.findFileByFileName(fileName, request: request)
   }
 
-=======
     internal func findExtensionsFieldNumbersOfType(
         named typeName: String,
         request: Reflection_ServerReflectionRequest) throws -> Reflection_ServerReflectionResponse {
@@ -268,7 +254,6 @@ internal final class ReflectionServiceProvider: Reflection_ServerReflectionAsync
             
     }
     
->>>>>>> Stashed changes
   internal func serverReflectionInfo(
     requestStream: GRPCAsyncRequestStream<Reflection_ServerReflectionRequest>,
     responseStream: GRPCAsyncResponseStreamWriter<Reflection_ServerReflectionResponse>,
@@ -294,7 +279,6 @@ internal final class ReflectionServiceProvider: Reflection_ServerReflectionAsync
         )
         try await responseStream.send(response)
 
-<<<<<<< Updated upstream
       case let .fileContainingExtension(extensionRequest):
         let response = try self.findFileByExtension(
           extensionRequest: extensionRequest,
@@ -302,7 +286,6 @@ internal final class ReflectionServiceProvider: Reflection_ServerReflectionAsync
         )
         try await responseStream.send(response)
 
-=======
       case let .allExtensionNumbersOfType(typeName):
           let response = try self.findExtensionsFieldNumbersOfType(
             named: typeName,
@@ -310,7 +293,6 @@ internal final class ReflectionServiceProvider: Reflection_ServerReflectionAsync
           )
           try await responseStream.send(response)
           
->>>>>>> Stashed changes
       default:
         throw GRPCStatus(code: .unimplemented)
       }

--- a/Sources/GRPCReflectionService/Server/ReflectionService.swift
+++ b/Sources/GRPCReflectionService/Server/ReflectionService.swift
@@ -169,7 +169,7 @@ internal struct ReflectionServiceData: Sendable {
     return self.fileNameByExtensionDescriptor[key]
   }
 
-  // Returns nil if the type has no extensions.
+  // Returns an empty array if the type has no extensions.
   internal func extensionsFieldNumbersOfType(named typeName: String) throws -> [Int32] {
     guard let fieldNumbers = self.fieldNumbersByType[typeName] else {
       throw GRPCStatus(

--- a/Tests/GRPCTests/GRPCReflectionServiceTests/ReflectionServiceIntegrationTests.swift
+++ b/Tests/GRPCTests/GRPCReflectionServiceTests/ReflectionServiceIntegrationTests.swift
@@ -212,10 +212,10 @@ final class ReflectionServiceIntegrationTests: GRPCTestCase {
       if fileDescriptorProto == fileToFind {
         receivedProtoContainingExtension += 1
         XCTAssert(
-          fileDescriptorProto.extension.map { $0.name }.contains("extensionInputMessage1"),
+          fileDescriptorProto.extension.map { $0.name }.contains("extensioninputMessage1-2"),
           """
           The response doesn't contain the serialized file descriptor proto \
-          containing the \"extensionInputMessage1\" extension.
+          containing the \"extensioninputMessage1-2\" extension.
           """
         )
       } else {
@@ -224,7 +224,7 @@ final class ReflectionServiceIntegrationTests: GRPCTestCase {
           dependentProtos.contains(fileDescriptorProto),
           """
           The \(fileDescriptorProto.name) is not a dependency of the \
-          proto file containing the \"extensionInputMessage1\" symbol.
+          proto file containing the \"extensioninputMessage1-2\" extension.
           """
         )
       }
@@ -235,5 +235,26 @@ final class ReflectionServiceIntegrationTests: GRPCTestCase {
       "The file descriptor proto of the proto containing the extension was not received."
     )
     XCTAssertEqual(dependenciesCount, 3)
+  }
+
+  func testAllExtensionNumbersOfType() async throws {
+    try self.setUpServerAndChannel()
+    let client = Reflection_ServerReflectionAsyncClient(channel: self.channel!)
+    let serviceReflectionInfo = client.makeServerReflectionInfoCall()
+
+    try await serviceReflectionInfo.requestStream.send(
+      .with {
+        $0.host = "127.0.0.1"
+        $0.allExtensionNumbersOfType = "inputMessage2"
+      }
+    )
+
+    serviceReflectionInfo.requestStream.finish()
+    var iterator = serviceReflectionInfo.responseStream.makeAsyncIterator()
+    guard let message = try await iterator.next() else {
+      return XCTFail("Could not get a response message.")
+    }
+    XCTAssertEqual(message.allExtensionNumbersResponse.baseTypeName, "inputMessage2")
+    XCTAssertEqual(message.allExtensionNumbersResponse.extensionNumber, [1, 2, 3, 4, 5])
   }
 }

--- a/Tests/GRPCTests/GRPCReflectionServiceTests/ReflectionServiceIntegrationTests.swift
+++ b/Tests/GRPCTests/GRPCReflectionServiceTests/ReflectionServiceIntegrationTests.swift
@@ -174,7 +174,6 @@ final class ReflectionServiceIntegrationTests: GRPCTestCase {
       }
     }
   }
-<<<<<<< Updated upstream
 
   func testFileByExtension() async throws {
     try self.setUpServerAndChannel()
@@ -237,58 +236,4 @@ final class ReflectionServiceIntegrationTests: GRPCTestCase {
     )
     XCTAssertEqual(dependenciesCount, 3)
   }
-=======
-    
-    func testFileByExtension() async throws {
-         try self.setUpServerAndChannel()
-         let client = Reflection_ServerReflectionAsyncClient(channel: self.channel!)
-         let serviceReflectionInfo = client.makeServerReflectionInfoCall()
-
-         try await serviceReflectionInfo.requestStream.send(
-           .with {
-             $0.host = "127.0.0.1"
-             $0.fileContainingExtension = .with {
-               $0.containingType = "inputMessage1"
-               $0.extensionNumber = 2
-             }
-           }
-         )
-
-         serviceReflectionInfo.requestStream.finish()
-         var iterator = serviceReflectionInfo.responseStream.makeAsyncIterator()
-         guard let message = try await iterator.next() else {
-           return XCTFail("Could not get a response message.")
-         }
-         let receivedData: [Google_Protobuf_FileDescriptorProto]
-         do {
-           receivedData = try message.fileDescriptorResponse.fileDescriptorProto.map {
-             try Google_Protobuf_FileDescriptorProto(serializedData: $0)
-           }
-         } catch {
-           return XCTFail("Could not serialize data received as a message.")
-         }
-
-         let fileToFind = self.protos[0]
-         let dependentProtos = self.protos[1...]
-         for fileDescriptorProto in receivedData {
-           if fileDescriptorProto == fileToFind {
-             XCTAssert(
-               fileDescriptorProto.extension.names.contains("extensionInputMessage1"),
-               """
-               The response doesn't contain the serialized file descriptor proto \
-               containing the \"extensionInputMessage1\" extension.
-               """
-             )
-           } else {
-             XCTAssert(
-               dependentProtos.contains(fileDescriptorProto),
-               """
-               The \(fileDescriptorProto.name) is not a dependency of the \
-               proto file containing the \"extensionInputMessage1\" symbol.
-               """
-             )
-           }
-         }
-       }
->>>>>>> Stashed changes
 }

--- a/Tests/GRPCTests/GRPCReflectionServiceTests/ReflectionServiceIntegrationTests.swift
+++ b/Tests/GRPCTests/GRPCReflectionServiceTests/ReflectionServiceIntegrationTests.swift
@@ -212,7 +212,9 @@ final class ReflectionServiceIntegrationTests: GRPCTestCase {
       if fileDescriptorProto == fileToFind {
         receivedProtoContainingExtension += 1
         XCTAssert(
-          fileDescriptorProto.extension.map { $0.name }.contains("extension.packagebar1.inputMessage1-2"),
+          fileDescriptorProto.extension.map { $0.name }.contains(
+            "extension.packagebar1.inputMessage1-2"
+          ),
           """
           The response doesn't contain the serialized file descriptor proto \
           containing the \"extensioninputMessage1-2\" extension.

--- a/Tests/GRPCTests/GRPCReflectionServiceTests/ReflectionServiceIntegrationTests.swift
+++ b/Tests/GRPCTests/GRPCReflectionServiceTests/ReflectionServiceIntegrationTests.swift
@@ -184,7 +184,7 @@ final class ReflectionServiceIntegrationTests: GRPCTestCase {
       .with {
         $0.host = "127.0.0.1"
         $0.fileContainingExtension = .with {
-          $0.containingType = "inputMessage1"
+          $0.containingType = "packagebar1.inputMessage1"
           $0.extensionNumber = 2
         }
       }
@@ -212,7 +212,7 @@ final class ReflectionServiceIntegrationTests: GRPCTestCase {
       if fileDescriptorProto == fileToFind {
         receivedProtoContainingExtension += 1
         XCTAssert(
-          fileDescriptorProto.extension.map { $0.name }.contains("extensioninputMessage1-2"),
+          fileDescriptorProto.extension.map { $0.name }.contains("extension.packagebar1.inputMessage1-2"),
           """
           The response doesn't contain the serialized file descriptor proto \
           containing the \"extensioninputMessage1-2\" extension.
@@ -245,7 +245,7 @@ final class ReflectionServiceIntegrationTests: GRPCTestCase {
     try await serviceReflectionInfo.requestStream.send(
       .with {
         $0.host = "127.0.0.1"
-        $0.allExtensionNumbersOfType = "inputMessage2"
+        $0.allExtensionNumbersOfType = "packagebar2.inputMessage2"
       }
     )
 
@@ -254,7 +254,7 @@ final class ReflectionServiceIntegrationTests: GRPCTestCase {
     guard let message = try await iterator.next() else {
       return XCTFail("Could not get a response message.")
     }
-    XCTAssertEqual(message.allExtensionNumbersResponse.baseTypeName, "inputMessage2")
+    XCTAssertEqual(message.allExtensionNumbersResponse.baseTypeName, "packagebar2.inputMessage2")
     XCTAssertEqual(message.allExtensionNumbersResponse.extensionNumber, [1, 2, 3, 4, 5])
   }
 }

--- a/Tests/GRPCTests/GRPCReflectionServiceTests/ReflectionServiceUnitTests.swift
+++ b/Tests/GRPCTests/GRPCReflectionServiceTests/ReflectionServiceUnitTests.swift
@@ -392,23 +392,6 @@ final class ReflectionServiceUnitTests: GRPCTestCase {
     }
   }
 
-  // Testing the containsFullyQualifiedMessageType() method.
-
-  func testContainsMessageType() throws {
-    let protos = makeProtosWithDependencies()
-    let registry = try ReflectionServiceData(fileDescriptors: protos)
-    for proto in protos {
-      for messageType in proto.qualifiedMessageTypes {
-        XCTAssertTrue(registry.containsFullyQualifiedMessageType(name: messageType))
-      }
-    }
-
-    // Invalid type name.
-    XCTAssertFalse(
-      registry.containsFullyQualifiedMessageType(name: "packagebar1.invalidMessageType")
-    )
-  }
-
   // Testing the extensionsFieldNumbersOfType() method.
 
   func testExtensionsFieldNumbersOfType() throws {
@@ -444,9 +427,6 @@ final class ReflectionServiceUnitTests: GRPCTestCase {
       named: "packagebar1.noExtensionMessage"
     )
     XCTAssertEqual(extensionNumbers, [])
-    XCTAssertTrue(
-      registry.containsFullyQualifiedMessageType(name: "packagebar1.noExtensionMessage")
-    )
   }
 
   func testExtensionsFieldNumbersOfTypeInvalidTypeName() throws {

--- a/Tests/GRPCTests/GRPCReflectionServiceTests/ReflectionServiceUnitTests.swift
+++ b/Tests/GRPCTests/GRPCReflectionServiceTests/ReflectionServiceUnitTests.swift
@@ -330,16 +330,16 @@ final class ReflectionServiceUnitTests: GRPCTestCase {
     }
   }
 
-    func testExtractTypeNameFrom() throws {
-        let initialExtendeeName = ".package.extendeeName"
-        XCTAssertEqual(
-            ReflectionServiceData.extractTypeNameFrom(
-                fullyQualifiedName: initialExtendeeName
-            ),
-            "package.extendeeName"
-        )
-    }
-    
+  func testExtractTypeNameFrom() throws {
+    let initialExtendeeName = ".package.extendeeName"
+    XCTAssertEqual(
+      ReflectionServiceData.extractTypeNameFrom(
+        fullyQualifiedName: initialExtendeeName
+      ),
+      "package.extendeeName"
+    )
+  }
+
   // Testing the nameOfFileContainingExtension() method.
 
   func testNameOfFileContainingExtensions() throws {
@@ -347,9 +347,9 @@ final class ReflectionServiceUnitTests: GRPCTestCase {
     let registry = try ReflectionServiceData(fileDescriptors: protos)
     for proto in protos {
       for `extension` in proto.extension {
-          let typeName = ReflectionServiceData.extractTypeNameFrom(
-            fullyQualifiedName: `extension`.extendee
-          )
+        let typeName = ReflectionServiceData.extractTypeNameFrom(
+          fullyQualifiedName: `extension`.extendee
+        )
         let registryFileName = registry.nameOfFileContainingExtension(
           extendeeName: typeName,
           fieldNumber: `extension`.number
@@ -431,15 +431,19 @@ final class ReflectionServiceUnitTests: GRPCTestCase {
       }
     )
     let registry = try ReflectionServiceData(fileDescriptors: protos)
-    let extensionNumbers = registry.extensionsFieldNumbersOfType(named: "packagebar1.noExtensionMessage")
+    let extensionNumbers = registry.extensionsFieldNumbersOfType(
+      named: "packagebar1.noExtensionMessage"
+    )
     XCTAssertNil(extensionNumbers)
     XCTAssertTrue(registry.containsMessageType(name: "packagebar1.noExtensionMessage"))
   }
 
   func testExtensionsFieldNumbersOfTypeInvalidTypeName() throws {
-      let protos = makeProtosWithDependencies()
+    let protos = makeProtosWithDependencies()
     let registry = try ReflectionServiceData(fileDescriptors: protos)
-    let extensionNumbers = registry.extensionsFieldNumbersOfType(named: "packagebar1.invalidTypeMessage")
+    let extensionNumbers = registry.extensionsFieldNumbersOfType(
+      named: "packagebar1.invalidTypeMessage"
+    )
     XCTAssertNil(extensionNumbers)
     XCTAssertFalse(registry.containsMessageType(name: "packagebar1.noExtensionMessage"))
   }

--- a/Tests/GRPCTests/GRPCReflectionServiceTests/ReflectionServiceUnitTests.swift
+++ b/Tests/GRPCTests/GRPCReflectionServiceTests/ReflectionServiceUnitTests.swift
@@ -330,16 +330,6 @@ final class ReflectionServiceUnitTests: GRPCTestCase {
     }
   }
 
-  func testExtractTypeNameFrom() throws {
-    let initialExtendeeName = ".package.extendeeName"
-    XCTAssertEqual(
-      ReflectionServiceData.extractTypeNameFrom(
-        fullyQualifiedName: initialExtendeeName
-      ),
-      "package.extendeeName"
-    )
-  }
-
   // Testing the nameOfFileContainingExtension() method.
 
   func testNameOfFileContainingExtensions() throws {
@@ -347,9 +337,7 @@ final class ReflectionServiceUnitTests: GRPCTestCase {
     let registry = try ReflectionServiceData(fileDescriptors: protos)
     for proto in protos {
       for `extension` in proto.extension {
-        let typeName = ReflectionServiceData.extractTypeNameFrom(
-          fullyQualifiedName: `extension`.extendee
-        )
+        let typeName = String(`extension`.extendee.drop(while: { $0 == "." }))
         let registryFileName = registry.nameOfFileContainingExtension(
           extendeeName: typeName,
           fieldNumber: `extension`.number

--- a/Tests/GRPCTests/GRPCReflectionServiceTests/Utils.swift
+++ b/Tests/GRPCTests/GRPCReflectionServiceTests/Utils.swift
@@ -20,7 +20,11 @@ import SwiftProtobuf
 
 internal func generateFileDescriptorProto(
   fileName name: String,
+<<<<<<< Updated upstream
   suffix: String
+=======
+  suffix : String
+>>>>>>> Stashed changes
 ) -> Google_Protobuf_FileDescriptorProto {
   let inputMessage = Google_Protobuf_DescriptorProto.with {
     $0.name = "inputMessage" + suffix
@@ -32,12 +36,21 @@ internal func generateFileDescriptorProto(
     ]
   }
 
+<<<<<<< Updated upstream
   let inputMessageExtension = Google_Protobuf_FieldDescriptorProto.with {
     $0.name = "extensionInputMessage" + suffix
     $0.extendee = "inputMessage" + suffix
     $0.number = 2
   }
 
+=======
+    let inputMessageExtension = Google_Protobuf_FieldDescriptorProto.with {
+         $0.name = "extensionInputMessage" + suffix
+         $0.extendee = "inputMessage" + suffix
+         $0.number = 2
+       }
+    
+>>>>>>> Stashed changes
   let outputMessage = Google_Protobuf_DescriptorProto.with {
     $0.name = "outputMessage" + suffix
     $0.field = [
@@ -101,6 +114,7 @@ internal func makeProtosWithComplexDependencies() -> [Google_Protobuf_FileDescri
   var protos: [Google_Protobuf_FileDescriptorProto] = []
   protos.append(generateFileDescriptorProto(fileName: "foo", suffix: "0"))
   for id in 1 ... 10 {
+<<<<<<< Updated upstream
     let fileDescriptorProtoA = generateFileDescriptorProto(
       fileName: "fooA",
       suffix: String(id) + "A"
@@ -109,6 +123,10 @@ internal func makeProtosWithComplexDependencies() -> [Google_Protobuf_FileDescri
       fileName: "fooB",
       suffix: String(id) + "B"
     )
+=======
+    let fileDescriptorProtoA = generateFileDescriptorProto(fileName: "fooA", suffix: String(id))
+    let fileDescriptorProtoB = generateFileDescriptorProto(fileName: "fooB", suffix: String(id))
+>>>>>>> Stashed changes
     let parent = protos.count > 1 ? protos.count - Int.random(in: 1 ..< 3) : protos.count - 1
     protos[parent].dependency.append(fileDescriptorProtoA.name)
     protos[parent].dependency.append(fileDescriptorProtoB.name)
@@ -128,4 +146,10 @@ extension Sequence where Element == Google_Protobuf_EnumDescriptorProto {
   var names: [String] {
     self.map { $0.name }
   }
+}
+
+extension Sequence where Element == Google_Protobuf_FieldDescriptorProto {
+   var names: [String] {
+     self.map { $0.name }
+   }
 }

--- a/Tests/GRPCTests/GRPCReflectionServiceTests/Utils.swift
+++ b/Tests/GRPCTests/GRPCReflectionServiceTests/Utils.swift
@@ -49,7 +49,11 @@ internal func generateFileDescriptorProto(
     ]
   }
 
-  let inputMessageExtensions = makeExtensions(forType: "inputMessage" + suffix, number: 5)
+    let packageName = "package" + name + suffix
+    let inputMessageExtensions = makeExtensions(
+        forType: "." + packageName + "." + "inputMessage" + suffix,
+        number: 5
+    )
 
   let outputMessage = Google_Protobuf_DescriptorProto.with {
     $0.name = "outputMessage" + suffix

--- a/Tests/GRPCTests/GRPCReflectionServiceTests/Utils.swift
+++ b/Tests/GRPCTests/GRPCReflectionServiceTests/Utils.swift
@@ -49,11 +49,11 @@ internal func generateFileDescriptorProto(
     ]
   }
 
-    let packageName = "package" + name + suffix
-    let inputMessageExtensions = makeExtensions(
-        forType: "." + packageName + "." + "inputMessage" + suffix,
-        number: 5
-    )
+  let packageName = "package" + name + suffix
+  let inputMessageExtensions = makeExtensions(
+    forType: "." + packageName + "." + "inputMessage" + suffix,
+    number: 5
+  )
 
   let outputMessage = Google_Protobuf_DescriptorProto.with {
     $0.name = "outputMessage" + suffix

--- a/Tests/GRPCTests/GRPCReflectionServiceTests/Utils.swift
+++ b/Tests/GRPCTests/GRPCReflectionServiceTests/Utils.swift
@@ -18,6 +18,23 @@ import Foundation
 import GRPC
 import SwiftProtobuf
 
+internal func makeExtensions(
+  forType typeName: String,
+  number: Int
+) -> [Google_Protobuf_FieldDescriptorProto] {
+  var extensions: [Google_Protobuf_FieldDescriptorProto] = []
+  for id in 1 ... number {
+    extensions.append(
+      Google_Protobuf_FieldDescriptorProto.with {
+        $0.name = "extension" + typeName + "-" + String(id)
+        $0.extendee = typeName
+        $0.number = Int32(id)
+      }
+    )
+  }
+  return extensions
+}
+
 internal func generateFileDescriptorProto(
   fileName name: String,
   suffix: String
@@ -32,11 +49,7 @@ internal func generateFileDescriptorProto(
     ]
   }
 
-  let inputMessageExtension = Google_Protobuf_FieldDescriptorProto.with {
-    $0.name = "extensionInputMessage" + suffix
-    $0.extendee = "inputMessage" + suffix
-    $0.number = 2
-  }
+  let inputMessageExtensions = makeExtensions(forType: "inputMessage" + suffix, number: 5)
 
   let outputMessage = Google_Protobuf_DescriptorProto.with {
     $0.name = "outputMessage" + suffix
@@ -77,7 +90,7 @@ internal func generateFileDescriptorProto(
     $0.package = "package" + name + suffix
     $0.messageType = [inputMessage, outputMessage]
     $0.enumType = [enumType]
-    $0.extension = [inputMessageExtension]
+    $0.extension = inputMessageExtensions
   }
 
   return fileDescriptorProto
@@ -129,10 +142,4 @@ extension Sequence where Element == Google_Protobuf_EnumDescriptorProto {
   var names: [String] {
     self.map { $0.name }
   }
-}
-
-extension Sequence where Element == Google_Protobuf_FieldDescriptorProto {
-   var names: [String] {
-     self.map { $0.name }
-   }
 }

--- a/Tests/GRPCTests/GRPCReflectionServiceTests/Utils.swift
+++ b/Tests/GRPCTests/GRPCReflectionServiceTests/Utils.swift
@@ -20,11 +20,7 @@ import SwiftProtobuf
 
 internal func generateFileDescriptorProto(
   fileName name: String,
-<<<<<<< Updated upstream
   suffix: String
-=======
-  suffix : String
->>>>>>> Stashed changes
 ) -> Google_Protobuf_FileDescriptorProto {
   let inputMessage = Google_Protobuf_DescriptorProto.with {
     $0.name = "inputMessage" + suffix
@@ -36,21 +32,12 @@ internal func generateFileDescriptorProto(
     ]
   }
 
-<<<<<<< Updated upstream
   let inputMessageExtension = Google_Protobuf_FieldDescriptorProto.with {
     $0.name = "extensionInputMessage" + suffix
     $0.extendee = "inputMessage" + suffix
     $0.number = 2
   }
 
-=======
-    let inputMessageExtension = Google_Protobuf_FieldDescriptorProto.with {
-         $0.name = "extensionInputMessage" + suffix
-         $0.extendee = "inputMessage" + suffix
-         $0.number = 2
-       }
-    
->>>>>>> Stashed changes
   let outputMessage = Google_Protobuf_DescriptorProto.with {
     $0.name = "outputMessage" + suffix
     $0.field = [
@@ -114,7 +101,6 @@ internal func makeProtosWithComplexDependencies() -> [Google_Protobuf_FileDescri
   var protos: [Google_Protobuf_FileDescriptorProto] = []
   protos.append(generateFileDescriptorProto(fileName: "foo", suffix: "0"))
   for id in 1 ... 10 {
-<<<<<<< Updated upstream
     let fileDescriptorProtoA = generateFileDescriptorProto(
       fileName: "fooA",
       suffix: String(id) + "A"
@@ -123,10 +109,7 @@ internal func makeProtosWithComplexDependencies() -> [Google_Protobuf_FileDescri
       fileName: "fooB",
       suffix: String(id) + "B"
     )
-=======
-    let fileDescriptorProtoA = generateFileDescriptorProto(fileName: "fooA", suffix: String(id))
-    let fileDescriptorProtoB = generateFileDescriptorProto(fileName: "fooB", suffix: String(id))
->>>>>>> Stashed changes
+
     let parent = protos.count > 1 ? protos.count - Int.random(in: 1 ..< 3) : protos.count - 1
     protos[parent].dependency.append(fileDescriptorProtoA.name)
     protos[parent].dependency.append(fileDescriptorProtoB.name)


### PR DESCRIPTION
Motivation:

The reflection service should provide the possibility for users to request the list with all the field numbers of
the extensions of a type.

Modifications:

- Implemented the dictionary that stores the arrays of integers representing the field numbers of the extensions
for each type that has extensions.
- Implemented the methods of the Reflection Service that create the specific response with the array of integers
representing the field numbers or an empty array for the case that the type doesn't have any extensions (but is a valid type).
- Implemented integration and Unit tests.

Result:

The Reflection Service will enable users to find all the extension field numbers for a specific type they requested.