### PR TITLE
guard testPreviousRPCAttemptsValidValues

### DIFF
--- a/Tests/GRPCCoreTests/Internal/Metadata+GRPCTests.swift
+++ b/Tests/GRPCCoreTests/Internal/Metadata+GRPCTests.swift
@@ -18,6 +18,7 @@ import XCTest
 
 @testable import GRPCCore
 
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 final class MetadataGRPCTests: XCTestCase {
   func testPreviousRPCAttemptsValidValues() {
     let testData = [("0", 0), ("1", 1), ("-1", -1)]


### PR DESCRIPTION
It relies on `metadata.previousRPCAttempts`, `retryPushback` which are only available on macOS 13.0 and newer.