### PR TITLE
Simplify client and server init

### DIFF
--- a/Sources/GRPCCore/ClientError.swift
+++ b/Sources/GRPCCore/ClientError.swift
@@ -109,7 +109,6 @@ extension ClientError {
   public struct Code: Hashable, Sendable {
     private enum Value {
       case clientIsAlreadyRunning
-      case clientIsNotRunning
       case clientIsStopped
       case transportError
     }
@@ -122,11 +121,6 @@ extension ClientError {
     /// At attempt to start the client was made but it is already running.
     public static var clientIsAlreadyRunning: Self {
       Self(.clientIsAlreadyRunning)
-    }
-
-    /// An attempt to start an RPC was made but the client is not running.
-    public static var clientIsNotRunning: Self {
-      Self(.clientIsNotRunning)
     }
 
     /// At attempt to start the client was made but it has already stopped.

--- a/Sources/GRPCCore/Transport/ServerTransport.swift
+++ b/Sources/GRPCCore/Transport/ServerTransport.swift
@@ -15,7 +15,7 @@
  */
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-public protocol ServerTransport {
+public protocol ServerTransport: Sendable {
   typealias Inbound = RPCAsyncSequence<RPCRequestPart>
   typealias Outbound = RPCWriter<RPCResponsePart>.Closable
 


### PR DESCRIPTION
Motivation:

When configuring a client and server must users will specify only the transport and services (for a server) and potentially interceptors too. This should be the "easy" path. Moreover these are all reference types so it makes sense to separate them from "raw" configuration.

Creating a client also diverged somewhat from the server. Having both follow a similar pattern simplifies things for users.

Modifications:

- Move interceptors from the client config to the init.
- Modify the server to follow a similar pattern to the server.

Results:

Server and client are configured similarly.