### PR TITLE
Add missing available annotations to test code

### DIFF
--- a/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTestSupport/ClientRPCExecutorTestHarness+Transport.swift
+++ b/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTestSupport/ClientRPCExecutorTestHarness+Transport.swift
@@ -17,6 +17,7 @@ import Atomics
 
 @testable import GRPCCore
 
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension InProcessServerTransport {
   func spawnClientTransport(
     throttle: RetryThrottle = RetryThrottle(maximumTokens: 10, tokenRatio: 0.1)

--- a/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests+Hedging.swift
+++ b/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests+Hedging.swift
@@ -16,6 +16,7 @@
 import GRPCCore
 import XCTest
 
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension ClientRPCExecutorTests {
   func testHedgingWhenAllAttemptsResultInNonFatalCodes() async throws {
     let harness = ClientRPCExecutorTestHarness(
@@ -185,6 +186,7 @@ extension ClientRPCExecutorTests {
   }
 }
 
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension ClientRPCExecutionConfiguration {
   fileprivate static func hedge(
     maximumAttempts: Int = 5,

--- a/Tests/GRPCCoreTests/Transport/InProcessClientTransportTests.swift
+++ b/Tests/GRPCCoreTests/Transport/InProcessClientTransportTests.swift
@@ -18,6 +18,7 @@ import XCTest
 
 @testable import GRPCCore
 
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 final class InProcessClientTransportTests: XCTestCase {
   struct FailTest: Error {}
 


### PR DESCRIPTION
### Motivation

Tests couldn't build on macOS 12 and older because they are making use of code that is available only on macOS 13 or newer.

### Modifications

Add `@available` annotations to the test code.

### Result

Tests now build on macOS 12.

### Notes

Also depends on #1719.