### PR TITLE
Add missing compiler directive to ServerCodeTranslatorSnippetBasedTests.swift

### DIFF
--- a/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#if os(macOS) || os(Linux)  // swift-format doesn't like canImport(Foundation.Process)
+
 import XCTest
 
 @testable import GRPCCodeGen
@@ -429,3 +431,5 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     try XCTAssertEqualWithDiff(contents, expectedSwift)
   }
 }
+
+#endif  // os(macOS) || os(Linux)


### PR DESCRIPTION
## Motivation
A missing compiler directive to avoid compiling the snippet-based tests in non-macOS/Linux platforms was causing the build to fail on iOS/tvOS/watchOS. 

## Modifications
Add the compiler directive, which was present in other snippet-based test files.

## Result
Builds are green again in iOS/tvOS/watchOS.