### PR TITLE
allow setting protoc-gen-grpc-swift via config

### DIFF
--- a/Plugins/GRPCSwiftPlugin/plugin.swift
+++ b/Plugins/GRPCSwiftPlugin/plugin.swift
@@ -80,6 +80,11 @@ struct GRPCSwiftPlugin {
     ///
     /// If this is not set, SPM will try to find the tool itself.
     var protocPath: String?
+    
+    /// The path to the `protoc-gen-grpc-swift` binary.
+    ///
+    /// If this is not set, SPM will try to find the tool itself.
+    var protocGenGRPCSwiftPath: String?
 
     /// A list of invocations of `protoc` with the `GRPCSwiftPlugin`.
     var invocations: [Invocation]
@@ -129,7 +134,17 @@ struct GRPCSwiftPlugin {
       // The user didn't set anything so let's try see if SPM can find a binary for us
       protocPath = try tool("protoc").path
     }
-    let protocGenGRPCSwiftPath = try tool("protoc-gen-grpc-swift").path
+      
+      let protocGenGRPCSwiftPath: Path
+      if let configuredProtocGenGRPCSwiftPath = configuration.protocGenGRPCSwiftPath {
+        protocGenGRPCSwiftPath = Path(configuredProtocGenGRPCSwiftPath)
+      } else if let environmentPath = ProcessInfo.processInfo.environment["PROTOC_GEN_GRPC_SWIFT_PATH"] {
+        // The user set the env variable, so let's take that
+          protocGenGRPCSwiftPath = Path(environmentPath)
+      } else {
+        // The user didn't set anything so let's try see if SPM can find a binary for us
+          protocGenGRPCSwiftPath = try tool("protoc-gen-grpc-swift").path
+      }
 
     return configuration.invocations.map { invocation in
       self.invokeProtoc(


### PR DESCRIPTION
I ran into the same issue described in https://github.com/apple/swift-protobuf/issues/1506 where protoc-gen-grpc-swift is missing some frameworks it needs to run.

Until this is solve(able/d), this PR allows the user to set the path to protoc-gen-grpc-swift via the configuration, e.g. to use protoc-gen-grpc-swift installed via mint.

Is this something that could be merged? if so, I can update the docs and the tests for this.

- [ ] TODO: update docs
- [ ] TODO: update tests