### PR TITLE
Update available to fix build for non-macOS Apple platforms

### DIFF
--- a/Sources/Examples/PacketCapture/PacketCapture.swift
+++ b/Sources/Examples/PacketCapture/PacketCapture.swift
@@ -21,7 +21,7 @@ import NIOExtras
 import NIOPosix
 
 @main
-@available(macOS 10.15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 struct PCAP: AsyncParsableCommand {
   @Option(help: "The port to connect to")
   var port = 1234

--- a/Tests/GRPCCodeGenTests/Internal/Translator/SnippetBasedTranslatorTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/SnippetBasedTranslatorTests.swift
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#if os(macOS) || os(Linux)  // swift-format doesn't like canImport(Foundation.Process)
+
 import XCTest
 
 @testable import GRPCCodeGen
@@ -517,3 +519,5 @@ extension SnippetBasedTranslatorTests {
     )
   }
 }
+
+#endif  // os(macOS) || os(Linux)

--- a/Tests/GRPCCodeGenTests/Internal/Translator/TestFunctions.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/TestFunctions.swift
@@ -26,6 +26,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+#if os(macOS) || os(Linux)  // swift-format doesn't like canImport(Foundation.Process)
+
 import XCTest
 
 private func diff(expected: String, actual: String) throws -> String {
@@ -65,3 +68,5 @@ internal func XCTAssertEqualWithDiff(
     line: line
   )
 }
+
+#endif  // os(macOS) || os(Linux)

--- a/Tests/GRPCCoreTests/Call/Client/ClientResponseTests.swift
+++ b/Tests/GRPCCoreTests/Call/Client/ClientResponseTests.swift
@@ -18,6 +18,7 @@ import XCTest
 
 @testable import GRPCCore
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class ClientResponseTests: XCTestCase {
   func testAcceptedSingleResponseConvenienceMethods() {
     let response = ClientResponse.Single(

--- a/Tests/GRPCCoreTests/Call/Server/ServerRequestTests.swift
+++ b/Tests/GRPCCoreTests/Call/Server/ServerRequestTests.swift
@@ -16,6 +16,7 @@
 @_spi(Testing) import GRPCCore
 import XCTest
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class ServerRequestTests: XCTestCase {
   func testSingleToStreamConversion() async throws {
     let single = ServerRequest.Single(metadata: ["bar": "baz"], message: "foo")

--- a/Tests/GRPCCoreTests/Call/Server/ServerResponseTests.swift
+++ b/Tests/GRPCCoreTests/Call/Server/ServerResponseTests.swift
@@ -16,6 +16,7 @@
 @_spi(Testing) import GRPCCore
 import XCTest
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class ServerResponseTests: XCTestCase {
   func testSingleConvenienceInit() {
     var response = ServerResponse.Single(

--- a/Tests/GRPCCoreTests/ServerErrorTests.swift
+++ b/Tests/GRPCCoreTests/ServerErrorTests.swift
@@ -16,6 +16,7 @@
 import GRPCCore
 import XCTest
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class ServerErrorTests: XCTestCase {
   func testCopyOnWrite() {
     // ServerError has a heap based storage, so check CoW semantics are correctly implemented.

--- a/Tests/GRPCCoreTests/Streaming/Internal/AsyncSequenceOfOne.swift
+++ b/Tests/GRPCCoreTests/Streaming/Internal/AsyncSequenceOfOne.swift
@@ -18,6 +18,7 @@ import XCTest
 
 @testable import GRPCCore
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 internal final class AsyncSequenceOfOneTests: XCTestCase {
   func testSuccessPath() async throws {
     let sequence = RPCAsyncSequence.one("foo")

--- a/Tests/GRPCCoreTests/Streaming/Internal/BufferedStreamTests.swift
+++ b/Tests/GRPCCoreTests/Streaming/Internal/BufferedStreamTests.swift
@@ -1080,6 +1080,7 @@ final class BufferedStreamTests: XCTestCase {
   }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension BufferedStream.Source.WriteResult {
   func assertIsProducerMore() {
     switch self {

--- a/Tests/GRPCCoreTests/Test Utilities/AsyncSequence+Utilities.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/AsyncSequence+Utilities.swift
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension AsyncSequence {
   func collect() async throws -> [Element] {
     return try await self.reduce(into: []) { $0.append($1) }
@@ -21,6 +22,7 @@ extension AsyncSequence {
 }
 
 #if swift(<5.9)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension AsyncStream {
   static func makeStream(
     of elementType: Element.Type = Element.self,
@@ -34,6 +36,7 @@ extension AsyncStream {
   }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension AsyncThrowingStream {
   static func makeStream(
     of elementType: Element.Type = Element.self,

--- a/Tests/GRPCCoreTests/Test Utilities/Call/Client/ClientInterceptors.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/Call/Client/ClientInterceptors.swift
@@ -16,6 +16,7 @@
 import Atomics
 import GRPCCore
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension ClientInterceptor where Self == RejectAllClientInterceptor {
   static func rejectAll(with error: RPCError) -> Self {
     return RejectAllClientInterceptor(error: error, throw: false)
@@ -27,6 +28,7 @@ extension ClientInterceptor where Self == RejectAllClientInterceptor {
 
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension ClientInterceptor where Self == RequestCountingClientInterceptor {
   static func requestCounter(_ counter: ManagedAtomic<Int>) -> Self {
     return RequestCountingClientInterceptor(counter: counter)
@@ -34,6 +36,7 @@ extension ClientInterceptor where Self == RequestCountingClientInterceptor {
 }
 
 /// Rejects all RPCs with the provided error.
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 struct RejectAllClientInterceptor: ClientInterceptor {
   /// The error to reject all RPCs with.
   let error: RPCError
@@ -62,6 +65,7 @@ struct RejectAllClientInterceptor: ClientInterceptor {
   }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 struct RequestCountingClientInterceptor: ClientInterceptor {
   /// The number of requests made.
   let counter: ManagedAtomic<Int>

--- a/Tests/GRPCCoreTests/Test Utilities/Call/Server/ServerInterceptors.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/Call/Server/ServerInterceptors.swift
@@ -16,6 +16,7 @@
 import Atomics
 import GRPCCore
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension ServerInterceptor where Self == RejectAllServerInterceptor {
   static func rejectAll(with error: RPCError) -> Self {
     return RejectAllServerInterceptor(error: error, throw: false)
@@ -26,6 +27,7 @@ extension ServerInterceptor where Self == RejectAllServerInterceptor {
   }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension ServerInterceptor where Self == RequestCountingServerInterceptor {
   static func requestCounter(_ counter: ManagedAtomic<Int>) -> Self {
     return RequestCountingServerInterceptor(counter: counter)
@@ -33,6 +35,7 @@ extension ServerInterceptor where Self == RequestCountingServerInterceptor {
 }
 
 /// Rejects all RPCs with the provided error.
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 struct RejectAllServerInterceptor: ServerInterceptor {
   /// The error to reject all RPCs with.
   let error: RPCError
@@ -61,6 +64,7 @@ struct RejectAllServerInterceptor: ServerInterceptor {
   }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 struct RequestCountingServerInterceptor: ServerInterceptor {
   /// The number of requests made.
   let counter: ManagedAtomic<Int>

--- a/Tests/GRPCCoreTests/Test Utilities/RPCAsyncSequence+Utilities.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/RPCAsyncSequence+Utilities.swift
@@ -16,7 +16,6 @@
 import GRPCCore
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension RPCAsyncSequence {
   static func elements(_ elements: Element...) -> Self {
     return .elements(elements)

--- a/Tests/GRPCCoreTests/Test Utilities/RPCAsyncSequence+Utilities.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/RPCAsyncSequence+Utilities.swift
@@ -15,6 +15,8 @@
  */
 import GRPCCore
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension RPCAsyncSequence {
   static func elements(_ elements: Element...) -> Self {
     return .elements(elements)

--- a/Tests/GRPCCoreTests/Test Utilities/RPCWriter+Utilities.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/RPCWriter+Utilities.swift
@@ -16,6 +16,7 @@
 import GRPCCore
 import XCTest
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension RPCWriter {
   /// Returns a writer which calls `XCTFail(_:)` on every write.
   static func failTestOnWrite(elementType: Element.Type = Element.self) -> Self {
@@ -28,12 +29,14 @@ extension RPCWriter {
   }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 private struct FailOnWrite<Element>: RPCWriterProtocol {
   func write(contentsOf elements: some Sequence<Element>) async throws {
     XCTFail("Unexpected write")
   }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 private struct AsyncStreamGatheringWriter<Element>: RPCWriterProtocol {
   let continuation: AsyncStream<Element>.Continuation
 

--- a/Tests/GRPCCoreTests/Test Utilities/Services/BinaryEcho.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/Services/BinaryEcho.swift
@@ -16,6 +16,7 @@
 import GRPCCore
 import XCTest
 
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 struct BinaryEcho: RegistrableRPCService {
   func get(
     _ request: ServerRequest.Single<[UInt8]>

--- a/Tests/GRPCCoreTests/Test Utilities/Transport/ThrowingTransport.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/Transport/ThrowingTransport.swift
@@ -50,6 +50,7 @@ struct ThrowOnStreamCreationTransport: ClientTransport {
   }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 struct ThrowOnRunServerTransport: ServerTransport {
   func listen() async throws -> RPCAsyncSequence<RPCStream<Inbound, Outbound>> {
     throw RPCError(
@@ -63,6 +64,7 @@ struct ThrowOnRunServerTransport: ServerTransport {
   }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 struct ThrowOnSignalServerTransport: ServerTransport {
   let signal: AsyncStream<Void>
 

--- a/Tests/GRPCCoreTests/Test Utilities/XCTest+Utilities.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/XCTest+Utilities.swift
@@ -25,6 +25,7 @@ func XCTAssertDescription(
   XCTAssertEqual(String(describing: subject), expected, file: file, line: line)
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 func XCTAssertThrowsErrorAsync<T>(
   _ expression: () async throws -> T,
   errorHandler: (Error) -> Void
@@ -50,6 +51,7 @@ func XCTAssertThrowsError<T, E: Error>(
   }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 func XCTAssertThrowsErrorAsync<T, E: Error>(
   ofType: E.Type = E.self,
   _ expression: () async throws -> T,
@@ -78,6 +80,7 @@ func XCTAssertThrowsRPCError<T>(
   }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 func XCTAssertThrowsRPCErrorAsync<T>(
   _ expression: () async throws -> T,
   errorHandler: (RPCError) -> Void
@@ -92,6 +95,7 @@ func XCTAssertThrowsRPCErrorAsync<T>(
   }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 func XCTAssertRejected<T>(
   _ response: ClientResponse.Stream<T>,
   errorHandler: (RPCError) -> Void
@@ -128,6 +132,7 @@ func XCTAssertMetadata(
   }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 func XCTAssertMetadata(
   _ part: RPCRequestPart?,
   metadataHandler: (Metadata) async throws -> Void = { _ in }
@@ -152,6 +157,7 @@ func XCTAssertMessage(
   }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 func XCTAssertMessage(
   _ part: RPCRequestPart?,
   messageHandler: ([UInt8]) async throws -> Void = { _ in }

--- a/Tests/GRPCCoreTests/TimeoutTests.swift
+++ b/Tests/GRPCCoreTests/TimeoutTests.swift
@@ -17,6 +17,7 @@ import XCTest
 
 @testable import GRPCCore
 
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 final class TimeoutTests: XCTestCase {
   func testDecodeInvalidTimeout_Empty() {
     let timeoutHeader = ""

--- a/Tests/GRPCInProcessTransportTests/InProcessServerTransportTests.swift
+++ b/Tests/GRPCInProcessTransportTests/InProcessServerTransportTests.swift
@@ -19,6 +19,7 @@ import XCTest
 @testable import GRPCCore
 @testable import GRPCInProcessTransport
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class InProcessServerTransportTests: XCTestCase {
   func testStartListening() async throws {
     let transport = InProcessServerTransport()

--- a/Tests/GRPCInProcessTransportTests/Test Utilities/XCTest+Utilities.swift
+++ b/Tests/GRPCInProcessTransportTests/Test Utilities/XCTest+Utilities.swift
@@ -28,6 +28,7 @@ func XCTAssertThrowsError<T, E: Error>(
   }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 func XCTAssertThrowsErrorAsync<T, E: Error>(
   ofType: E.Type = E.self,
   _ expression: () async throws -> T,

--- a/Tests/GRPCTests/AsyncAwaitSupport/AsyncServerHandler/ServerHandlerStateMachine/ServerHandlerStateMachineTests.swift
+++ b/Tests/GRPCTests/AsyncAwaitSupport/AsyncServerHandler/ServerHandlerStateMachine/ServerHandlerStateMachineTests.swift
@@ -265,6 +265,7 @@ internal final class ServerHandlerStateMachineTests: GRPCTestCase {
 
 // MARK: - Action Assertions
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension ServerHandlerStateMachine.HandleMetadataAction {
   func assertInvokeHandler() {
     XCTAssertEqual(self, .invokeHandler)
@@ -275,6 +276,7 @@ extension ServerHandlerStateMachine.HandleMetadataAction {
   }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension ServerHandlerStateMachine.HandleMessageAction {
   func assertForward() {
     XCTAssertEqual(self, .forward)
@@ -285,6 +287,7 @@ extension ServerHandlerStateMachine.HandleMessageAction {
   }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension ServerHandlerStateMachine.SendMessageAction {
   func assertInterceptHeadersThenMessage(_ verify: (HPACKHeaders) -> Void = { _ in }) {
     switch self {
@@ -304,6 +307,7 @@ extension ServerHandlerStateMachine.SendMessageAction {
   }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension ServerHandlerStateMachine.SendStatusAction {
   func assertIntercept(_ verify: (HPACKHeaders) -> Void = { _ in }) {
     switch self {
@@ -319,6 +323,7 @@ extension ServerHandlerStateMachine.SendStatusAction {
   }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension ServerHandlerStateMachine.CancelAction {
   func assertNone() {
     XCTAssertEqual(self, .none)

--- a/Tests/GRPCTests/EchoMetadataTests.swift
+++ b/Tests/GRPCTests/EchoMetadataTests.swift
@@ -81,7 +81,7 @@ internal final class EchoMetadataTests: GRPCTestCase {
     self.testServiceDescriptor(Echo_EchoClientMetadata.serviceDescriptor)
     self.testServiceDescriptor(Echo_EchoServerMetadata.serviceDescriptor)
 
-    if #available(macOS 12, *) {
+    if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
       self.testServiceDescriptor(Echo_EchoAsyncClient.serviceDescriptor)
     }
   }

--- a/Tests/GRPCTests/GRPCAsyncClientCallTests.swift
+++ b/Tests/GRPCTests/GRPCAsyncClientCallTests.swift
@@ -334,6 +334,7 @@ private actor RequestResponseCounter {
   }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 private final class AsyncEchoProvider: Echo_EchoAsyncProvider {
   let headers: HPACKHeaders
   let sendTwice: Bool

--- a/Tests/GRPCTests/GRPCAsyncServerHandlerTests.swift
+++ b/Tests/GRPCTests/GRPCAsyncServerHandlerTests.swift
@@ -522,6 +522,7 @@ class AsyncServerHandlerTests: GRPCTestCase {
   }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 internal final class AsyncResponseStream: GRPCServerResponseWriter {
   private let source:
     NIOAsyncSequenceProducer<

--- a/Tests/GRPCTests/GRPCNetworkFrameworkTests.swift
+++ b/Tests/GRPCTests/GRPCNetworkFrameworkTests.swift
@@ -27,7 +27,7 @@ import NIOTransportServices
 import Security
 import XCTest
 
-@available(macOS 10.14, iOS 12.0, watchOS 6.0, tvOS 12.0, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class GRPCNetworkFrameworkTests: GRPCTestCase {
   private var server: Server!
   private var client: ClientConnection!

--- a/Tests/GRPCTests/GRPCReflectionServiceTests/ReflectionServiceIntegrationTests.swift
+++ b/Tests/GRPCTests/GRPCReflectionServiceTests/ReflectionServiceIntegrationTests.swift
@@ -23,6 +23,7 @@ import XCTest
 
 @testable import GRPCReflectionService
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class ReflectionServiceIntegrationTests: GRPCTestCase {
   private var server: Server?
   private var channel: GRPCChannel?

--- a/Tests/GRPCTests/GRPCReflectionServiceTests/ReflectionServiceUnitTests.swift
+++ b/Tests/GRPCTests/GRPCReflectionServiceTests/ReflectionServiceUnitTests.swift
@@ -22,6 +22,7 @@ import XCTest
 
 @testable import GRPCReflectionService
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class ReflectionServiceUnitTests: GRPCTestCase {
   /// Testing the fileDescriptorDataByFilename dictionary of the ReflectionServiceData object.
   func testFileDescriptorDataByFilename() throws {

--- a/Tests/GRPCTests/ServerTLSErrorTests.swift
+++ b/Tests/GRPCTests/ServerTLSErrorTests.swift
@@ -129,6 +129,7 @@ class ServerTLSErrorTests: GRPCTestCase {
     }
   }
 
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   func testServerCustomVerificationCallback() async throws {
     let verificationCallbackInvoked = self.serverEventLoopGroup.next().makePromise(of: Void.self)
     let configuration = GRPCTLSConfiguration.makeServerConfigurationBackedByNIOSSL(


### PR DESCRIPTION
## Motivation

The package currently doesn't build for non-macOS Apple platforms, e.g. iOS, because of missing `@available` annotations, mostly in tests.

## Modifications

- Add missing `@available` annotations.
- Use `#if os(macOS) || os(Linux)` in test utils that require `Foundation.Process`. Ideally we'd use `#if canImport(Foundation.Process)`, but the version of `swift-format` used by this project doesn't understand it.

## Result

Code and tests can build for, and run on, other platforms, e.g. iOS.