### PR TITLE
Add missing compiler directive to ClientCodeTranslatorSnippetBasedTests

### DIFF
--- a/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#if os(macOS) || os(Linux) // swift-format doesn't like canImport(Foundation.Process)
+#if os(macOS) || os(Linux)  // swift-format doesn't like canImport(Foundation.Process)
 
 import XCTest
 

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#if os(macOS) || os(Linux) // swift-format doesn't like canImport(Foundation.Process)
+
 import XCTest
 
 @testable import GRPCCodeGen
@@ -540,3 +542,5 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     try XCTAssertEqualWithDiff(contents, expectedSwift)
   }
 }
+
+#endif  // os(macOS) || os(Linux)


### PR DESCRIPTION
Motivation:

A compiler directive that avoids compiling the snippet-based tests in non-macOS/Linux platforms is missing, causing the build to fail on iOS/tvOS/watchOS.

Modifications:

Added the compiler directive.

Result:

Builds won't fail again in iOS/tvOS/watchOS.