### PR TITLE
Make the connection pool error public

### DIFF
--- a/Tests/GRPCTests/GRPCStatusTests.swift
+++ b/Tests/GRPCTests/GRPCStatusTests.swift
@@ -113,10 +113,10 @@ class GRPCStatusTests: GRPCTestCase {
     // No message/cause, so uses the nil backing storage.
     XCTAssertEqual(status.testingOnly_storageObjectIdentifier, nilStorageID)
 
-    status.cause = ConnectionPoolError.tooManyWaiters(connectionError: nil)
+    status.cause = GRPCConnectionPoolError.tooManyWaiters(connectionError: nil)
     let storageID = status.testingOnly_storageObjectIdentifier
     XCTAssertNotEqual(storageID, nilStorageID)
-    XCTAssert(status.cause is ConnectionPoolError)
+    XCTAssert(status.cause is GRPCConnectionPoolError)
 
     // The storage of status should be uniquely ref'd, so setting cause to nil should not change
     // the backing storage (even if the nil storage could now be used).


### PR DESCRIPTION
Motivation:

Sometimes users end up with connection pool errors but they can't inspect them because the type is internal.

Modifications:

- Make the connection pool error extensible and public

Result:

Users can inspect connection pool errors.