### PR TITLE
Added availability check for OS version in unit tests for temporary directory path

### DIFF
--- a/Tests/GRPCTests/GRPCReflectionServiceTests/ReflectionServiceUnitTests.swift
+++ b/Tests/GRPCTests/GRPCReflectionServiceTests/ReflectionServiceUnitTests.swift
@@ -523,10 +523,15 @@ final class ReflectionServiceUnitTests: GRPCTestCase {
   func testReadSerializedFileDescriptorProto() throws {
     let initialFileDescriptorProto = generateFileDescriptorProto(fileName: "test", suffix: "1")
     let data = try initialFileDescriptorProto.serializedData().base64EncodedData()
+    let temporaryDirectory: String
     #if os(Linux)
-    let temporaryDirectory = "/tmp/"
+    temporaryDirectory = "/tmp/"
     #else
-    let temporaryDirectory = FileManager.default.temporaryDirectory.path()
+    if #available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *) {
+      temporaryDirectory = FileManager.default.temporaryDirectory.path()
+    } else {
+      temporaryDirectory = "/tmp/"
+    }
     #endif
     let filePath = "\(temporaryDirectory)test\(UUID()).grpc.reflection"
     FileManager.default.createFile(atPath: filePath, contents: data)
@@ -540,10 +545,15 @@ final class ReflectionServiceUnitTests: GRPCTestCase {
 
   func testReadSerializedFileDescriptorProtoInvalidFileContents() throws {
     let invalidData = "%%%%%££££".data(using: .utf8)
+    let temporaryDirectory: String
     #if os(Linux)
-    let temporaryDirectory = "/tmp/"
+    temporaryDirectory = "/tmp/"
     #else
-    let temporaryDirectory = FileManager.default.temporaryDirectory.path()
+    if #available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *) {
+      temporaryDirectory = FileManager.default.temporaryDirectory.path()
+    } else {
+      temporaryDirectory = "/tmp/"
+    }
     #endif
     let filePath = "\(temporaryDirectory)test\(UUID()).grpc.reflection"
     FileManager.default.createFile(atPath: filePath, contents: invalidData)
@@ -576,10 +586,15 @@ final class ReflectionServiceUnitTests: GRPCTestCase {
     for initialFileDescriptorProto in initialFileDescriptorProtos {
       let data = try initialFileDescriptorProto.serializedData()
         .base64EncodedData()
+      let temporaryDirectory: String
       #if os(Linux)
-      let temporaryDirectory = "/tmp/"
+      temporaryDirectory = "/tmp/"
       #else
-      let temporaryDirectory = FileManager.default.temporaryDirectory.path()
+      if #available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *) {
+        temporaryDirectory = FileManager.default.temporaryDirectory.path()
+      } else {
+        temporaryDirectory = "/tmp/"
+      }
       #endif
       let filePath = "\(temporaryDirectory)test\(UUID()).grpc.reflection"
       FileManager.default.createFile(atPath: filePath, contents: data)


### PR DESCRIPTION
Added availability check for OS version in unit tests for getting the path of the temporary directory

Motivation:

The .path() version is available only on macOS 13.0 or newer, hence the Skywagon errors.

Modifications:

Checked availability for macOS 13.0 or newer for calling the .path() function and used the "/tmp" directory for the older versions.

Result:

After your change, what will change.