### PR TITLE
[CodeGenLib] Translator for server code

### DIFF
--- a/Sources/GRPCCodeGen/Internal/Renderer/TextBasedRenderer.swift
+++ b/Sources/GRPCCodeGen/Internal/Renderer/TextBasedRenderer.swift
@@ -548,6 +548,8 @@ struct TextBasedRenderer: RendererProtocol {
       return "[\(renderedExistingTypeDescription(existingTypeDescription))]"
     case .dictionaryValue(let existingTypeDescription):
       return "[String: \(renderedExistingTypeDescription(existingTypeDescription))]"
+    case .inout(let existingTypeDescription):
+      return "inout \(renderedExistingTypeDescription(existingTypeDescription))"
     }
   }
 

--- a/Sources/GRPCCodeGen/Internal/Renderer/TextBasedRenderer.swift
+++ b/Sources/GRPCCodeGen/Internal/Renderer/TextBasedRenderer.swift
@@ -548,8 +548,6 @@ struct TextBasedRenderer: RendererProtocol {
       return "[\(renderedExistingTypeDescription(existingTypeDescription))]"
     case .dictionaryValue(let existingTypeDescription):
       return "[String: \(renderedExistingTypeDescription(existingTypeDescription))]"
-    case .inout(let existingTypeDescription):
-      return "inout \(renderedExistingTypeDescription(existingTypeDescription))"
     }
   }
 
@@ -841,6 +839,10 @@ struct TextBasedRenderer: RendererProtocol {
     }
     writer.writeLine(": ")
     writer.nextLineAppendsToLastLine()
+    if parameterDescription.inout {
+      writer.writeLine("inout ")
+      writer.nextLineAppendsToLastLine()
+    }
     writer.writeLine(renderedExistingTypeDescription(parameterDescription.type))
     if let defaultValue = parameterDescription.defaultValue {
       writer.nextLineAppendsToLastLine()

--- a/Sources/GRPCCodeGen/Internal/StructuredSwiftRepresentation.swift
+++ b/Sources/GRPCCodeGen/Internal/StructuredSwiftRepresentation.swift
@@ -420,11 +420,6 @@ indirect enum ExistingTypeDescription: Equatable, Codable {
   ///
   /// For example, `[String: Foo]`.
   case dictionaryValue(ExistingTypeDescription)
-
-  /// An inout parameter type.
-  ///
-  /// For example, `inout Int`.
-  case `inout`(ExistingTypeDescription)
 }
 
 /// A description of a typealias declaration.
@@ -495,6 +490,11 @@ struct ParameterDescription: Equatable, Codable {
   /// For example, in `bar baz: String = "hi"`, `defaultValue`
   /// represents `"hi"`.
   var defaultValue: Expression? = nil
+
+  /// An inout parameter type.
+  ///
+  /// For example, `bar baz: inout String`.
+  var `inout`: Bool = false
 }
 
 /// A function kind: `func` or `init`.

--- a/Sources/GRPCCodeGen/Internal/StructuredSwiftRepresentation.swift
+++ b/Sources/GRPCCodeGen/Internal/StructuredSwiftRepresentation.swift
@@ -420,6 +420,11 @@ indirect enum ExistingTypeDescription: Equatable, Codable {
   ///
   /// For example, `[String: Foo]`.
   case dictionaryValue(ExistingTypeDescription)
+
+  /// An inout parameter type.
+  ///
+  /// For example, `inout Int`.
+  case `inout`(ExistingTypeDescription)
 }
 
 /// A description of a typealias declaration.

--- a/Sources/GRPCCodeGen/Internal/Translator/IDLToStructuredSwiftTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/IDLToStructuredSwiftTranslator.swift
@@ -16,6 +16,7 @@
 
 struct IDLToStructuredSwiftTranslator: Translator {
   private let typealiasTranslator = TypealiasTranslator()
+  private let serverCodeTranslator = ServerCodeTranslator()
 
   func translate(
     codeGenerationRequest: CodeGenerationRequest,
@@ -30,6 +31,12 @@ struct IDLToStructuredSwiftTranslator: Translator {
     codeBlocks.append(
       contentsOf: try self.typealiasTranslator.translate(from: codeGenerationRequest)
     )
+
+    if server {
+      codeBlocks.append(
+        contentsOf: try self.serverCodeTranslator.translate(from: codeGenerationRequest)
+      )
+    }
 
     let fileDescription = FileDescription(
       topComment: topComment,

--- a/Sources/GRPCCodeGen/Internal/Translator/IDLToStructuredSwiftTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/IDLToStructuredSwiftTranslator.swift
@@ -48,3 +48,21 @@ struct IDLToStructuredSwiftTranslator: Translator {
     return StructuredSwiftRepresentation(file: file)
   }
 }
+
+extension CodeGenerationRequest.ServiceDescriptor {
+  var namespacedTypealiasPrefix: String {
+    if self.namespace.isEmpty {
+      return self.name
+    } else {
+      return "\(self.namespace).\(self.name)"
+    }
+  }
+
+  var namespacedPrefix: String {
+    if self.namespace.isEmpty {
+      return self.name
+    } else {
+      return "\(self.namespace)_\(self.name)"
+    }
+  }
+}

--- a/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
@@ -169,7 +169,7 @@ extension ServerCodeTranslator {
     let registerRPCsSignature = FunctionSignatureDescription(
       kind: .function(name: "registerRPCs"),
       parameters: [
-        .init(label: "with", name: "router", type: .member(["RPCRouter"]), `inout`: true)
+        .init(label: "with", name: "router", type: .member(["GRPCCore", "RPCRouter"]), `inout`: true)
       ]
     )
     let registerRPCsBody = self.makeRegisterRPCsMethodBody(for: service, in: codeGenerationRequest)

--- a/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
@@ -1,0 +1,508 @@
+/*
+ * Copyright 2023, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// Creates a representation for the server code that will be generated based on the``CodeGenerationRequest`` object
+/// specifications, using types from``StructuredSwiftRepresentation``.
+///
+/// For example, in the case of the ``Echo`` service, the ``ServerCodeTranslator`` will create
+/// a representation for the following generated code:
+///
+/// ```swift
+/// public protocol echo.Echo.ServiceStreamingProtocol: RPCService, Sendable {
+///  func get(
+///   request: ServerRequest.Stream<echo.Method.Get.Input>
+///  ) async throws -> ServerResponse.Stream<echo.Method.Get.Output>
+///
+///  func collect(
+///   request: ServerRequest.Stream<echo.Method.Collect.Input>
+///  ) async throws -> ServerResponse.Stream<echo.Method.Collect.Output>
+///
+///  func expand(
+///    request: ServerRequest.Stream<echo.Method.Expand.Input>
+///  ) async throws -> ServerResponse.Stream<echo.Method.Expand.Output>
+///
+///  func update(
+///    request: ServerRequest.Stream<echo.Method.Update.Input>
+///  ) async throws -> ServerResponse.Stream<echo.Method.Update.Output>
+/// }
+///
+///
+/// // Generated conformance to `RegistrableRPCService`.
+/// extension echo.Echo.StreamingServiceProtocol {
+///  public func registerRPCs(with router: inout RPCRouter) {
+///    router.registerHandler(
+///      for: echo.Method.Get.descriptor,
+///      deserializer: ProtobufDeserializer<echo.Method.Get.Input>(),
+///      serializer: ProtobufSerializer<echo.Method.Get.Output>(),
+///      handler: { request in try await self.get(request) }
+///    )
+///    router.registerHandler(...)
+/// }
+///
+/// public protocol echo.Echo.ServiceProtocol: echo.Echo.StreamingServiceProtocol {
+///   func get(
+///     request: ServerRequest.Single<EchoRequest>
+///   ) async throws -> ServerResponse.Single<EchoResponse>
+///
+///   func collect(
+///     request: ServerRequest.Stream<EchoResponse>
+///   ) async throws -> ServerResponse.Single<EchoResponse>
+///
+///   func expand(
+///     request: ServerRequest.Single<EchoRequest>
+///   ) async throws -> ServerResponse.Stream<EchoResponse>
+///
+///   func update(
+///     request: ServerRequest.Stream<EchoResponse>
+///   ) async throws -> ServerResponse.Stream<EchoResponse>
+/// }
+///
+///
+/// // Generated partial conformance to `echo.Echo.StreamingServiceProtocol`.
+/// extension echo.Echo.ServiceProtocol {
+///  public func get(
+///    request: ServerRequest.Stream<EchoRequest>
+///  ) async throws -> ServerResponse.Stream<EchoResponse> {
+///    let response = try await self.get(request: ServerRequest.Single(stream: request)
+///    return ServerResponse.Stream(single: response)
+///  }
+///
+///  public func collect(
+///    request: ServerRequest.Stream<EchoResponse>
+///  ) async throws -> ServerResponse.Stream<EchoResponse> {
+///    let response = try await self.collect(request: request))
+///    return ServerResponse.Stream(single: response)
+///  }
+///
+///  public func expand(
+///  request: ServerRequest.Stream<EchoRequest>
+///  ) async throws -> ServerResponse.Stream<EchoResponse> {
+///    let response = try await self.expand(request: ServerRequest.Single(stream: request))
+///    return response
+///  }
+///}
+///```
+struct ServerCodeTranslator: SpecializedTranslator {
+  func translate(from codeGenerationRequest: CodeGenerationRequest) throws -> [CodeBlock] {
+    var codeBlocks = [CodeBlock]()
+    for service in codeGenerationRequest.services {
+      // Create the streaming protocol that declares the service methods as bidirectional streaming.
+      let streamingProtocol = CodeBlockItem.declaration(self.makeStreamingProtocol(for: service))
+      codeBlocks.append(CodeBlock(item: streamingProtocol))
+
+      // Create extension for implementing the 'registerRPCs' function which is a 'RegistrableRPCService' requirement.
+      let conformanceToRPCServiceExtension = CodeBlockItem.declaration(
+        self.makeConformanceToRPCServiceExtension(for: service, in: codeGenerationRequest)
+      )
+      codeBlocks.append(
+        CodeBlock(
+          comment: .inline("Generated conformance to `RegistrableRPCService`."),
+          item: conformanceToRPCServiceExtension
+        )
+      )
+
+      // Create the service protocol that declares the service methods as they are described in the Source IDL (unary,
+      // client/server streaming or bidirectional streaming).
+      let serviceProtocol = CodeBlockItem.declaration(self.makeServiceProtocol(for: service))
+      codeBlocks.append(CodeBlock(item: serviceProtocol))
+
+      // Create extension for partial conformance to the streaming protocol.
+      let extensionServiceProtocol = CodeBlockItem.declaration(
+        self.makeExtensionServiceProtocol(for: service)
+      )
+      codeBlocks.append(
+        CodeBlock(
+          comment: .inline(
+            "Generated partial conformance to `\(self.serviceProtocolName(for: service, streaming: true))`."
+          ),
+          item: extensionServiceProtocol
+        )
+      )
+    }
+
+    return codeBlocks
+  }
+}
+
+extension ServerCodeTranslator {
+  private func makeStreamingProtocol(
+    for service: CodeGenerationRequest.ServiceDescriptor
+  ) -> Declaration {
+    var methods = [Declaration]()
+    for method in service.methods {
+      methods.append(
+        .function(
+          signature: FunctionSignatureDescription(
+            kind: .function(name: method.name),
+            parameters: [
+              .init(
+                label: "request",
+                type: .generic(
+                  wrapper: .member(["ServerRequest", "Stream"]),
+                  wrapped: .member(
+                    self.methodInputOutputTypealias(for: method, service: service, type: .input)
+                  )
+                )
+              )
+            ],
+            keywords: [.async, .throws],
+            returnType: .identifierType(
+              .generic(
+                wrapper: .member(["ServerResponse", "Stream"]),
+                wrapped: .member(
+                  self.methodInputOutputTypealias(for: method, service: service, type: .output)
+                )
+              )
+            )
+          )
+        )
+      )
+    }
+
+    let streamingProtocol = Declaration.protocol(
+      .init(
+        name: self.serviceProtocolName(for: service, streaming: true),
+        conformances: ["RegistrableRPCService", "Sendable"],
+        members: methods
+      )
+    )
+
+    return streamingProtocol
+  }
+
+  private func makeConformanceToRPCServiceExtension(
+    for service: CodeGenerationRequest.ServiceDescriptor,
+    in codeGenerationRequest: CodeGenerationRequest
+  ) -> Declaration {
+    let streamingProtocol = self.serviceProtocolName(for: service, streaming: true)
+    let registerRPCMethod = self.makeRegisterRPCsMethod(for: service, in: codeGenerationRequest)
+    return .extension(
+      accessModifier: .public,
+      onType: streamingProtocol,
+      declarations: [registerRPCMethod]
+    )
+
+  }
+
+  private func makeRegisterRPCsMethod(
+    for service: CodeGenerationRequest.ServiceDescriptor,
+    in codeGenerationRequest: CodeGenerationRequest
+  ) -> Declaration {
+    let registerRPCsSignature = FunctionSignatureDescription(
+      kind: .function(name: "registerRPCs"),
+      parameters: [.init(label: "with", name: "router", type: .inout(.member(["RPCRouter"])))]
+    )
+    let registerRPCsBody = self.makeRegisterRPCsMethodBody(for: service, in: codeGenerationRequest)
+    return .function(signature: registerRPCsSignature, body: registerRPCsBody)
+  }
+
+  private func makeRegisterRPCsMethodBody(
+    for service: CodeGenerationRequest.ServiceDescriptor,
+    in codeGenerationRequest: CodeGenerationRequest
+  ) -> [CodeBlock]? {
+    var registerHandlerCalls = [CodeBlock]()
+    for method in service.methods {
+      let arguments = self.makeArgumentsForRegisterHandler(
+        for: method,
+        in: service,
+        from: codeGenerationRequest
+      )
+      let registerHandlerCall = Expression.functionCall(
+        calledExpression: .memberAccess(
+          MemberAccessDescription(left: .identifierPattern("router"), right: "registerHandler")
+        ),
+        arguments: arguments
+      )
+
+      registerHandlerCalls.append(.expression(registerHandlerCall))
+    }
+
+    return registerHandlerCalls
+  }
+
+  private func makeArgumentsForRegisterHandler(
+    for method: CodeGenerationRequest.ServiceDescriptor.MethodDescriptor,
+    in service: CodeGenerationRequest.ServiceDescriptor,
+    from codeGenerationRequest: CodeGenerationRequest
+  ) -> [FunctionArgumentDescription] {
+    var arguments = [FunctionArgumentDescription]()
+    arguments.append(
+      .init(
+        label: "for",
+        expression: .identifierPattern(
+          self.methodDescriptorPath(for: method, service: service)
+        )
+      )
+    )
+
+    arguments.append(
+      .init(
+        label: "deserializer",
+        expression: .identifierPattern(
+          codeGenerationRequest.lookupDeserializer(
+            self.methodInputOutputTypealias(for: method, service: service, type: .input)
+          )
+        )
+      )
+    )
+
+    arguments.append(
+      .init(
+        label: "serializer",
+        expression:
+          .identifierPattern(
+            codeGenerationRequest.lookupSerializer(
+              self.methodInputOutputTypealias(for: method, service: service, type: .output)
+            )
+          )
+      )
+    )
+
+    let getFunctionCall = Expression.functionCall(
+      calledExpression: .memberAccess(
+        MemberAccessDescription(left: .identifierPattern("self"), right: method.name)
+      ),
+      arguments: [FunctionArgumentDescription(expression: .identifierPattern("request"))]
+    )
+
+    let handlerClosureBody = Expression.unaryKeyword(
+      kind: .try,
+      expression: .unaryKeyword(kind: .await, expression: getFunctionCall)
+    )
+
+    arguments.append(
+      .init(
+        label: "handler",
+        expression: .closureInvocation(
+          .init(argumentNames: ["request"], body: [.expression(handlerClosureBody)])
+        )
+      )
+    )
+
+    return arguments
+  }
+
+  private func makeServiceProtocol(
+    for service: CodeGenerationRequest.ServiceDescriptor
+  ) -> Declaration {
+    var methods = [Declaration]()
+    for method in service.methods {
+      let methodDeclaration = self.makeServiceProtocolMethod(for: method, in: service)
+      methods.append(methodDeclaration)
+    }
+    let protocolName = self.serviceProtocolName(for: service, streaming: false)
+    let streamingProtocol = self.serviceProtocolName(for: service, streaming: true)
+
+    return .protocol(
+      ProtocolDescription(name: protocolName, conformances: [streamingProtocol], members: methods)
+    )
+  }
+
+  private func makeServiceProtocolMethod(
+    for method: CodeGenerationRequest.ServiceDescriptor.MethodDescriptor,
+    in service: CodeGenerationRequest.ServiceDescriptor
+  ) -> Declaration {
+    let inputStreaming = method.isInputStreaming ? "Stream" : "Single"
+    let outputStreaming = method.isOutputStreaming ? "Stream" : "Single"
+
+    let inputTypealiasComponents = self.methodInputOutputTypealias(
+      for: method,
+      service: service,
+      type: .input
+    )
+    let outputTypealiasComponents = self.methodInputOutputTypealias(
+      for: method,
+      service: service,
+      type: .output
+    )
+
+    let functionSignature = FunctionSignatureDescription(
+      kind: .function(name: method.name),
+      parameters: [
+        .init(
+          label: "request",
+          type:
+            .generic(
+              wrapper: .member(["ServerRequest", inputStreaming]),
+              wrapped: .member(inputTypealiasComponents)
+            )
+        )
+      ],
+      keywords: [.async, .throws],
+      returnType: .identifierType(
+        .generic(
+          wrapper: .member(["ServerResponse", outputStreaming]),
+          wrapped: .member(outputTypealiasComponents)
+        )
+      )
+    )
+
+    return .function(FunctionDescription(signature: functionSignature))
+  }
+
+  private func makeExtensionServiceProtocol(
+    for service: CodeGenerationRequest.ServiceDescriptor
+  ) -> Declaration {
+    var methods = [Declaration]()
+    for method in service.methods {
+      if let methodDeclaration = self.makeServiceProtocolExtensionMethod(for: method, in: service) {
+        methods.append(methodDeclaration)
+      }
+    }
+    let protocolName = self.serviceProtocolName(for: service, streaming: false)
+    return .extension(accessModifier: .public, onType: protocolName, declarations: methods)
+  }
+
+  private func makeServiceProtocolExtensionMethod(
+    for method: CodeGenerationRequest.ServiceDescriptor.MethodDescriptor,
+    in: CodeGenerationRequest.ServiceDescriptor
+  ) -> Declaration? {
+    // The method has the same definition in StreamingServiceProtocol and ServiceProtocol.
+    if method.isInputStreaming && method.isOutputStreaming {
+      return nil
+    }
+
+    let response = CodeBlock(item: .declaration(self.makeResponse(for: method)))
+    let returnStatement = CodeBlock(item: .expression(self.makeReturnStatement(for: method)))
+
+    return .function(
+      signature: FunctionSignatureDescription(kind: .function(name: method.name)),
+      body: [response, returnStatement]
+    )
+  }
+
+  private func makeResponse(
+    for method: CodeGenerationRequest.ServiceDescriptor.MethodDescriptor
+  ) -> Declaration {
+    let serverRequest: Expression
+    if !method.isInputStreaming {
+      // Transform the streaming request into a unary request.
+      serverRequest = Expression.functionCall(
+        calledExpression: .memberAccess(
+          MemberAccessDescription(
+            left: .identifierPattern("ServerRequest"),
+            right: "Single"
+          )
+        ),
+        arguments: [
+          FunctionArgumentDescription(label: "stream", expression: .identifierPattern("request"))
+        ]
+      )
+    } else {
+      serverRequest = Expression.identifierPattern("request")
+    }
+    // Call to the corresponding ServiceProtocol method.
+    let serviceProtocolMethod = Expression.functionCall(
+      calledExpression: .memberAccess(
+        MemberAccessDescription(left: .identifierPattern("self"), right: method.name)
+      ),
+      arguments: [FunctionArgumentDescription(label: "request", expression: serverRequest)]
+    )
+
+    let responseValue = Expression.unaryKeyword(
+      kind: .try,
+      expression: .unaryKeyword(kind: .await, expression: serviceProtocolMethod)
+    )
+
+    return .variable(kind: .let, left: "response", right: responseValue)
+  }
+
+  private func makeReturnStatement(
+    for method: CodeGenerationRequest.ServiceDescriptor.MethodDescriptor
+  ) -> Expression {
+    let returnValue: Expression
+    // Transforming the unary response into a streaming one.
+    if !method.isOutputStreaming {
+      returnValue = .functionCall(
+        calledExpression: .memberAccess(
+          MemberAccessDescription(
+            left: .identifierType(.member(["ServerResponse"])),
+            right: "Stream"
+          )
+        ),
+        arguments: [
+          (FunctionArgumentDescription(label: "single", expression: .identifierPattern("response")))
+        ]
+      )
+    } else {
+      returnValue = .identifierPattern("response")
+    }
+
+    return .unaryKeyword(kind: .return, expression: returnValue)
+  }
+
+  /// Generates the fully qualified name of the type alias for a service descriptor.
+  private func serviceProtocolName(
+    for service: CodeGenerationRequest.ServiceDescriptor,
+    streaming: Bool
+  ) -> String {
+    let namespacedPrefix: String
+    if service.namespace.isEmpty {
+      namespacedPrefix = service.name
+    } else {
+      namespacedPrefix = "\(service.namespace).\(service.name)"
+    }
+    if streaming {
+      return "\(namespacedPrefix).StreamingServiceProtocol"
+    }
+    return "\(namespacedPrefix).ServiceProtocol"
+  }
+
+  private func fullyQualifiedMethodDescriptor() {}
+
+  fileprivate enum InputOutputType {
+    case input
+    case output
+  }
+
+  /// Generates the fully qualified name of the typealias for the input or output type of a method.
+  private func methodInputOutputTypealias(
+    for method: CodeGenerationRequest.ServiceDescriptor.MethodDescriptor,
+    service: CodeGenerationRequest.ServiceDescriptor,
+    type: InputOutputType
+  ) -> String {
+    var components: String = ""
+    if service.namespace.isEmpty {
+      components = "\(service.name).Methods.\(method.name)"
+    } else {
+      components = "\(service.namespace).\(service.name).Methods.\(method.name)"
+    }
+
+    switch type {
+    case .input:
+      components.append(".Input")
+    case .output:
+      components.append(".Output")
+    }
+
+    return components
+  }
+
+  /// Generates the fully qualified name of a method descriptor.
+  private func methodDescriptorPath(
+    for method: CodeGenerationRequest.ServiceDescriptor.MethodDescriptor,
+    service: CodeGenerationRequest.ServiceDescriptor
+  ) -> String {
+    var components: String = ""
+    if service.namespace.isEmpty {
+      components = "\(service.name).Methods.\(method.name)"
+    } else {
+      components = "\(service.namespace).\(service.name).Methods.\(method.name)"
+    }
+
+    return components.appending(".descriptor")
+  }
+}

--- a/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
@@ -169,7 +169,12 @@ extension ServerCodeTranslator {
     let registerRPCsSignature = FunctionSignatureDescription(
       kind: .function(name: "registerRPCs"),
       parameters: [
-        .init(label: "with", name: "router", type: .member(["GRPCCore", "RPCRouter"]), `inout`: true)
+        .init(
+          label: "with",
+          name: "router",
+          type: .member(["GRPCCore", "RPCRouter"]),
+          `inout`: true
+        )
       ]
     )
     let registerRPCsBody = self.makeRegisterRPCsMethodBody(for: service, in: codeGenerationRequest)

--- a/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
@@ -271,8 +271,11 @@ extension ServerCodeTranslator {
     let protocolName = self.protocolName(service: service, streaming: false)
     let streamingProtocol = self.protocolNameTypealias(service: service, streaming: true)
 
-    return .protocol(
-      ProtocolDescription(name: protocolName, conformances: [streamingProtocol], members: methods)
+    return .commentable(
+      .inline(service.documentation),
+      .protocol(
+        ProtocolDescription(name: protocolName, conformances: [streamingProtocol], members: methods)
+      )
     )
   }
 
@@ -315,7 +318,10 @@ extension ServerCodeTranslator {
       )
     )
 
-    return .function(FunctionDescription(signature: functionSignature))
+    return .commentable(
+      .inline(method.documentation),
+      .function(FunctionDescription(signature: functionSignature))
+    )
   }
 
   private func makeExtensionServiceProtocol(

--- a/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
@@ -36,6 +36,7 @@
 ///       serializer: ProtobufSerializer<foo.Methods.baz.Output>(),
 ///       handler: { request in try await self.baz(request: request) }
 ///     )
+///   }
 /// }
 /// public protocol foo_BarServiceProtocol: foo.Bar.StreamingServiceProtocol {
 ///   func baz(
@@ -49,8 +50,8 @@
 ///   ) async throws -> ServerResponse.Stream<foo.Bar.Methods.baz.Output> {
 ///     let response = try await self.baz(request: ServerRequest.Single(stream: request)
 ///     return ServerResponse.Stream(single: response)
+///   }
 /// }
-///}
 ///```
 struct ServerCodeTranslator: SpecializedTranslator {
   func translate(from codeGenerationRequest: CodeGenerationRequest) throws -> [CodeBlock] {
@@ -66,7 +67,7 @@ struct ServerCodeTranslator: SpecializedTranslator {
       )
       codeBlocks.append(
         CodeBlock(
-          comment: .inline("Generated conformance to `GRPCCore.RegistrableRPCService`."),
+          comment: .doc("Conformance to `GRPCCore.RegistrableRPCService`."),
           item: conformanceToRPCServiceExtension
         )
       )
@@ -82,8 +83,8 @@ struct ServerCodeTranslator: SpecializedTranslator {
       )
       codeBlocks.append(
         CodeBlock(
-          comment: .inline(
-            "Generated partial conformance to `\(self.protocolName(service: service, streaming: true))`."
+          comment: .doc(
+            "Partial conformance to `\(self.protocolName(service: service, streaming: true))`."
           ),
           item: extensionServiceProtocol
         )
@@ -100,7 +101,7 @@ extension ServerCodeTranslator {
   ) -> Declaration {
     let methods = service.methods.compactMap {
       Declaration.commentable(
-        .inline($0.documentation),
+        .doc($0.documentation),
         .function(
           FunctionDescription(
             signature: self.makeStreamingMethodSignature(for: $0, in: service)
@@ -117,7 +118,7 @@ extension ServerCodeTranslator {
       )
     )
 
-    return .commentable(.inline(service.documentation), streamingProtocol)
+    return .commentable(.doc(service.documentation), streamingProtocol)
   }
 
   private func makeStreamingMethodSignature(
@@ -277,7 +278,7 @@ extension ServerCodeTranslator {
     let streamingProtocol = self.protocolNameTypealias(service: service, streaming: true)
 
     return .commentable(
-      .inline(service.documentation),
+      .doc(service.documentation),
       .protocol(
         ProtocolDescription(name: protocolName, conformances: [streamingProtocol], members: methods)
       )
@@ -324,7 +325,7 @@ extension ServerCodeTranslator {
     )
 
     return .commentable(
-      .inline(method.documentation),
+      .doc(method.documentation),
       .function(FunctionDescription(signature: functionSignature))
     )
   }

--- a/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
@@ -461,8 +461,6 @@ extension ServerCodeTranslator {
     return "\(namespacedPrefix).ServiceProtocol"
   }
 
-  private func fullyQualifiedMethodDescriptor() {}
-
   fileprivate enum InputOutputType {
     case input
     case output

--- a/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
@@ -27,8 +27,6 @@
 ///   request: ServerRequest.Stream<foo.Method.baz.Input>
 ///  ) async throws -> ServerResponse.Stream<foo.Method.baz.Output>
 /// }
-///
-///
 /// // Generated conformance to `RegistrableRPCService`.
 /// extension foo.Bar.StreamingServiceProtocol {
 ///  public func registerRPCs(with router: inout RPCRouter) {
@@ -39,14 +37,11 @@
 ///      handler: { request in try await self.baz(request) }
 ///    )
 /// }
-///
 /// public protocol foo_BarServiceProtocol: foo.Bar.StreamingServiceProtocol {
 ///   func baz(
 ///     request: ServerRequest.Single<foo.Bar.Methods.baz.Input>
 ///   ) async throws -> ServerResponse.Single<foo.Bar.Methods.baz.Output>
 /// }
-///
-///
 /// // Generated partial conformance to `foo_BarStreamingServiceProtocol`.
 /// extension foo.Bar.ServiceProtocol {
 ///  public func baz(

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
@@ -39,12 +39,12 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     )
     let expectedSwift =
       """
-      // Documentation for ServiceA
+      /// Documentation for ServiceA
       protocol namespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
-          // Documentation for unaryMethod
+          /// Documentation for unaryMethod
           func unaryMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.unaryMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.unaryMethod.Output>
       }
-      // Generated conformance to `GRPCCore.RegistrableRPCService`.
+      /// Conformance to `GRPCCore.RegistrableRPCService`.
       public extension namespaceA.ServiceA.StreamingServiceProtocol {
           func registerRPCs(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
@@ -57,12 +57,12 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
               )
           }
       }
-      // Documentation for ServiceA
+      /// Documentation for ServiceA
       protocol namespaceA_ServiceAServiceProtocol: namespaceA.ServiceA.StreamingServiceProtocol {
-          // Documentation for unaryMethod
+          /// Documentation for unaryMethod
           func unaryMethod(request: ServerRequest.Single<namespaceA.ServiceA.Methods.unaryMethod.Input>) async throws -> ServerResponse.Single<namespaceA.ServiceA.Methods.unaryMethod.Output>
       }
-      // Generated partial conformance to `namespaceA_ServiceAStreamingServiceProtocol`.
+      /// Partial conformance to `namespaceA_ServiceAStreamingServiceProtocol`.
       public extension namespaceA.ServiceA.ServiceProtocol {
           func unaryMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.unaryMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.unaryMethod.Output> {
               let response = try await self.unaryMethod(request: ServerRequest.Single(stream: request))
@@ -94,12 +94,12 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     )
     let expectedSwift =
       """
-      // Documentation for ServiceA
+      /// Documentation for ServiceA
       protocol namespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
-          // Documentation for inputStreamingMethod
+          /// Documentation for inputStreamingMethod
           func inputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Output>
       }
-      // Generated conformance to `GRPCCore.RegistrableRPCService`.
+      /// Conformance to `GRPCCore.RegistrableRPCService`.
       public extension namespaceA.ServiceA.StreamingServiceProtocol {
           func registerRPCs(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
@@ -112,12 +112,12 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
               )
           }
       }
-      // Documentation for ServiceA
+      /// Documentation for ServiceA
       protocol namespaceA_ServiceAServiceProtocol: namespaceA.ServiceA.StreamingServiceProtocol {
-          // Documentation for inputStreamingMethod
+          /// Documentation for inputStreamingMethod
           func inputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Input>) async throws -> ServerResponse.Single<namespaceA.ServiceA.Methods.inputStreamingMethod.Output>
       }
-      // Generated partial conformance to `namespaceA_ServiceAStreamingServiceProtocol`.
+      /// Partial conformance to `namespaceA_ServiceAStreamingServiceProtocol`.
       public extension namespaceA.ServiceA.ServiceProtocol {
           func inputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Output> {
               let response = try await self.inputStreamingMethod(request: request)
@@ -149,12 +149,12 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     )
     let expectedSwift =
       """
-      // Documentation for ServiceA
+      /// Documentation for ServiceA
       protocol namespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
-          // Documentation for outputStreamingMethod
+          /// Documentation for outputStreamingMethod
           func outputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Output>
       }
-      // Generated conformance to `GRPCCore.RegistrableRPCService`.
+      /// Conformance to `GRPCCore.RegistrableRPCService`.
       public extension namespaceA.ServiceA.StreamingServiceProtocol {
           func registerRPCs(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
@@ -167,12 +167,12 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
               )
           }
       }
-      // Documentation for ServiceA
+      /// Documentation for ServiceA
       protocol namespaceA_ServiceAServiceProtocol: namespaceA.ServiceA.StreamingServiceProtocol {
-          // Documentation for outputStreamingMethod
+          /// Documentation for outputStreamingMethod
           func outputStreamingMethod(request: ServerRequest.Single<namespaceA.ServiceA.Methods.outputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Output>
       }
-      // Generated partial conformance to `namespaceA_ServiceAStreamingServiceProtocol`.
+      /// Partial conformance to `namespaceA_ServiceAStreamingServiceProtocol`.
       public extension namespaceA.ServiceA.ServiceProtocol {
           func outputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Output> {
               let response = try await self.outputStreamingMethod(request: ServerRequest.Single(stream: request))
@@ -204,12 +204,12 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     )
     let expectedSwift =
       """
-      // Documentation for ServiceA
+      /// Documentation for ServiceA
       protocol namespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
-          // Documentation for bidirectionalStreamingMethod
+          /// Documentation for bidirectionalStreamingMethod
           func bidirectionalStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.bidirectionalStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.bidirectionalStreamingMethod.Output>
       }
-      // Generated conformance to `GRPCCore.RegistrableRPCService`.
+      /// Conformance to `GRPCCore.RegistrableRPCService`.
       public extension namespaceA.ServiceA.StreamingServiceProtocol {
           func registerRPCs(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
@@ -222,12 +222,12 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
               )
           }
       }
-      // Documentation for ServiceA
+      /// Documentation for ServiceA
       protocol namespaceA_ServiceAServiceProtocol: namespaceA.ServiceA.StreamingServiceProtocol {
-          // Documentation for bidirectionalStreamingMethod
+          /// Documentation for bidirectionalStreamingMethod
           func bidirectionalStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.bidirectionalStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.bidirectionalStreamingMethod.Output>
       }
-      // Generated partial conformance to `namespaceA_ServiceAStreamingServiceProtocol`.
+      /// Partial conformance to `namespaceA_ServiceAStreamingServiceProtocol`.
       public extension namespaceA.ServiceA.ServiceProtocol {
       }
       """
@@ -263,14 +263,14 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     )
     let expectedSwift =
       """
-      // Documentation for ServiceA
+      /// Documentation for ServiceA
       protocol namespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
-          // Documentation for inputStreamingMethod
+          /// Documentation for inputStreamingMethod
           func inputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Output>
-          // Documentation for outputStreamingMethod
+          /// Documentation for outputStreamingMethod
           func outputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Output>
       }
-      // Generated conformance to `GRPCCore.RegistrableRPCService`.
+      /// Conformance to `GRPCCore.RegistrableRPCService`.
       public extension namespaceA.ServiceA.StreamingServiceProtocol {
           func registerRPCs(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
@@ -291,14 +291,14 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
               )
           }
       }
-      // Documentation for ServiceA
+      /// Documentation for ServiceA
       protocol namespaceA_ServiceAServiceProtocol: namespaceA.ServiceA.StreamingServiceProtocol {
-          // Documentation for inputStreamingMethod
+          /// Documentation for inputStreamingMethod
           func inputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Input>) async throws -> ServerResponse.Single<namespaceA.ServiceA.Methods.inputStreamingMethod.Output>
-          // Documentation for outputStreamingMethod
+          /// Documentation for outputStreamingMethod
           func outputStreamingMethod(request: ServerRequest.Single<namespaceA.ServiceA.Methods.outputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Output>
       }
-      // Generated partial conformance to `namespaceA_ServiceAStreamingServiceProtocol`.
+      /// Partial conformance to `namespaceA_ServiceAStreamingServiceProtocol`.
       public extension namespaceA.ServiceA.ServiceProtocol {
           func inputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Output> {
               let response = try await self.inputStreamingMethod(request: request)
@@ -334,12 +334,12 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     )
     let expectedSwift =
       """
-      // Documentation for ServiceA
+      /// Documentation for ServiceA
       protocol ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
-          // Documentation for MethodA
+          /// Documentation for MethodA
           func methodA(request: ServerRequest.Stream<ServiceA.Methods.methodA.Input>) async throws -> ServerResponse.Stream<ServiceA.Methods.methodA.Output>
       }
-      // Generated conformance to `GRPCCore.RegistrableRPCService`.
+      /// Conformance to `GRPCCore.RegistrableRPCService`.
       public extension ServiceA.StreamingServiceProtocol {
           func registerRPCs(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
@@ -352,12 +352,12 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
               )
           }
       }
-      // Documentation for ServiceA
+      /// Documentation for ServiceA
       protocol ServiceAServiceProtocol: ServiceA.StreamingServiceProtocol {
-          // Documentation for MethodA
+          /// Documentation for MethodA
           func methodA(request: ServerRequest.Single<ServiceA.Methods.methodA.Input>) async throws -> ServerResponse.Single<ServiceA.Methods.methodA.Output>
       }
-      // Generated partial conformance to `ServiceAStreamingServiceProtocol`.
+      /// Partial conformance to `ServiceAStreamingServiceProtocol`.
       public extension ServiceA.ServiceProtocol {
           func methodA(request: ServerRequest.Stream<ServiceA.Methods.methodA.Input>) async throws -> ServerResponse.Stream<ServiceA.Methods.methodA.Output> {
               let response = try await self.methodA(request: ServerRequest.Single(stream: request))
@@ -387,26 +387,26 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     )
     let expectedSwift =
       """
-      // Documentation for ServiceA
+      /// Documentation for ServiceA
       protocol namespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {}
-      // Generated conformance to `GRPCCore.RegistrableRPCService`.
+      /// Conformance to `GRPCCore.RegistrableRPCService`.
       public extension namespaceA.ServiceA.StreamingServiceProtocol {
           func registerRPCs(with router: inout GRPCCore.RPCRouter) {}
       }
-      // Documentation for ServiceA
+      /// Documentation for ServiceA
       protocol namespaceA_ServiceAServiceProtocol: namespaceA.ServiceA.StreamingServiceProtocol {}
-      // Generated partial conformance to `namespaceA_ServiceAStreamingServiceProtocol`.
+      /// Partial conformance to `namespaceA_ServiceAStreamingServiceProtocol`.
       public extension namespaceA.ServiceA.ServiceProtocol {
       }
-      // Documentation for ServiceB
+      /// Documentation for ServiceB
       protocol namespaceA_ServiceBStreamingServiceProtocol: GRPCCore.RegistrableRPCService {}
-      // Generated conformance to `GRPCCore.RegistrableRPCService`.
+      /// Conformance to `GRPCCore.RegistrableRPCService`.
       public extension namespaceA.ServiceB.StreamingServiceProtocol {
           func registerRPCs(with router: inout GRPCCore.RPCRouter) {}
       }
-      // Documentation for ServiceB
+      /// Documentation for ServiceB
       protocol namespaceA_ServiceBServiceProtocol: namespaceA.ServiceB.StreamingServiceProtocol {}
-      // Generated partial conformance to `namespaceA_ServiceBStreamingServiceProtocol`.
+      /// Partial conformance to `namespaceA_ServiceBStreamingServiceProtocol`.
       public extension namespaceA.ServiceB.ServiceProtocol {
       }
       """

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
@@ -1,0 +1,398 @@
+/*
+ * Copyright 2023, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+
+@testable import GRPCCodeGen
+
+extension SnippetBasedTranslatorTests {
+  func testServerCodeTranslatorUnaryMethod() throws {
+    let method = MethodDescriptor(
+      documentation: "Documentation for unaryMethod",
+      name: "unaryMethod",
+      isInputStreaming: false,
+      isOutputStreaming: false,
+      inputType: "NamespaceA_ServiceARequest",
+      outputType: "NamespaceA_ServiceAResponse"
+    )
+    let service = ServiceDescriptor(
+      documentation: "Documentation for ServiceA",
+      name: "ServiceA",
+      namespace: "namespaceA",
+      methods: [method]
+    )
+    let expectedSwift =
+      """
+      protocol namespaceA.ServiceA.StreamingServiceProtocol: RegistrableRPCService, Sendable {
+          func unaryMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.unaryMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.unaryMethod.Output>
+      }
+      // Generated conformance to `RegistrableRPCService`.
+      public extension namespaceA.ServiceA.StreamingServiceProtocol {
+          func registerRPCs(with router: inout RPCRouter) {
+              router.registerHandler(
+                  for: namespaceA.ServiceA.Methods.unaryMethod.descriptor,
+                  deserializer: ProtobufDeserializer<namespaceA.ServiceA.Methods.unaryMethod.Input>(),
+                  serializer: ProtobufSerializer<namespaceA.ServiceA.Methods.unaryMethod.Output>(),
+                  handler: { request in
+                      try await self.unaryMethod(request)
+                  }
+              )
+          }
+      }
+      protocol namespaceA.ServiceA.ServiceProtocol: namespaceA.ServiceA.StreamingServiceProtocol {
+          func unaryMethod(request: ServerRequest.Single<namespaceA.ServiceA.Methods.unaryMethod.Input>) async throws -> ServerResponse.Single<namespaceA.ServiceA.Methods.unaryMethod.Output>
+      }
+      // Generated partial conformance to `namespaceA.ServiceA.StreamingServiceProtocol`.
+      public extension namespaceA.ServiceA.ServiceProtocol {
+          func unaryMethod() {
+              let response = try await self.unaryMethod(request: ServerRequest.Single(stream: request))
+              return ServerResponse.Stream(single: response)
+          }
+      }
+      """
+
+    try self.assertServerCodeTranslation(
+      codeGenerationRequest: self.makeCodeGenerationRequest(services: [service]),
+      expectedSwift: expectedSwift
+    )
+  }
+
+  func testServerCodeTranslatorInputStreamingMethod() throws {
+    let method = MethodDescriptor(
+      documentation: "Documentation for inputStreamingMethod",
+      name: "inputStreamingMethod",
+      isInputStreaming: true,
+      isOutputStreaming: false,
+      inputType: "NamespaceA_ServiceARequest",
+      outputType: "NamespaceA_ServiceAResponse"
+    )
+    let service = ServiceDescriptor(
+      documentation: "Documentation for ServiceA",
+      name: "ServiceA",
+      namespace: "namespaceA",
+      methods: [method]
+    )
+    let expectedSwift =
+      """
+      protocol namespaceA.ServiceA.StreamingServiceProtocol: RegistrableRPCService, Sendable {
+          func inputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Output>
+      }
+      // Generated conformance to `RegistrableRPCService`.
+      public extension namespaceA.ServiceA.StreamingServiceProtocol {
+          func registerRPCs(with router: inout RPCRouter) {
+              router.registerHandler(
+                  for: namespaceA.ServiceA.Methods.inputStreamingMethod.descriptor,
+                  deserializer: ProtobufDeserializer<namespaceA.ServiceA.Methods.inputStreamingMethod.Input>(),
+                  serializer: ProtobufSerializer<namespaceA.ServiceA.Methods.inputStreamingMethod.Output>(),
+                  handler: { request in
+                      try await self.inputStreamingMethod(request)
+                  }
+              )
+          }
+      }
+      protocol namespaceA.ServiceA.ServiceProtocol: namespaceA.ServiceA.StreamingServiceProtocol {
+          func inputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Input>) async throws -> ServerResponse.Single<namespaceA.ServiceA.Methods.inputStreamingMethod.Output>
+      }
+      // Generated partial conformance to `namespaceA.ServiceA.StreamingServiceProtocol`.
+      public extension namespaceA.ServiceA.ServiceProtocol {
+          func inputStreamingMethod() {
+              let response = try await self.inputStreamingMethod(request: request)
+              return ServerResponse.Stream(single: response)
+          }
+      }
+      """
+
+    try self.assertServerCodeTranslation(
+      codeGenerationRequest: self.makeCodeGenerationRequest(services: [service]),
+      expectedSwift: expectedSwift
+    )
+  }
+
+  func testServerCodeTranslatorOutputStreamingMethod() throws {
+    let method = MethodDescriptor(
+      documentation: "Documentation for outputStreamingMethod",
+      name: "outputStreamingMethod",
+      isInputStreaming: false,
+      isOutputStreaming: true,
+      inputType: "NamespaceA_ServiceARequest",
+      outputType: "NamespaceA_ServiceAResponse"
+    )
+    let service = ServiceDescriptor(
+      documentation: "Documentation for ServiceA",
+      name: "ServiceA",
+      namespace: "namespaceA",
+      methods: [method]
+    )
+    let expectedSwift =
+      """
+      protocol namespaceA.ServiceA.StreamingServiceProtocol: RegistrableRPCService, Sendable {
+          func outputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Output>
+      }
+      // Generated conformance to `RegistrableRPCService`.
+      public extension namespaceA.ServiceA.StreamingServiceProtocol {
+          func registerRPCs(with router: inout RPCRouter) {
+              router.registerHandler(
+                  for: namespaceA.ServiceA.Methods.outputStreamingMethod.descriptor,
+                  deserializer: ProtobufDeserializer<namespaceA.ServiceA.Methods.outputStreamingMethod.Input>(),
+                  serializer: ProtobufSerializer<namespaceA.ServiceA.Methods.outputStreamingMethod.Output>(),
+                  handler: { request in
+                      try await self.outputStreamingMethod(request)
+                  }
+              )
+          }
+      }
+      protocol namespaceA.ServiceA.ServiceProtocol: namespaceA.ServiceA.StreamingServiceProtocol {
+          func outputStreamingMethod(request: ServerRequest.Single<namespaceA.ServiceA.Methods.outputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Output>
+      }
+      // Generated partial conformance to `namespaceA.ServiceA.StreamingServiceProtocol`.
+      public extension namespaceA.ServiceA.ServiceProtocol {
+          func outputStreamingMethod() {
+              let response = try await self.outputStreamingMethod(request: ServerRequest.Single(stream: request))
+              return response
+          }
+      }
+      """
+
+    try self.assertServerCodeTranslation(
+      codeGenerationRequest: self.makeCodeGenerationRequest(services: [service]),
+      expectedSwift: expectedSwift
+    )
+  }
+
+  func testServerCodeTranslatorBidirectionalStreamingMethod() throws {
+    let method = MethodDescriptor(
+      documentation: "Documentation for bidirectionalStreamingMethod",
+      name: "bidirectionalStreamingMethod",
+      isInputStreaming: true,
+      isOutputStreaming: true,
+      inputType: "NamespaceA_ServiceARequest",
+      outputType: "NamespaceA_ServiceAResponse"
+    )
+    let service = ServiceDescriptor(
+      documentation: "Documentation for ServiceA",
+      name: "ServiceA",
+      namespace: "namespaceA",
+      methods: [method]
+    )
+    let expectedSwift =
+      """
+      protocol namespaceA.ServiceA.StreamingServiceProtocol: RegistrableRPCService, Sendable {
+          func bidirectionalStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.bidirectionalStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.bidirectionalStreamingMethod.Output>
+      }
+      // Generated conformance to `RegistrableRPCService`.
+      public extension namespaceA.ServiceA.StreamingServiceProtocol {
+          func registerRPCs(with router: inout RPCRouter) {
+              router.registerHandler(
+                  for: namespaceA.ServiceA.Methods.bidirectionalStreamingMethod.descriptor,
+                  deserializer: ProtobufDeserializer<namespaceA.ServiceA.Methods.bidirectionalStreamingMethod.Input>(),
+                  serializer: ProtobufSerializer<namespaceA.ServiceA.Methods.bidirectionalStreamingMethod.Output>(),
+                  handler: { request in
+                      try await self.bidirectionalStreamingMethod(request)
+                  }
+              )
+          }
+      }
+      protocol namespaceA.ServiceA.ServiceProtocol: namespaceA.ServiceA.StreamingServiceProtocol {
+          func bidirectionalStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.bidirectionalStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.bidirectionalStreamingMethod.Output>
+      }
+      // Generated partial conformance to `namespaceA.ServiceA.StreamingServiceProtocol`.
+      public extension namespaceA.ServiceA.ServiceProtocol {
+      }
+      """
+
+    try self.assertServerCodeTranslation(
+      codeGenerationRequest: self.makeCodeGenerationRequest(services: [service]),
+      expectedSwift: expectedSwift
+    )
+  }
+
+  func testServerCodeTranslatorMultipleMethods() throws {
+    let inputStreamingMethod = MethodDescriptor(
+      documentation: "Documentation for inputStreamingMethod",
+      name: "inputStreamingMethod",
+      isInputStreaming: true,
+      isOutputStreaming: false,
+      inputType: "NamespaceA_ServiceARequest",
+      outputType: "NamespaceA_ServiceAResponse"
+    )
+    let outputStreamingMethod = MethodDescriptor(
+      documentation: "Documentation for outputStreamingMethod",
+      name: "outputStreamingMethod",
+      isInputStreaming: false,
+      isOutputStreaming: true,
+      inputType: "NamespaceA_ServiceARequest",
+      outputType: "NamespaceA_ServiceAResponse"
+    )
+    let service = ServiceDescriptor(
+      documentation: "Documentation for ServiceA",
+      name: "ServiceA",
+      namespace: "namespaceA",
+      methods: [inputStreamingMethod, outputStreamingMethod]
+    )
+    let expectedSwift =
+      """
+      protocol namespaceA.ServiceA.StreamingServiceProtocol: RegistrableRPCService, Sendable {
+          func inputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Output>
+          func outputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Output>
+      }
+      // Generated conformance to `RegistrableRPCService`.
+      public extension namespaceA.ServiceA.StreamingServiceProtocol {
+          func registerRPCs(with router: inout RPCRouter) {
+              router.registerHandler(
+                  for: namespaceA.ServiceA.Methods.inputStreamingMethod.descriptor,
+                  deserializer: ProtobufDeserializer<namespaceA.ServiceA.Methods.inputStreamingMethod.Input>(),
+                  serializer: ProtobufSerializer<namespaceA.ServiceA.Methods.inputStreamingMethod.Output>(),
+                  handler: { request in
+                      try await self.inputStreamingMethod(request)
+                  }
+              )
+              router.registerHandler(
+                  for: namespaceA.ServiceA.Methods.outputStreamingMethod.descriptor,
+                  deserializer: ProtobufDeserializer<namespaceA.ServiceA.Methods.outputStreamingMethod.Input>(),
+                  serializer: ProtobufSerializer<namespaceA.ServiceA.Methods.outputStreamingMethod.Output>(),
+                  handler: { request in
+                      try await self.outputStreamingMethod(request)
+                  }
+              )
+          }
+      }
+      protocol namespaceA.ServiceA.ServiceProtocol: namespaceA.ServiceA.StreamingServiceProtocol {
+          func inputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Input>) async throws -> ServerResponse.Single<namespaceA.ServiceA.Methods.inputStreamingMethod.Output>
+          func outputStreamingMethod(request: ServerRequest.Single<namespaceA.ServiceA.Methods.outputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Output>
+      }
+      // Generated partial conformance to `namespaceA.ServiceA.StreamingServiceProtocol`.
+      public extension namespaceA.ServiceA.ServiceProtocol {
+          func inputStreamingMethod() {
+              let response = try await self.inputStreamingMethod(request: request)
+              return ServerResponse.Stream(single: response)
+          }
+          func outputStreamingMethod() {
+              let response = try await self.outputStreamingMethod(request: ServerRequest.Single(stream: request))
+              return response
+          }
+      }
+      """
+
+    try self.assertServerCodeTranslation(
+      codeGenerationRequest: self.makeCodeGenerationRequest(services: [service]),
+      expectedSwift: expectedSwift
+    )
+  }
+
+  func testServerCodeTranslatorNoNamespaceService() throws {
+    let method = MethodDescriptor(
+      documentation: "Documentation for MethodA",
+      name: "methodA",
+      isInputStreaming: false,
+      isOutputStreaming: false,
+      inputType: "NamespaceA_ServiceARequest",
+      outputType: "NamespaceA_ServiceAResponse"
+    )
+    let service = ServiceDescriptor(
+      documentation: "Documentation for ServiceA",
+      name: "ServiceA",
+      namespace: "",
+      methods: [method]
+    )
+    let expectedSwift =
+      """
+      protocol ServiceA.StreamingServiceProtocol: RegistrableRPCService, Sendable {
+          func methodA(request: ServerRequest.Stream<ServiceA.Methods.methodA.Input>) async throws -> ServerResponse.Stream<ServiceA.Methods.methodA.Output>
+      }
+      // Generated conformance to `RegistrableRPCService`.
+      public extension ServiceA.StreamingServiceProtocol {
+          func registerRPCs(with router: inout RPCRouter) {
+              router.registerHandler(
+                  for: ServiceA.Methods.methodA.descriptor,
+                  deserializer: ProtobufDeserializer<ServiceA.Methods.methodA.Input>(),
+                  serializer: ProtobufSerializer<ServiceA.Methods.methodA.Output>(),
+                  handler: { request in
+                      try await self.methodA(request)
+                  }
+              )
+          }
+      }
+      protocol ServiceA.ServiceProtocol: ServiceA.StreamingServiceProtocol {
+          func methodA(request: ServerRequest.Single<ServiceA.Methods.methodA.Input>) async throws -> ServerResponse.Single<ServiceA.Methods.methodA.Output>
+      }
+      // Generated partial conformance to `ServiceA.StreamingServiceProtocol`.
+      public extension ServiceA.ServiceProtocol {
+          func methodA() {
+              let response = try await self.methodA(request: ServerRequest.Single(stream: request))
+              return ServerResponse.Stream(single: response)
+          }
+      }
+      """
+
+    try self.assertServerCodeTranslation(
+      codeGenerationRequest: self.makeCodeGenerationRequest(services: [service]),
+      expectedSwift: expectedSwift
+    )
+  }
+
+  func testServerCodeTranslatorMoreServicesOrder() throws {
+    let serviceA = ServiceDescriptor(
+      documentation: "Documentation for ServiceA",
+      name: "ServiceA",
+      namespace: "namespaceA",
+      methods: []
+    )
+    let serviceB = ServiceDescriptor(
+      documentation: "Documentation for ServiceB",
+      name: "ServiceB",
+      namespace: "namespaceA",
+      methods: []
+    )
+    let expectedSwift =
+      """
+      protocol namespaceA.ServiceA.StreamingServiceProtocol: RegistrableRPCService, Sendable {}
+      // Generated conformance to `RegistrableRPCService`.
+      public extension namespaceA.ServiceA.StreamingServiceProtocol {
+          func registerRPCs(with router: inout RPCRouter) {}
+      }
+      protocol namespaceA.ServiceA.ServiceProtocol: namespaceA.ServiceA.StreamingServiceProtocol {}
+      // Generated partial conformance to `namespaceA.ServiceA.StreamingServiceProtocol`.
+      public extension namespaceA.ServiceA.ServiceProtocol {
+      }
+      protocol namespaceA.ServiceB.StreamingServiceProtocol: RegistrableRPCService, Sendable {}
+      // Generated conformance to `RegistrableRPCService`.
+      public extension namespaceA.ServiceB.StreamingServiceProtocol {
+          func registerRPCs(with router: inout RPCRouter) {}
+      }
+      protocol namespaceA.ServiceB.ServiceProtocol: namespaceA.ServiceB.StreamingServiceProtocol {}
+      // Generated partial conformance to `namespaceA.ServiceB.StreamingServiceProtocol`.
+      public extension namespaceA.ServiceB.ServiceProtocol {
+      }
+      """
+
+    try self.assertServerCodeTranslation(
+      codeGenerationRequest: self.makeCodeGenerationRequest(services: [serviceA, serviceB]),
+      expectedSwift: expectedSwift
+    )
+  }
+
+  private func assertServerCodeTranslation(
+    codeGenerationRequest: CodeGenerationRequest,
+    expectedSwift: String
+  ) throws {
+    let translator = ServerCodeTranslator()
+    let codeBlocks = try translator.translate(from: codeGenerationRequest)
+    let renderer = TextBasedRenderer.default
+    renderer.renderCodeBlocks(codeBlocks)
+    let contents = renderer.renderedContents()
+    try XCTAssertEqualWithDiff(contents, expectedSwift)
+  }
+}

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
@@ -18,7 +18,10 @@ import XCTest
 
 @testable import GRPCCodeGen
 
-extension SnippetBasedTranslatorTests {
+final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
+  typealias MethodDescriptor = GRPCCodeGen.CodeGenerationRequest.ServiceDescriptor.MethodDescriptor
+  typealias ServiceDescriptor = GRPCCodeGen.CodeGenerationRequest.ServiceDescriptor
+
   func testServerCodeTranslatorUnaryMethod() throws {
     let method = MethodDescriptor(
       documentation: "Documentation for unaryMethod",
@@ -36,10 +39,10 @@ extension SnippetBasedTranslatorTests {
     )
     let expectedSwift =
       """
-      protocol namespaceA.ServiceA.StreamingServiceProtocol: RegistrableRPCService, Sendable {
+      protocol namespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           func unaryMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.unaryMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.unaryMethod.Output>
       }
-      // Generated conformance to `RegistrableRPCService`.
+      // Generated conformance to `GRPCCore.RegistrableRPCService`.
       public extension namespaceA.ServiceA.StreamingServiceProtocol {
           func registerRPCs(with router: inout RPCRouter) {
               router.registerHandler(
@@ -52,12 +55,12 @@ extension SnippetBasedTranslatorTests {
               )
           }
       }
-      protocol namespaceA.ServiceA.ServiceProtocol: namespaceA.ServiceA.StreamingServiceProtocol {
+      protocol namespaceA_ServiceAServiceProtocol: namespaceA.ServiceA.StreamingServiceProtocol {
           func unaryMethod(request: ServerRequest.Single<namespaceA.ServiceA.Methods.unaryMethod.Input>) async throws -> ServerResponse.Single<namespaceA.ServiceA.Methods.unaryMethod.Output>
       }
-      // Generated partial conformance to `namespaceA.ServiceA.StreamingServiceProtocol`.
+      // Generated partial conformance to `namespaceA_ServiceAStreamingServiceProtocol`.
       public extension namespaceA.ServiceA.ServiceProtocol {
-          func unaryMethod() {
+          func unaryMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.unaryMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.unaryMethod.Output> {
               let response = try await self.unaryMethod(request: ServerRequest.Single(stream: request))
               return ServerResponse.Stream(single: response)
           }
@@ -65,7 +68,7 @@ extension SnippetBasedTranslatorTests {
       """
 
     try self.assertServerCodeTranslation(
-      codeGenerationRequest: self.makeCodeGenerationRequest(services: [service]),
+      codeGenerationRequest: makeCodeGenerationRequest(services: [service]),
       expectedSwift: expectedSwift
     )
   }
@@ -87,10 +90,10 @@ extension SnippetBasedTranslatorTests {
     )
     let expectedSwift =
       """
-      protocol namespaceA.ServiceA.StreamingServiceProtocol: RegistrableRPCService, Sendable {
+      protocol namespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           func inputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Output>
       }
-      // Generated conformance to `RegistrableRPCService`.
+      // Generated conformance to `GRPCCore.RegistrableRPCService`.
       public extension namespaceA.ServiceA.StreamingServiceProtocol {
           func registerRPCs(with router: inout RPCRouter) {
               router.registerHandler(
@@ -103,12 +106,12 @@ extension SnippetBasedTranslatorTests {
               )
           }
       }
-      protocol namespaceA.ServiceA.ServiceProtocol: namespaceA.ServiceA.StreamingServiceProtocol {
+      protocol namespaceA_ServiceAServiceProtocol: namespaceA.ServiceA.StreamingServiceProtocol {
           func inputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Input>) async throws -> ServerResponse.Single<namespaceA.ServiceA.Methods.inputStreamingMethod.Output>
       }
-      // Generated partial conformance to `namespaceA.ServiceA.StreamingServiceProtocol`.
+      // Generated partial conformance to `namespaceA_ServiceAStreamingServiceProtocol`.
       public extension namespaceA.ServiceA.ServiceProtocol {
-          func inputStreamingMethod() {
+          func inputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Output> {
               let response = try await self.inputStreamingMethod(request: request)
               return ServerResponse.Stream(single: response)
           }
@@ -116,7 +119,7 @@ extension SnippetBasedTranslatorTests {
       """
 
     try self.assertServerCodeTranslation(
-      codeGenerationRequest: self.makeCodeGenerationRequest(services: [service]),
+      codeGenerationRequest: makeCodeGenerationRequest(services: [service]),
       expectedSwift: expectedSwift
     )
   }
@@ -138,10 +141,10 @@ extension SnippetBasedTranslatorTests {
     )
     let expectedSwift =
       """
-      protocol namespaceA.ServiceA.StreamingServiceProtocol: RegistrableRPCService, Sendable {
+      protocol namespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           func outputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Output>
       }
-      // Generated conformance to `RegistrableRPCService`.
+      // Generated conformance to `GRPCCore.RegistrableRPCService`.
       public extension namespaceA.ServiceA.StreamingServiceProtocol {
           func registerRPCs(with router: inout RPCRouter) {
               router.registerHandler(
@@ -154,12 +157,12 @@ extension SnippetBasedTranslatorTests {
               )
           }
       }
-      protocol namespaceA.ServiceA.ServiceProtocol: namespaceA.ServiceA.StreamingServiceProtocol {
+      protocol namespaceA_ServiceAServiceProtocol: namespaceA.ServiceA.StreamingServiceProtocol {
           func outputStreamingMethod(request: ServerRequest.Single<namespaceA.ServiceA.Methods.outputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Output>
       }
-      // Generated partial conformance to `namespaceA.ServiceA.StreamingServiceProtocol`.
+      // Generated partial conformance to `namespaceA_ServiceAStreamingServiceProtocol`.
       public extension namespaceA.ServiceA.ServiceProtocol {
-          func outputStreamingMethod() {
+          func outputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Output> {
               let response = try await self.outputStreamingMethod(request: ServerRequest.Single(stream: request))
               return response
           }
@@ -167,7 +170,7 @@ extension SnippetBasedTranslatorTests {
       """
 
     try self.assertServerCodeTranslation(
-      codeGenerationRequest: self.makeCodeGenerationRequest(services: [service]),
+      codeGenerationRequest: makeCodeGenerationRequest(services: [service]),
       expectedSwift: expectedSwift
     )
   }
@@ -189,10 +192,10 @@ extension SnippetBasedTranslatorTests {
     )
     let expectedSwift =
       """
-      protocol namespaceA.ServiceA.StreamingServiceProtocol: RegistrableRPCService, Sendable {
+      protocol namespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           func bidirectionalStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.bidirectionalStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.bidirectionalStreamingMethod.Output>
       }
-      // Generated conformance to `RegistrableRPCService`.
+      // Generated conformance to `GRPCCore.RegistrableRPCService`.
       public extension namespaceA.ServiceA.StreamingServiceProtocol {
           func registerRPCs(with router: inout RPCRouter) {
               router.registerHandler(
@@ -205,16 +208,16 @@ extension SnippetBasedTranslatorTests {
               )
           }
       }
-      protocol namespaceA.ServiceA.ServiceProtocol: namespaceA.ServiceA.StreamingServiceProtocol {
+      protocol namespaceA_ServiceAServiceProtocol: namespaceA.ServiceA.StreamingServiceProtocol {
           func bidirectionalStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.bidirectionalStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.bidirectionalStreamingMethod.Output>
       }
-      // Generated partial conformance to `namespaceA.ServiceA.StreamingServiceProtocol`.
+      // Generated partial conformance to `namespaceA_ServiceAStreamingServiceProtocol`.
       public extension namespaceA.ServiceA.ServiceProtocol {
       }
       """
 
     try self.assertServerCodeTranslation(
-      codeGenerationRequest: self.makeCodeGenerationRequest(services: [service]),
+      codeGenerationRequest: makeCodeGenerationRequest(services: [service]),
       expectedSwift: expectedSwift
     )
   }
@@ -244,11 +247,11 @@ extension SnippetBasedTranslatorTests {
     )
     let expectedSwift =
       """
-      protocol namespaceA.ServiceA.StreamingServiceProtocol: RegistrableRPCService, Sendable {
+      protocol namespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           func inputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Output>
           func outputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Output>
       }
-      // Generated conformance to `RegistrableRPCService`.
+      // Generated conformance to `GRPCCore.RegistrableRPCService`.
       public extension namespaceA.ServiceA.StreamingServiceProtocol {
           func registerRPCs(with router: inout RPCRouter) {
               router.registerHandler(
@@ -269,25 +272,25 @@ extension SnippetBasedTranslatorTests {
               )
           }
       }
-      protocol namespaceA.ServiceA.ServiceProtocol: namespaceA.ServiceA.StreamingServiceProtocol {
+      protocol namespaceA_ServiceAServiceProtocol: namespaceA.ServiceA.StreamingServiceProtocol {
           func inputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Input>) async throws -> ServerResponse.Single<namespaceA.ServiceA.Methods.inputStreamingMethod.Output>
           func outputStreamingMethod(request: ServerRequest.Single<namespaceA.ServiceA.Methods.outputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Output>
       }
-      // Generated partial conformance to `namespaceA.ServiceA.StreamingServiceProtocol`.
+      // Generated partial conformance to `namespaceA_ServiceAStreamingServiceProtocol`.
       public extension namespaceA.ServiceA.ServiceProtocol {
-          func inputStreamingMethod() {
+          func inputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Output> {
               let response = try await self.inputStreamingMethod(request: request)
               return ServerResponse.Stream(single: response)
           }
-          func outputStreamingMethod() {
+          func outputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Output> {
               let response = try await self.outputStreamingMethod(request: ServerRequest.Single(stream: request))
               return response
           }
       }
       """
 
-    try self.assertServerCodeTranslation(
-      codeGenerationRequest: self.makeCodeGenerationRequest(services: [service]),
+    try assertServerCodeTranslation(
+      codeGenerationRequest: makeCodeGenerationRequest(services: [service]),
       expectedSwift: expectedSwift
     )
   }
@@ -309,10 +312,10 @@ extension SnippetBasedTranslatorTests {
     )
     let expectedSwift =
       """
-      protocol ServiceA.StreamingServiceProtocol: RegistrableRPCService, Sendable {
+      protocol ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           func methodA(request: ServerRequest.Stream<ServiceA.Methods.methodA.Input>) async throws -> ServerResponse.Stream<ServiceA.Methods.methodA.Output>
       }
-      // Generated conformance to `RegistrableRPCService`.
+      // Generated conformance to `GRPCCore.RegistrableRPCService`.
       public extension ServiceA.StreamingServiceProtocol {
           func registerRPCs(with router: inout RPCRouter) {
               router.registerHandler(
@@ -325,12 +328,12 @@ extension SnippetBasedTranslatorTests {
               )
           }
       }
-      protocol ServiceA.ServiceProtocol: ServiceA.StreamingServiceProtocol {
+      protocol ServiceAServiceProtocol: ServiceA.StreamingServiceProtocol {
           func methodA(request: ServerRequest.Single<ServiceA.Methods.methodA.Input>) async throws -> ServerResponse.Single<ServiceA.Methods.methodA.Output>
       }
-      // Generated partial conformance to `ServiceA.StreamingServiceProtocol`.
+      // Generated partial conformance to `ServiceAStreamingServiceProtocol`.
       public extension ServiceA.ServiceProtocol {
-          func methodA() {
+          func methodA(request: ServerRequest.Stream<ServiceA.Methods.methodA.Input>) async throws -> ServerResponse.Stream<ServiceA.Methods.methodA.Output> {
               let response = try await self.methodA(request: ServerRequest.Single(stream: request))
               return ServerResponse.Stream(single: response)
           }
@@ -338,7 +341,7 @@ extension SnippetBasedTranslatorTests {
       """
 
     try self.assertServerCodeTranslation(
-      codeGenerationRequest: self.makeCodeGenerationRequest(services: [service]),
+      codeGenerationRequest: makeCodeGenerationRequest(services: [service]),
       expectedSwift: expectedSwift
     )
   }
@@ -358,28 +361,28 @@ extension SnippetBasedTranslatorTests {
     )
     let expectedSwift =
       """
-      protocol namespaceA.ServiceA.StreamingServiceProtocol: RegistrableRPCService, Sendable {}
-      // Generated conformance to `RegistrableRPCService`.
+      protocol namespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {}
+      // Generated conformance to `GRPCCore.RegistrableRPCService`.
       public extension namespaceA.ServiceA.StreamingServiceProtocol {
           func registerRPCs(with router: inout RPCRouter) {}
       }
-      protocol namespaceA.ServiceA.ServiceProtocol: namespaceA.ServiceA.StreamingServiceProtocol {}
-      // Generated partial conformance to `namespaceA.ServiceA.StreamingServiceProtocol`.
+      protocol namespaceA_ServiceAServiceProtocol: namespaceA.ServiceA.StreamingServiceProtocol {}
+      // Generated partial conformance to `namespaceA_ServiceAStreamingServiceProtocol`.
       public extension namespaceA.ServiceA.ServiceProtocol {
       }
-      protocol namespaceA.ServiceB.StreamingServiceProtocol: RegistrableRPCService, Sendable {}
-      // Generated conformance to `RegistrableRPCService`.
+      protocol namespaceA_ServiceBStreamingServiceProtocol: GRPCCore.RegistrableRPCService {}
+      // Generated conformance to `GRPCCore.RegistrableRPCService`.
       public extension namespaceA.ServiceB.StreamingServiceProtocol {
           func registerRPCs(with router: inout RPCRouter) {}
       }
-      protocol namespaceA.ServiceB.ServiceProtocol: namespaceA.ServiceB.StreamingServiceProtocol {}
-      // Generated partial conformance to `namespaceA.ServiceB.StreamingServiceProtocol`.
+      protocol namespaceA_ServiceBServiceProtocol: namespaceA.ServiceB.StreamingServiceProtocol {}
+      // Generated partial conformance to `namespaceA_ServiceBStreamingServiceProtocol`.
       public extension namespaceA.ServiceB.ServiceProtocol {
       }
       """
 
     try self.assertServerCodeTranslation(
-      codeGenerationRequest: self.makeCodeGenerationRequest(services: [serviceA, serviceB]),
+      codeGenerationRequest: makeCodeGenerationRequest(services: [serviceA, serviceB]),
       expectedSwift: expectedSwift
     )
   }

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
@@ -55,7 +55,9 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
               )
           }
       }
+      // Documentation for ServiceA
       protocol namespaceA_ServiceAServiceProtocol: namespaceA.ServiceA.StreamingServiceProtocol {
+          // Documentation for unaryMethod
           func unaryMethod(request: ServerRequest.Single<namespaceA.ServiceA.Methods.unaryMethod.Input>) async throws -> ServerResponse.Single<namespaceA.ServiceA.Methods.unaryMethod.Output>
       }
       // Generated partial conformance to `namespaceA_ServiceAStreamingServiceProtocol`.
@@ -106,7 +108,9 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
               )
           }
       }
+      // Documentation for ServiceA
       protocol namespaceA_ServiceAServiceProtocol: namespaceA.ServiceA.StreamingServiceProtocol {
+          // Documentation for inputStreamingMethod
           func inputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Input>) async throws -> ServerResponse.Single<namespaceA.ServiceA.Methods.inputStreamingMethod.Output>
       }
       // Generated partial conformance to `namespaceA_ServiceAStreamingServiceProtocol`.
@@ -157,7 +161,9 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
               )
           }
       }
+      // Documentation for ServiceA
       protocol namespaceA_ServiceAServiceProtocol: namespaceA.ServiceA.StreamingServiceProtocol {
+          // Documentation for outputStreamingMethod
           func outputStreamingMethod(request: ServerRequest.Single<namespaceA.ServiceA.Methods.outputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Output>
       }
       // Generated partial conformance to `namespaceA_ServiceAStreamingServiceProtocol`.
@@ -208,7 +214,9 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
               )
           }
       }
+      // Documentation for ServiceA
       protocol namespaceA_ServiceAServiceProtocol: namespaceA.ServiceA.StreamingServiceProtocol {
+          // Documentation for bidirectionalStreamingMethod
           func bidirectionalStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.bidirectionalStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.bidirectionalStreamingMethod.Output>
       }
       // Generated partial conformance to `namespaceA_ServiceAStreamingServiceProtocol`.
@@ -272,8 +280,11 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
               )
           }
       }
+      // Documentation for ServiceA
       protocol namespaceA_ServiceAServiceProtocol: namespaceA.ServiceA.StreamingServiceProtocol {
+          // Documentation for inputStreamingMethod
           func inputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Input>) async throws -> ServerResponse.Single<namespaceA.ServiceA.Methods.inputStreamingMethod.Output>
+          // Documentation for outputStreamingMethod
           func outputStreamingMethod(request: ServerRequest.Single<namespaceA.ServiceA.Methods.outputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Output>
       }
       // Generated partial conformance to `namespaceA_ServiceAStreamingServiceProtocol`.
@@ -328,7 +339,9 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
               )
           }
       }
+      // Documentation for ServiceA
       protocol ServiceAServiceProtocol: ServiceA.StreamingServiceProtocol {
+          // Documentation for MethodA
           func methodA(request: ServerRequest.Single<ServiceA.Methods.methodA.Input>) async throws -> ServerResponse.Single<ServiceA.Methods.methodA.Output>
       }
       // Generated partial conformance to `ServiceAStreamingServiceProtocol`.
@@ -366,6 +379,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       public extension namespaceA.ServiceA.StreamingServiceProtocol {
           func registerRPCs(with router: inout RPCRouter) {}
       }
+      // Documentation for ServiceA
       protocol namespaceA_ServiceAServiceProtocol: namespaceA.ServiceA.StreamingServiceProtocol {}
       // Generated partial conformance to `namespaceA_ServiceAStreamingServiceProtocol`.
       public extension namespaceA.ServiceA.ServiceProtocol {
@@ -375,6 +389,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       public extension namespaceA.ServiceB.StreamingServiceProtocol {
           func registerRPCs(with router: inout RPCRouter) {}
       }
+      // Documentation for ServiceB
       protocol namespaceA_ServiceBServiceProtocol: namespaceA.ServiceB.StreamingServiceProtocol {}
       // Generated partial conformance to `namespaceA_ServiceBStreamingServiceProtocol`.
       public extension namespaceA.ServiceB.ServiceProtocol {

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
@@ -39,18 +39,20 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     )
     let expectedSwift =
       """
+      // Documentation for ServiceA
       protocol namespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
+          // Documentation for unaryMethod
           func unaryMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.unaryMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.unaryMethod.Output>
       }
       // Generated conformance to `GRPCCore.RegistrableRPCService`.
       public extension namespaceA.ServiceA.StreamingServiceProtocol {
-          func registerRPCs(with router: inout RPCRouter) {
+          func registerRPCs(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
                   for: namespaceA.ServiceA.Methods.unaryMethod.descriptor,
                   deserializer: ProtobufDeserializer<namespaceA.ServiceA.Methods.unaryMethod.Input>(),
                   serializer: ProtobufSerializer<namespaceA.ServiceA.Methods.unaryMethod.Output>(),
                   handler: { request in
-                      try await self.unaryMethod(request)
+                      try await self.unaryMethod(request: request)
                   }
               )
           }
@@ -92,18 +94,20 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     )
     let expectedSwift =
       """
+      // Documentation for ServiceA
       protocol namespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
+          // Documentation for inputStreamingMethod
           func inputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Output>
       }
       // Generated conformance to `GRPCCore.RegistrableRPCService`.
       public extension namespaceA.ServiceA.StreamingServiceProtocol {
-          func registerRPCs(with router: inout RPCRouter) {
+          func registerRPCs(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
                   for: namespaceA.ServiceA.Methods.inputStreamingMethod.descriptor,
                   deserializer: ProtobufDeserializer<namespaceA.ServiceA.Methods.inputStreamingMethod.Input>(),
                   serializer: ProtobufSerializer<namespaceA.ServiceA.Methods.inputStreamingMethod.Output>(),
                   handler: { request in
-                      try await self.inputStreamingMethod(request)
+                      try await self.inputStreamingMethod(request: request)
                   }
               )
           }
@@ -145,18 +149,20 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     )
     let expectedSwift =
       """
+      // Documentation for ServiceA
       protocol namespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
+          // Documentation for outputStreamingMethod
           func outputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Output>
       }
       // Generated conformance to `GRPCCore.RegistrableRPCService`.
       public extension namespaceA.ServiceA.StreamingServiceProtocol {
-          func registerRPCs(with router: inout RPCRouter) {
+          func registerRPCs(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
                   for: namespaceA.ServiceA.Methods.outputStreamingMethod.descriptor,
                   deserializer: ProtobufDeserializer<namespaceA.ServiceA.Methods.outputStreamingMethod.Input>(),
                   serializer: ProtobufSerializer<namespaceA.ServiceA.Methods.outputStreamingMethod.Output>(),
                   handler: { request in
-                      try await self.outputStreamingMethod(request)
+                      try await self.outputStreamingMethod(request: request)
                   }
               )
           }
@@ -198,18 +204,20 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     )
     let expectedSwift =
       """
+      // Documentation for ServiceA
       protocol namespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
+          // Documentation for bidirectionalStreamingMethod
           func bidirectionalStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.bidirectionalStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.bidirectionalStreamingMethod.Output>
       }
       // Generated conformance to `GRPCCore.RegistrableRPCService`.
       public extension namespaceA.ServiceA.StreamingServiceProtocol {
-          func registerRPCs(with router: inout RPCRouter) {
+          func registerRPCs(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
                   for: namespaceA.ServiceA.Methods.bidirectionalStreamingMethod.descriptor,
                   deserializer: ProtobufDeserializer<namespaceA.ServiceA.Methods.bidirectionalStreamingMethod.Input>(),
                   serializer: ProtobufSerializer<namespaceA.ServiceA.Methods.bidirectionalStreamingMethod.Output>(),
                   handler: { request in
-                      try await self.bidirectionalStreamingMethod(request)
+                      try await self.bidirectionalStreamingMethod(request: request)
                   }
               )
           }
@@ -255,19 +263,22 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     )
     let expectedSwift =
       """
+      // Documentation for ServiceA
       protocol namespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
+          // Documentation for inputStreamingMethod
           func inputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Output>
+          // Documentation for outputStreamingMethod
           func outputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Output>
       }
       // Generated conformance to `GRPCCore.RegistrableRPCService`.
       public extension namespaceA.ServiceA.StreamingServiceProtocol {
-          func registerRPCs(with router: inout RPCRouter) {
+          func registerRPCs(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
                   for: namespaceA.ServiceA.Methods.inputStreamingMethod.descriptor,
                   deserializer: ProtobufDeserializer<namespaceA.ServiceA.Methods.inputStreamingMethod.Input>(),
                   serializer: ProtobufSerializer<namespaceA.ServiceA.Methods.inputStreamingMethod.Output>(),
                   handler: { request in
-                      try await self.inputStreamingMethod(request)
+                      try await self.inputStreamingMethod(request: request)
                   }
               )
               router.registerHandler(
@@ -275,7 +286,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
                   deserializer: ProtobufDeserializer<namespaceA.ServiceA.Methods.outputStreamingMethod.Input>(),
                   serializer: ProtobufSerializer<namespaceA.ServiceA.Methods.outputStreamingMethod.Output>(),
                   handler: { request in
-                      try await self.outputStreamingMethod(request)
+                      try await self.outputStreamingMethod(request: request)
                   }
               )
           }
@@ -323,18 +334,20 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     )
     let expectedSwift =
       """
+      // Documentation for ServiceA
       protocol ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
+          // Documentation for MethodA
           func methodA(request: ServerRequest.Stream<ServiceA.Methods.methodA.Input>) async throws -> ServerResponse.Stream<ServiceA.Methods.methodA.Output>
       }
       // Generated conformance to `GRPCCore.RegistrableRPCService`.
       public extension ServiceA.StreamingServiceProtocol {
-          func registerRPCs(with router: inout RPCRouter) {
+          func registerRPCs(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
                   for: ServiceA.Methods.methodA.descriptor,
                   deserializer: ProtobufDeserializer<ServiceA.Methods.methodA.Input>(),
                   serializer: ProtobufSerializer<ServiceA.Methods.methodA.Output>(),
                   handler: { request in
-                      try await self.methodA(request)
+                      try await self.methodA(request: request)
                   }
               )
           }
@@ -374,20 +387,22 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     )
     let expectedSwift =
       """
+      // Documentation for ServiceA
       protocol namespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {}
       // Generated conformance to `GRPCCore.RegistrableRPCService`.
       public extension namespaceA.ServiceA.StreamingServiceProtocol {
-          func registerRPCs(with router: inout RPCRouter) {}
+          func registerRPCs(with router: inout GRPCCore.RPCRouter) {}
       }
       // Documentation for ServiceA
       protocol namespaceA_ServiceAServiceProtocol: namespaceA.ServiceA.StreamingServiceProtocol {}
       // Generated partial conformance to `namespaceA_ServiceAStreamingServiceProtocol`.
       public extension namespaceA.ServiceA.ServiceProtocol {
       }
+      // Documentation for ServiceB
       protocol namespaceA_ServiceBStreamingServiceProtocol: GRPCCore.RegistrableRPCService {}
       // Generated conformance to `GRPCCore.RegistrableRPCService`.
       public extension namespaceA.ServiceB.StreamingServiceProtocol {
-          func registerRPCs(with router: inout RPCRouter) {}
+          func registerRPCs(with router: inout GRPCCore.RPCRouter) {}
       }
       // Documentation for ServiceB
       protocol namespaceA_ServiceBServiceProtocol: namespaceA.ServiceB.StreamingServiceProtocol {}

--- a/Tests/GRPCCodeGenTests/Internal/Translator/SnippetBasedTranslatorTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/SnippetBasedTranslatorTests.swift
@@ -487,7 +487,7 @@ extension SnippetBasedTranslatorTests {
     try XCTAssertEqualWithDiff(contents, expectedSwift)
   }
 
-  private func assertThrowsError<T, E: Error>(
+  internal func assertThrowsError<T, E: Error>(
     ofType: E.Type,
     _ expression: @autoclosure () throws -> T,
     _ errorHandler: (E) -> Void
@@ -502,7 +502,7 @@ extension SnippetBasedTranslatorTests {
 }
 
 extension SnippetBasedTranslatorTests {
-  private func makeCodeGenerationRequest(services: [ServiceDescriptor]) -> CodeGenerationRequest {
+  internal func makeCodeGenerationRequest(services: [ServiceDescriptor]) -> CodeGenerationRequest {
     return CodeGenerationRequest(
       fileName: "test.grpc",
       leadingTrivia: "Some really exciting license header 2023.",

--- a/Tests/GRPCCodeGenTests/Internal/Translator/TestFunctions.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/TestFunctions.swift
@@ -26,6 +26,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+#if os(macOS) || os(Linux)  // swift-format doesn't like canImport(Foundation.Process)
+
 import XCTest
 
 @testable import GRPCCodeGen
@@ -97,3 +100,5 @@ internal func XCTAssertThrowsError<T, E: Error>(
     errorHandler(error)
   }
 }
+
+#endif  // os(macOS) || os(Linux)

--- a/Tests/GRPCCodeGenTests/Internal/Translator/TestFunctions.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/TestFunctions.swift
@@ -1,3 +1,4 @@
+import GRPCCodeGen
 /*
  * Copyright 2023, gRPC Authors All rights reserved.
  *
@@ -64,4 +65,34 @@ internal func XCTAssertEqualWithDiff(
     file: file,
     line: line
   )
+}
+
+internal func makeCodeGenerationRequest(
+  services: [CodeGenerationRequest.ServiceDescriptor]
+) -> CodeGenerationRequest {
+  return CodeGenerationRequest(
+    fileName: "test.grpc",
+    leadingTrivia: "Some really exciting license header 2023.",
+    dependencies: [],
+    services: services,
+    lookupSerializer: {
+      "ProtobufSerializer<\($0)>()"
+    },
+    lookupDeserializer: {
+      "ProtobufDeserializer<\($0)>()"
+    }
+  )
+}
+
+internal func XCTAssertThrowsError<T, E: Error>(
+  ofType: E.Type,
+  _ expression: @autoclosure () throws -> T,
+  _ errorHandler: (E) -> Void
+) {
+  XCTAssertThrowsError(try expression()) { error in
+    guard let error = error as? E else {
+      return XCTFail("Error had unexpected type '\(type(of: error))'")
+    }
+    errorHandler(error)
+  }
 }

--- a/Tests/GRPCCodeGenTests/Internal/Translator/TestFunctions.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/TestFunctions.swift
@@ -31,7 +31,7 @@
 
 import XCTest
 
-@testable import GRPCCodeGen
+import GRPCCodeGen
 
 private func diff(expected: String, actual: String) throws -> String {
   let process = Process()

--- a/Tests/GRPCCodeGenTests/Internal/Translator/TestFunctions.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/TestFunctions.swift
@@ -1,4 +1,3 @@
-import GRPCCodeGen
 /*
  * Copyright 2023, gRPC Authors All rights reserved.
  *
@@ -28,6 +27,8 @@ import GRPCCodeGen
 //
 //===----------------------------------------------------------------------===//
 import XCTest
+
+@testable import GRPCCodeGen
 
 private func diff(expected: String, actual: String) throws -> String {
   let process = Process()

--- a/Tests/GRPCCodeGenTests/Internal/Translator/TypealiasTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/TypealiasTranslatorSnippetBasedTests.swift
@@ -18,7 +18,7 @@ import XCTest
 
 @testable import GRPCCodeGen
 
-final class SnippetBasedTranslatorTests: XCTestCase {
+final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
   typealias MethodDescriptor = GRPCCodeGen.CodeGenerationRequest.ServiceDescriptor.MethodDescriptor
   typealias ServiceDescriptor = GRPCCodeGen.CodeGenerationRequest.ServiceDescriptor
 
@@ -61,7 +61,7 @@ final class SnippetBasedTranslatorTests: XCTestCase {
       """
 
     try self.assertTypealiasTranslation(
-      codeGenerationRequest: self.makeCodeGenerationRequest(services: [service]),
+      codeGenerationRequest: makeCodeGenerationRequest(services: [service]),
       expectedSwift: expectedSwift
     )
   }
@@ -103,7 +103,7 @@ final class SnippetBasedTranslatorTests: XCTestCase {
       """
 
     try self.assertTypealiasTranslation(
-      codeGenerationRequest: self.makeCodeGenerationRequest(services: [service]),
+      codeGenerationRequest: makeCodeGenerationRequest(services: [service]),
       expectedSwift: expectedSwift
     )
   }
@@ -164,7 +164,7 @@ final class SnippetBasedTranslatorTests: XCTestCase {
       """
 
     try self.assertTypealiasTranslation(
-      codeGenerationRequest: self.makeCodeGenerationRequest(services: [service]),
+      codeGenerationRequest: makeCodeGenerationRequest(services: [service]),
       expectedSwift: expectedSwift
     )
   }
@@ -189,7 +189,7 @@ final class SnippetBasedTranslatorTests: XCTestCase {
       """
 
     try self.assertTypealiasTranslation(
-      codeGenerationRequest: self.makeCodeGenerationRequest(services: [service]),
+      codeGenerationRequest: makeCodeGenerationRequest(services: [service]),
       expectedSwift: expectedSwift
     )
   }
@@ -228,7 +228,7 @@ final class SnippetBasedTranslatorTests: XCTestCase {
       """
 
     try self.assertTypealiasTranslation(
-      codeGenerationRequest: self.makeCodeGenerationRequest(services: [serviceB, serviceA]),
+      codeGenerationRequest: makeCodeGenerationRequest(services: [serviceB, serviceA]),
       expectedSwift: expectedSwift
     )
   }
@@ -265,7 +265,7 @@ final class SnippetBasedTranslatorTests: XCTestCase {
       """
 
     try self.assertTypealiasTranslation(
-      codeGenerationRequest: self.makeCodeGenerationRequest(services: [serviceB, serviceA]),
+      codeGenerationRequest: makeCodeGenerationRequest(services: [serviceB, serviceA]),
       expectedSwift: expectedSwift
     )
   }
@@ -306,7 +306,7 @@ final class SnippetBasedTranslatorTests: XCTestCase {
       """
 
     try self.assertTypealiasTranslation(
-      codeGenerationRequest: self.makeCodeGenerationRequest(services: [serviceB, serviceA]),
+      codeGenerationRequest: makeCodeGenerationRequest(services: [serviceB, serviceA]),
       expectedSwift: expectedSwift
     )
   }
@@ -343,7 +343,7 @@ final class SnippetBasedTranslatorTests: XCTestCase {
       """
 
     try self.assertTypealiasTranslation(
-      codeGenerationRequest: self.makeCodeGenerationRequest(services: [serviceA, serviceB]),
+      codeGenerationRequest: makeCodeGenerationRequest(services: [serviceA, serviceB]),
       expectedSwift: expectedSwift
     )
   }
@@ -356,9 +356,9 @@ final class SnippetBasedTranslatorTests: XCTestCase {
       methods: []
     )
 
-    let codeGenerationRequest = self.makeCodeGenerationRequest(services: [serviceA, serviceA])
+    let codeGenerationRequest = makeCodeGenerationRequest(services: [serviceA, serviceA])
     let translator = TypealiasTranslator()
-    self.assertThrowsError(
+    XCTAssertThrowsError(
       ofType: CodeGenError.self,
       try translator.translate(from: codeGenerationRequest)
     ) {
@@ -384,9 +384,9 @@ final class SnippetBasedTranslatorTests: XCTestCase {
       methods: []
     )
 
-    let codeGenerationRequest = self.makeCodeGenerationRequest(services: [serviceA, serviceA])
+    let codeGenerationRequest = makeCodeGenerationRequest(services: [serviceA, serviceA])
     let translator = TypealiasTranslator()
-    self.assertThrowsError(
+    XCTAssertThrowsError(
       ofType: CodeGenError.self,
       try translator.translate(from: codeGenerationRequest)
     ) {
@@ -420,9 +420,9 @@ final class SnippetBasedTranslatorTests: XCTestCase {
       methods: [methodA, methodA]
     )
 
-    let codeGenerationRequest = self.makeCodeGenerationRequest(services: [service])
+    let codeGenerationRequest = makeCodeGenerationRequest(services: [service])
     let translator = TypealiasTranslator()
-    self.assertThrowsError(
+    XCTAssertThrowsError(
       ofType: CodeGenError.self,
       try translator.translate(from: codeGenerationRequest)
     ) {
@@ -453,9 +453,9 @@ final class SnippetBasedTranslatorTests: XCTestCase {
       namespace: "SameName",
       methods: []
     )
-    let codeGenerationRequest = self.makeCodeGenerationRequest(services: [serviceA, serviceB])
+    let codeGenerationRequest = makeCodeGenerationRequest(services: [serviceA, serviceB])
     let translator = TypealiasTranslator()
-    self.assertThrowsError(
+    XCTAssertThrowsError(
       ofType: CodeGenError.self,
       try translator.translate(from: codeGenerationRequest)
     ) {
@@ -474,7 +474,7 @@ final class SnippetBasedTranslatorTests: XCTestCase {
   }
 }
 
-extension SnippetBasedTranslatorTests {
+extension TypealiasTranslatorSnippetBasedTests {
   private func assertTypealiasTranslation(
     codeGenerationRequest: CodeGenerationRequest,
     expectedSwift: String
@@ -485,35 +485,5 @@ extension SnippetBasedTranslatorTests {
     renderer.renderCodeBlocks(codeBlocks)
     let contents = renderer.renderedContents()
     try XCTAssertEqualWithDiff(contents, expectedSwift)
-  }
-
-  internal func assertThrowsError<T, E: Error>(
-    ofType: E.Type,
-    _ expression: @autoclosure () throws -> T,
-    _ errorHandler: (E) -> Void
-  ) {
-    XCTAssertThrowsError(try expression()) { error in
-      guard let error = error as? E else {
-        return XCTFail("Error had unexpected type '\(type(of: error))'")
-      }
-      errorHandler(error)
-    }
-  }
-}
-
-extension SnippetBasedTranslatorTests {
-  internal func makeCodeGenerationRequest(services: [ServiceDescriptor]) -> CodeGenerationRequest {
-    return CodeGenerationRequest(
-      fileName: "test.grpc",
-      leadingTrivia: "Some really exciting license header 2023.",
-      dependencies: [],
-      services: services,
-      lookupSerializer: {
-        "ProtobufSerializer<\($0)>()"
-      },
-      lookupDeserializer: {
-        "ProtobufDeserializer<\($0)>()"
-      }
-    )
   }
 }

--- a/Tests/GRPCCodeGenTests/Internal/Translator/TypealiasTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/TypealiasTranslatorSnippetBasedTests.swift
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#if os(macOS) || os(Linux)  // swift-format doesn't like canImport(Foundation.Process)
+
 import XCTest
 
 @testable import GRPCCodeGen
@@ -487,3 +489,5 @@ extension TypealiasTranslatorSnippetBasedTests {
     try XCTAssertEqualWithDiff(contents, expectedSwift)
   }
 }
+
+#endif  // os(macOS) || os(Linux)


### PR DESCRIPTION
Motivation:

In the generated server code for a service described in a Source IDL file we want to have:
- a protocol defining all the methods as bidirectional streaming, conforming to `RegistrableRPCService`
- an extension for the streaming protocol that implements the `registerRPCs` function that is required by the `RegistrableRPCService` conformance
- a service protocol that defines the methods of the service, as they are descibed in the Source IDL (unary/input-streaming/output-streaming/bidirectional-streaming) that conforms to the streaming protocol.
- the extension of the service protocol that implements the bidirectional streaming methods required by the conformance to the streaming protocol, using calls to the service methods (in case a service method is bidirectional streaming), it doesn't need to be reimplemented.

Modifications:

- Created the ServerCodeTranslator that conforms to SpecializedTranslator and contains all the methods for creating the representation of the generated code that we want using StructuredSwiftRepresentation format.
- Implemented snippet tests that test the ServerCodeTranslator.
- added the inout parameter type as a case of ExistingTypeDescription in StructuredSwiftRepresentation, as it is needed by the `registerRPCs` function.

Result:

Server code can now be generated for a CodeGenerationRequest object.