### PR TITLE
Add reflection service to .spi.yml

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,4 +1,4 @@
 version: 1
 builder:
   configs:
-    - documentation_targets: [GRPC, protoc-gen-grpc-swift]
+    - documentation_targets: [GRPC, GRPCReflectionService, protoc-gen-grpc-swift]


### PR DESCRIPTION
Motivation:

No docs are generated on Swift Package Index for the reflection service as it isn't included in the configuration.

Modifications:

Add reflection service to .spi.yml

Result:

Docs generate for the reflection service