### PR TITLE
Add benchmark thresholds for nightly

### DIFF
--- a/Performance/Benchmarks/Thresholds/main/GRPCSwiftBenchmark.Metadata_Add_binary.p90.json
+++ b/Performance/Benchmarks/Thresholds/main/GRPCSwiftBenchmark.Metadata_Add_binary.p90.json
@@ -1,0 +1,7 @@
+{
+  "mallocCountTotal" : 11,
+  "memoryLeaked" : 0,
+  "releaseCount" : 3012,
+  "retainCount" : 2000,
+  "syscalls" : 0
+}

--- a/Performance/Benchmarks/Thresholds/main/GRPCSwiftBenchmark.Metadata_Add_string.p90.json
+++ b/Performance/Benchmarks/Thresholds/main/GRPCSwiftBenchmark.Metadata_Add_string.p90.json
@@ -1,0 +1,7 @@
+{
+  "mallocCountTotal" : 11,
+  "memoryLeaked" : 0,
+  "releaseCount" : 4012,
+  "retainCount" : 2000,
+  "syscalls" : 0
+}

--- a/Performance/Benchmarks/Thresholds/main/GRPCSwiftBenchmark.Metadata_Iterate_all_values.p90.json
+++ b/Performance/Benchmarks/Thresholds/main/GRPCSwiftBenchmark.Metadata_Iterate_all_values.p90.json
@@ -1,0 +1,7 @@
+{
+  "mallocCountTotal" : 0,
+  "memoryLeaked" : 0,
+  "releaseCount" : 3001,
+  "retainCount" : 1000,
+  "syscalls" : 0
+}

--- a/Performance/Benchmarks/Thresholds/main/GRPCSwiftBenchmark.Metadata_Iterate_binary_values_when_only_binary_values_stored.p90.json
+++ b/Performance/Benchmarks/Thresholds/main/GRPCSwiftBenchmark.Metadata_Iterate_binary_values_when_only_binary_values_stored.p90.json
@@ -1,0 +1,7 @@
+{
+  "mallocCountTotal" : 0,
+  "memoryLeaked" : 0,
+  "releaseCount" : 3001,
+  "retainCount" : 1000,
+  "syscalls" : 0
+}

--- a/Performance/Benchmarks/Thresholds/main/GRPCSwiftBenchmark.Metadata_Iterate_binary_values_when_only_strings_stored.p90.json
+++ b/Performance/Benchmarks/Thresholds/main/GRPCSwiftBenchmark.Metadata_Iterate_binary_values_when_only_strings_stored.p90.json
@@ -1,0 +1,7 @@
+{
+  "mallocCountTotal" : 2000,
+  "memoryLeaked" : 0,
+  "releaseCount" : 6001,
+  "retainCount" : 2000,
+  "syscalls" : 0
+}

--- a/Performance/Benchmarks/Thresholds/main/GRPCSwiftBenchmark.Metadata_Iterate_string_values.p90.json
+++ b/Performance/Benchmarks/Thresholds/main/GRPCSwiftBenchmark.Metadata_Iterate_string_values.p90.json
@@ -1,0 +1,7 @@
+{
+  "mallocCountTotal" : 0,
+  "memoryLeaked" : 0,
+  "releaseCount" : 3001,
+  "retainCount" : 1000,
+  "syscalls" : 0
+}

--- a/Performance/Benchmarks/Thresholds/main/GRPCSwiftBenchmark.Metadata_Remove_values_for_key.p90.json
+++ b/Performance/Benchmarks/Thresholds/main/GRPCSwiftBenchmark.Metadata_Remove_values_for_key.p90.json
@@ -1,0 +1,7 @@
+{
+  "mallocCountTotal" : 0,
+  "memoryLeaked" : 0,
+  "releaseCount" : 2002001,
+  "retainCount" : 1999000,
+  "syscalls" : 0
+}


### PR DESCRIPTION
Motivation:

The benchmarks are run on nightly builds but there are no thresholds. This is causing nightly CI to fail as the benchmark package is now more stringent about missing thresholds.

Modifications:

- Add thresholds for nightly

Result:

CI passes