### PR TITLE
availability guards

### DIFF
--- a/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests+Retries.swift
+++ b/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests+Retries.swift
@@ -16,6 +16,7 @@
 import GRPCCore
 import XCTest
 
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension ClientRPCExecutorTests {
   fileprivate func makeHarnessForRetries(
     rejectUntilAttempt firstSuccessfulAttempt: Int,
@@ -284,6 +285,7 @@ extension ClientRPCExecutorTests {
   }
 }
 
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension ClientRPCExecutionConfiguration {
   fileprivate static func retry(
     maximumAttempts: Int = 5,

--- a/Tests/GRPCCoreTests/Call/Client/RetryDelaySequenceTests.swift
+++ b/Tests/GRPCCoreTests/Call/Client/RetryDelaySequenceTests.swift
@@ -17,6 +17,7 @@ import XCTest
 
 @testable import GRPCCore
 
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 final class RetryDelaySequenceTests: XCTestCase {
   func testSequence() {
     let policy = RetryPolicy(


### PR DESCRIPTION
Availability guards to fix test building on < macOS 13.0