### PR TITLE
Add in-process client transport

### DIFF
--- a/Sources/GRPCCore/Call/Client/ClientRPCExecutionConfigurationCollection.swift
+++ b/Sources/GRPCCore/Call/Client/ClientRPCExecutionConfigurationCollection.swift
@@ -20,7 +20,10 @@ public struct ClientRPCExecutionConfigurationCollection: Sendable, Hashable {
   private let defaultConfiguration: ClientRPCExecutionConfiguration
 
   public init(
-    defaultConfiguration: ClientRPCExecutionConfiguration = ClientRPCExecutionConfiguration(executionPolicy: nil, timeout: nil)
+    defaultConfiguration: ClientRPCExecutionConfiguration = ClientRPCExecutionConfiguration(
+      executionPolicy: nil,
+      timeout: nil
+    )
   ) {
     self.elements = [:]
     self.defaultConfiguration = defaultConfiguration
@@ -35,7 +38,7 @@ public struct ClientRPCExecutionConfigurationCollection: Sendable, Hashable {
       serviceLevelDescriptor.method = ""
       return self.elements[serviceLevelDescriptor, default: self.defaultConfiguration]
     }
-    
+
     set {
       if descriptor.service.isEmpty {
         preconditionFailure("Method descriptor's service cannot be empty.")

--- a/Sources/GRPCCore/Call/Client/ClientRPCExecutionConfigurationCollection.swift
+++ b/Sources/GRPCCore/Call/Client/ClientRPCExecutionConfigurationCollection.swift
@@ -18,20 +18,25 @@
 public struct ClientRPCExecutionConfigurationCollection: Sendable {
   private var elements: [MethodDescriptor: ClientRPCExecutionConfiguration]
   private let defaultConfiguration: ClientRPCExecutionConfiguration
-  
+
   public init(defaultConfiguration: ClientRPCExecutionConfiguration) {
     self.elements = [:]
     self.defaultConfiguration = defaultConfiguration
   }
-  
-  public mutating func addConfiguration(_ configuration: ClientRPCExecutionConfiguration, forMethod descriptor: MethodDescriptor) {
+
+  public mutating func addConfiguration(
+    _ configuration: ClientRPCExecutionConfiguration,
+    forMethod descriptor: MethodDescriptor
+  ) {
     self.elements[descriptor] = configuration
   }
-  
-  public func getConfiguration(forMethod descriptor: MethodDescriptor) -> ClientRPCExecutionConfiguration {
+
+  public func getConfiguration(
+    forMethod descriptor: MethodDescriptor
+  ) -> ClientRPCExecutionConfiguration {
     self.elements[descriptor, default: self.defaultConfiguration]
   }
-  
+
   public subscript(_ descriptor: MethodDescriptor) -> ClientRPCExecutionConfiguration {
     self.getConfiguration(forMethod: descriptor)
   }

--- a/Sources/GRPCCore/Call/Client/ClientRPCExecutionConfigurationCollection.swift
+++ b/Sources/GRPCCore/Call/Client/ClientRPCExecutionConfigurationCollection.swift
@@ -15,6 +15,15 @@
  */
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+
+/// A collection of ``ClientRPCExecutionConfiguration``s, mapped to specific methods or services.
+///
+/// When creating a new instance, you must provide a default configuration to be used when getting
+/// a configuration for a method that has not been given a specific override.
+/// Use ``setDefaultConfiguration(_:forService:)`` to set a specific override for a whole
+/// service.
+///
+/// Use the subscript to get and set configurations for methods.
 public struct ClientRPCExecutionConfigurationCollection: Sendable, Hashable {
   private var elements: [MethodDescriptor: ClientRPCExecutionConfiguration]
   private let defaultConfiguration: ClientRPCExecutionConfiguration
@@ -40,10 +49,28 @@ public struct ClientRPCExecutionConfigurationCollection: Sendable, Hashable {
     }
 
     set {
-      if descriptor.service.isEmpty {
-        preconditionFailure("Method descriptor's service cannot be empty.")
-      }
+      precondition(
+        !descriptor.service.isEmpty,
+        "Method descriptor's service cannot be empty."
+      )
+      
       self.elements[descriptor] = newValue
     }
+  }
+  
+  /// Set a default configuration for a service.
+  ///
+  /// If getting a configuration for a method that's part of a service, and the method itself doesn't have an
+  /// override, then this configuration will be used instead of the default configuration passed when creating
+  /// this instance of ``ClientRPCExecutionConfigurationCollection``.
+  ///
+  /// - Parameters:
+  ///   - configuration: The default configuration for the service.
+  ///   - service: The name of the service for which this override applies.
+  mutating public func setDefaultConfiguration(
+    _ configuration: ClientRPCExecutionConfiguration,
+    forService service: String
+  ) {
+    self[MethodDescriptor(service: service, method: "")] = configuration
   }
 }

--- a/Sources/GRPCCore/Call/Client/ClientRPCExecutionConfigurationCollection.swift
+++ b/Sources/GRPCCore/Call/Client/ClientRPCExecutionConfigurationCollection.swift
@@ -15,32 +15,24 @@
  */
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-struct ClientRPCExecutionConfigurationCollection: ExpressibleByDictionaryLiteral {
+public struct ClientRPCExecutionConfigurationCollection: Sendable {
   private var elements: [MethodDescriptor: ClientRPCExecutionConfiguration]
   private let defaultConfiguration: ClientRPCExecutionConfiguration
   
-  init(defaultConfiguration: ClientRPCExecutionConfiguration) {
+  public init(defaultConfiguration: ClientRPCExecutionConfiguration) {
     self.elements = [:]
     self.defaultConfiguration = defaultConfiguration
   }
   
-  init(dictionaryLiteral elements: (Key, Value)...) {
-    elements.forEach({ (key, value) in
-      self.elements[key] = value
-    })
-  }
-  
-  mutating func addConfiguration(_ configuration: ClientRPCExecutionConfiguration, forMethod descriptor: MethodDescriptor) {
+  public mutating func addConfiguration(_ configuration: ClientRPCExecutionConfiguration, forMethod descriptor: MethodDescriptor) {
     self.elements[descriptor] = configuration
   }
   
-  func getConfiguration(forMethod descriptor: MethodDescriptor) -> ClientRPCExecutionConfiguration {
-    self.elements[descriptor] ?? self.defaultConfiguration
+  public func getConfiguration(forMethod descriptor: MethodDescriptor) -> ClientRPCExecutionConfiguration {
+    self.elements[descriptor, default: self.defaultConfiguration]
   }
   
-  subscript(_ descriptor: MethodDescriptor) -> ClientRPCExecutionConfiguration {
+  public subscript(_ descriptor: MethodDescriptor) -> ClientRPCExecutionConfiguration {
     self.getConfiguration(forMethod: descriptor)
   }
-  
-  
 }

--- a/Sources/GRPCCore/Call/Client/ClientRPCExecutionConfigurationCollection.swift
+++ b/Sources/GRPCCore/Call/Client/ClientRPCExecutionConfigurationCollection.swift
@@ -67,7 +67,7 @@ public struct ClientRPCExecutionConfigurationCollection: Sendable, Hashable {
   /// - Parameters:
   ///   - configuration: The default configuration for the service.
   ///   - service: The name of the service for which this override applies.
-  mutating public func setDefaultConfiguration(
+  public mutating func setDefaultConfiguration(
     _ configuration: ClientRPCExecutionConfiguration,
     forService service: String
   ) {

--- a/Sources/GRPCCore/Call/Client/ClientRPCExecutionConfigurationCollection.swift
+++ b/Sources/GRPCCore/Call/Client/ClientRPCExecutionConfigurationCollection.swift
@@ -53,11 +53,11 @@ public struct ClientRPCExecutionConfigurationCollection: Sendable, Hashable {
         !descriptor.service.isEmpty,
         "Method descriptor's service cannot be empty."
       )
-      
+
       self.elements[descriptor] = newValue
     }
   }
-  
+
   /// Set a default configuration for a service.
   ///
   /// If getting a configuration for a method that's part of a service, and the method itself doesn't have an

--- a/Sources/GRPCCore/Call/Client/ClientRPCExecutionConfigurationCollection.swift
+++ b/Sources/GRPCCore/Call/Client/ClientRPCExecutionConfigurationCollection.swift
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+struct ClientRPCExecutionConfigurationCollection: ExpressibleByDictionaryLiteral {
+  private var elements: [MethodDescriptor: ClientRPCExecutionConfiguration]
+  private let defaultConfiguration: ClientRPCExecutionConfiguration
+  
+  init(defaultConfiguration: ClientRPCExecutionConfiguration) {
+    self.elements = [:]
+    self.defaultConfiguration = defaultConfiguration
+  }
+  
+  init(dictionaryLiteral elements: (Key, Value)...) {
+    elements.forEach({ (key, value) in
+      self.elements[key] = value
+    })
+  }
+  
+  mutating func addConfiguration(_ configuration: ClientRPCExecutionConfiguration, forMethod descriptor: MethodDescriptor) {
+    self.elements[descriptor] = configuration
+  }
+  
+  func getConfiguration(forMethod descriptor: MethodDescriptor) -> ClientRPCExecutionConfiguration {
+    self.elements[descriptor] ?? self.defaultConfiguration
+  }
+  
+  subscript(_ descriptor: MethodDescriptor) -> ClientRPCExecutionConfiguration {
+    self.getConfiguration(forMethod: descriptor)
+  }
+  
+  
+}

--- a/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor+OneShotExecutor.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor+OneShotExecutor.swift
@@ -69,63 +69,70 @@ extension ClientRPCExecutor.OneShotExecutor {
       of: _OneShotExecutorTask<R>.self,
       returning: Result<R, Error>.self
     ) { group in
-      if let timeout = self.timeout {
-        group.addTask {
-          let result = await Result {
-            try await Task.sleep(until: .now.advanced(by: timeout), clock: .continuous)
+      do {
+        return try await self.transport.withStream(descriptor: method) { stream in
+          if let timeout = self.timeout {
+            group.addTask {
+              let result = await Result {
+                try await Task.sleep(until: .now.advanced(by: timeout), clock: .continuous)
+              }
+              return .timedOut(result)
+            }
           }
-          return .timedOut(result)
+          
+          let streamExecutor = ClientStreamExecutor(transport: self.transport)
+          group.addTask {
+            await streamExecutor.run()
+            return .streamExecutorCompleted
+          }
+          
+          group.addTask {
+            let response = await ClientRPCExecutor.unsafeExecute(
+              request: request,
+              method: method,
+              attempt: 1,
+              serializer: self.serializer,
+              deserializer: self.deserializer,
+              interceptors: self.interceptors,
+              streamProcessor: streamExecutor,
+              stream: stream
+            )
+            
+            let result = await Result {
+              try await responseHandler(response)
+            }
+            
+            return .responseHandled(result)
+          }
+          
+          while let result = await group.next() {
+            switch result {
+            case .streamExecutorCompleted:
+              // Stream finished; wait for the response to be handled.
+              ()
+              
+            case .timedOut(.success):
+              // The deadline passed; cancel the ongoing work group.
+              group.cancelAll()
+              
+            case .timedOut(.failure):
+              // The deadline task failed (because the task was cancelled). Wait for the response
+              // to be handled.
+              ()
+              
+            case .responseHandled(let result):
+              // Response handled: cancel any other remaining tasks.
+              group.cancelAll()
+              return result
+            }
+          }
+          
+          // Unreachable: exactly one task returns `responseHandled` and we return when it completes.
+          fatalError("Internal inconsistency")
         }
+      } catch {
+        return .failure(error)
       }
-
-      let streamExecutor = ClientStreamExecutor(transport: self.transport)
-      group.addTask {
-        await streamExecutor.run()
-        return .streamExecutorCompleted
-      }
-
-      group.addTask {
-        let response = await ClientRPCExecutor.unsafeExecute(
-          request: request,
-          method: method,
-          attempt: 1,
-          serializer: self.serializer,
-          deserializer: self.deserializer,
-          interceptors: self.interceptors,
-          streamProcessor: streamExecutor
-        )
-
-        let result = await Result {
-          try await responseHandler(response)
-        }
-
-        return .responseHandled(result)
-      }
-
-      while let result = await group.next() {
-        switch result {
-        case .streamExecutorCompleted:
-          // Stream finished; wait for the response to be handled.
-          ()
-
-        case .timedOut(.success):
-          // The deadline passed; cancel the ongoing work group.
-          group.cancelAll()
-
-        case .timedOut(.failure):
-          // The deadline task failed (because the task was cancelled). Wait for the response
-          // to be handled.
-          ()
-
-        case .responseHandled(let result):
-          // Response handled: cancel any other remaining tasks.
-          group.cancelAll()
-          return result
-        }
-      }
-
-      // Unreachable: exactly one task returns `responseHandled` and we return when it completes.
-      fatalError("Internal inconsistency")
     }
 
     return try result.get()

--- a/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor+RetryExecutor.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor+RetryExecutor.swift
@@ -118,169 +118,180 @@ extension ClientRPCExecutor.RetryExecutor {
       var delayIterator = delaySequence.makeIterator()
 
       for attempt in 1 ... self.policy.maximumAttempts {
-        group.addTask {
-          await withTaskGroup(
-            of: _RetryExecutorSubTask<R>.self,
-            returning: _RetryExecutorTask<R>.self
-          ) { thisAttemptGroup in
-            let streamExecutor = ClientStreamExecutor(transport: self.transport)
-            thisAttemptGroup.addTask {
-              await streamExecutor.run()
-              return .streamProcessed
-            }
-
-            thisAttemptGroup.addTask {
-              let response = await ClientRPCExecutor.unsafeExecute(
-                request: ClientRequest.Stream(metadata: request.metadata) {
-                  try await $0.write(contentsOf: retry.stream)
-                },
-                method: method,
-                attempt: attempt,
-                serializer: self.serializer,
-                deserializer: self.deserializer,
-                interceptors: self.interceptors,
-                streamProcessor: streamExecutor
-              )
-
-              let shouldRetry: Bool
-              let retryDelayOverride: Duration?
-
-              switch response.accepted {
-              case .success:
-                // Request was accepted. This counts as success to the throttle and there's no need
-                // to retry.
-                self.transport.retryThrottle.recordSuccess()
-                retryDelayOverride = nil
-                shouldRetry = false
-
-              case .failure(let error):
-                // The request was rejected. Determine whether a retry should be carried out. The
-                // following conditions must be checked:
-                //
-                // - Whether the status code is retryable.
-                // - Whether more attempts are permitted by the config.
-                // - Whether the throttle permits another retry to be carried out.
-                // - Whether the server pushed back to either stop further retries or to override
-                //   the delay before the next retry.
-                let code = Status.Code(error.code)
-                let isRetryableStatusCode = self.policy.retryableStatusCodes.contains(code)
-
-                if isRetryableStatusCode {
-                  // Counted as failure for throttling.
-                  let throttled = self.transport.retryThrottle.recordFailure()
-
-                  // Status code can be retried, Did the server send pushback?
-                  switch error.metadata.retryPushback {
-                  case .retryAfter(let delay):
-                    // Pushback: only retry if our config permits it.
-                    shouldRetry = (attempt < self.policy.maximumAttempts) && !throttled
-                    retryDelayOverride = delay
-                  case .stopRetrying:
-                    // Server told us to stop trying.
+        do {
+          let attemptResult = try await self.transport.withStream(descriptor: method) { stream in
+            group.addTask {
+              await withTaskGroup(
+                of: _RetryExecutorSubTask<R>.self,
+                returning: _RetryExecutorTask<R>.self
+              ) { thisAttemptGroup in
+                let streamExecutor = ClientStreamExecutor(transport: self.transport)
+                thisAttemptGroup.addTask {
+                  await streamExecutor.run()
+                  return .streamProcessed
+                }
+                
+                thisAttemptGroup.addTask {
+                  let response = await ClientRPCExecutor.unsafeExecute(
+                    request: ClientRequest.Stream(metadata: request.metadata) {
+                      try await $0.write(contentsOf: retry.stream)
+                    },
+                    method: method,
+                    attempt: attempt,
+                    serializer: self.serializer,
+                    deserializer: self.deserializer,
+                    interceptors: self.interceptors,
+                    streamProcessor: streamExecutor,
+                    stream: stream
+                  )
+                  
+                  let shouldRetry: Bool
+                  let retryDelayOverride: Duration?
+                  
+                  switch response.accepted {
+                  case .success:
+                    // Request was accepted. This counts as success to the throttle and there's no need
+                    // to retry.
+                    self.transport.retryThrottle.recordSuccess()
+                    retryDelayOverride = nil
                     shouldRetry = false
-                    retryDelayOverride = nil
-                  case .none:
-                    // No pushback: only retry if our config permits it.
-                    shouldRetry = (attempt < self.policy.maximumAttempts) && !throttled
-                    retryDelayOverride = nil
-                    break
+                    
+                  case .failure(let error):
+                    // The request was rejected. Determine whether a retry should be carried out. The
+                    // following conditions must be checked:
+                    //
+                    // - Whether the status code is retryable.
+                    // - Whether more attempts are permitted by the config.
+                    // - Whether the throttle permits another retry to be carried out.
+                    // - Whether the server pushed back to either stop further retries or to override
+                    //   the delay before the next retry.
+                    let code = Status.Code(error.code)
+                    let isRetryableStatusCode = self.policy.retryableStatusCodes.contains(code)
+                    
+                    if isRetryableStatusCode {
+                      // Counted as failure for throttling.
+                      let throttled = self.transport.retryThrottle.recordFailure()
+                      
+                      // Status code can be retried, Did the server send pushback?
+                      switch error.metadata.retryPushback {
+                      case .retryAfter(let delay):
+                        // Pushback: only retry if our config permits it.
+                        shouldRetry = (attempt < self.policy.maximumAttempts) && !throttled
+                        retryDelayOverride = delay
+                      case .stopRetrying:
+                        // Server told us to stop trying.
+                        shouldRetry = false
+                        retryDelayOverride = nil
+                      case .none:
+                        // No pushback: only retry if our config permits it.
+                        shouldRetry = (attempt < self.policy.maximumAttempts) && !throttled
+                        retryDelayOverride = nil
+                        break
+                      }
+                    } else {
+                      // Not-retryable; this is considered a success.
+                      self.transport.retryThrottle.recordSuccess()
+                      shouldRetry = false
+                      retryDelayOverride = nil
+                    }
                   }
-                } else {
-                  // Not-retryable; this is considered a success.
-                  self.transport.retryThrottle.recordSuccess()
-                  shouldRetry = false
-                  retryDelayOverride = nil
+                  
+                  if shouldRetry {
+                    // Cancel subscribers of the broadcast sequence. This is safe as we are the only
+                    // subscriber and maximises the chances that 'isKnownSafeForNextSubscriber' will
+                    // return true.
+                    //
+                    // Note: this must only be called if we should retry, otherwise we may cancel a
+                    // subscriber for an accepted request.
+                    retry.stream.invalidateAllSubscriptions()
+                    
+                    // Only retry if we know it's safe for the next subscriber, that is, the first
+                    // element is still in the buffer. It's safe to call this because there's only
+                    // ever one attempt at a time and the existing subscribers have been invalidated.
+                    if retry.stream.isKnownSafeForNextSubscriber {
+                      return .retry(retryDelayOverride)
+                    }
+                  }
+                  
+                  // Not retrying or not safe to retry.
+                  let result = await Result {
+                    // Check for cancellation; the RPC may have timed out in which case we should skip
+                    // the response handler.
+                    try Task.checkCancellation()
+                    return try await responseHandler(response)
+                  }
+                  return .handledResponse(result)
                 }
-              }
-
-              if shouldRetry {
-                // Cancel subscribers of the broadcast sequence. This is safe as we are the only
-                // subscriber and maximises the chances that 'isKnownSafeForNextSubscriber' will
-                // return true.
-                //
-                // Note: this must only be called if we should retry, otherwise we may cancel a
-                // subscriber for an accepted request.
-                retry.stream.invalidateAllSubscriptions()
-
-                // Only retry if we know it's safe for the next subscriber, that is, the first
-                // element is still in the buffer. It's safe to call this because there's only
-                // ever one attempt at a time and the existing subscribers have been invalidated.
-                if retry.stream.isKnownSafeForNextSubscriber {
-                  return .retry(retryDelayOverride)
+                
+                while let result = await thisAttemptGroup.next() {
+                  switch result {
+                  case .streamProcessed:
+                    ()  // Continue processing; wait for the response to be handled.
+                    
+                  case .retry(let delayOverride):
+                    thisAttemptGroup.cancelAll()
+                    return .retry(delayOverride)
+                    
+                  case .handledResponse(let result):
+                    thisAttemptGroup.cancelAll()
+                    return .handledResponse(result)
+                  }
                 }
+                
+                fatalError("Internal inconsistency")
               }
-
-              // Not retrying or not safe to retry.
-              let result = await Result {
-                // Check for cancellation; the RPC may have timed out in which case we should skip
-                // the response handler.
-                try Task.checkCancellation()
-                return try await responseHandler(response)
-              }
-              return .handledResponse(result)
             }
-
-            while let result = await thisAttemptGroup.next() {
-              switch result {
-              case .streamProcessed:
-                ()  // Continue processing; wait for the response to be handled.
-
-              case .retry(let delayOverride):
-                thisAttemptGroup.cancelAll()
-                return .retry(delayOverride)
-
+            
+            loop: while let next = await group.next() {
+              switch next {
               case .handledResponse(let result):
-                thisAttemptGroup.cancelAll()
-                return .handledResponse(result)
+                // A usable response; cancel the remaining work and return the result.
+                group.cancelAll()
+                return Optional.some(result)
+                
+              case .retry(let delayOverride):
+                // The attempt failed, wait a bit and then retry. The server might have overridden the
+                // delay via pushback so preferentially use that value.
+                //
+                // Any error will come from cancellation: if it happens while we're sleeping we can
+                // just loop around, the next attempt will be cancelled immediately and we will return
+                // its response to the client.
+                if let delayOverride = delayOverride {
+                  // If the delay is overridden with server pushback then reset the iterator for the
+                  // next retry.
+                  delayIterator = delaySequence.makeIterator()
+                  try? await Task.sleep(until: .now.advanced(by: delayOverride), clock: .continuous)
+                } else {
+                  // The delay iterator never terminates.
+                  try? await Task.sleep(
+                    until: .now.advanced(by: delayIterator.next()!),
+                    clock: .continuous
+                  )
+                }
+                
+                break loop  // from the while loop so another attempt can be started.
+                
+              case .timedOut(.success), .outboundFinished(.failure):
+                // Timeout task fired successfully or failed to process the outbound stream. Cancel and
+                // wait for a usable response (which is likely to be an error).
+                group.cancelAll()
+                
+              case .timedOut(.failure), .outboundFinished(.success):
+                // Timeout task failed which means it was cancelled (so no need to cancel again) or the
+                // outbound stream was successfully processed (so don't need to do anything).
+                ()
               }
             }
-
-            fatalError("Internal inconsistency")
+            return nil
           }
-        }
-
-        loop: while let next = await group.next() {
-          switch next {
-          case .handledResponse(let result):
-            // A usable response; cancel the remaining work and return the result.
-            group.cancelAll()
-            return result
-
-          case .retry(let delayOverride):
-            // The attempt failed, wait a bit and then retry. The server might have overridden the
-            // delay via pushback so preferentially use that value.
-            //
-            // Any error will come from cancellation: if it happens while we're sleeping we can
-            // just loop around, the next attempt will be cancelled immediately and we will return
-            // its response to the client.
-            if let delayOverride = delayOverride {
-              // If the delay is overridden with server pushback then reset the iterator for the
-              // next retry.
-              delayIterator = delaySequence.makeIterator()
-              try? await Task.sleep(until: .now.advanced(by: delayOverride), clock: .continuous)
-            } else {
-              // The delay iterator never terminates.
-              try? await Task.sleep(
-                until: .now.advanced(by: delayIterator.next()!),
-                clock: .continuous
-              )
-            }
-
-            break loop  // from the while loop so another attempt can be started.
-
-          case .timedOut(.success), .outboundFinished(.failure):
-            // Timeout task fired successfully or failed to process the outbound stream. Cancel and
-            // wait for a usable response (which is likely to be an error).
-            group.cancelAll()
-
-          case .timedOut(.failure), .outboundFinished(.success):
-            // Timeout task failed which means it was cancelled (so no need to cancel again) or the
-            // outbound stream was successfully processed (so don't need to do anything).
-            ()
+          
+          if let attemptResult {
+            return attemptResult
           }
+        } catch {
+          return .failure(error)
         }
       }
-
       fatalError("Internal inconsistency")
     }
 

--- a/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor.swift
@@ -99,14 +99,15 @@ extension ClientRPCExecutor {
   ///   - streamProcessor: A processor which executes the serialized request.
   /// - Returns: The deserialized response.
   @inlinable
-  static func unsafeExecute<Input: Sendable, Output: Sendable>(
+  static func unsafeExecute<Transport: ClientTransport, Input: Sendable, Output: Sendable>(
     request: ClientRequest.Stream<Input>,
     method: MethodDescriptor,
     attempt: Int,
     serializer: some MessageSerializer<Input>,
     deserializer: some MessageDeserializer<Output>,
     interceptors: [any ClientInterceptor],
-    streamProcessor: ClientStreamExecutor<some ClientTransport>
+    streamProcessor: ClientStreamExecutor<Transport>,
+    stream: RPCStream<Transport.Inbound, Transport.Outbound>
   ) async -> ClientResponse.Stream<Output> {
     let context = ClientInterceptorContext(descriptor: method)
 
@@ -125,7 +126,8 @@ extension ClientRPCExecutor {
         request: ClientRequest.Stream<[UInt8]>(metadata: metadata) { writer in
           try await request.producer(.serializing(into: writer, with: serializer))
         },
-        method: context.descriptor
+        method: context.descriptor,
+        stream: stream
       )
 
       // Attach the number of previous attempts, it can be useful information for callers.

--- a/Sources/GRPCCore/Streaming/RPCAsyncSequence.swift
+++ b/Sources/GRPCCore/Streaming/RPCAsyncSequence.swift
@@ -40,7 +40,8 @@ public struct RPCAsyncSequence<Element>: AsyncSequence, Sendable {
     }
 
     public mutating func next() async throws -> Element? {
-      return try await self.iterator.next() as? Element
+      let elem = try await self.iterator.next()
+      return elem as? Element
     }
   }
 }

--- a/Sources/GRPCCore/Transport/ClientTransport.swift
+++ b/Sources/GRPCCore/Transport/ClientTransport.swift
@@ -68,7 +68,7 @@ public protocol ClientTransport: Sendable {
   /// - Returns: Whatever value was returned from `closure`.
   func withStream<T>(
     descriptor: MethodDescriptor,
-    _ closure: (RPCStream<Inbound, Outbound>) async throws -> T
+    _ closure: (_ stream: RPCStream<Inbound, Outbound>) async throws -> T
   ) async throws -> T
 
   /// Returns the execution configuration for a given method.

--- a/Sources/GRPCCore/Transport/ClientTransport.swift
+++ b/Sources/GRPCCore/Transport/ClientTransport.swift
@@ -46,7 +46,7 @@ public protocol ClientTransport: Sendable {
 
   /// Signal to the transport that no new streams may be created.
   ///
-  /// Existing streams may run to completion naturally but calling ``openStream(descriptor:)``
+  /// Existing streams may run to completion naturally but calling ``withStream(descriptor:_:)``
   /// should result in an ``RPCError`` with code ``RPCError/Code/failedPrecondition`` being thrown.
   ///
   /// If you want to forcefully cancel all active streams then cancel the task
@@ -55,7 +55,7 @@ public protocol ClientTransport: Sendable {
 
   /// Opens a stream using the transport, and uses it as input into a user-provided closure.
   ///
-  /// The opened stream is closed after the closure is finished.
+  /// - Important: The opened stream is closed after the closure is finished.
   ///
   /// Transport implementations should throw an ``RPCError`` with the following error codes:
   /// - ``RPCError/Code/failedPrecondition`` if the transport is closing or has been closed.

--- a/Sources/GRPCCore/Transport/ClientTransport.swift
+++ b/Sources/GRPCCore/Transport/ClientTransport.swift
@@ -61,7 +61,7 @@ public protocol ClientTransport: Sendable {
   /// - ``RPCError/Code/failedPrecondition`` if the transport is closing or has been closed.
   /// - ``RPCError/Code/unavailable`` if it's temporarily not possible to create a stream and it
   ///   may be possible after some backoff period.
-  /// 
+  ///
   /// - Parameters:
   ///   - descriptor: A description of the method to open a stream for.
   ///   - closure: A closure that takes the opened stream as parameter.

--- a/Sources/GRPCCore/Transport/InProcessClientTransport.swift
+++ b/Sources/GRPCCore/Transport/InProcessClientTransport.swift
@@ -17,30 +17,135 @@
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 /// An in-process implementation of a ``ClientTransport``.
 public struct InProcessClientTransport: ClientTransport {
+  private enum State: Sendable {
+    case unconnected(InProcessServerTransport)
+    case connected(InProcessServerTransport)
+    case closed
+  }
+
   public typealias Inbound = RPCAsyncSequence<RPCResponsePart>
   public typealias Outbound = RPCWriter<RPCRequestPart>.Closable
   
   public var retryThrottle: RetryThrottle
   
-  private var executionConfigurations: ClientRPCExecutionConfigurationCollection
+  private let executionConfigurations: ClientRPCExecutionConfigurationCollection
+  private let state: LockedValueBox<State>
   
-  public init() {
+  public init(
+    server: InProcessServerTransport,
+    executionConfigurations: ClientRPCExecutionConfigurationCollection
+  ) {
     self.retryThrottle = .init(maximumTokens: 10, tokenRatio: 0.1)
+    self.executionConfigurations = executionConfigurations
+    self.state = .init(.unconnected(server))
   }
   
+  /// Establish and maintain a connection to the remote destination.
+  ///
+  /// Maintains a long-lived connection, or set of connections, to a remote destination.
+  /// Connections may be added or removed over time as required by the implementation and the
+  /// demand for streams by the client.
+  ///
+  /// Implementations of this function will typically create a long-lived task group which
+  /// maintains connections. The function exits when all open streams have been closed and new connections
+  /// are no longer required by the caller who signals this by calling ``close()``, or by cancelling the
+  /// task this function runs in.
+  ///
+  /// - Parameter lazily: This parameter is ignored in this implementation.
   public func connect(lazily: Bool) async throws {
-    <#code#>
+    try self.state.withLockedValue { state in
+      switch state {
+      case .unconnected(let server):
+        state = .connected(server)
+        _ = server.listen()
+      case .connected:
+        throw RPCError(
+          code: .failedPrecondition,
+          message: "Already connected to server."
+        )
+      case .closed:
+        throw RPCError(
+          code: .failedPrecondition,
+          message: "Can't connect to server, transport is closed."
+        )
+      }
+    }
   }
   
   public func close() {
-    <#code#>
+    self.state.withLockedValue { state in
+      switch state {
+      case .unconnected(let server):
+        state = .closed
+        server.stopListening()
+      case .connected(let server):
+        state = .closed
+        server.stopListening()
+      case .closed:
+        ()
+      }
+    }
   }
   
-  public func openStream(descriptor: MethodDescriptor) async throws -> RPCStream<Inbound, Outbound> {
+  public func withStream<T>(
+    descriptor: MethodDescriptor,
+    _ closure: (RPCStream<Inbound, Outbound>) async throws -> T
+  ) async throws -> T {
+    let request = RPCAsyncSequence<RPCRequestPart>.makeBackpressuredStream(watermarks: (16, 32))
+    let response = RPCAsyncSequence<RPCResponsePart>.makeBackpressuredStream(watermarks: (16, 32))
+
+    let clientStream = RPCStream(
+      descriptor: descriptor,
+      inbound: response.stream,
+      outbound: request.writer
+    )
+
+    let serverStream = RPCStream(
+      descriptor: descriptor,
+      inbound: request.stream,
+      outbound: response.writer
+    )
     
+    let error: RPCError? = try self.state.withLockedValue { state in
+      switch state {
+      case .connected(let transport):
+        do {
+          try transport.acceptStream(serverStream)
+          state = .connected(transport)
+        } catch let acceptStreamError as RPCError {
+          return acceptStreamError
+        }
+        return nil
+
+      case .unconnected:
+        return RPCError(
+          code: .failedPrecondition,
+          message: "The client transport must be connected before streams can be created."
+        )
+
+      case .closed:
+        return RPCError(
+          code: .failedPrecondition,
+          message: "The client transport is closed."
+        )
+      }
+    }
+
+    if let error = error {
+      serverStream.outbound.finish()
+      clientStream.outbound.finish()
+      throw error
+    }
+    
+    let result = try await closure(clientStream)
+    
+    serverStream.outbound.finish()
+    clientStream.outbound.finish()
+    
+    return result
   }
   
   public func executionConfiguration(forMethod descriptor: MethodDescriptor) -> ClientRPCExecutionConfiguration? {
-    self.executionConfiguration(forMethod: descriptor)
+    self.executionConfigurations[descriptor]
   }
 }

--- a/Sources/GRPCCore/Transport/InProcessClientTransport.swift
+++ b/Sources/GRPCCore/Transport/InProcessClientTransport.swift
@@ -25,12 +25,12 @@ public struct InProcessClientTransport: ClientTransport {
 
   public typealias Inbound = RPCAsyncSequence<RPCResponsePart>
   public typealias Outbound = RPCWriter<RPCRequestPart>.Closable
-  
+
   public var retryThrottle: RetryThrottle
-  
+
   private let executionConfigurations: ClientRPCExecutionConfigurationCollection
   private let state: LockedValueBox<State>
-  
+
   public init(
     server: InProcessServerTransport,
     executionConfigurations: ClientRPCExecutionConfigurationCollection
@@ -39,7 +39,7 @@ public struct InProcessClientTransport: ClientTransport {
     self.executionConfigurations = executionConfigurations
     self.state = .init(.unconnected(server))
   }
-  
+
   /// Establish and maintain a connection to the remote destination.
   ///
   /// Maintains a long-lived connection, or set of connections, to a remote destination.
@@ -71,7 +71,7 @@ public struct InProcessClientTransport: ClientTransport {
       }
     }
   }
-  
+
   public func close() {
     self.state.withLockedValue { state in
       switch state {
@@ -86,7 +86,7 @@ public struct InProcessClientTransport: ClientTransport {
       }
     }
   }
-  
+
   public func withStream<T>(
     descriptor: MethodDescriptor,
     _ closure: (RPCStream<Inbound, Outbound>) async throws -> T
@@ -105,7 +105,7 @@ public struct InProcessClientTransport: ClientTransport {
       inbound: request.stream,
       outbound: response.writer
     )
-    
+
     let error: RPCError? = try self.state.withLockedValue { state in
       switch state {
       case .connected(let transport):
@@ -136,16 +136,18 @@ public struct InProcessClientTransport: ClientTransport {
       clientStream.outbound.finish()
       throw error
     }
-    
+
     let result = try await closure(clientStream)
-    
+
     serverStream.outbound.finish()
     clientStream.outbound.finish()
-    
+
     return result
   }
-  
-  public func executionConfiguration(forMethod descriptor: MethodDescriptor) -> ClientRPCExecutionConfiguration? {
+
+  public func executionConfiguration(
+    forMethod descriptor: MethodDescriptor
+  ) -> ClientRPCExecutionConfiguration? {
     self.executionConfigurations[descriptor]
   }
 }

--- a/Sources/GRPCCore/Transport/InProcessClientTransport.swift
+++ b/Sources/GRPCCore/Transport/InProcessClientTransport.swift
@@ -236,7 +236,7 @@ public struct InProcessClientTransport: ClientTransport {
       inbound: request.stream,
       outbound: response.writer
     )
-    
+
     let waitForConnectionStream: AsyncStream<Void>? = self.state.withLockedValue { state in
       if case .unconnected(var unconnectedState) = state {
         let (stream, continuation) = AsyncStream<Void>.makeStream()
@@ -246,7 +246,7 @@ public struct InProcessClientTransport: ClientTransport {
       }
       return nil
     }
-    
+
     if let waitForConnectionStream {
       for await _ in waitForConnectionStream {
         // This loop will exit either when the task is cancelled or when the

--- a/Sources/GRPCCore/Transport/InProcessClientTransport.swift
+++ b/Sources/GRPCCore/Transport/InProcessClientTransport.swift
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+/// An in-process implementation of a ``ClientTransport``.
+public struct InProcessClientTransport: ClientTransport {
+  public typealias Inbound = RPCAsyncSequence<RPCResponsePart>
+  public typealias Outbound = RPCWriter<RPCRequestPart>.Closable
+  
+  public var retryThrottle: RetryThrottle
+  
+  private var executionConfigurations: ClientRPCExecutionConfigurationCollection
+  
+  public init() {
+    self.retryThrottle = .init(maximumTokens: 10, tokenRatio: 0.1)
+  }
+  
+  public func connect(lazily: Bool) async throws {
+    <#code#>
+  }
+  
+  public func close() {
+    <#code#>
+  }
+  
+  public func openStream(descriptor: MethodDescriptor) async throws -> RPCStream<Inbound, Outbound> {
+    
+  }
+  
+  public func executionConfiguration(forMethod descriptor: MethodDescriptor) -> ClientRPCExecutionConfiguration? {
+    self.executionConfiguration(forMethod: descriptor)
+  }
+}

--- a/Sources/GRPCCore/Transport/InProcessClientTransport.swift
+++ b/Sources/GRPCCore/Transport/InProcessClientTransport.swift
@@ -101,7 +101,7 @@ public struct InProcessClientTransport: ClientTransport {
         )
       }
     }
-    
+
     for await _ in stream {
       // This for-await loop will exit (and thus `connect(lazily:)` will return)
       // only when the task is cancelled, or when the stream's continuation is
@@ -132,7 +132,7 @@ public struct InProcessClientTransport: ClientTransport {
       }
     }
   }
-  
+
   private enum WithStreamResult {
     case success
     case pending(AsyncStream<Void>)
@@ -194,13 +194,15 @@ public struct InProcessClientTransport: ClientTransport {
         return .success(.pending(stream))
 
       case .closed:
-        return .failure(RPCError(
-          code: .failedPrecondition,
-          message: "The client transport is closed."
-        ))
+        return .failure(
+          RPCError(
+            code: .failedPrecondition,
+            message: "The client transport is closed."
+          )
+        )
       }
     }
-    
+
     let withStreamResult: WithStreamResult
     do {
       withStreamResult = try result.get()
@@ -209,7 +211,7 @@ public struct InProcessClientTransport: ClientTransport {
       clientStream.outbound.finish()
       throw error
     }
-    
+
     switch withStreamResult {
     case .success:
       ()
@@ -219,7 +221,7 @@ public struct InProcessClientTransport: ClientTransport {
         // client connects and this stream can be opened.
       }
       try Task.checkCancellation()
-      
+
       try self.state.withLockedValue { state in
         switch state {
         case .unconnected:
@@ -243,7 +245,7 @@ public struct InProcessClientTransport: ClientTransport {
         }
       }
     }
-    
+
     defer {
       self.state.withLockedValue { state in
         switch state {

--- a/Sources/GRPCCore/Transport/InProcessServerTransport.swift
+++ b/Sources/GRPCCore/Transport/InProcessServerTransport.swift
@@ -16,7 +16,7 @@
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 /// An in-process implementation of a ``ServerTransport``.
-public struct InProcessServerTransport: ServerTransport {
+public struct InProcessServerTransport: ServerTransport, Sendable {
   public typealias Inbound = RPCAsyncSequence<RPCRequestPart>
   public typealias Outbound = RPCWriter<RPCResponsePart>.Closable
 

--- a/Sources/GRPCCore/Transport/InProcessServerTransport.swift
+++ b/Sources/GRPCCore/Transport/InProcessServerTransport.swift
@@ -16,6 +16,15 @@
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 /// An in-process implementation of a ``ServerTransport``.
+///
+/// This is useful when you're interested in testing your application without any actual networking layers
+/// involved, as the client and server will communicate directly with each other via in-process streams.
+///
+/// To use this server, you call ``listen()`` and iterate over the returned `AsyncSequence` to get all
+/// RPC requests made from clients (as ``RPCStream``s).
+/// To stop listening to new requests, call ``stopListening()``.
+///
+/// - SeeAlso: ``ClientTransport``
 public struct InProcessServerTransport: ServerTransport, Sendable {
   public typealias Inbound = RPCAsyncSequence<RPCRequestPart>
   public typealias Outbound = RPCWriter<RPCResponsePart>.Closable
@@ -56,6 +65,8 @@ public struct InProcessServerTransport: ServerTransport, Sendable {
   ///
   /// All further calls to ``acceptStream(_:)`` will not produce any new elements on the
   /// ``RPCAsyncSequence`` returned by ``listen()``.
+  ///
+  /// - SeeAlso: ``ServerTransport``
   public func stopListening() {
     self.newStreamsContinuation.finish()
   }

--- a/Tests/GRPCCoreTests/Call/Client/ClientRPCExecutionConfigurationCollectionTests.swift
+++ b/Tests/GRPCCoreTests/Call/Client/ClientRPCExecutionConfigurationCollectionTests.swift
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import GRPCCore
+import XCTest
+
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+final class ClientRPCExecutionConfigurationCollectionTests: XCTestCase {
+  func testCollection() {
+    let policy = HedgingPolicy(
+      maximumAttempts: 10,
+      hedgingDelay: .seconds(1),
+      nonFatalStatusCodes: []
+    )
+    let defaultConfiguration = ClientRPCExecutionConfiguration(hedgingPolicy: policy)
+    var configurations = ClientRPCExecutionConfigurationCollection(defaultConfiguration: defaultConfiguration)
+    
+    let firstDescriptor = MethodDescriptor(service: "test", method: "first")
+    XCTAssertEqual(configurations[firstDescriptor], defaultConfiguration)
+    XCTAssertEqual(configurations.getConfiguration(forMethod: firstDescriptor), defaultConfiguration)
+    
+    let retryPolicy = RetryPolicy(
+      maximumAttempts: 10,
+      initialBackoff: .seconds(1),
+      maximumBackoff: .seconds(1),
+      backoffMultiplier: 1.0,
+      retryableStatusCodes: [.unavailable]
+    )
+    let overrideConfiguration = ClientRPCExecutionConfiguration(retryPolicy: retryPolicy)
+    configurations.addConfiguration(
+      overrideConfiguration,
+      forMethod: firstDescriptor
+    )
+    let secondDescriptor = MethodDescriptor(service: "test", method: "second")
+    XCTAssertEqual(configurations[firstDescriptor], overrideConfiguration)
+    XCTAssertEqual(configurations[secondDescriptor], defaultConfiguration)
+    XCTAssertEqual(configurations.getConfiguration(forMethod: firstDescriptor), overrideConfiguration)
+    XCTAssertEqual(configurations.getConfiguration(forMethod: secondDescriptor), defaultConfiguration)
+  }
+}

--- a/Tests/GRPCCoreTests/Call/Client/ClientRPCExecutionConfigurationCollectionTests.swift
+++ b/Tests/GRPCCoreTests/Call/Client/ClientRPCExecutionConfigurationCollectionTests.swift
@@ -38,10 +38,10 @@ final class ClientRPCExecutionConfigurationCollectionTests: XCTestCase {
     )
     let overrideConfiguration = ClientRPCExecutionConfiguration(retryPolicy: retryPolicy)
     configurations[descriptor] = overrideConfiguration
-    
+
     XCTAssertEqual(configurations[descriptor], overrideConfiguration)
   }
-  
+
   func testGetConfigurationForUnknownMethodButServiceOverride() {
     let policy = HedgingPolicy(
       maximumAttempts: 10,
@@ -62,11 +62,11 @@ final class ClientRPCExecutionConfigurationCollectionTests: XCTestCase {
     )
     let overrideConfiguration = ClientRPCExecutionConfiguration(retryPolicy: retryPolicy)
     configurations[firstDescriptor] = overrideConfiguration
-    
+
     let secondDescriptor = MethodDescriptor(service: "test", method: "second")
     XCTAssertEqual(configurations[secondDescriptor], overrideConfiguration)
   }
-  
+
   func testGetConfigurationForUnknownMethodDefaultValue() {
     let policy = HedgingPolicy(
       maximumAttempts: 10,
@@ -87,7 +87,7 @@ final class ClientRPCExecutionConfigurationCollectionTests: XCTestCase {
     )
     let overrideConfiguration = ClientRPCExecutionConfiguration(retryPolicy: retryPolicy)
     configurations[firstDescriptor] = overrideConfiguration
-    
+
     let secondDescriptor = MethodDescriptor(service: "test2", method: "second")
     XCTAssertEqual(configurations[secondDescriptor], defaultConfiguration)
   }

--- a/Tests/GRPCCoreTests/Call/Client/ClientRPCExecutionConfigurationCollectionTests.swift
+++ b/Tests/GRPCCoreTests/Call/Client/ClientRPCExecutionConfigurationCollectionTests.swift
@@ -25,12 +25,17 @@ final class ClientRPCExecutionConfigurationCollectionTests: XCTestCase {
       nonFatalStatusCodes: []
     )
     let defaultConfiguration = ClientRPCExecutionConfiguration(hedgingPolicy: policy)
-    var configurations = ClientRPCExecutionConfigurationCollection(defaultConfiguration: defaultConfiguration)
-    
+    var configurations = ClientRPCExecutionConfigurationCollection(
+      defaultConfiguration: defaultConfiguration
+    )
+
     let firstDescriptor = MethodDescriptor(service: "test", method: "first")
     XCTAssertEqual(configurations[firstDescriptor], defaultConfiguration)
-    XCTAssertEqual(configurations.getConfiguration(forMethod: firstDescriptor), defaultConfiguration)
-    
+    XCTAssertEqual(
+      configurations.getConfiguration(forMethod: firstDescriptor),
+      defaultConfiguration
+    )
+
     let retryPolicy = RetryPolicy(
       maximumAttempts: 10,
       initialBackoff: .seconds(1),
@@ -46,7 +51,13 @@ final class ClientRPCExecutionConfigurationCollectionTests: XCTestCase {
     let secondDescriptor = MethodDescriptor(service: "test", method: "second")
     XCTAssertEqual(configurations[firstDescriptor], overrideConfiguration)
     XCTAssertEqual(configurations[secondDescriptor], defaultConfiguration)
-    XCTAssertEqual(configurations.getConfiguration(forMethod: firstDescriptor), overrideConfiguration)
-    XCTAssertEqual(configurations.getConfiguration(forMethod: secondDescriptor), defaultConfiguration)
+    XCTAssertEqual(
+      configurations.getConfiguration(forMethod: firstDescriptor),
+      overrideConfiguration
+    )
+    XCTAssertEqual(
+      configurations.getConfiguration(forMethod: secondDescriptor),
+      defaultConfiguration
+    )
   }
 }

--- a/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTestSupport/ClientRPCExecutorTestHarness+Transport.swift
+++ b/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTestSupport/ClientRPCExecutorTestHarness+Transport.swift
@@ -17,148 +17,17 @@ import Atomics
 
 @testable import GRPCCore
 
-// TODO: replace with real in-process transport
-
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-final class TestingClientTransport: ClientTransport, Sendable {
-  typealias Inbound = RPCAsyncSequence<RPCResponsePart>
-  typealias Outbound = RPCWriter<RPCRequestPart>.Closable
-
-  let retryThrottle: RetryThrottle
-
-  private let state: LockedValueBox<State>
-  private enum State {
-    case unconnected(TestingServerTransport)
-    case connected(TestingServerTransport)
-    case closed
-  }
-
-  fileprivate init(server: TestingServerTransport, throttle: RetryThrottle) {
-    self.state = LockedValueBox(.unconnected(server))
-    self.retryThrottle = throttle
-  }
-
-  deinit {
-    self.state.withLockedValue { state in
-      switch state {
-      case .unconnected(let server), .connected(let server):
-        server.stopListening()
-      case .closed:
-        ()
-      }
-    }
-  }
-
-  func connect(lazily: Bool) async throws {
-    try self.state.withLockedValue { state in
-      switch state {
-      case let .unconnected(server):
-        state = .connected(server)
-
-      case .connected:
-        ()
-
-      case .closed:
-        throw RPCError(
-          code: .failedPrecondition,
-          message: "Can't connect to server, transport is closed."
-        )
-      }
-    }
-  }
-
-  func close() {
-    self.state.withLockedValue { state in
-      switch state {
-      case .unconnected(let server), .connected(let server):
-        state = .closed
-        server.stopListening()
-
-      case .closed:
-        ()
-      }
-    }
-  }
-
-  func executionConfiguration(
-    forMethod descriptor: MethodDescriptor
-  ) -> ClientRPCExecutionConfiguration? {
-    nil
-  }
-
-  func openStream(
-    descriptor: MethodDescriptor
-  ) async throws -> RPCStream<Inbound, Outbound> {
-    let request = RPCAsyncSequence<RPCRequestPart>.makeBackpressuredStream(watermarks: (16, 32))
-    let response = RPCAsyncSequence<RPCResponsePart>.makeBackpressuredStream(watermarks: (16, 32))
-
-    let clientStream = RPCStream(
-      descriptor: descriptor,
-      inbound: response.stream,
-      outbound: request.writer
-    )
-
-    let serverStream = RPCStream(
-      descriptor: descriptor,
-      inbound: request.stream,
-      outbound: response.writer
-    )
-
-    let error: RPCError? = self.state.withLockedValue { state in
-      switch state {
-      case .connected(let transport):
-        transport.acceptStream(serverStream)
-        return nil
-
-      case .unconnected:
-        return RPCError(
-          code: .failedPrecondition,
-          message: "The client transport must be connected before streams can be created."
-        )
-
-      case .closed:
-        return RPCError(code: .failedPrecondition, message: "The client transport is closed.")
-      }
-    }
-
-    if let error = error {
-      serverStream.outbound.finish()
-      clientStream.outbound.finish()
-      throw error
-    } else {
-      return clientStream
-    }
-  }
-}
-
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-final class TestingServerTransport: ServerTransport, Sendable {
-  typealias Inbound = RPCAsyncSequence<RPCRequestPart>
-  typealias Outbound = RPCWriter<RPCResponsePart>.Closable
-
-  typealias Stream = RPCStream<Inbound, Outbound>
-  private let accepted:
-    (stream: AsyncStream<Stream>, continuation: AsyncStream<Stream>.Continuation)
-
-  init() {
-    self.accepted = AsyncStream.makeStream()
-  }
-
-  fileprivate func acceptStream(_ stream: RPCStream<Inbound, Outbound>) {
-    self.accepted.continuation.yield(stream)
-  }
-
-  func listen() async throws -> RPCAsyncSequence<RPCStream<Inbound, Outbound>> {
-    return RPCAsyncSequence(wrapping: self.accepted.stream)
-  }
-
-  func stopListening() {
-    self.accepted.continuation.finish()
-  }
-
+internal extension InProcessServerTransport {
   func spawnClientTransport(
     throttle: RetryThrottle = RetryThrottle(maximumTokens: 10, tokenRatio: 0.1)
-  ) -> TestingClientTransport {
-    return TestingClientTransport(server: self, throttle: throttle)
+  ) -> InProcessClientTransport {
+    return InProcessClientTransport(
+      server: self,
+      executionConfigurations: .init(defaultConfiguration: .init(hedgingPolicy: .init(
+        maximumAttempts: 2,
+        hedgingDelay: .milliseconds(100),
+        nonFatalStatusCodes: []
+      )))
+    )
   }
 }

--- a/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTestSupport/ClientRPCExecutorTestHarness+Transport.swift
+++ b/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTestSupport/ClientRPCExecutorTestHarness+Transport.swift
@@ -17,17 +17,21 @@ import Atomics
 
 @testable import GRPCCore
 
-internal extension InProcessServerTransport {
+extension InProcessServerTransport {
   func spawnClientTransport(
     throttle: RetryThrottle = RetryThrottle(maximumTokens: 10, tokenRatio: 0.1)
   ) -> InProcessClientTransport {
     return InProcessClientTransport(
       server: self,
-      executionConfigurations: .init(defaultConfiguration: .init(hedgingPolicy: .init(
-        maximumAttempts: 2,
-        hedgingDelay: .milliseconds(100),
-        nonFatalStatusCodes: []
-      )))
+      executionConfigurations: .init(
+        defaultConfiguration: .init(
+          hedgingPolicy: .init(
+            maximumAttempts: 2,
+            hedgingDelay: .milliseconds(100),
+            nonFatalStatusCodes: []
+          )
+        )
+      )
     )
   }
 }

--- a/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTestSupport/ClientRPCExecutorTestHarness.swift
+++ b/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTestSupport/ClientRPCExecutorTestHarness.swift
@@ -47,13 +47,13 @@ struct ClientRPCExecutorTestHarness {
 
     switch transport {
     case .inProcess:
-      let server = TestingServerTransport()
+      let server = InProcessServerTransport()
       let client = server.spawnClientTransport()
       self.serverTransport = StreamCountingServerTransport(wrapping: server)
       self.clientTransport = StreamCountingClientTransport(wrapping: client)
 
     case .throwsOnStreamCreation(let code):
-      let server = TestingServerTransport()  // Will never be called.
+      let server = InProcessServerTransport()  // Will never be called.
       let client = ThrowOnStreamCreationTransport(code: code)
       self.serverTransport = StreamCountingServerTransport(wrapping: server)
       self.clientTransport = StreamCountingClientTransport(wrapping: client)

--- a/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTestSupport/ClientRPCExecutorTestHarness.swift
+++ b/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTestSupport/ClientRPCExecutorTestHarness.swift
@@ -137,7 +137,9 @@ struct ClientRPCExecutorTestHarness {
         }
       }
 
-      try await self.clientTransport.connect(lazily: false)
+      group.addTask {
+        try await self.clientTransport.connect(lazily: false)
+      }
 
       let executionConfiguration: ClientRPCExecutionConfiguration
       if let configuration = configuration {

--- a/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests.swift
+++ b/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests.swift
@@ -149,10 +149,12 @@ final class ClientRPCExecutorTests: XCTestCase {
       transport: .throwsOnStreamCreation(code: .aborted),
       server: .failTest
     )
-      
-    await XCTAssertThrowsRPCErrorAsync({ try await tester.unary(
-      request: ClientRequest.Single(message: [1, 2, 3], metadata: ["foo": "bar"])
-    ) { _ in } }) {
+
+    await XCTAssertThrowsRPCErrorAsync({
+      try await tester.unary(
+        request: ClientRequest.Single(message: [1, 2, 3], metadata: ["foo": "bar"])
+      ) { _ in }
+    }) {
       XCTAssertEqual($0.code, .aborted)
     }
 
@@ -167,11 +169,13 @@ final class ClientRPCExecutorTests: XCTestCase {
       server: .failTest
     )
 
-    await XCTAssertThrowsRPCErrorAsync({ try await tester.clientStreaming(
-      request: ClientRequest.Stream(metadata: ["foo": "bar"]) {
-        try await $0.write([1, 2, 3])
-      }
-    ) { _ in } }) {
+    await XCTAssertThrowsRPCErrorAsync({
+      try await tester.clientStreaming(
+        request: ClientRequest.Stream(metadata: ["foo": "bar"]) {
+          try await $0.write([1, 2, 3])
+        }
+      ) { _ in }
+    }) {
       XCTAssertEqual($0.code, .aborted)
     }
 
@@ -185,7 +189,7 @@ final class ClientRPCExecutorTests: XCTestCase {
       transport: .throwsOnStreamCreation(code: .aborted),
       server: .failTest
     )
-    
+
     await XCTAssertThrowsRPCErrorAsync {
       try await tester.serverStreaming(
         request: ClientRequest.Single(message: [1, 2, 3], metadata: ["foo": "bar"])

--- a/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests.swift
+++ b/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests.swift
@@ -149,13 +149,13 @@ final class ClientRPCExecutorTests: XCTestCase {
       transport: .throwsOnStreamCreation(code: .aborted),
       server: .failTest
     )
-
-    await XCTAssertThrowsRPCErrorAsync({
+      
+    await XCTAssertThrowsRPCErrorAsync {
       try await tester.unary(
         request: ClientRequest.Single(message: [1, 2, 3], metadata: ["foo": "bar"])
       ) { _ in }
-    }) {
-      XCTAssertEqual($0.code, .aborted)
+    } errorHandler: { error in
+      XCTAssertEqual(error.code, .aborted)
     }
 
     XCTAssertEqual(tester.clientStreamsOpened, 0)
@@ -169,14 +169,14 @@ final class ClientRPCExecutorTests: XCTestCase {
       server: .failTest
     )
 
-    await XCTAssertThrowsRPCErrorAsync({
+    await XCTAssertThrowsRPCErrorAsync {
       try await tester.clientStreaming(
         request: ClientRequest.Stream(metadata: ["foo": "bar"]) {
           try await $0.write([1, 2, 3])
         }
       ) { _ in }
-    }) {
-      XCTAssertEqual($0.code, .aborted)
+    } errorHandler: { error in
+      XCTAssertEqual(error.code, .aborted)
     }
 
     XCTAssertEqual(tester.clientStreamsOpened, 0)

--- a/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests.swift
+++ b/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests.swift
@@ -149,13 +149,11 @@ final class ClientRPCExecutorTests: XCTestCase {
       transport: .throwsOnStreamCreation(code: .aborted),
       server: .failTest
     )
-
-    try await tester.unary(
+      
+    await XCTAssertThrowsRPCErrorAsync({ try await tester.unary(
       request: ClientRequest.Single(message: [1, 2, 3], metadata: ["foo": "bar"])
-    ) { response in
-      XCTAssertThrowsRPCError(try response.message) {
-        XCTAssertEqual($0.code, .aborted)
-      }
+    ) { _ in } }) {
+      XCTAssertEqual($0.code, .aborted)
     }
 
     XCTAssertEqual(tester.clientStreamsOpened, 0)
@@ -169,14 +167,12 @@ final class ClientRPCExecutorTests: XCTestCase {
       server: .failTest
     )
 
-    try await tester.clientStreaming(
+    await XCTAssertThrowsRPCErrorAsync({ try await tester.clientStreaming(
       request: ClientRequest.Stream(metadata: ["foo": "bar"]) {
         try await $0.write([1, 2, 3])
       }
-    ) { response in
-      XCTAssertThrowsRPCError(try response.message) {
-        XCTAssertEqual($0.code, .aborted)
-      }
+    ) { _ in } }) {
+      XCTAssertEqual($0.code, .aborted)
     }
 
     XCTAssertEqual(tester.clientStreamsOpened, 0)
@@ -189,15 +185,13 @@ final class ClientRPCExecutorTests: XCTestCase {
       transport: .throwsOnStreamCreation(code: .aborted),
       server: .failTest
     )
-
-    try await tester.serverStreaming(
-      request: ClientRequest.Single(message: [1, 2, 3], metadata: ["foo": "bar"])
-    ) { response in
-      await XCTAssertThrowsRPCErrorAsync {
-        try await response.messages.collect()
-      } errorHandler: {
-        XCTAssertEqual($0.code, .aborted)
-      }
+    
+    await XCTAssertThrowsRPCErrorAsync {
+      try await tester.serverStreaming(
+        request: ClientRequest.Single(message: [1, 2, 3], metadata: ["foo": "bar"])
+      ) { _ in }
+    } errorHandler: {
+      XCTAssertEqual($0.code, .aborted)
     }
 
     XCTAssertEqual(tester.clientStreamsOpened, 0)
@@ -211,16 +205,14 @@ final class ClientRPCExecutorTests: XCTestCase {
       server: .failTest
     )
 
-    try await tester.bidirectional(
-      request: ClientRequest.Stream(metadata: ["foo": "bar"]) {
-        try await $0.write([1, 2, 3])
-      }
-    ) { response in
-      await XCTAssertThrowsRPCErrorAsync {
-        try await response.messages.collect()
-      } errorHandler: {
-        XCTAssertEqual($0.code, .aborted)
-      }
+    await XCTAssertThrowsRPCErrorAsync {
+      try await tester.bidirectional(
+        request: ClientRequest.Stream(metadata: ["foo": "bar"]) {
+          try await $0.write([1, 2, 3])
+        }
+      ) { _ in }
+    } errorHandler: {
+      XCTAssertEqual($0.code, .aborted)
     }
 
     XCTAssertEqual(tester.clientStreamsOpened, 0)

--- a/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests.swift
+++ b/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests.swift
@@ -149,7 +149,7 @@ final class ClientRPCExecutorTests: XCTestCase {
       transport: .throwsOnStreamCreation(code: .aborted),
       server: .failTest
     )
-      
+
     await XCTAssertThrowsRPCErrorAsync {
       try await tester.unary(
         request: ClientRequest.Single(message: [1, 2, 3], metadata: ["foo": "bar"])

--- a/Tests/GRPCCoreTests/Test Utilities/Transport/AnyTransport.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/Transport/AnyTransport.swift
@@ -21,12 +21,15 @@ struct AnyClientTransport: ClientTransport, Sendable {
   typealias Outbound = RPCWriter<RPCRequestPart>.Closable
 
   private let _retryThrottle: @Sendable () -> RetryThrottle
-  private let _withStream: @Sendable (MethodDescriptor, (RPCStream<Inbound, Outbound>) async throws -> Any) async throws -> Any
+  private let _withStream:
+    @Sendable (MethodDescriptor, (RPCStream<Inbound, Outbound>) async throws -> Any) async throws ->
+      Any
   private let _connect: @Sendable (Bool) async throws -> Void
   private let _close: @Sendable () -> Void
   private let _configuration: @Sendable (MethodDescriptor) -> ClientRPCExecutionConfiguration?
 
-  init<Transport: ClientTransport>(wrapping transport: Transport) where Transport.Inbound == Inbound, Transport.Outbound == Outbound {
+  init<Transport: ClientTransport>(wrapping transport: Transport)
+  where Transport.Inbound == Inbound, Transport.Outbound == Outbound {
     self._retryThrottle = { transport.retryThrottle }
     self._withStream = { descriptor, closure in
       try await transport.withStream(descriptor: descriptor) { stream in

--- a/Tests/GRPCCoreTests/Test Utilities/Transport/AnyTransport.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/Transport/AnyTransport.swift
@@ -21,10 +21,11 @@ struct AnyClientTransport: ClientTransport, Sendable {
   typealias Outbound = RPCWriter<RPCRequestPart>.Closable
 
   private let _retryThrottle: @Sendable () -> RetryThrottle
-  private let _withStream: @Sendable (
-    _ method: MethodDescriptor,
-    _ body: (RPCStream<Inbound, Outbound>) async throws -> Any
-  ) async throws -> Any
+  private let _withStream:
+    @Sendable (
+      _ method: MethodDescriptor,
+      _ body: (RPCStream<Inbound, Outbound>) async throws -> Any
+    ) async throws -> Any
   private let _connect: @Sendable (Bool) async throws -> Void
   private let _close: @Sendable () -> Void
   private let _configuration: @Sendable (MethodDescriptor) -> ClientRPCExecutionConfiguration?

--- a/Tests/GRPCCoreTests/Test Utilities/Transport/AnyTransport.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/Transport/AnyTransport.swift
@@ -21,20 +21,17 @@ struct AnyClientTransport: ClientTransport, Sendable {
   typealias Outbound = RPCWriter<RPCRequestPart>.Closable
 
   private let _retryThrottle: @Sendable () -> RetryThrottle
-  private let _openStream: @Sendable (MethodDescriptor) async throws -> RPCStream<Inbound, Outbound>
+  private let _withStream: @Sendable (MethodDescriptor, (RPCStream<Inbound, Outbound>) async throws -> Any) async throws -> Any
   private let _connect: @Sendable (Bool) async throws -> Void
   private let _close: @Sendable () -> Void
   private let _configuration: @Sendable (MethodDescriptor) -> ClientRPCExecutionConfiguration?
 
-  init<Transport: ClientTransport>(wrapping transport: Transport) {
+  init<Transport: ClientTransport>(wrapping transport: Transport) where Transport.Inbound == Inbound, Transport.Outbound == Outbound {
     self._retryThrottle = { transport.retryThrottle }
-    self._openStream = { descriptor in
-      let stream = try await transport.openStream(descriptor: descriptor)
-      return RPCStream(
-        descriptor: stream.descriptor,
-        inbound: RPCAsyncSequence(wrapping: stream.inbound),
-        outbound: RPCWriter.Closable(wrapping: stream.outbound)
-      )
+    self._withStream = { descriptor, closure in
+      try await transport.withStream(descriptor: descriptor) { stream in
+        try await closure(stream) as Any
+      }
     }
 
     self._connect = { lazily in
@@ -62,10 +59,12 @@ struct AnyClientTransport: ClientTransport, Sendable {
     self._close()
   }
 
-  func openStream(
-    descriptor: MethodDescriptor
-  ) async throws -> RPCStream<Inbound, Outbound> {
-    try await self._openStream(descriptor)
+  func withStream<T>(
+    descriptor: MethodDescriptor,
+    _ closure: (RPCStream<Inbound, Outbound>) async throws -> T
+  ) async throws -> T {
+    let result = try await self._withStream(descriptor, closure)
+    return result as! T
   }
 
   func executionConfiguration(

--- a/Tests/GRPCCoreTests/Test Utilities/Transport/AnyTransport.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/Transport/AnyTransport.swift
@@ -21,9 +21,10 @@ struct AnyClientTransport: ClientTransport, Sendable {
   typealias Outbound = RPCWriter<RPCRequestPart>.Closable
 
   private let _retryThrottle: @Sendable () -> RetryThrottle
-  private let _withStream:
-    @Sendable (MethodDescriptor, (RPCStream<Inbound, Outbound>) async throws -> Any) async throws ->
-      Any
+  private let _withStream: @Sendable (
+    _ method: MethodDescriptor,
+    _ body: (RPCStream<Inbound, Outbound>) async throws -> Any
+  ) async throws -> Any
   private let _connect: @Sendable (Bool) async throws -> Void
   private let _close: @Sendable () -> Void
   private let _configuration: @Sendable (MethodDescriptor) -> ClientRPCExecutionConfiguration?

--- a/Tests/GRPCCoreTests/Test Utilities/Transport/StreamCountingTransport.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/Transport/StreamCountingTransport.swift
@@ -34,7 +34,7 @@ struct StreamCountingClientTransport: ClientTransport, Sendable {
     self._streamFailures.load(ordering: .sequentiallyConsistent)
   }
 
-  init<Transport: ClientTransport>(wrapping transport: Transport) {
+  init<Transport: ClientTransport>(wrapping transport: Transport) where Transport.Inbound == Inbound, Transport.Outbound == Outbound {
     self.transport = AnyClientTransport(wrapping: transport)
   }
 
@@ -50,13 +50,15 @@ struct StreamCountingClientTransport: ClientTransport, Sendable {
     self.transport.close()
   }
 
-  func openStream(
-    descriptor: MethodDescriptor
-  ) async throws -> RPCStream<Inbound, Outbound> {
+  func withStream<T>(
+    descriptor: MethodDescriptor,
+    _ closure: (RPCStream<Inbound, Outbound>) async throws -> T
+  ) async throws -> T {
     do {
-      let stream = try await self.transport.openStream(descriptor: descriptor)
-      self._streamsOpened.wrappingIncrement(ordering: .sequentiallyConsistent)
-      return stream
+      return try await self.transport.withStream(descriptor: descriptor) { stream in
+        self._streamsOpened.wrappingIncrement(ordering: .sequentiallyConsistent)
+        return try await closure(stream)
+      }
     } catch {
       self._streamFailures.wrappingIncrement(ordering: .sequentiallyConsistent)
       throw error

--- a/Tests/GRPCCoreTests/Test Utilities/Transport/StreamCountingTransport.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/Transport/StreamCountingTransport.swift
@@ -34,7 +34,8 @@ struct StreamCountingClientTransport: ClientTransport, Sendable {
     self._streamFailures.load(ordering: .sequentiallyConsistent)
   }
 
-  init<Transport: ClientTransport>(wrapping transport: Transport) where Transport.Inbound == Inbound, Transport.Outbound == Outbound {
+  init<Transport: ClientTransport>(wrapping transport: Transport)
+  where Transport.Inbound == Inbound, Transport.Outbound == Outbound {
     self.transport = AnyClientTransport(wrapping: transport)
   }
 

--- a/Tests/GRPCCoreTests/Test Utilities/Transport/ThrowingTransport.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/Transport/ThrowingTransport.swift
@@ -41,10 +41,11 @@ struct ThrowOnStreamCreationTransport: ClientTransport {
   ) -> ClientRPCExecutionConfiguration? {
     return nil
   }
-
-  func openStream(
-    descriptor: MethodDescriptor
-  ) async throws -> RPCStream<Inbound, Outbound> {
+  
+  func withStream<T>(
+    descriptor: MethodDescriptor,
+    _ closure: (RPCStream<Inbound, Outbound>) async throws -> T
+  ) async throws -> T {
     throw RPCError(code: self.code, message: "")
   }
 }

--- a/Tests/GRPCCoreTests/Test Utilities/Transport/ThrowingTransport.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/Transport/ThrowingTransport.swift
@@ -41,7 +41,7 @@ struct ThrowOnStreamCreationTransport: ClientTransport {
   ) -> ClientRPCExecutionConfiguration? {
     return nil
   }
-  
+
   func withStream<T>(
     descriptor: MethodDescriptor,
     _ closure: (RPCStream<Inbound, Outbound>) async throws -> T

--- a/Tests/GRPCCoreTests/Transport/InProcessClientTransportTest.swift
+++ b/Tests/GRPCCoreTests/Transport/InProcessClientTransportTest.swift
@@ -1,0 +1,305 @@
+/*
+ * Copyright 2023, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+
+@testable import GRPCCore
+
+final class InProcessClientTransportTest: XCTestCase {
+  func testConnectWhenConnected() async throws {
+    let retryPolicy = RetryPolicy(
+      maximumAttempts: 10,
+      initialBackoff: .seconds(1),
+      maximumBackoff: .seconds(1),
+      backoffMultiplier: 1.0,
+      retryableStatusCodes: [.unavailable]
+    )
+    let client = InProcessClientTransport(
+      server: .init(),
+      executionConfigurations: .init(defaultConfiguration: .init(retryPolicy: retryPolicy))
+    )
+    
+    try await withThrowingTaskGroup(of: Void.self) { group in
+      group.addTask {
+        try await client.connect(lazily: false)
+      }
+      group.addTask {
+        try await client.connect(lazily: false)
+      }
+      
+      try await group.next()
+      await XCTAssertThrowsRPCErrorAsync({ try await group.next() }) { error in
+        XCTAssertEqual(error.code, .failedPrecondition)
+      }
+      group.cancelAll()
+    }
+  }
+  
+  func testConnectWhenClosed() async {
+    let retryPolicy = RetryPolicy(
+      maximumAttempts: 10,
+      initialBackoff: .seconds(1),
+      maximumBackoff: .seconds(1),
+      backoffMultiplier: 1.0,
+      retryableStatusCodes: [.unavailable]
+    )
+    let client = InProcessClientTransport(
+      server: .init(),
+      executionConfigurations: .init(defaultConfiguration: .init(retryPolicy: retryPolicy))
+    )
+    
+    client.close()
+    
+    await XCTAssertThrowsRPCErrorAsync({ try await client.connect(lazily: false) }) { error in
+      XCTAssertEqual(error.code, .failedPrecondition)
+    }
+  }
+  
+  func testConnectWhenClosedAfterCancellation() async throws {
+    let retryPolicy = RetryPolicy(
+      maximumAttempts: 10,
+      initialBackoff: .seconds(1),
+      maximumBackoff: .seconds(1),
+      backoffMultiplier: 1.0,
+      retryableStatusCodes: [.unavailable]
+    )
+    let client = InProcessClientTransport(
+      server: .init(),
+      executionConfigurations: .init(defaultConfiguration: .init(retryPolicy: retryPolicy))
+    )
+    
+    try await withThrowingTaskGroup(of: Void.self) { group in
+      group.addTask {
+        try await client.connect(lazily: false)
+      }
+      group.addTask {
+        try await Task.sleep(for: .milliseconds(100))
+      }
+      
+      try await group.next()
+      group.cancelAll()
+      
+      await XCTAssertThrowsRPCErrorAsync({ try await client.connect(lazily: false) }) { error in
+        XCTAssertEqual(error.code, .failedPrecondition)
+      }
+    }
+  }
+  
+  func testCloseWhenUnconnected() {
+    let retryPolicy = RetryPolicy(
+      maximumAttempts: 10,
+      initialBackoff: .seconds(1),
+      maximumBackoff: .seconds(1),
+      backoffMultiplier: 1.0,
+      retryableStatusCodes: [.unavailable]
+    )
+    let client = InProcessClientTransport(
+      server: .init(),
+      executionConfigurations: .init(defaultConfiguration: .init(retryPolicy: retryPolicy))
+    )
+    
+    XCTAssertNoThrow(client.close())
+  }
+  
+  func testCloseWhenClosed() {
+    func testCloseWhenUnconnected() {
+      let retryPolicy = RetryPolicy(
+        maximumAttempts: 10,
+        initialBackoff: .seconds(1),
+        maximumBackoff: .seconds(1),
+        backoffMultiplier: 1.0,
+        retryableStatusCodes: [.unavailable]
+      )
+      let client = InProcessClientTransport(
+        server: .init(),
+        executionConfigurations: .init(defaultConfiguration: .init(retryPolicy: retryPolicy))
+      )
+      
+      client.close()
+      XCTAssertNoThrow(client.close())
+    }
+  }
+  
+  func testConnectSuccessfullyAndThenClose() async throws {
+    let retryPolicy = RetryPolicy(
+      maximumAttempts: 10,
+      initialBackoff: .seconds(1),
+      maximumBackoff: .seconds(1),
+      backoffMultiplier: 1.0,
+      retryableStatusCodes: [.unavailable]
+    )
+    let client = InProcessClientTransport(
+      server: .init(),
+      executionConfigurations: .init(defaultConfiguration: .init(retryPolicy: retryPolicy))
+    )
+    
+    try await withThrowingTaskGroup(of: Void.self) { group in
+      group.addTask {
+        try await client.connect(lazily: false)
+      }
+      group.addTask {
+        try await Task.sleep(for: .milliseconds(100))
+      }
+      
+      try await group.next()
+      client.close()
+    }
+  }
+  
+  func testOpenStreamWhenUnconnected() async {
+    let retryPolicy = RetryPolicy(
+      maximumAttempts: 10,
+      initialBackoff: .seconds(1),
+      maximumBackoff: .seconds(1),
+      backoffMultiplier: 1.0,
+      retryableStatusCodes: [.unavailable]
+    )
+    let client = InProcessClientTransport(
+      server: .init(),
+      executionConfigurations: .init(defaultConfiguration: .init(retryPolicy: retryPolicy))
+    )
+    
+    
+    
+    await XCTAssertThrowsRPCErrorAsync({ try await client.withStream(descriptor: .init(service: "test", method: "test")) { _ in } }) { error in
+      XCTAssertEqual(error.code, .failedPrecondition)
+    }
+  }
+  
+  func testOpenStreamWhenClosed() async {
+    let retryPolicy = RetryPolicy(
+      maximumAttempts: 10,
+      initialBackoff: .seconds(1),
+      maximumBackoff: .seconds(1),
+      backoffMultiplier: 1.0,
+      retryableStatusCodes: [.unavailable]
+    )
+    let client = InProcessClientTransport(
+      server: .init(),
+      executionConfigurations: .init(defaultConfiguration: .init(retryPolicy: retryPolicy))
+    )
+    
+    client.close()
+    
+    await XCTAssertThrowsRPCErrorAsync({ try await client.withStream(descriptor: .init(service: "test", method: "test")) { _ in } }) { error in
+      XCTAssertEqual(error.code, .failedPrecondition)
+    }
+  }
+  
+  func testOpenStreamSuccessfullyAndThenClose() async throws {
+    let retryPolicy = RetryPolicy(
+      maximumAttempts: 10,
+      initialBackoff: .seconds(1),
+      maximumBackoff: .seconds(1),
+      backoffMultiplier: 1.0,
+      retryableStatusCodes: [.unavailable]
+    )
+    let server = InProcessServerTransport()
+    let client = InProcessClientTransport(
+      server: server,
+      executionConfigurations: .init(defaultConfiguration: .init(retryPolicy: retryPolicy))
+    )
+    
+    let receivedMessages = LockedValueBox([[UInt8]]())
+    
+    try await client.connect(lazily: false)
+    
+    try await withThrowingTaskGroup(of: Void.self) { group in
+      group.addTask {
+        try await client.withStream(descriptor: .init(service: "test", method: "test")) { stream in
+          try await stream.outbound.write(.message([1]))
+          for try await response in stream.inbound {
+            guard case .message(let message) = response else {
+              XCTFail()
+              fatalError()
+            }
+            receivedMessages.withLockedValue({ $0.append(message) })
+          }
+        }
+      }
+      
+      group.addTask {
+        for try await stream in server.listen() {
+          try await stream.outbound.write(contentsOf: stream.inbound.map({ requestPart in
+            guard case .message(let message) = requestPart else {
+              XCTFail()
+              fatalError()
+            }
+            receivedMessages.withLockedValue({ $0.append(message) })
+            return RPCResponsePart.message([42])
+          }))
+        }
+      }
+      
+      group.addTask {
+        try await Task.sleep(for: .milliseconds(100))
+        client.close()
+        await XCTAssertThrowsRPCErrorAsync {
+          try await client.withStream(descriptor: .init(service: "test", method: "test")) { _ in }
+        } errorHandler: { error in
+          XCTAssertEqual(error.code, .failedPrecondition)
+          XCTAssertEqual(error.message, "The client transport is closed.")
+        }
+
+      }
+      
+      try await group.next()
+      let finalReceivedMessages = receivedMessages.withLockedValue { $0 }
+      XCTAssertEqual(finalReceivedMessages, [[1], [42]])
+      group.cancelAll()
+    }
+    
+    await XCTAssertThrowsRPCErrorAsync {
+      try await client.connect(lazily: false)
+    } errorHandler: { error in
+      XCTAssertEqual(error.code, .failedPrecondition)
+      XCTAssertEqual(error.message, "Can't connect to server, transport is closed.")
+    }
+
+  }
+  
+  func testExecutionConfiguration() {
+    let policy = HedgingPolicy(
+      maximumAttempts: 10,
+      hedgingDelay: .seconds(1),
+      nonFatalStatusCodes: []
+    )
+    let defaultConfiguration = ClientRPCExecutionConfiguration(hedgingPolicy: policy)
+    var configurations = ClientRPCExecutionConfigurationCollection(defaultConfiguration: defaultConfiguration)
+    
+    var client = InProcessClientTransport(server: .init(), executionConfigurations: configurations)
+    
+    let firstDescriptor = MethodDescriptor(service: "test", method: "first")
+    XCTAssertEqual(client.executionConfiguration(forMethod: firstDescriptor), defaultConfiguration)
+    
+    let retryPolicy = RetryPolicy(
+      maximumAttempts: 10,
+      initialBackoff: .seconds(1),
+      maximumBackoff: .seconds(1),
+      backoffMultiplier: 1.0,
+      retryableStatusCodes: [.unavailable]
+    )
+    let overrideConfiguration = ClientRPCExecutionConfiguration(retryPolicy: retryPolicy)
+    configurations.addConfiguration(
+      overrideConfiguration,
+      forMethod: firstDescriptor
+    )
+    client = InProcessClientTransport(server: .init(), executionConfigurations: configurations)
+    let secondDescriptor = MethodDescriptor(service: "test", method: "second")
+    XCTAssertEqual(client.executionConfiguration(forMethod: firstDescriptor), overrideConfiguration)
+    XCTAssertEqual(client.executionConfiguration(forMethod: secondDescriptor), defaultConfiguration)
+  }
+}

--- a/Tests/GRPCCoreTests/Transport/InProcessClientTransportTests.swift
+++ b/Tests/GRPCCoreTests/Transport/InProcessClientTransportTests.swift
@@ -20,7 +20,7 @@ import XCTest
 
 final class InProcessClientTransportTests: XCTestCase {
   struct FailTest: Error {}
-  
+
   func testConnectWhenConnected() async {
     let client = makeClient()
 
@@ -78,14 +78,14 @@ final class InProcessClientTransportTests: XCTestCase {
 
   func testCloseWhenUnconnected() {
     let client = makeClient()
-    
+
     XCTAssertNoThrow(client.close())
   }
 
   func testCloseWhenClosed() {
     let client = makeClient()
     client.close()
-    
+
     XCTAssertNoThrow(client.close())
   }
 
@@ -155,7 +155,7 @@ final class InProcessClientTransportTests: XCTestCase {
           try await stream.outbound.write(.message([1]))
           stream.outbound.finish()
           let receivedMessages = try await stream.inbound.collect()
-          
+
           XCTAssertEqual(receivedMessages, [.message([42])])
         }
       }
@@ -210,7 +210,7 @@ final class InProcessClientTransportTests: XCTestCase {
     XCTAssertEqual(client.executionConfiguration(forMethod: firstDescriptor), overrideConfiguration)
     XCTAssertEqual(client.executionConfiguration(forMethod: secondDescriptor), defaultConfiguration)
   }
-  
+
   func makeClient(
     configuration: ClientRPCExecutionConfiguration? = nil,
     server: InProcessServerTransport = InProcessServerTransport()
@@ -222,10 +222,12 @@ final class InProcessClientTransportTests: XCTestCase {
       backoffMultiplier: 1.0,
       retryableStatusCodes: [.unavailable]
     )
-    
+
     return InProcessClientTransport(
       server: server,
-      executionConfigurations: .init(defaultConfiguration: configuration ?? .init(retryPolicy: defaultPolicy))
+      executionConfigurations: .init(
+        defaultConfiguration: configuration ?? .init(retryPolicy: defaultPolicy)
+      )
     )
   }
 }

--- a/Tests/GRPCCoreTests/Transport/InProcessClientTransportTests.swift
+++ b/Tests/GRPCCoreTests/Transport/InProcessClientTransportTests.swift
@@ -210,7 +210,7 @@ final class InProcessClientTransportTests: XCTestCase {
     XCTAssertEqual(client.executionConfiguration(forMethod: firstDescriptor), overrideConfiguration)
     XCTAssertEqual(client.executionConfiguration(forMethod: secondDescriptor), defaultConfiguration)
   }
-  
+
   func testOpenMultipleStreamsThenClose() async throws {
     let server = InProcessServerTransport()
     let client = makeClient(server: server)
@@ -225,7 +225,7 @@ final class InProcessClientTransportTests: XCTestCase {
           try await Task.sleep(for: .milliseconds(100))
         }
       }
-      
+
       group.addTask {
         try await client.withStream(descriptor: .init(service: "test", method: "test")) { stream in
           try await Task.sleep(for: .milliseconds(100))

--- a/Tests/GRPCCoreTests/Transport/InProcessClientTransportTests.swift
+++ b/Tests/GRPCCoreTests/Transport/InProcessClientTransportTests.swift
@@ -145,8 +145,6 @@ final class InProcessClientTransportTests: XCTestCase {
     let server = InProcessServerTransport()
     let client = makeClient(server: server)
 
-    let receivedMessages = LockedValueBox([[UInt8]]())
-
     try await withThrowingTaskGroup(of: Void.self) { group in
       group.addTask {
         try await client.connect(lazily: false)

--- a/Tests/GRPCCoreTests/Transport/InProcessClientTransportTests.swift
+++ b/Tests/GRPCCoreTests/Transport/InProcessClientTransportTests.swift
@@ -36,12 +36,14 @@ final class InProcessClientTransportTests: XCTestCase {
       group.addTask {
         try await client.connect(lazily: false)
       }
-      
+
       group.addTask {
         try await client.connect(lazily: false)
       }
 
-      await XCTAssertThrowsRPCErrorAsync({ try await group.next() }) { error in
+      await XCTAssertThrowsRPCErrorAsync {
+        try await group.next()
+      } errorHandler: { error in
         XCTAssertEqual(error.code, .failedPrecondition)
       }
       group.cancelAll()
@@ -63,7 +65,9 @@ final class InProcessClientTransportTests: XCTestCase {
 
     client.close()
 
-    await XCTAssertThrowsRPCErrorAsync({ try await client.connect(lazily: false) }) { error in
+    await XCTAssertThrowsRPCErrorAsync {
+      try await client.connect(lazily: false)
+    } errorHandler: { error in
       XCTAssertEqual(error.code, .failedPrecondition)
     }
   }
@@ -92,7 +96,9 @@ final class InProcessClientTransportTests: XCTestCase {
       try await group.next()
       group.cancelAll()
 
-      await XCTAssertThrowsRPCErrorAsync({ try await client.connect(lazily: false) }) { error in
+      await XCTAssertThrowsRPCErrorAsync {
+        try await client.connect(lazily: false)
+      } errorHandler: { error in
         XCTAssertEqual(error.code, .failedPrecondition)
       }
     }
@@ -171,7 +177,7 @@ final class InProcessClientTransportTests: XCTestCase {
       server: .init(),
       executionConfigurations: .init(defaultConfiguration: .init(retryPolicy: retryPolicy))
     )
-    
+
     try await withThrowingTaskGroup(of: Void.self) { group in
       group.addTask {
         try await client.withStream(descriptor: .init(service: "test", method: "test")) { _ in
@@ -181,14 +187,14 @@ final class InProcessClientTransportTests: XCTestCase {
           client.close()
         }
       }
-      
+
       group.addTask {
         // Add a sleep to make sure connection happens after `withStream` has been called,
         // to test pending streams are handled correctly.
         try await Task.sleep(for: .milliseconds(100))
         try await client.connect(lazily: false)
       }
-      
+
       try await group.waitForAll()
     }
   }
@@ -208,9 +214,9 @@ final class InProcessClientTransportTests: XCTestCase {
 
     client.close()
 
-    await XCTAssertThrowsRPCErrorAsync({
+    await XCTAssertThrowsRPCErrorAsync {
       try await client.withStream(descriptor: .init(service: "test", method: "test")) { _ in }
-    }) { error in
+    } errorHandler: { error in
       XCTAssertEqual(error.code, .failedPrecondition)
     }
   }

--- a/Tests/GRPCCoreTests/Transport/InProcessServerTransportTests.swift
+++ b/Tests/GRPCCoreTests/Transport/InProcessServerTransportTests.swift
@@ -18,7 +18,7 @@ import XCTest
 
 @testable import GRPCCore
 
-final class InProcessServerTransportTest: XCTestCase {
+final class InProcessServerTransportTests: XCTestCase {
   func testStartListening() async throws {
     let transport = InProcessServerTransport()
     let stream = RPCStream<RPCAsyncSequence<RPCRequestPart>, RPCWriter<RPCResponsePart>.Closable>(


### PR DESCRIPTION
## Motivation
We want to have a basic in-process transport implementation, to be used for example for testing purposes.

## Modification
- Added a new `InProcessClientTransport`.
- To allow for multiple configurations to be used for each method, a new `ClientRPCExecutionConfigurationCollection` was also added.
- Finally, `ClientTransport/openStream` was replaced by `ClientTransport/withStream`.

## Result
We now have an in-process implementation of `ClientTransport`.