### PR TITLE
Allow binding to a socket address via server builder

### DIFF
--- a/Sources/GRPC/ServerBuilder.swift
+++ b/Sources/GRPC/ServerBuilder.swift
@@ -62,8 +62,20 @@ extension Server {
       return Server.start(configuration: self.configuration)
     }
 
+    public func bind(to socketAddress: SocketAddress) -> EventLoopFuture<Server> {
+      self.configuration.target = .socketAddress(socketAddress)
+      self.configuration.tlsConfiguration = self.maybeTLS
+      return Server.start(configuration: self.configuration)
+    }
+
     public func bind(vsockAddress: VsockAddress) -> EventLoopFuture<Server> {
       self.configuration.target = .vsockAddress(vsockAddress)
+      self.configuration.tlsConfiguration = self.maybeTLS
+      return Server.start(configuration: self.configuration)
+    }
+
+    public func bind(to target: BindTarget) -> EventLoopFuture<Server> {
+      self.configuration.target = target
       self.configuration.tlsConfiguration = self.maybeTLS
       return Server.start(configuration: self.configuration)
     }


### PR DESCRIPTION
Motivation:

Users can bind to a socket address if they use the server config but not the builder.

Modifications:

- Add API to connect to a socket address or bind target via the server builder API

Result:

More convenient APIs