### PR TITLE
Add some missing Sendable annotations

### DIFF
--- a/Sources/GRPC/ConnectionPool/ConnectionPool+Waiter.swift
+++ b/Sources/GRPC/ConnectionPool/ConnectionPool+Waiter.swift
@@ -30,7 +30,7 @@ extension ConnectionPool {
 
     /// The channel initializer.
     @usableFromInline
-    internal let _channelInitializer: (Channel) -> EventLoopFuture<Void>
+    internal let _channelInitializer: @Sendable (Channel) -> EventLoopFuture<Void>
 
     /// The deadline at which the timeout is scheduled.
     @usableFromInline
@@ -51,7 +51,7 @@ extension ConnectionPool {
     internal init(
       deadline: NIODeadline,
       promise: EventLoopPromise<Channel>,
-      channelInitializer: @escaping (Channel) -> EventLoopFuture<Void>
+      channelInitializer: @escaping @Sendable (Channel) -> EventLoopFuture<Void>
     ) {
       self._deadline = deadline
       self._promise = promise

--- a/Sources/GRPC/ConnectionPool/ConnectionPool.swift
+++ b/Sources/GRPC/ConnectionPool/ConnectionPool.swift
@@ -215,7 +215,7 @@ internal final class ConnectionPool {
     deadline: NIODeadline,
     promise: EventLoopPromise<Channel>,
     logger: GRPCLogger,
-    initializer: @escaping (Channel) -> EventLoopFuture<Void>
+    initializer: @escaping @Sendable (Channel) -> EventLoopFuture<Void>
   ) {
     if self.eventLoop.inEventLoop {
       self._makeStream(
@@ -241,7 +241,7 @@ internal final class ConnectionPool {
   internal func makeStream(
     deadline: NIODeadline,
     logger: GRPCLogger,
-    initializer: @escaping (Channel) -> EventLoopFuture<Void>
+    initializer: @escaping @Sendable (Channel) -> EventLoopFuture<Void>
   ) -> EventLoopFuture<Channel> {
     let promise = self.eventLoop.makePromise(of: Channel.self)
     self.makeStream(deadline: deadline, promise: promise, logger: logger, initializer: initializer)
@@ -277,7 +277,7 @@ internal final class ConnectionPool {
     deadline: NIODeadline,
     promise: EventLoopPromise<Channel>,
     logger: GRPCLogger,
-    initializer: @escaping (Channel) -> EventLoopFuture<Void>
+    initializer: @escaping @Sendable (Channel) -> EventLoopFuture<Void>
   ) {
     self.eventLoop.assertInEventLoop()
 
@@ -310,7 +310,7 @@ internal final class ConnectionPool {
   @inlinable
   internal func _tryMakeStream(
     promise: EventLoopPromise<Channel>,
-    initializer: @escaping (Channel) -> EventLoopFuture<Void>
+    initializer: @escaping @Sendable (Channel) -> EventLoopFuture<Void>
   ) -> Bool {
     // We shouldn't jump the queue.
     guard self.waiters.isEmpty else {
@@ -344,7 +344,7 @@ internal final class ConnectionPool {
     deadline: NIODeadline,
     promise: EventLoopPromise<Channel>,
     logger: GRPCLogger,
-    initializer: @escaping (Channel) -> EventLoopFuture<Void>
+    initializer: @escaping @Sendable (Channel) -> EventLoopFuture<Void>
   ) {
     // Don't overwhelm the pool with too many waiters.
     guard self.waiters.count < self.maxWaiters else {

--- a/Sources/GRPC/ConnectionPool/PoolManager.swift
+++ b/Sources/GRPC/ConnectionPool/PoolManager.swift
@@ -281,7 +281,7 @@ internal final class PoolManager {
     preferredEventLoop: EventLoop?,
     deadline: NIODeadline,
     logger: GRPCLogger,
-    streamInitializer initializer: @escaping (Channel) -> EventLoopFuture<Void>
+    streamInitializer initializer: @escaping @Sendable (Channel) -> EventLoopFuture<Void>
   ) -> PooledStreamChannel {
     let preferredEventLoopID = preferredEventLoop.map { EventLoopID($0) }
     let reservedPool = self.lock.withLock {

--- a/Sources/GRPC/GRPCServerPipelineConfigurator.swift
+++ b/Sources/GRPC/GRPCServerPipelineConfigurator.swift
@@ -104,13 +104,11 @@ final class GRPCServerPipelineConfigurator: ChannelInboundHandler, RemovableChan
 
   /// Makes an HTTP/2 multiplexer suitable handling gRPC requests.
   private func makeHTTP2Multiplexer(for channel: Channel) -> HTTP2StreamMultiplexer {
-    var logger = self.configuration.logger
-
     return .init(
       mode: .server,
       channel: channel,
       targetWindowSize: self.configuration.httpTargetWindowSize
-    ) { stream in
+    ) { [logger = self.configuration.logger] stream in
       // Sync options were added to the HTTP/2 stream channel in 1.17.0 (we require at least this)
       // so this shouldn't be `nil`, but it's not a problem if it is.
       let http2StreamID = try? stream.syncOptions?.getOption(HTTP2StreamChannelOptions.streamID)
@@ -119,6 +117,7 @@ final class GRPCServerPipelineConfigurator: ChannelInboundHandler, RemovableChan
           return String(Int(streamID))
         } ?? "<unknown>"
 
+      var logger = logger
       logger[metadataKey: MetadataKey.h2StreamID] = "\(streamID)"
 
       do {


### PR DESCRIPTION
Motivation:

The latest HTTP2 release added a number of senability annotations which now cause warnings in our internal code.

Modifications:

- Add missing `Sendable` annotations

Result:

Fewer warnings