### PR TITLE
Fixed list services response of reflection service

### DIFF
--- a/Sources/GRPCReflectionService/Server/ReflectionService.swift
+++ b/Sources/GRPCReflectionService/Server/ReflectionService.swift
@@ -98,8 +98,9 @@ internal struct ReflectionServiceData: Sendable {
         dependencyFileNames: fileDescriptorProto.dependency
       )
       self.fileDescriptorDataByFilename[fileDescriptorProto.name] = protoData
-      self.serviceNames.append(contentsOf: fileDescriptorProto.service.map { $0.name })
-
+      self.serviceNames.append(
+        contentsOf: fileDescriptorProto.service.map { fileDescriptorProto.package + "." + $0.name }
+      )
       // Populating the <symbol, file name> dictionary.
       for qualifiedSybolName in fileDescriptorProto.qualifiedSymbolNames {
         let oldValue = self.fileNameBySymbol.updateValue(

--- a/Tests/GRPCTests/GRPCReflectionServiceTests/ReflectionServiceIntegrationTests.swift
+++ b/Tests/GRPCTests/GRPCReflectionServiceTests/ReflectionServiceIntegrationTests.swift
@@ -121,7 +121,8 @@ final class ReflectionServiceIntegrationTests: GRPCTestCase {
     }
 
     let receivedServices = message.listServicesResponse.service.map { $0.name }.sorted()
-    let servicesNames = (self.protos + [self.independentProto]).serviceNames.sorted()
+    let servicesNames = (self.protos + [self.independentProto]).flatMap { $0.qualifiedServiceNames }
+      .sorted()
 
     XCTAssertEqual(receivedServices, servicesNames)
   }

--- a/Tests/GRPCTests/GRPCReflectionServiceTests/ReflectionServiceUnitTests.swift
+++ b/Tests/GRPCTests/GRPCReflectionServiceTests/ReflectionServiceUnitTests.swift
@@ -56,7 +56,7 @@ final class ReflectionServiceUnitTests: GRPCTestCase {
   /// Testing the serviceNames array of the ReflectionServiceData object.
   func testServiceNames() throws {
     let protos = makeProtosWithDependencies()
-    let servicesNames = protos.serviceNames.sorted()
+    let servicesNames = protos.flatMap { $0.qualifiedServiceNames }.sorted()
     let registry = try ReflectionServiceData(fileDescriptors: protos)
     let registryServices = registry.serviceNames.sorted()
     XCTAssertEqual(registryServices, servicesNames)

--- a/Tests/GRPCTests/GRPCReflectionServiceTests/Utils.swift
+++ b/Tests/GRPCTests/GRPCReflectionServiceTests/Utils.swift
@@ -150,9 +150,9 @@ func XCTAssertThrowsGRPCStatus<T>(
   }
 }
 
-extension Sequence where Element == Google_Protobuf_FileDescriptorProto {
-  var serviceNames: [String] {
-    self.flatMap { $0.service.map { $0.name } }
+extension Google_Protobuf_FileDescriptorProto {
+  var qualifiedServiceNames: [String] {
+    self.service.map { self.package + "." + $0.name }
   }
 }
 


### PR DESCRIPTION
Motivation:

The response should contain the fully qualified names of the services, not just the services' names

Modifications:

- added the package name for each service i the serviceNames array of the proto registry
- modified unit test and integration test accordingly

Result:

When requesting listServices, we will receive the fully qualified names of the services.