### PR TITLE
Add SourceFile type for CodeGenLib

### DIFF
--- a/Sources/GRPCCodeGen/SourceFile.swift
+++ b/Sources/GRPCCodeGen/SourceFile.swift
@@ -16,17 +16,17 @@
 
 /// Representation of the file to be created by the code generator, that contains the
 /// generated Swift source code.
-public struct SourceFile: Sendable {
+public struct SourceFile: Sendable, Hashable {
   /// The base name of the file.
   public var name: String
 
   /// The generated code as a String.
-  public var sourceCode: String
+  public var contents: String
 
   /// Creates a representation of a file containing Swift code with the specified name
   /// and contents.
-  public init(name: String, sourceCode: String) {
+  public init(name: String, contents: String) {
     self.name = name
-    self.sourceCode = sourceCode
+    self.contents = contents
   }
 }

--- a/Sources/GRPCCodeGen/SourceFile.swift
+++ b/Sources/GRPCCodeGen/SourceFile.swift
@@ -20,12 +20,12 @@ public struct SourceFile: Sendable {
   /// The base name of the file.
   public var name: String
 
-  /// The generated code encoded as UTF-8 data.
-  public var sourceCode: Data
+  /// The generated code as a String.
+  public var sourceCode: String
 
   /// Creates a representation of a file containing Swift code with the specified name
-  /// and  contents.
-  public init(name: String, sourceCode: Data) {
+  /// and contents.
+  public init(name: String, sourceCode: String) {
     self.name = name
     self.sourceCode = sourceCode
   }

--- a/Sources/GRPCCodeGen/SourceFile.swift
+++ b/Sources/GRPCCodeGen/SourceFile.swift
@@ -1,8 +1,32 @@
-//
-//  File.swift
-//  
-//
-//  Created by Stefana Dranca on 27/11/2023.
-//
+/*
+ * Copyright 2023, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import Foundation
+/// Representation of the file to be created by the code generator, that contains the
+/// generated Swift source code.
+public struct SourceFile: Sendable {
+  /// The base name of the file.
+  public var name: String
+
+  /// The generated code encoded as UTF-8 data.
+  public var sourceCode: Data
+
+  /// Creates a representation of a file containing Swift code with the specified name
+  /// and  contents.
+  public init(name: String, sourceCode: Data) {
+    self.name = name
+    self.sourceCode = sourceCode
+  }
+}

--- a/Sources/GRPCCodeGen/SourceFile.swift
+++ b/Sources/GRPCCodeGen/SourceFile.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by Stefana Dranca on 27/11/2023.
+//
+
+import Foundation


### PR DESCRIPTION
Created the SorceFile struct that represents the file to be created by the code generator.

Motivation:

The CodeRenderer needs to create objects of some type representing the files containing the
generated code. This type is SourceFile.

Modifications:

Implemented the SourceFile struct, containing the base name and the generated code as strings.

Result:

The Code Renderer can now be brought from the OpenAPI generator, as it will have an output type.
The code generator will use objects of this type to create the files containing the generated Swift code.