### PR TITLE
[CodeGenLib]  Differentiate type names from identifying names

### DIFF
--- a/Sources/GRPCCodeGen/CodeGenError.swift
+++ b/Sources/GRPCCodeGen/CodeGenError.swift
@@ -39,7 +39,6 @@ extension CodeGenError {
       case nonUniqueServiceName
       case nonUniqueMethodName
       case invalidKind
-      case invalidGeneratedNamespace
     }
 
     private var value: Value
@@ -60,11 +59,6 @@ extension CodeGenError {
     /// An invalid kind name is used for an import.
     public static var invalidKind: Self {
       Self(.invalidKind)
-    }
-
-    /// An invalid generated namespace is used for an import.
-    public static var invalidGeneratedNamespace: Self {
-      Self(.invalidGeneratedNamespace)
     }
   }
 }

--- a/Sources/GRPCCodeGen/CodeGenError.swift
+++ b/Sources/GRPCCodeGen/CodeGenError.swift
@@ -39,6 +39,7 @@ extension CodeGenError {
       case nonUniqueServiceName
       case nonUniqueMethodName
       case invalidKind
+      case invalidGeneratedNamespace
     }
 
     private var value: Value
@@ -59,6 +60,11 @@ extension CodeGenError {
     /// An invalid kind name is used for an import.
     public static var invalidKind: Self {
       Self(.invalidKind)
+    }
+
+    /// An invalid generated namespace is used for an import.
+    public static var invalidGeneratedNamespace: Self {
+      Self(.invalidGeneratedNamespace)
     }
   }
 }

--- a/Sources/GRPCCodeGen/CodeGenerationRequest.swift
+++ b/Sources/GRPCCodeGen/CodeGenerationRequest.swift
@@ -220,12 +220,16 @@ public struct CodeGenerationRequest {
     /// Documentation from comments above the IDL service description.
     public var documentation: String
 
-    /// Service name in different formats.
+    /// The service name in different formats.
+    ///
+    /// All properties of this object must be unique for each service from within a namespace.
     public var name: Name
 
     /// The service namespace in different formats.
     ///
-    /// For `.proto` files it is the package name.
+    /// All different services from within the same namespace must have
+    /// the same ``Name`` object as this property.
+    /// For `.proto` files the base name of this object is the package name.
     public var namespace: Name
 
     /// A description of each method of a service.
@@ -251,6 +255,9 @@ public struct CodeGenerationRequest {
       public var documentation: String
 
       /// Method name in different formats.
+      ///
+      /// All properties of this object must be unique for each method
+      /// from within a service.
       public var name: Name
 
       /// Identifies if the method is input streaming.
@@ -283,38 +290,31 @@ public struct CodeGenerationRequest {
     }
   }
 
-  /// Represents the name associated with a namespace, service or a method, in three different formats,
-  /// which are used in specific parts of the generated code. There must be only one ``Name`` object
-  /// for each namespace, service or method.
-  ///
-  /// The base name, the generatedUpperCase (and the generatedLowerCase) must be unique for methods
-  /// from within the same service and for services within the same namespace.
+  /// Represents the name associated with a namespace, service or a method, in three different formats.
   public struct Name: Hashable {
     /// The base name is the name used for the namespace/service/method in the IDL file, so it should follow
     /// the specific casing of the IDL.
     ///
     /// The base name is also used in the descriptors that identify a specific method or service :
     /// `<service_namespace_baseName>.<service_baseName>.<method_baseName>`.
-    public let base: String
+    public var base: String
 
-    /// The `generatedUpperCase` name is used as part of generated type names, which begin with a capital letter
-    /// and are (partially) using CamelCase. It is using UpperCamelCase in order to follow the Swift naming conventions.
+    /// The `generatedUpperCase` name is used in the generated code. It is expected
+    /// to be the UpperCamelCase version of the base name
     ///
-    /// It is used in the generated code as an enum name and as part of protocol names.
-    /// For example, in the generated server code the name of the service protocol
-    /// follows this pattern:
-    /// `<service_namespace_generatedUpperCaseName>_<service_generatedUpperCaseName>ServiceProtocol`.
-    public let generatedUpperCase: String
+    /// For example, if `base` is "fooBar", then `generatedUpperCase` is "FooBar".
+    public var generatedUpperCase: String
 
-    /// The `generatedLowerCase` name is used as the function name in the method declarations or definitions.
-    /// It is using lowerCamelCase in order to follow the Swift naming conventions.
+    /// The `generatedLowerCase` name is used in the generated code. It is expected
+    /// to be the lowerCamelCase version of the base name
     ///
-    /// It is used only for the methods, so in the case of a namespace or service, it can be an empty String.
-    /// For example, for a method with the base name "FooBar", the generatedLowerCase is "fooBar" and it is
-    /// used in:
-    /// ```swift
-    /// public func fooBar(){}
-    /// ```
-    public let generatedLowerCase: String
+    /// For example, if `base` is "FooBar", then `generatedLowerCase` is "fooBar".
+    public var generatedLowerCase: String
+
+    public init(base: String, generatedUpperCase: String, generatedLowerCase: String) {
+      self.base = base
+      self.generatedUpperCase = generatedUpperCase
+      self.generatedLowerCase = generatedLowerCase
+    }
   }
 }

--- a/Sources/GRPCCodeGen/CodeGenerationRequest.swift
+++ b/Sources/GRPCCodeGen/CodeGenerationRequest.swift
@@ -220,19 +220,13 @@ public struct CodeGenerationRequest {
     /// Documentation from comments above the IDL service description.
     public var documentation: String
 
-    /// Service name.
-    public var name: String
+    /// Service name in different formats.
+    public var name: Name
 
-    /// The service name used in the generated type names.
-    public var generatedName: String
-
-    /// The service namespace.
+    /// The service namespace in different formats.
     ///
     /// For `.proto` files it is the package name.
-    public var namespace: String
-
-    /// The namespace identifier used in the generated type names.
-    public var generatedNamespace: String
+    public var namespace: Name
 
     /// A description of each method of a service.
     ///
@@ -241,17 +235,13 @@ public struct CodeGenerationRequest {
 
     public init(
       documentation: String,
-      name: String,
-      generatedName: String,
-      namespace: String,
-      generatedNamespace: String,
+      name: Name,
+      namespace: Name,
       methods: [MethodDescriptor]
     ) {
       self.documentation = documentation
       self.name = name
-      self.generatedName = generatedName
       self.namespace = namespace
-      self.generatedNamespace = generatedNamespace
       self.methods = methods
     }
 
@@ -260,14 +250,8 @@ public struct CodeGenerationRequest {
       /// Documentation from comments above the IDL method description.
       public var documentation: String
 
-      /// Method name.
-      public var name: String
-
-      /// The name used in the generated type names.
-      public var generatedName: String
-
-      /// The function name used in the generated code in declarations of the method.
-      public var signatureName: String
+      /// Method name in different formats.
+      public var name: Name
 
       /// Identifies if the method is input streaming.
       public var isInputStreaming: Bool
@@ -283,9 +267,7 @@ public struct CodeGenerationRequest {
 
       public init(
         documentation: String,
-        name: String,
-        generatedName: String,
-        signatureName: String,
+        name: Name,
         isInputStreaming: Bool,
         isOutputStreaming: Bool,
         inputType: String,
@@ -293,13 +275,46 @@ public struct CodeGenerationRequest {
       ) {
         self.documentation = documentation
         self.name = name
-        self.generatedName = generatedName
-        self.signatureName = signatureName
         self.isInputStreaming = isInputStreaming
         self.isOutputStreaming = isOutputStreaming
         self.inputType = inputType
         self.outputType = outputType
       }
     }
+  }
+
+  /// Represents the name associated with a namespace, service or a method, in three different formats,
+  /// which are used in specific parts of the generated code. There must be only one ``Name`` object
+  /// for each namespace, service or method.
+  ///
+  /// The base name, the generatedUpperCase (and the generatedLowerCase) must be unique for methods
+  /// from within the same service and for services within the same namespace.
+  public struct Name: Hashable {
+    /// The base name is the name used for the namespace/service/method in the IDL file, so it should follow
+    /// the specific casing of the IDL.
+    ///
+    /// The base name is also used in the descriptors that identify a specific method or service :
+    /// `<service_namespace_baseName>.<service_baseName>.<method_baseName>`.
+    public let base: String
+
+    /// The `generatedUpperCase` name is used as part of generated type names, which begin with a capital letter
+    /// and are (partially) using CamelCase. It is using UpperCamelCase in order to follow the Swift naming conventions.
+    ///
+    /// It is used in the generated code as an enum name and as part of protocol names.
+    /// For example, in the generated server code the name of the service protocol
+    /// follows this pattern:
+    /// `<service_namespace_generatedUpperCaseName>_<service_generatedUpperCaseName>ServiceProtocol`.
+    public let generatedUpperCase: String
+
+    /// The `generatedLowerCase` name is used as the function name in the method declarations or definitions.
+    /// It is using lowerCamelCase in order to follow the Swift naming conventions.
+    ///
+    /// It is used only for the methods, so in the case of a namespace or service, it can be an empty String.
+    /// For example, for a method with the base name "FooBar", the generatedLowerCase is "fooBar" and it is
+    /// used in:
+    /// ```swift
+    /// public func fooBar(){}
+    /// ```
+    public let generatedLowerCase: String
   }
 }

--- a/Sources/GRPCCodeGen/CodeGenerationRequest.swift
+++ b/Sources/GRPCCodeGen/CodeGenerationRequest.swift
@@ -216,17 +216,23 @@ public struct CodeGenerationRequest {
   }
 
   /// Represents a service described in an IDL file.
-  public struct ServiceDescriptor {
+  public struct ServiceDescriptor: Hashable {
     /// Documentation from comments above the IDL service description.
     public var documentation: String
 
     /// Service name.
     public var name: String
 
+    /// The service name used in the generated type names.
+    public var generatedName: String
+
     /// The service namespace.
     ///
     /// For `.proto` files it is the package name.
     public var namespace: String
+
+    /// The namespace identifier used in the generated type names.
+    public var generatedNamespace: String
 
     /// A description of each method of a service.
     ///
@@ -236,22 +242,32 @@ public struct CodeGenerationRequest {
     public init(
       documentation: String,
       name: String,
+      generatedName: String,
       namespace: String,
+      generatedNamespace: String,
       methods: [MethodDescriptor]
     ) {
       self.documentation = documentation
       self.name = name
+      self.generatedName = generatedName
       self.namespace = namespace
+      self.generatedNamespace = generatedNamespace
       self.methods = methods
     }
 
     /// Represents a method described in an IDL file.
-    public struct MethodDescriptor {
+    public struct MethodDescriptor: Hashable {
       /// Documentation from comments above the IDL method description.
       public var documentation: String
 
       /// Method name.
       public var name: String
+
+      /// The name used in the generated type names.
+      public var generatedName: String
+
+      /// The function name used in the generated code in declarations of the method.
+      public var signatureName: String
 
       /// Identifies if the method is input streaming.
       public var isInputStreaming: Bool
@@ -268,6 +284,8 @@ public struct CodeGenerationRequest {
       public init(
         documentation: String,
         name: String,
+        generatedName: String,
+        signatureName: String,
         isInputStreaming: Bool,
         isOutputStreaming: Bool,
         inputType: String,
@@ -275,6 +293,8 @@ public struct CodeGenerationRequest {
       ) {
         self.documentation = documentation
         self.name = name
+        self.generatedName = generatedName
+        self.signatureName = signatureName
         self.isInputStreaming = isInputStreaming
         self.isOutputStreaming = isOutputStreaming
         self.inputType = inputType

--- a/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
@@ -151,7 +151,7 @@ extension ClientCodeTranslator {
     )
     let functionSignature = FunctionSignatureDescription(
       kind: .function(
-        name: method.signatureName,
+        name: method.name.generatedLowerCase,
         isStatic: false
       ),
       generics: [.member("R")],
@@ -180,7 +180,10 @@ extension ClientCodeTranslator {
   ) -> [CodeBlock] {
     let functionCall = Expression.functionCall(
       calledExpression: .memberAccess(
-        MemberAccessDescription(left: .identifierPattern("self"), right: method.signatureName)
+        MemberAccessDescription(
+          left: .identifierPattern("self"),
+          right: method.name.generatedLowerCase
+        )
       ),
       arguments: [
         FunctionArgumentDescription(label: "request", expression: .identifierPattern("request")),
@@ -380,7 +383,7 @@ extension ClientCodeTranslator {
         .init(
           label: "descriptor",
           expression: .identifierPattern(
-            "\(service.namespacedTypealiasGeneratedName).Methods.\(method.generatedName).descriptor"
+            "\(service.namespacedTypealiasGeneratedName).Methods.\(method.name.generatedUpperCase).descriptor"
           )
         ),
         .init(label: "serializer", expression: .identifierPattern("serializer")),
@@ -395,7 +398,7 @@ extension ClientCodeTranslator {
 
     return .function(
       kind: .function(
-        name: "\(method.signatureName)",
+        name: "\(method.name.generatedLowerCase)",
         isStatic: false
       ),
       generics: [.member("R")],
@@ -419,7 +422,7 @@ extension ClientCodeTranslator {
     type: InputOutputType
   ) -> String {
     var components: String =
-      "\(service.namespacedTypealiasGeneratedName).Methods.\(method.generatedName)"
+      "\(service.namespacedTypealiasGeneratedName).Methods.\(method.name.generatedUpperCase)"
 
     switch type {
     case .input:

--- a/Sources/GRPCCodeGen/Internal/Translator/IDLToStructuredSwiftTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/IDLToStructuredSwiftTranslator.swift
@@ -273,7 +273,7 @@ extension IDLToStructuredSwiftTranslator {
             code: .invalidGeneratedNamespace,
             message: """
               All services within a namespace must have the same generated namespace. \
-              \(service.name) has not the same generated namespace as other services \
+              \(service.name) doesn't have the same generated namespace as other services \
               within the \(service.namespace) namespace.
               """
           )

--- a/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
@@ -126,7 +126,7 @@ extension ServerCodeTranslator {
     in service: CodeGenerationRequest.ServiceDescriptor
   ) -> FunctionSignatureDescription {
     return FunctionSignatureDescription(
-      kind: .function(name: method.signatureName),
+      kind: .function(name: method.name.generatedLowerCase),
       parameters: [
         .init(
           label: "request",
@@ -244,7 +244,10 @@ extension ServerCodeTranslator {
 
     let getFunctionCall = Expression.functionCall(
       calledExpression: .memberAccess(
-        MemberAccessDescription(left: .identifierPattern("self"), right: method.signatureName)
+        MemberAccessDescription(
+          left: .identifierPattern("self"),
+          right: method.name.generatedLowerCase
+        )
       ),
       arguments: [
         FunctionArgumentDescription(label: "request", expression: .identifierPattern("request"))
@@ -304,7 +307,7 @@ extension ServerCodeTranslator {
     )
 
     let functionSignature = FunctionSignatureDescription(
-      kind: .function(name: method.signatureName),
+      kind: .function(name: method.name.generatedLowerCase),
       parameters: [
         .init(
           label: "request",
@@ -382,7 +385,10 @@ extension ServerCodeTranslator {
     // Call to the corresponding ServiceProtocol method.
     let serviceProtocolMethod = Expression.functionCall(
       calledExpression: .memberAccess(
-        MemberAccessDescription(left: .identifierPattern("self"), right: method.signatureName)
+        MemberAccessDescription(
+          left: .identifierPattern("self"),
+          right: method.name.generatedLowerCase
+        )
       ),
       arguments: [FunctionArgumentDescription(label: "request", expression: serverRequest)]
     )
@@ -431,7 +437,7 @@ extension ServerCodeTranslator {
     type: InputOutputType
   ) -> String {
     var components: String =
-      "\(service.namespacedTypealiasGeneratedName).Methods.\(method.generatedName)"
+      "\(service.namespacedTypealiasGeneratedName).Methods.\(method.name.generatedUpperCase)"
 
     switch type {
     case .input:
@@ -448,7 +454,8 @@ extension ServerCodeTranslator {
     for method: CodeGenerationRequest.ServiceDescriptor.MethodDescriptor,
     service: CodeGenerationRequest.ServiceDescriptor
   ) -> String {
-    return "\(service.namespacedTypealiasGeneratedName).Methods.\(method.generatedName).descriptor"
+    return
+      "\(service.namespacedTypealiasGeneratedName).Methods.\(method.name.generatedUpperCase).descriptor"
   }
 
   /// Generates the fully qualified name of the type alias for a service protocol.

--- a/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
@@ -126,7 +126,7 @@ extension ServerCodeTranslator {
     in service: CodeGenerationRequest.ServiceDescriptor
   ) -> FunctionSignatureDescription {
     return FunctionSignatureDescription(
-      kind: .function(name: method.name),
+      kind: .function(name: method.signatureName),
       parameters: [
         .init(
           label: "request",
@@ -244,7 +244,7 @@ extension ServerCodeTranslator {
 
     let getFunctionCall = Expression.functionCall(
       calledExpression: .memberAccess(
-        MemberAccessDescription(left: .identifierPattern("self"), right: method.name)
+        MemberAccessDescription(left: .identifierPattern("self"), right: method.signatureName)
       ),
       arguments: [
         FunctionArgumentDescription(label: "request", expression: .identifierPattern("request"))
@@ -304,7 +304,7 @@ extension ServerCodeTranslator {
     )
 
     let functionSignature = FunctionSignatureDescription(
-      kind: .function(name: method.name),
+      kind: .function(name: method.signatureName),
       parameters: [
         .init(
           label: "request",
@@ -382,7 +382,7 @@ extension ServerCodeTranslator {
     // Call to the corresponding ServiceProtocol method.
     let serviceProtocolMethod = Expression.functionCall(
       calledExpression: .memberAccess(
-        MemberAccessDescription(left: .identifierPattern("self"), right: method.name)
+        MemberAccessDescription(left: .identifierPattern("self"), right: method.signatureName)
       ),
       arguments: [FunctionArgumentDescription(label: "request", expression: serverRequest)]
     )
@@ -430,7 +430,8 @@ extension ServerCodeTranslator {
     service: CodeGenerationRequest.ServiceDescriptor,
     type: InputOutputType
   ) -> String {
-    var components: String = "\(service.namespacedTypealiasPrefix).Methods.\(method.name)"
+    var components: String =
+      "\(service.namespacedTypealiasGeneratedName).Methods.\(method.generatedName)"
 
     switch type {
     case .input:
@@ -447,7 +448,7 @@ extension ServerCodeTranslator {
     for method: CodeGenerationRequest.ServiceDescriptor.MethodDescriptor,
     service: CodeGenerationRequest.ServiceDescriptor
   ) -> String {
-    return "\(service.namespacedTypealiasPrefix).Methods.\(method.name).descriptor"
+    return "\(service.namespacedTypealiasGeneratedName).Methods.\(method.generatedName).descriptor"
   }
 
   /// Generates the fully qualified name of the type alias for a service protocol.
@@ -456,9 +457,9 @@ extension ServerCodeTranslator {
     streaming: Bool
   ) -> String {
     if streaming {
-      return "\(service.namespacedTypealiasPrefix).StreamingServiceProtocol"
+      return "\(service.namespacedTypealiasGeneratedName).StreamingServiceProtocol"
     }
-    return "\(service.namespacedTypealiasPrefix).ServiceProtocol"
+    return "\(service.namespacedTypealiasGeneratedName).ServiceProtocol"
   }
 
   /// Generates the name of a service protocol.
@@ -467,8 +468,8 @@ extension ServerCodeTranslator {
     streaming: Bool
   ) -> String {
     if streaming {
-      return "\(service.namespacedPrefix)StreamingServiceProtocol"
+      return "\(service.namespacedGeneratedName)StreamingServiceProtocol"
     }
-    return "\(service.namespacedPrefix)ServiceProtocol"
+    return "\(service.namespacedGeneratedName)ServiceProtocol"
   }
 }

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
@@ -23,13 +23,12 @@ import XCTest
 final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
   typealias MethodDescriptor = GRPCCodeGen.CodeGenerationRequest.ServiceDescriptor.MethodDescriptor
   typealias ServiceDescriptor = GRPCCodeGen.CodeGenerationRequest.ServiceDescriptor
+  typealias Name = GRPCCodeGen.CodeGenerationRequest.Name
 
   func testClientCodeTranslatorUnaryMethod() throws {
     let method = MethodDescriptor(
       documentation: "Documentation for MethodA",
-      name: "MethodA",
-      generatedName: "MethodA",
-      signatureName: "methodA",
+      name: Name(base: "MethodA", generatedUpperCase: "MethodA", generatedLowerCase: "methodA"),
       isInputStreaming: false,
       isOutputStreaming: false,
       inputType: "NamespaceA_ServiceARequest",
@@ -37,10 +36,8 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     )
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
-      name: "ServiceA",
-      generatedName: "ServiceA",
-      namespace: "namespaceA",
-      generatedNamespace: "NamespaceA",
+      name: Name(base: "ServiceA", generatedUpperCase: "ServiceA", generatedLowerCase: ""),
+      namespace: Name(base: "namespaceA", generatedUpperCase: "NamespaceA", generatedLowerCase: ""),
       methods: [method]
     )
     let expectedSwift =
@@ -101,9 +98,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
   func testClientCodeTranslatorClientStreamingMethod() throws {
     let method = MethodDescriptor(
       documentation: "Documentation for MethodA",
-      name: "MethodA",
-      generatedName: "MethodA",
-      signatureName: "methodA",
+      name: Name(base: "MethodA", generatedUpperCase: "MethodA", generatedLowerCase: "methodA"),
       isInputStreaming: true,
       isOutputStreaming: false,
       inputType: "NamespaceA_ServiceARequest",
@@ -111,10 +106,8 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     )
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
-      name: "ServiceA",
-      generatedName: "ServiceA",
-      namespace: "namespaceA",
-      generatedNamespace: "NamespaceA",
+      name: Name(base: "ServiceA", generatedUpperCase: "ServiceA", generatedLowerCase: ""),
+      namespace: Name(base: "namespaceA", generatedUpperCase: "NamespaceA", generatedLowerCase: ""),
       methods: [method]
     )
     let expectedSwift =
@@ -175,9 +168,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
   func testClientCodeTranslatorServerStreamingMethod() throws {
     let method = MethodDescriptor(
       documentation: "Documentation for MethodA",
-      name: "methodA",
-      generatedName: "MethodA",
-      signatureName: "methodA",
+      name: Name(base: "MethodA", generatedUpperCase: "MethodA", generatedLowerCase: "methodA"),
       isInputStreaming: false,
       isOutputStreaming: true,
       inputType: "NamespaceA_ServiceARequest",
@@ -185,10 +176,8 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     )
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
-      name: "ServiceA",
-      generatedName: "ServiceA",
-      namespace: "namespaceA",
-      generatedNamespace: "NamespaceA",
+      name: Name(base: "ServiceA", generatedUpperCase: "ServiceA", generatedLowerCase: ""),
+      namespace: Name(base: "namespaceA", generatedUpperCase: "NamespaceA", generatedLowerCase: ""),
       methods: [method]
     )
     let expectedSwift =
@@ -249,9 +238,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
   func testClientCodeTranslatorBidirectionalStreamingMethod() throws {
     let method = MethodDescriptor(
       documentation: "Documentation for MethodA",
-      name: "methodA",
-      generatedName: "MethodA",
-      signatureName: "methodA",
+      name: Name(base: "MethodA", generatedUpperCase: "MethodA", generatedLowerCase: "methodA"),
       isInputStreaming: true,
       isOutputStreaming: true,
       inputType: "NamespaceA_ServiceARequest",
@@ -259,10 +246,8 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     )
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
-      name: "ServiceA",
-      generatedName: "ServiceA",
-      namespace: "namespaceA",
-      generatedNamespace: "NamespaceA",
+      name: Name(base: "ServiceA", generatedUpperCase: "ServiceA", generatedLowerCase: ""),
+      namespace: Name(base: "namespaceA", generatedUpperCase: "NamespaceA", generatedLowerCase: ""),
       methods: [method]
     )
     let expectedSwift =
@@ -323,9 +308,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
   func testClientCodeTranslatorMultipleMethods() throws {
     let methodA = MethodDescriptor(
       documentation: "Documentation for MethodA",
-      name: "methodA",
-      generatedName: "MethodA",
-      signatureName: "methodA",
+      name: Name(base: "MethodA", generatedUpperCase: "MethodA", generatedLowerCase: "methodA"),
       isInputStreaming: true,
       isOutputStreaming: false,
       inputType: "NamespaceA_ServiceARequest",
@@ -333,9 +316,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     )
     let methodB = MethodDescriptor(
       documentation: "Documentation for MethodB",
-      name: "methodB",
-      generatedName: "MethodB",
-      signatureName: "methodB",
+      name: Name(base: "MethodB", generatedUpperCase: "MethodB", generatedLowerCase: "methodB"),
       isInputStreaming: false,
       isOutputStreaming: true,
       inputType: "NamespaceA_ServiceARequest",
@@ -343,10 +324,8 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     )
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
-      name: "ServiceA",
-      generatedName: "ServiceA",
-      namespace: "namespaceA",
-      generatedNamespace: "NamespaceA",
+      name: Name(base: "ServiceA", generatedUpperCase: "ServiceA", generatedLowerCase: ""),
+      namespace: Name(base: "namespaceA", generatedUpperCase: "NamespaceA", generatedLowerCase: ""),
       methods: [methodA, methodB]
     )
     let expectedSwift =
@@ -440,9 +419,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
   func testClientCodeTranslatorNoNamespaceService() throws {
     let method = MethodDescriptor(
       documentation: "Documentation for MethodA",
-      name: "methodA",
-      generatedName: "MethodA",
-      signatureName: "methodA",
+      name: Name(base: "MethodA", generatedUpperCase: "MethodA", generatedLowerCase: "methodA"),
       isInputStreaming: false,
       isOutputStreaming: false,
       inputType: "ServiceARequest",
@@ -450,10 +427,8 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     )
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
-      name: "ServiceA",
-      generatedName: "ServiceA",
-      namespace: "",
-      generatedNamespace: "",
+      name: Name(base: "ServiceA", generatedUpperCase: "ServiceA", generatedLowerCase: ""),
+      namespace: Name(base: "", generatedUpperCase: "", generatedLowerCase: ""),
       methods: [method]
     )
     let expectedSwift =
@@ -514,18 +489,18 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
   func testClientCodeTranslatorMultipleServices() throws {
     let serviceA = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
-      name: "ServiceA",
-      generatedName: "ServiceA",
-      namespace: "namespaceA",
-      generatedNamespace: "NamespaceA",
+      name: Name(base: "ServiceA", generatedUpperCase: "ServiceA", generatedLowerCase: ""),
+      namespace: Name(
+        base: "nammespaceA",
+        generatedUpperCase: "NamespaceA",
+        generatedLowerCase: ""
+      ),
       methods: []
     )
     let serviceB = ServiceDescriptor(
       documentation: "Documentation for ServiceB",
-      name: "ServiceB",
-      generatedName: "ServiceB",
-      namespace: "",
-      generatedNamespace: "",
+      name: Name(base: "ServiceB", generatedUpperCase: "ServiceB", generatedLowerCase: ""),
+      namespace: Name(base: "", generatedUpperCase: "", generatedLowerCase: ""),
       methods: []
     )
     let expectedSwift =

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
@@ -27,7 +27,9 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
   func testClientCodeTranslatorUnaryMethod() throws {
     let method = MethodDescriptor(
       documentation: "Documentation for MethodA",
-      name: "methodA",
+      name: "MethodA",
+      generatedName: "MethodA",
+      signatureName: "methodA",
       isInputStreaming: false,
       isOutputStreaming: false,
       inputType: "NamespaceA_ServiceARequest",
@@ -36,50 +38,52 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
       name: "ServiceA",
+      generatedName: "ServiceA",
       namespace: "namespaceA",
+      generatedNamespace: "NamespaceA",
       methods: [method]
     )
     let expectedSwift =
       """
       /// Documentation for ServiceA
-      protocol namespaceA_ServiceAClientProtocol: Sendable {
+      protocol NamespaceA_ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
-              request: ClientRequest.Single<namespaceA.ServiceA.Methods.methodA.Input>,
-              serializer: some MessageSerializer<namespaceA.ServiceA.Methods.methodA.Input>,
-              deserializer: some MessageDeserializer<namespaceA.ServiceA.Methods.methodA.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Single<namespaceA.ServiceA.Methods.methodA.Output>) async throws -> R
+              request: ClientRequest.Single<NamespaceA.ServiceA.Methods.MethodA.Input>,
+              serializer: some MessageSerializer<NamespaceA.ServiceA.Methods.MethodA.Input>,
+              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Methods.MethodA.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Methods.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable
       }
-      extension namespaceA.ServiceA.ClientProtocol {
+      extension NamespaceA.ServiceA.ClientProtocol {
           func methodA<R>(
-              request: ClientRequest.Single<namespaceA.ServiceA.Methods.methodA.Input>,
-              _ body: @Sendable @escaping (ClientResponse.Single<namespaceA.ServiceA.Methods.methodA.Output>) async throws -> R
+              request: ClientRequest.Single<NamespaceA.ServiceA.Methods.MethodA.Input>,
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Methods.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.methodA(
                   request: request,
-                  serializer: ProtobufSerializer<namespaceA.ServiceA.Methods.methodA.Input>(),
-                  deserializer: ProtobufDeserializer<namespaceA.ServiceA.Methods.methodA.Output>(),
+                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Methods.MethodA.Input>(),
+                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Methods.MethodA.Output>(),
                   body
               )
           }
       }
       /// Documentation for ServiceA
-      struct namespaceA_ServiceAClient: namespaceA.ServiceA.ClientProtocol {
+      struct NamespaceA_ServiceAClient: NamespaceA.ServiceA.ClientProtocol {
           let client: GRPCCore.GRPCClient
           init(client: GRPCCore.GRPCClient) {
               self.client = client
           }
           /// Documentation for MethodA
           func methodA<R>(
-              request: ClientRequest.Single<namespaceA.ServiceA.Methods.methodA.Input>,
-              serializer: some MessageSerializer<namespaceA.ServiceA.Methods.methodA.Input>,
-              deserializer: some MessageDeserializer<namespaceA.ServiceA.Methods.methodA.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Single<namespaceA.ServiceA.Methods.methodA.Output>) async throws -> R
+              request: ClientRequest.Single<NamespaceA.ServiceA.Methods.MethodA.Input>,
+              serializer: some MessageSerializer<NamespaceA.ServiceA.Methods.MethodA.Input>,
+              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Methods.MethodA.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Methods.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.client.unary(
                   request: request,
-                  descriptor: namespaceA.ServiceA.Methods.methodA.descriptor,
+                  descriptor: NamespaceA.ServiceA.Methods.MethodA.descriptor,
                   serializer: serializer,
                   deserializer: deserializer,
                   handler: body
@@ -97,7 +101,9 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
   func testClientCodeTranslatorClientStreamingMethod() throws {
     let method = MethodDescriptor(
       documentation: "Documentation for MethodA",
-      name: "methodA",
+      name: "MethodA",
+      generatedName: "MethodA",
+      signatureName: "methodA",
       isInputStreaming: true,
       isOutputStreaming: false,
       inputType: "NamespaceA_ServiceARequest",
@@ -106,50 +112,52 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
       name: "ServiceA",
+      generatedName: "ServiceA",
       namespace: "namespaceA",
+      generatedNamespace: "NamespaceA",
       methods: [method]
     )
     let expectedSwift =
       """
       /// Documentation for ServiceA
-      protocol namespaceA_ServiceAClientProtocol: Sendable {
+      protocol NamespaceA_ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
-              request: ClientRequest.Stream<namespaceA.ServiceA.Methods.methodA.Input>,
-              serializer: some MessageSerializer<namespaceA.ServiceA.Methods.methodA.Input>,
-              deserializer: some MessageDeserializer<namespaceA.ServiceA.Methods.methodA.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Single<namespaceA.ServiceA.Methods.methodA.Output>) async throws -> R
+              request: ClientRequest.Stream<NamespaceA.ServiceA.Methods.MethodA.Input>,
+              serializer: some MessageSerializer<NamespaceA.ServiceA.Methods.MethodA.Input>,
+              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Methods.MethodA.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Methods.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable
       }
-      extension namespaceA.ServiceA.ClientProtocol {
+      extension NamespaceA.ServiceA.ClientProtocol {
           func methodA<R>(
-              request: ClientRequest.Stream<namespaceA.ServiceA.Methods.methodA.Input>,
-              _ body: @Sendable @escaping (ClientResponse.Single<namespaceA.ServiceA.Methods.methodA.Output>) async throws -> R
+              request: ClientRequest.Stream<NamespaceA.ServiceA.Methods.MethodA.Input>,
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Methods.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.methodA(
                   request: request,
-                  serializer: ProtobufSerializer<namespaceA.ServiceA.Methods.methodA.Input>(),
-                  deserializer: ProtobufDeserializer<namespaceA.ServiceA.Methods.methodA.Output>(),
+                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Methods.MethodA.Input>(),
+                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Methods.MethodA.Output>(),
                   body
               )
           }
       }
       /// Documentation for ServiceA
-      struct namespaceA_ServiceAClient: namespaceA.ServiceA.ClientProtocol {
+      struct NamespaceA_ServiceAClient: NamespaceA.ServiceA.ClientProtocol {
           let client: GRPCCore.GRPCClient
           init(client: GRPCCore.GRPCClient) {
               self.client = client
           }
           /// Documentation for MethodA
           func methodA<R>(
-              request: ClientRequest.Stream<namespaceA.ServiceA.Methods.methodA.Input>,
-              serializer: some MessageSerializer<namespaceA.ServiceA.Methods.methodA.Input>,
-              deserializer: some MessageDeserializer<namespaceA.ServiceA.Methods.methodA.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Single<namespaceA.ServiceA.Methods.methodA.Output>) async throws -> R
+              request: ClientRequest.Stream<NamespaceA.ServiceA.Methods.MethodA.Input>,
+              serializer: some MessageSerializer<NamespaceA.ServiceA.Methods.MethodA.Input>,
+              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Methods.MethodA.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Methods.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.client.clientStreaming(
                   request: request,
-                  descriptor: namespaceA.ServiceA.Methods.methodA.descriptor,
+                  descriptor: NamespaceA.ServiceA.Methods.MethodA.descriptor,
                   serializer: serializer,
                   deserializer: deserializer,
                   handler: body
@@ -168,6 +176,8 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let method = MethodDescriptor(
       documentation: "Documentation for MethodA",
       name: "methodA",
+      generatedName: "MethodA",
+      signatureName: "methodA",
       isInputStreaming: false,
       isOutputStreaming: true,
       inputType: "NamespaceA_ServiceARequest",
@@ -176,50 +186,52 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
       name: "ServiceA",
+      generatedName: "ServiceA",
       namespace: "namespaceA",
+      generatedNamespace: "NamespaceA",
       methods: [method]
     )
     let expectedSwift =
       """
       /// Documentation for ServiceA
-      protocol namespaceA_ServiceAClientProtocol: Sendable {
+      protocol NamespaceA_ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
-              request: ClientRequest.Single<namespaceA.ServiceA.Methods.methodA.Input>,
-              serializer: some MessageSerializer<namespaceA.ServiceA.Methods.methodA.Input>,
-              deserializer: some MessageDeserializer<namespaceA.ServiceA.Methods.methodA.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Stream<namespaceA.ServiceA.Methods.methodA.Output>) async throws -> R
+              request: ClientRequest.Single<NamespaceA.ServiceA.Methods.MethodA.Input>,
+              serializer: some MessageSerializer<NamespaceA.ServiceA.Methods.MethodA.Input>,
+              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Methods.MethodA.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Methods.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable
       }
-      extension namespaceA.ServiceA.ClientProtocol {
+      extension NamespaceA.ServiceA.ClientProtocol {
           func methodA<R>(
-              request: ClientRequest.Single<namespaceA.ServiceA.Methods.methodA.Input>,
-              _ body: @Sendable @escaping (ClientResponse.Stream<namespaceA.ServiceA.Methods.methodA.Output>) async throws -> R
+              request: ClientRequest.Single<NamespaceA.ServiceA.Methods.MethodA.Input>,
+              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Methods.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.methodA(
                   request: request,
-                  serializer: ProtobufSerializer<namespaceA.ServiceA.Methods.methodA.Input>(),
-                  deserializer: ProtobufDeserializer<namespaceA.ServiceA.Methods.methodA.Output>(),
+                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Methods.MethodA.Input>(),
+                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Methods.MethodA.Output>(),
                   body
               )
           }
       }
       /// Documentation for ServiceA
-      struct namespaceA_ServiceAClient: namespaceA.ServiceA.ClientProtocol {
+      struct NamespaceA_ServiceAClient: NamespaceA.ServiceA.ClientProtocol {
           let client: GRPCCore.GRPCClient
           init(client: GRPCCore.GRPCClient) {
               self.client = client
           }
           /// Documentation for MethodA
           func methodA<R>(
-              request: ClientRequest.Single<namespaceA.ServiceA.Methods.methodA.Input>,
-              serializer: some MessageSerializer<namespaceA.ServiceA.Methods.methodA.Input>,
-              deserializer: some MessageDeserializer<namespaceA.ServiceA.Methods.methodA.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Stream<namespaceA.ServiceA.Methods.methodA.Output>) async throws -> R
+              request: ClientRequest.Single<NamespaceA.ServiceA.Methods.MethodA.Input>,
+              serializer: some MessageSerializer<NamespaceA.ServiceA.Methods.MethodA.Input>,
+              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Methods.MethodA.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Methods.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.client.serverStreaming(
                   request: request,
-                  descriptor: namespaceA.ServiceA.Methods.methodA.descriptor,
+                  descriptor: NamespaceA.ServiceA.Methods.MethodA.descriptor,
                   serializer: serializer,
                   deserializer: deserializer,
                   handler: body
@@ -238,6 +250,8 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let method = MethodDescriptor(
       documentation: "Documentation for MethodA",
       name: "methodA",
+      generatedName: "MethodA",
+      signatureName: "methodA",
       isInputStreaming: true,
       isOutputStreaming: true,
       inputType: "NamespaceA_ServiceARequest",
@@ -246,50 +260,52 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
       name: "ServiceA",
+      generatedName: "ServiceA",
       namespace: "namespaceA",
+      generatedNamespace: "NamespaceA",
       methods: [method]
     )
     let expectedSwift =
       """
       /// Documentation for ServiceA
-      protocol namespaceA_ServiceAClientProtocol: Sendable {
+      protocol NamespaceA_ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
-              request: ClientRequest.Stream<namespaceA.ServiceA.Methods.methodA.Input>,
-              serializer: some MessageSerializer<namespaceA.ServiceA.Methods.methodA.Input>,
-              deserializer: some MessageDeserializer<namespaceA.ServiceA.Methods.methodA.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Stream<namespaceA.ServiceA.Methods.methodA.Output>) async throws -> R
+              request: ClientRequest.Stream<NamespaceA.ServiceA.Methods.MethodA.Input>,
+              serializer: some MessageSerializer<NamespaceA.ServiceA.Methods.MethodA.Input>,
+              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Methods.MethodA.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Methods.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable
       }
-      extension namespaceA.ServiceA.ClientProtocol {
+      extension NamespaceA.ServiceA.ClientProtocol {
           func methodA<R>(
-              request: ClientRequest.Stream<namespaceA.ServiceA.Methods.methodA.Input>,
-              _ body: @Sendable @escaping (ClientResponse.Stream<namespaceA.ServiceA.Methods.methodA.Output>) async throws -> R
+              request: ClientRequest.Stream<NamespaceA.ServiceA.Methods.MethodA.Input>,
+              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Methods.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.methodA(
                   request: request,
-                  serializer: ProtobufSerializer<namespaceA.ServiceA.Methods.methodA.Input>(),
-                  deserializer: ProtobufDeserializer<namespaceA.ServiceA.Methods.methodA.Output>(),
+                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Methods.MethodA.Input>(),
+                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Methods.MethodA.Output>(),
                   body
               )
           }
       }
       /// Documentation for ServiceA
-      struct namespaceA_ServiceAClient: namespaceA.ServiceA.ClientProtocol {
+      struct NamespaceA_ServiceAClient: NamespaceA.ServiceA.ClientProtocol {
           let client: GRPCCore.GRPCClient
           init(client: GRPCCore.GRPCClient) {
               self.client = client
           }
           /// Documentation for MethodA
           func methodA<R>(
-              request: ClientRequest.Stream<namespaceA.ServiceA.Methods.methodA.Input>,
-              serializer: some MessageSerializer<namespaceA.ServiceA.Methods.methodA.Input>,
-              deserializer: some MessageDeserializer<namespaceA.ServiceA.Methods.methodA.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Stream<namespaceA.ServiceA.Methods.methodA.Output>) async throws -> R
+              request: ClientRequest.Stream<NamespaceA.ServiceA.Methods.MethodA.Input>,
+              serializer: some MessageSerializer<NamespaceA.ServiceA.Methods.MethodA.Input>,
+              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Methods.MethodA.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Methods.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.client.bidirectionalStreaming(
                   request: request,
-                  descriptor: namespaceA.ServiceA.Methods.methodA.descriptor,
+                  descriptor: NamespaceA.ServiceA.Methods.MethodA.descriptor,
                   serializer: serializer,
                   deserializer: deserializer,
                   handler: body
@@ -308,6 +324,8 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let methodA = MethodDescriptor(
       documentation: "Documentation for MethodA",
       name: "methodA",
+      generatedName: "MethodA",
+      signatureName: "methodA",
       isInputStreaming: true,
       isOutputStreaming: false,
       inputType: "NamespaceA_ServiceARequest",
@@ -316,6 +334,8 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let methodB = MethodDescriptor(
       documentation: "Documentation for MethodB",
       name: "methodB",
+      generatedName: "MethodB",
+      signatureName: "methodB",
       isInputStreaming: false,
       isOutputStreaming: true,
       inputType: "NamespaceA_ServiceARequest",
@@ -324,68 +344,70 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
       name: "ServiceA",
+      generatedName: "ServiceA",
       namespace: "namespaceA",
+      generatedNamespace: "NamespaceA",
       methods: [methodA, methodB]
     )
     let expectedSwift =
       """
       /// Documentation for ServiceA
-      protocol namespaceA_ServiceAClientProtocol: Sendable {
+      protocol NamespaceA_ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
-              request: ClientRequest.Stream<namespaceA.ServiceA.Methods.methodA.Input>,
-              serializer: some MessageSerializer<namespaceA.ServiceA.Methods.methodA.Input>,
-              deserializer: some MessageDeserializer<namespaceA.ServiceA.Methods.methodA.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Single<namespaceA.ServiceA.Methods.methodA.Output>) async throws -> R
+              request: ClientRequest.Stream<NamespaceA.ServiceA.Methods.MethodA.Input>,
+              serializer: some MessageSerializer<NamespaceA.ServiceA.Methods.MethodA.Input>,
+              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Methods.MethodA.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Methods.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable
           /// Documentation for MethodB
           func methodB<R>(
-              request: ClientRequest.Single<namespaceA.ServiceA.Methods.methodB.Input>,
-              serializer: some MessageSerializer<namespaceA.ServiceA.Methods.methodB.Input>,
-              deserializer: some MessageDeserializer<namespaceA.ServiceA.Methods.methodB.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Stream<namespaceA.ServiceA.Methods.methodB.Output>) async throws -> R
+              request: ClientRequest.Single<NamespaceA.ServiceA.Methods.MethodB.Input>,
+              serializer: some MessageSerializer<NamespaceA.ServiceA.Methods.MethodB.Input>,
+              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Methods.MethodB.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Methods.MethodB.Output>) async throws -> R
           ) async throws -> R where R: Sendable
       }
-      extension namespaceA.ServiceA.ClientProtocol {
+      extension NamespaceA.ServiceA.ClientProtocol {
           func methodA<R>(
-              request: ClientRequest.Stream<namespaceA.ServiceA.Methods.methodA.Input>,
-              _ body: @Sendable @escaping (ClientResponse.Single<namespaceA.ServiceA.Methods.methodA.Output>) async throws -> R
+              request: ClientRequest.Stream<NamespaceA.ServiceA.Methods.MethodA.Input>,
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Methods.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.methodA(
                   request: request,
-                  serializer: ProtobufSerializer<namespaceA.ServiceA.Methods.methodA.Input>(),
-                  deserializer: ProtobufDeserializer<namespaceA.ServiceA.Methods.methodA.Output>(),
+                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Methods.MethodA.Input>(),
+                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Methods.MethodA.Output>(),
                   body
               )
           }
           func methodB<R>(
-              request: ClientRequest.Single<namespaceA.ServiceA.Methods.methodB.Input>,
-              _ body: @Sendable @escaping (ClientResponse.Stream<namespaceA.ServiceA.Methods.methodB.Output>) async throws -> R
+              request: ClientRequest.Single<NamespaceA.ServiceA.Methods.MethodB.Input>,
+              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Methods.MethodB.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.methodB(
                   request: request,
-                  serializer: ProtobufSerializer<namespaceA.ServiceA.Methods.methodB.Input>(),
-                  deserializer: ProtobufDeserializer<namespaceA.ServiceA.Methods.methodB.Output>(),
+                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Methods.MethodB.Input>(),
+                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Methods.MethodB.Output>(),
                   body
               )
           }
       }
       /// Documentation for ServiceA
-      struct namespaceA_ServiceAClient: namespaceA.ServiceA.ClientProtocol {
+      struct NamespaceA_ServiceAClient: NamespaceA.ServiceA.ClientProtocol {
           let client: GRPCCore.GRPCClient
           init(client: GRPCCore.GRPCClient) {
               self.client = client
           }
           /// Documentation for MethodA
           func methodA<R>(
-              request: ClientRequest.Stream<namespaceA.ServiceA.Methods.methodA.Input>,
-              serializer: some MessageSerializer<namespaceA.ServiceA.Methods.methodA.Input>,
-              deserializer: some MessageDeserializer<namespaceA.ServiceA.Methods.methodA.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Single<namespaceA.ServiceA.Methods.methodA.Output>) async throws -> R
+              request: ClientRequest.Stream<NamespaceA.ServiceA.Methods.MethodA.Input>,
+              serializer: some MessageSerializer<NamespaceA.ServiceA.Methods.MethodA.Input>,
+              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Methods.MethodA.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Methods.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.client.clientStreaming(
                   request: request,
-                  descriptor: namespaceA.ServiceA.Methods.methodA.descriptor,
+                  descriptor: NamespaceA.ServiceA.Methods.MethodA.descriptor,
                   serializer: serializer,
                   deserializer: deserializer,
                   handler: body
@@ -393,14 +415,14 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           }
           /// Documentation for MethodB
           func methodB<R>(
-              request: ClientRequest.Single<namespaceA.ServiceA.Methods.methodB.Input>,
-              serializer: some MessageSerializer<namespaceA.ServiceA.Methods.methodB.Input>,
-              deserializer: some MessageDeserializer<namespaceA.ServiceA.Methods.methodB.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Stream<namespaceA.ServiceA.Methods.methodB.Output>) async throws -> R
+              request: ClientRequest.Single<NamespaceA.ServiceA.Methods.MethodB.Input>,
+              serializer: some MessageSerializer<NamespaceA.ServiceA.Methods.MethodB.Input>,
+              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Methods.MethodB.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Methods.MethodB.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.client.serverStreaming(
                   request: request,
-                  descriptor: namespaceA.ServiceA.Methods.methodB.descriptor,
+                  descriptor: NamespaceA.ServiceA.Methods.MethodB.descriptor,
                   serializer: serializer,
                   deserializer: deserializer,
                   handler: body
@@ -419,6 +441,8 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let method = MethodDescriptor(
       documentation: "Documentation for MethodA",
       name: "methodA",
+      generatedName: "MethodA",
+      signatureName: "methodA",
       isInputStreaming: false,
       isOutputStreaming: false,
       inputType: "ServiceARequest",
@@ -427,7 +451,9 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
       name: "ServiceA",
+      generatedName: "ServiceA",
       namespace: "",
+      generatedNamespace: "",
       methods: [method]
     )
     let expectedSwift =
@@ -436,21 +462,21 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       protocol ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
-              request: ClientRequest.Single<ServiceA.Methods.methodA.Input>,
-              serializer: some MessageSerializer<ServiceA.Methods.methodA.Input>,
-              deserializer: some MessageDeserializer<ServiceA.Methods.methodA.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Single<ServiceA.Methods.methodA.Output>) async throws -> R
+              request: ClientRequest.Single<ServiceA.Methods.MethodA.Input>,
+              serializer: some MessageSerializer<ServiceA.Methods.MethodA.Input>,
+              deserializer: some MessageDeserializer<ServiceA.Methods.MethodA.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Single<ServiceA.Methods.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable
       }
       extension ServiceA.ClientProtocol {
           func methodA<R>(
-              request: ClientRequest.Single<ServiceA.Methods.methodA.Input>,
-              _ body: @Sendable @escaping (ClientResponse.Single<ServiceA.Methods.methodA.Output>) async throws -> R
+              request: ClientRequest.Single<ServiceA.Methods.MethodA.Input>,
+              _ body: @Sendable @escaping (ClientResponse.Single<ServiceA.Methods.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.methodA(
                   request: request,
-                  serializer: ProtobufSerializer<ServiceA.Methods.methodA.Input>(),
-                  deserializer: ProtobufDeserializer<ServiceA.Methods.methodA.Output>(),
+                  serializer: ProtobufSerializer<ServiceA.Methods.MethodA.Input>(),
+                  deserializer: ProtobufDeserializer<ServiceA.Methods.MethodA.Output>(),
                   body
               )
           }
@@ -463,14 +489,14 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           }
           /// Documentation for MethodA
           func methodA<R>(
-              request: ClientRequest.Single<ServiceA.Methods.methodA.Input>,
-              serializer: some MessageSerializer<ServiceA.Methods.methodA.Input>,
-              deserializer: some MessageDeserializer<ServiceA.Methods.methodA.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Single<ServiceA.Methods.methodA.Output>) async throws -> R
+              request: ClientRequest.Single<ServiceA.Methods.MethodA.Input>,
+              serializer: some MessageSerializer<ServiceA.Methods.MethodA.Input>,
+              deserializer: some MessageDeserializer<ServiceA.Methods.MethodA.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Single<ServiceA.Methods.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.client.unary(
                   request: request,
-                  descriptor: ServiceA.Methods.methodA.descriptor,
+                  descriptor: ServiceA.Methods.MethodA.descriptor,
                   serializer: serializer,
                   deserializer: deserializer,
                   handler: body
@@ -489,23 +515,27 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let serviceA = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
       name: "ServiceA",
+      generatedName: "ServiceA",
       namespace: "namespaceA",
+      generatedNamespace: "NamespaceA",
       methods: []
     )
     let serviceB = ServiceDescriptor(
       documentation: "Documentation for ServiceB",
       name: "ServiceB",
+      generatedName: "ServiceB",
       namespace: "",
+      generatedNamespace: "",
       methods: []
     )
     let expectedSwift =
       """
       /// Documentation for ServiceA
-      protocol namespaceA_ServiceAClientProtocol: Sendable {}
-      extension namespaceA.ServiceA.ClientProtocol {
+      protocol NamespaceA_ServiceAClientProtocol: Sendable {}
+      extension NamespaceA.ServiceA.ClientProtocol {
       }
       /// Documentation for ServiceA
-      struct namespaceA_ServiceAClient: namespaceA.ServiceA.ClientProtocol {
+      struct NamespaceA_ServiceAClient: NamespaceA.ServiceA.ClientProtocol {
           let client: GRPCCore.GRPCClient
           init(client: GRPCCore.GRPCClient) {
               self.client = client

--- a/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
@@ -23,6 +23,7 @@ import XCTest
 final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
   typealias MethodDescriptor = GRPCCodeGen.CodeGenerationRequest.ServiceDescriptor.MethodDescriptor
   typealias ServiceDescriptor = GRPCCodeGen.CodeGenerationRequest.ServiceDescriptor
+  typealias Name = GRPCCodeGen.CodeGenerationRequest.Name
 
   func testImports() throws {
     var dependencies = [CodeGenerationRequest.Dependency]()
@@ -149,10 +150,8 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
   func testSameNameServicesNoNamespaceError() throws {
     let serviceA = ServiceDescriptor(
       documentation: "Documentation for AService",
-      name: "AService",
-      generatedName: "AService",
-      namespace: "",
-      generatedNamespace: "",
+      name: Name(base: "AService", generatedUpperCase: "AService", generatedLowerCase: "aService"),
+      namespace: Name(base: "", generatedUpperCase: "", generatedLowerCase: ""),
       methods: []
     )
 
@@ -172,30 +171,26 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
         CodeGenError(
           code: .nonUniqueServiceName,
           message: """
-            Services in an empty namespace must have unique names. \
-            AService is used as a name for multiple services without namespaces.
+            Services must have unique descriptors. \
+            AService is the descriptor of at least two different services.
             """
         )
       )
     }
   }
 
-  func testSameGeneratedNameServicesNoNamespaceError() throws {
+  func testSameDescriptorsServicesNoNamespaceError() throws {
     let serviceA = ServiceDescriptor(
       documentation: "Documentation for AService",
-      name: "AService",
-      generatedName: "AService",
-      namespace: "",
-      generatedNamespace: "",
+      name: Name(base: "AService", generatedUpperCase: "AService", generatedLowerCase: "aService"),
+      namespace: Name(base: "", generatedUpperCase: "", generatedLowerCase: ""),
       methods: []
     )
 
     let serviceB = ServiceDescriptor(
       documentation: "Documentation for BService",
-      name: "BService",
-      generatedName: "AService",
-      namespace: "",
-      generatedNamespace: "",
+      name: Name(base: "AService", generatedUpperCase: "AService", generatedLowerCase: "aService"),
+      namespace: Name(base: "", generatedUpperCase: "", generatedLowerCase: ""),
       methods: []
     )
 
@@ -215,20 +210,21 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
         CodeGenError(
           code: .nonUniqueServiceName,
           message: """
-            Services in an empty namespace must have unique generated names. \
-            AService is used as a name for multiple services without namespaces.
+            Services must have unique descriptors. AService is the descriptor of at least two different services.
             """
         )
       )
     }
   }
-  func testSameNameServicesSameNamespaceError() throws {
+  func testSameDescriptorsSameNamespaceError() throws {
     let serviceA = ServiceDescriptor(
       documentation: "Documentation for AService",
-      name: "AService",
-      generatedName: "AService",
-      namespace: "namespacea",
-      generatedNamespace: "NamespaceA",
+      name: Name(base: "AService", generatedUpperCase: "AService", generatedLowerCase: "aService"),
+      namespace: Name(
+        base: "namespacea",
+        generatedUpperCase: "NamespaceA",
+        generatedLowerCase: "namespacea"
+      ),
       methods: []
     )
 
@@ -248,8 +244,8 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
         CodeGenError(
           code: .nonUniqueServiceName,
           message: """
-            Services within the same namespace must have unique names. \
-            AService is used as a name for multiple services in the namespacea namespace.
+            Services must have unique descriptors. \
+            namespacea.AService is the descriptor of at least two different services.
             """
         )
       )
@@ -259,18 +255,22 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
   func testSameGeneratedNameServicesSameNamespaceError() throws {
     let serviceA = ServiceDescriptor(
       documentation: "Documentation for AService",
-      name: "AService",
-      generatedName: "AService",
-      namespace: "namespacea",
-      generatedNamespace: "NamespaceA",
+      name: Name(base: "AService", generatedUpperCase: "AService", generatedLowerCase: "aService"),
+      namespace: Name(
+        base: "namespacea",
+        generatedUpperCase: "NamespaceA",
+        generatedLowerCase: "namespacea"
+      ),
       methods: []
     )
     let serviceB = ServiceDescriptor(
       documentation: "Documentation for BService",
-      name: "BService",
-      generatedName: "AService",
-      namespace: "namespacea",
-      generatedNamespace: "NamespaceA",
+      name: Name(base: "BService", generatedUpperCase: "AService", generatedLowerCase: "aService"),
+      namespace: Name(
+        base: "namespacea",
+        generatedUpperCase: "NamespaceA",
+        generatedLowerCase: "namespacea"
+      ),
       methods: []
     )
 
@@ -290,20 +290,18 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
         CodeGenError(
           code: .nonUniqueServiceName,
           message: """
-            Services within the same namespace must have unique generated names. \
-            AService is used as a generated name for multiple services in the namespacea namespace.
+            Services within the same namespace must have unique generated upper case names. \
+            AService is used as a generated upper case name for multiple services in the namespacea namespace.
             """
         )
       )
     }
   }
 
-  func testSameNameMethodsSameServiceError() throws {
+  func testSameBaseNameMethodsSameServiceError() throws {
     let methodA = MethodDescriptor(
       documentation: "Documentation for MethodA",
-      name: "MethodA",
-      generatedName: "MethodA",
-      signatureName: "methodA",
+      name: Name(base: "MethodA", generatedUpperCase: "MethodA", generatedLowerCase: "methodA"),
       isInputStreaming: false,
       isOutputStreaming: false,
       inputType: "NamespaceA_ServiceARequest",
@@ -311,10 +309,12 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
     )
     let service = ServiceDescriptor(
       documentation: "Documentation for AService",
-      name: "AService",
-      generatedName: "AService",
-      namespace: "namespacea",
-      generatedNamespace: "NamespaceA",
+      name: Name(base: "AService", generatedUpperCase: "AService", generatedLowerCase: "aService"),
+      namespace: Name(
+        base: "namespacea",
+        generatedUpperCase: "NamespaceA",
+        generatedLowerCase: "namespacea"
+      ),
       methods: [methodA, methodA]
     )
 
@@ -334,20 +334,18 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
         CodeGenError(
           code: .nonUniqueMethodName,
           message: """
-            Methods of a service must have unique names. \
-            MethodA is used as a name for multiple methods of the AService service.
+            Methods of a service must have unique base names. \
+            MethodA is used as a base name for multiple methods of the AService service.
             """
         )
       )
     }
   }
 
-  func testSameGeneratedNameMethodsSameServiceError() throws {
+  func testSameGeneratedUpperCaseNameMethodsSameServiceError() throws {
     let methodA = MethodDescriptor(
       documentation: "Documentation for MethodA",
-      name: "MethodA",
-      generatedName: "MethodA",
-      signatureName: "methodA",
+      name: Name(base: "MethodA", generatedUpperCase: "MethodA", generatedLowerCase: "methodA"),
       isInputStreaming: false,
       isOutputStreaming: false,
       inputType: "NamespaceA_ServiceARequest",
@@ -355,9 +353,7 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
     )
     let methodB = MethodDescriptor(
       documentation: "Documentation for MethodA",
-      name: "MethodB",
-      generatedName: "MethodA",
-      signatureName: "methodB",
+      name: Name(base: "MethodB", generatedUpperCase: "MethodA", generatedLowerCase: "methodA"),
       isInputStreaming: false,
       isOutputStreaming: false,
       inputType: "NamespaceA_ServiceARequest",
@@ -365,10 +361,12 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
     )
     let service = ServiceDescriptor(
       documentation: "Documentation for AService",
-      name: "AService",
-      generatedName: "AService",
-      namespace: "namespacea",
-      generatedNamespace: "NamespaceA",
+      name: Name(base: "AService", generatedUpperCase: "AService", generatedLowerCase: "aService"),
+      namespace: Name(
+        base: "namespacea",
+        generatedUpperCase: "NamespaceA",
+        generatedLowerCase: "namespacea"
+      ),
       methods: [methodA, methodB]
     )
 
@@ -388,20 +386,18 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
         CodeGenError(
           code: .nonUniqueMethodName,
           message: """
-            Methods of a service must have unique generated names. \
-            MethodA is used as a generated name for multiple methods of the AService service.
+            Methods of a service must have unique generated upper case names. \
+            MethodA is used as a generated upper case name for multiple methods of the AService service.
             """
         )
       )
     }
   }
 
-  func testSameSignatureNameMethodsSameServiceError() throws {
+  func testSameLowerCaseNameMethodsSameServiceError() throws {
     let methodA = MethodDescriptor(
       documentation: "Documentation for MethodA",
-      name: "MethodA",
-      generatedName: "MethodA",
-      signatureName: "methodA",
+      name: Name(base: "MethodA", generatedUpperCase: "MethodA", generatedLowerCase: "methodA"),
       isInputStreaming: false,
       isOutputStreaming: false,
       inputType: "NamespaceA_ServiceARequest",
@@ -409,9 +405,7 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
     )
     let methodB = MethodDescriptor(
       documentation: "Documentation for MethodA",
-      name: "MethodB",
-      generatedName: "MethodB",
-      signatureName: "methodA",
+      name: Name(base: "MethodB", generatedUpperCase: "MethodB", generatedLowerCase: "methodA"),
       isInputStreaming: false,
       isOutputStreaming: false,
       inputType: "NamespaceA_ServiceARequest",
@@ -419,10 +413,12 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
     )
     let service = ServiceDescriptor(
       documentation: "Documentation for AService",
-      name: "AService",
-      generatedName: "AService",
-      namespace: "namespacea",
-      generatedNamespace: "NamespaceA",
+      name: Name(base: "AService", generatedUpperCase: "AService", generatedLowerCase: "aService"),
+      namespace: Name(
+        base: "namespacea",
+        generatedUpperCase: "NamespaceA",
+        generatedLowerCase: "namespacea"
+      ),
       methods: [methodA, methodB]
     )
 
@@ -442,7 +438,7 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
         CodeGenError(
           code: .nonUniqueMethodName,
           message: """
-            Methods of a service must have unique signature names. \
+            Methods of a service must have unique lower case names. \
             methodA is used as a signature name for multiple methods of the AService service.
             """
         )
@@ -453,18 +449,18 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
   func testSameGeneratedNameNoNamespaceServiceAndNamespaceError() throws {
     let serviceA = ServiceDescriptor(
       documentation: "Documentation for SameName service with no namespace",
-      name: "SameName",
-      generatedName: "SameName",
-      namespace: "",
-      generatedNamespace: "",
+      name: Name(base: "SameName", generatedUpperCase: "SameName", generatedLowerCase: "sameName"),
+      namespace: Name(base: "", generatedUpperCase: "", generatedLowerCase: ""),
       methods: []
     )
     let serviceB = ServiceDescriptor(
       documentation: "Documentation for BService",
-      name: "BService",
-      generatedName: "BService",
-      namespace: "SameName",
-      generatedNamespace: "SameName",
+      name: Name(base: "BService", generatedUpperCase: "BService", generatedLowerCase: "bService"),
+      namespace: Name(
+        base: "sameName",
+        generatedUpperCase: "SameName",
+        generatedLowerCase: "sameName"
+      ),
       methods: []
     )
     let codeGenerationRequest = makeCodeGenerationRequest(services: [serviceA, serviceB])
@@ -483,119 +479,8 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
         CodeGenError(
           code: .nonUniqueServiceName,
           message: """
-            Services with no namespace must not have the same generated names as the namespaces. \
-            SameName is used as a generated name for a service with no namespace and a namespace.
-            """
-        )
-      )
-    }
-  }
-
-  func testEmptyNamespaceAndNonEmptyGeneratedNamespaceError() throws {
-    let serviceA = ServiceDescriptor(
-      documentation: "Documentation for SameName service with no namespace",
-      name: "SameName",
-      generatedName: "SameName",
-      namespace: "",
-      generatedNamespace: "NonEmpty",
-      methods: []
-    )
-
-    let codeGenerationRequest = makeCodeGenerationRequest(services: [serviceA])
-    let translator = IDLToStructuredSwiftTranslator()
-    XCTAssertThrowsError(
-      ofType: CodeGenError.self,
-      try translator.translate(
-        codeGenerationRequest: codeGenerationRequest,
-        client: true,
-        server: true
-      )
-    ) {
-      error in
-      XCTAssertEqual(
-        error as CodeGenError,
-        CodeGenError(
-          code: .invalidGeneratedNamespace,
-          message: """
-            Services with an empty namespace must have an empty generated namespace. \
-            SameName has an empty namespace, but a non-empty generated namespace.
-            """
-        )
-      )
-    }
-  }
-
-  func testNonEmptyNamespaceAndEmptyGeneratedNamespaceError() throws {
-    let serviceA = ServiceDescriptor(
-      documentation: "Documentation for SameName service with no namespace",
-      name: "SameName",
-      generatedName: "SameName",
-      namespace: "NonEmpty",
-      generatedNamespace: "",
-      methods: []
-    )
-
-    let codeGenerationRequest = makeCodeGenerationRequest(services: [serviceA])
-    let translator = IDLToStructuredSwiftTranslator()
-    XCTAssertThrowsError(
-      ofType: CodeGenError.self,
-      try translator.translate(
-        codeGenerationRequest: codeGenerationRequest,
-        client: true,
-        server: true
-      )
-    ) {
-      error in
-      XCTAssertEqual(
-        error as CodeGenError,
-        CodeGenError(
-          code: .invalidGeneratedNamespace,
-          message: """
-            Services with a non-empty namespace must have a non-empty generated namespace. \
-            SameName has a non-empty namespace, but an empty generated namespace.
-            """
-        )
-      )
-    }
-  }
-
-  func testNamespaceAndGeneratedNamespaceServicesCoincide() throws {
-    // Same namespaces, different generated namespaces.
-    let serviceA = ServiceDescriptor(
-      documentation: "Documentation for SameName service with no namespace",
-      name: "ServiceA",
-      generatedName: "ServiceA",
-      namespace: "namespaceA",
-      generatedNamespace: "NamespaceA",
-      methods: []
-    )
-    let serviceB = ServiceDescriptor(
-      documentation: "Documentation for SameName service with no namespace",
-      name: "ServiceB",
-      generatedName: "ServiceB",
-      namespace: "namespaceA",
-      generatedNamespace: "NamespaceB",
-      methods: []
-    )
-    let codeGenerationRequest = makeCodeGenerationRequest(services: [serviceA, serviceB])
-    let translator = IDLToStructuredSwiftTranslator()
-    XCTAssertThrowsError(
-      ofType: CodeGenError.self,
-      try translator.translate(
-        codeGenerationRequest: codeGenerationRequest,
-        client: true,
-        server: true
-      )
-    ) {
-      error in
-      XCTAssertEqual(
-        error as CodeGenError,
-        CodeGenError(
-          code: .invalidGeneratedNamespace,
-          message: """
-            All services within a namespace must have the same generated namespace. \
-            ServiceB doesn't have the same generated namespace as other services \
-            within the namespaceA namespace.
+            Services with no namespace must not have the same generated upper case names as the namespaces. \
+            SameName is used as a generated upper case name for a service with no namespace and a namespace.
             """
         )
       )

--- a/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
@@ -569,7 +569,7 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
       generatedNamespace: "NamespaceA",
       methods: []
     )
-    var serviceB = ServiceDescriptor(
+    let serviceB = ServiceDescriptor(
       documentation: "Documentation for SameName service with no namespace",
       name: "ServiceB",
       generatedName: "ServiceB",
@@ -577,7 +577,7 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
       generatedNamespace: "NamespaceB",
       methods: []
     )
-    var codeGenerationRequest = makeCodeGenerationRequest(services: [serviceA, serviceB])
+    let codeGenerationRequest = makeCodeGenerationRequest(services: [serviceA, serviceB])
     let translator = IDLToStructuredSwiftTranslator()
     XCTAssertThrowsError(
       ofType: CodeGenError.self,
@@ -593,8 +593,9 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
         CodeGenError(
           code: .invalidGeneratedNamespace,
           message: """
-            Services within a namespace must have the same generated namespace. \
-            Not all services within namespaceA have the NamespaceA generated namespace.
+            All services within a namespace must have the same generated namespace. \
+            ServiceB doesn't have the same generated namespace as other services \
+            within the namespaceA namespace.
             """
         )
       )

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
@@ -27,7 +27,9 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
   func testServerCodeTranslatorUnaryMethod() throws {
     let method = MethodDescriptor(
       documentation: "Documentation for unaryMethod",
-      name: "unaryMethod",
+      name: "UnaryMethod",
+      generatedName: "Unary",
+      signatureName: "unary",
       isInputStreaming: false,
       isOutputStreaming: false,
       inputType: "NamespaceA_ServiceARequest",
@@ -35,39 +37,41 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     )
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
-      name: "ServiceA",
+      name: "AlongNameForServiceA",
+      generatedName: "ServiceA",
       namespace: "namespaceA",
+      generatedNamespace: "NamespaceA",
       methods: [method]
     )
     let expectedSwift =
       """
       /// Documentation for ServiceA
-      protocol namespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
+      protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for unaryMethod
-          func unaryMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.unaryMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.unaryMethod.Output>
+          func unary(request: ServerRequest.Stream<NamespaceA.ServiceA.Methods.Unary.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Methods.Unary.Output>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
-      public extension namespaceA.ServiceA.StreamingServiceProtocol {
+      public extension NamespaceA.ServiceA.StreamingServiceProtocol {
           func registerRPCs(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
-                  for: namespaceA.ServiceA.Methods.unaryMethod.descriptor,
-                  deserializer: ProtobufDeserializer<namespaceA.ServiceA.Methods.unaryMethod.Input>(),
-                  serializer: ProtobufSerializer<namespaceA.ServiceA.Methods.unaryMethod.Output>(),
+                  for: NamespaceA.ServiceA.Methods.Unary.descriptor,
+                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Methods.Unary.Input>(),
+                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Methods.Unary.Output>(),
                   handler: { request in
-                      try await self.unaryMethod(request: request)
+                      try await self.unary(request: request)
                   }
               )
           }
       }
       /// Documentation for ServiceA
-      protocol namespaceA_ServiceAServiceProtocol: namespaceA.ServiceA.StreamingServiceProtocol {
+      protocol NamespaceA_ServiceAServiceProtocol: NamespaceA.ServiceA.StreamingServiceProtocol {
           /// Documentation for unaryMethod
-          func unaryMethod(request: ServerRequest.Single<namespaceA.ServiceA.Methods.unaryMethod.Input>) async throws -> ServerResponse.Single<namespaceA.ServiceA.Methods.unaryMethod.Output>
+          func unary(request: ServerRequest.Single<NamespaceA.ServiceA.Methods.Unary.Input>) async throws -> ServerResponse.Single<NamespaceA.ServiceA.Methods.Unary.Output>
       }
-      /// Partial conformance to `namespaceA_ServiceAStreamingServiceProtocol`.
-      public extension namespaceA.ServiceA.ServiceProtocol {
-          func unaryMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.unaryMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.unaryMethod.Output> {
-              let response = try await self.unaryMethod(request: ServerRequest.Single(stream: request))
+      /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
+      public extension NamespaceA.ServiceA.ServiceProtocol {
+          func unary(request: ServerRequest.Stream<NamespaceA.ServiceA.Methods.Unary.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Methods.Unary.Output> {
+              let response = try await self.unary(request: ServerRequest.Single(stream: request))
               return ServerResponse.Stream(single: response)
           }
       }
@@ -82,7 +86,9 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
   func testServerCodeTranslatorInputStreamingMethod() throws {
     let method = MethodDescriptor(
       documentation: "Documentation for inputStreamingMethod",
-      name: "inputStreamingMethod",
+      name: "InputStreamingMethod",
+      generatedName: "InputStreaming",
+      signatureName: "inputStreaming",
       isInputStreaming: true,
       isOutputStreaming: false,
       inputType: "NamespaceA_ServiceARequest",
@@ -91,38 +97,40 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
       name: "ServiceA",
+      generatedName: "ServiceA",
       namespace: "namespaceA",
+      generatedNamespace: "NamespaceA",
       methods: [method]
     )
     let expectedSwift =
       """
       /// Documentation for ServiceA
-      protocol namespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
+      protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for inputStreamingMethod
-          func inputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Output>
+          func inputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Methods.InputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Methods.InputStreaming.Output>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
-      public extension namespaceA.ServiceA.StreamingServiceProtocol {
+      public extension NamespaceA.ServiceA.StreamingServiceProtocol {
           func registerRPCs(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
-                  for: namespaceA.ServiceA.Methods.inputStreamingMethod.descriptor,
-                  deserializer: ProtobufDeserializer<namespaceA.ServiceA.Methods.inputStreamingMethod.Input>(),
-                  serializer: ProtobufSerializer<namespaceA.ServiceA.Methods.inputStreamingMethod.Output>(),
+                  for: NamespaceA.ServiceA.Methods.InputStreaming.descriptor,
+                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Methods.InputStreaming.Input>(),
+                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Methods.InputStreaming.Output>(),
                   handler: { request in
-                      try await self.inputStreamingMethod(request: request)
+                      try await self.inputStreaming(request: request)
                   }
               )
           }
       }
       /// Documentation for ServiceA
-      protocol namespaceA_ServiceAServiceProtocol: namespaceA.ServiceA.StreamingServiceProtocol {
+      protocol NamespaceA_ServiceAServiceProtocol: NamespaceA.ServiceA.StreamingServiceProtocol {
           /// Documentation for inputStreamingMethod
-          func inputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Input>) async throws -> ServerResponse.Single<namespaceA.ServiceA.Methods.inputStreamingMethod.Output>
+          func inputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Methods.InputStreaming.Input>) async throws -> ServerResponse.Single<NamespaceA.ServiceA.Methods.InputStreaming.Output>
       }
-      /// Partial conformance to `namespaceA_ServiceAStreamingServiceProtocol`.
-      public extension namespaceA.ServiceA.ServiceProtocol {
-          func inputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Output> {
-              let response = try await self.inputStreamingMethod(request: request)
+      /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
+      public extension NamespaceA.ServiceA.ServiceProtocol {
+          func inputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Methods.InputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Methods.InputStreaming.Output> {
+              let response = try await self.inputStreaming(request: request)
               return ServerResponse.Stream(single: response)
           }
       }
@@ -137,7 +145,9 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
   func testServerCodeTranslatorOutputStreamingMethod() throws {
     let method = MethodDescriptor(
       documentation: "Documentation for outputStreamingMethod",
-      name: "outputStreamingMethod",
+      name: "OutputStreamingMethod",
+      generatedName: "OutputStreaming",
+      signatureName: "outputStreaming",
       isInputStreaming: false,
       isOutputStreaming: true,
       inputType: "NamespaceA_ServiceARequest",
@@ -145,39 +155,41 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     )
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
-      name: "ServiceA",
+      name: "ServiceATest",
+      generatedName: "ServiceA",
       namespace: "namespaceA",
+      generatedNamespace: "NamespaceA",
       methods: [method]
     )
     let expectedSwift =
       """
       /// Documentation for ServiceA
-      protocol namespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
+      protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for outputStreamingMethod
-          func outputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Output>
+          func outputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Methods.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Methods.OutputStreaming.Output>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
-      public extension namespaceA.ServiceA.StreamingServiceProtocol {
+      public extension NamespaceA.ServiceA.StreamingServiceProtocol {
           func registerRPCs(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
-                  for: namespaceA.ServiceA.Methods.outputStreamingMethod.descriptor,
-                  deserializer: ProtobufDeserializer<namespaceA.ServiceA.Methods.outputStreamingMethod.Input>(),
-                  serializer: ProtobufSerializer<namespaceA.ServiceA.Methods.outputStreamingMethod.Output>(),
+                  for: NamespaceA.ServiceA.Methods.OutputStreaming.descriptor,
+                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Methods.OutputStreaming.Input>(),
+                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Methods.OutputStreaming.Output>(),
                   handler: { request in
-                      try await self.outputStreamingMethod(request: request)
+                      try await self.outputStreaming(request: request)
                   }
               )
           }
       }
       /// Documentation for ServiceA
-      protocol namespaceA_ServiceAServiceProtocol: namespaceA.ServiceA.StreamingServiceProtocol {
+      protocol NamespaceA_ServiceAServiceProtocol: NamespaceA.ServiceA.StreamingServiceProtocol {
           /// Documentation for outputStreamingMethod
-          func outputStreamingMethod(request: ServerRequest.Single<namespaceA.ServiceA.Methods.outputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Output>
+          func outputStreaming(request: ServerRequest.Single<NamespaceA.ServiceA.Methods.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Methods.OutputStreaming.Output>
       }
-      /// Partial conformance to `namespaceA_ServiceAStreamingServiceProtocol`.
-      public extension namespaceA.ServiceA.ServiceProtocol {
-          func outputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Output> {
-              let response = try await self.outputStreamingMethod(request: ServerRequest.Single(stream: request))
+      /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
+      public extension NamespaceA.ServiceA.ServiceProtocol {
+          func outputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Methods.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Methods.OutputStreaming.Output> {
+              let response = try await self.outputStreaming(request: ServerRequest.Single(stream: request))
               return response
           }
       }
@@ -192,7 +204,9 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
   func testServerCodeTranslatorBidirectionalStreamingMethod() throws {
     let method = MethodDescriptor(
       documentation: "Documentation for bidirectionalStreamingMethod",
-      name: "bidirectionalStreamingMethod",
+      name: "BidirectionalStreamingMethod",
+      generatedName: "BidirectionalStreaming",
+      signatureName: "bidirectionalStreaming",
       isInputStreaming: true,
       isOutputStreaming: true,
       inputType: "NamespaceA_ServiceARequest",
@@ -200,37 +214,39 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     )
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
-      name: "ServiceA",
+      name: "ServiceATest",
+      generatedName: "ServiceA",
       namespace: "namespaceA",
+      generatedNamespace: "NamespaceA",
       methods: [method]
     )
     let expectedSwift =
       """
       /// Documentation for ServiceA
-      protocol namespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
+      protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for bidirectionalStreamingMethod
-          func bidirectionalStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.bidirectionalStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.bidirectionalStreamingMethod.Output>
+          func bidirectionalStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Methods.BidirectionalStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Methods.BidirectionalStreaming.Output>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
-      public extension namespaceA.ServiceA.StreamingServiceProtocol {
+      public extension NamespaceA.ServiceA.StreamingServiceProtocol {
           func registerRPCs(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
-                  for: namespaceA.ServiceA.Methods.bidirectionalStreamingMethod.descriptor,
-                  deserializer: ProtobufDeserializer<namespaceA.ServiceA.Methods.bidirectionalStreamingMethod.Input>(),
-                  serializer: ProtobufSerializer<namespaceA.ServiceA.Methods.bidirectionalStreamingMethod.Output>(),
+                  for: NamespaceA.ServiceA.Methods.BidirectionalStreaming.descriptor,
+                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Methods.BidirectionalStreaming.Input>(),
+                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Methods.BidirectionalStreaming.Output>(),
                   handler: { request in
-                      try await self.bidirectionalStreamingMethod(request: request)
+                      try await self.bidirectionalStreaming(request: request)
                   }
               )
           }
       }
       /// Documentation for ServiceA
-      protocol namespaceA_ServiceAServiceProtocol: namespaceA.ServiceA.StreamingServiceProtocol {
+      protocol NamespaceA_ServiceAServiceProtocol: NamespaceA.ServiceA.StreamingServiceProtocol {
           /// Documentation for bidirectionalStreamingMethod
-          func bidirectionalStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.bidirectionalStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.bidirectionalStreamingMethod.Output>
+          func bidirectionalStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Methods.BidirectionalStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Methods.BidirectionalStreaming.Output>
       }
-      /// Partial conformance to `namespaceA_ServiceAStreamingServiceProtocol`.
-      public extension namespaceA.ServiceA.ServiceProtocol {
+      /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
+      public extension NamespaceA.ServiceA.ServiceProtocol {
       }
       """
 
@@ -243,7 +259,9 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
   func testServerCodeTranslatorMultipleMethods() throws {
     let inputStreamingMethod = MethodDescriptor(
       documentation: "Documentation for inputStreamingMethod",
-      name: "inputStreamingMethod",
+      name: "InputStreamingMethod",
+      generatedName: "InputStreaming",
+      signatureName: "inputStreaming",
       isInputStreaming: true,
       isOutputStreaming: false,
       inputType: "NamespaceA_ServiceARequest",
@@ -252,6 +270,8 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     let outputStreamingMethod = MethodDescriptor(
       documentation: "Documentation for outputStreamingMethod",
       name: "outputStreamingMethod",
+      generatedName: "OutputStreaming",
+      signatureName: "outputStreaming",
       isInputStreaming: false,
       isOutputStreaming: true,
       inputType: "NamespaceA_ServiceARequest",
@@ -259,55 +279,57 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     )
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
-      name: "ServiceA",
+      name: "ServiceATest",
+      generatedName: "ServiceA",
       namespace: "namespaceA",
+      generatedNamespace: "NamespaceA",
       methods: [inputStreamingMethod, outputStreamingMethod]
     )
     let expectedSwift =
       """
       /// Documentation for ServiceA
-      protocol namespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
+      protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for inputStreamingMethod
-          func inputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Output>
+          func inputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Methods.InputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Methods.InputStreaming.Output>
           /// Documentation for outputStreamingMethod
-          func outputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Output>
+          func outputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Methods.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Methods.OutputStreaming.Output>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
-      public extension namespaceA.ServiceA.StreamingServiceProtocol {
+      public extension NamespaceA.ServiceA.StreamingServiceProtocol {
           func registerRPCs(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
-                  for: namespaceA.ServiceA.Methods.inputStreamingMethod.descriptor,
-                  deserializer: ProtobufDeserializer<namespaceA.ServiceA.Methods.inputStreamingMethod.Input>(),
-                  serializer: ProtobufSerializer<namespaceA.ServiceA.Methods.inputStreamingMethod.Output>(),
+                  for: NamespaceA.ServiceA.Methods.InputStreaming.descriptor,
+                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Methods.InputStreaming.Input>(),
+                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Methods.InputStreaming.Output>(),
                   handler: { request in
-                      try await self.inputStreamingMethod(request: request)
+                      try await self.inputStreaming(request: request)
                   }
               )
               router.registerHandler(
-                  for: namespaceA.ServiceA.Methods.outputStreamingMethod.descriptor,
-                  deserializer: ProtobufDeserializer<namespaceA.ServiceA.Methods.outputStreamingMethod.Input>(),
-                  serializer: ProtobufSerializer<namespaceA.ServiceA.Methods.outputStreamingMethod.Output>(),
+                  for: NamespaceA.ServiceA.Methods.OutputStreaming.descriptor,
+                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Methods.OutputStreaming.Input>(),
+                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Methods.OutputStreaming.Output>(),
                   handler: { request in
-                      try await self.outputStreamingMethod(request: request)
+                      try await self.outputStreaming(request: request)
                   }
               )
           }
       }
       /// Documentation for ServiceA
-      protocol namespaceA_ServiceAServiceProtocol: namespaceA.ServiceA.StreamingServiceProtocol {
+      protocol NamespaceA_ServiceAServiceProtocol: NamespaceA.ServiceA.StreamingServiceProtocol {
           /// Documentation for inputStreamingMethod
-          func inputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Input>) async throws -> ServerResponse.Single<namespaceA.ServiceA.Methods.inputStreamingMethod.Output>
+          func inputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Methods.InputStreaming.Input>) async throws -> ServerResponse.Single<NamespaceA.ServiceA.Methods.InputStreaming.Output>
           /// Documentation for outputStreamingMethod
-          func outputStreamingMethod(request: ServerRequest.Single<namespaceA.ServiceA.Methods.outputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Output>
+          func outputStreaming(request: ServerRequest.Single<NamespaceA.ServiceA.Methods.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Methods.OutputStreaming.Output>
       }
-      /// Partial conformance to `namespaceA_ServiceAStreamingServiceProtocol`.
-      public extension namespaceA.ServiceA.ServiceProtocol {
-          func inputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.inputStreamingMethod.Output> {
-              let response = try await self.inputStreamingMethod(request: request)
+      /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
+      public extension NamespaceA.ServiceA.ServiceProtocol {
+          func inputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Methods.InputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Methods.InputStreaming.Output> {
+              let response = try await self.inputStreaming(request: request)
               return ServerResponse.Stream(single: response)
           }
-          func outputStreamingMethod(request: ServerRequest.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Input>) async throws -> ServerResponse.Stream<namespaceA.ServiceA.Methods.outputStreamingMethod.Output> {
-              let response = try await self.outputStreamingMethod(request: ServerRequest.Single(stream: request))
+          func outputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Methods.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Methods.OutputStreaming.Output> {
+              let response = try await self.outputStreaming(request: ServerRequest.Single(stream: request))
               return response
           }
       }
@@ -323,6 +345,8 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     let method = MethodDescriptor(
       documentation: "Documentation for MethodA",
       name: "methodA",
+      generatedName: "MethodA",
+      signatureName: "methodA",
       isInputStreaming: false,
       isOutputStreaming: false,
       inputType: "NamespaceA_ServiceARequest",
@@ -330,8 +354,10 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     )
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
-      name: "ServiceA",
+      name: "ServiceATest",
+      generatedName: "ServiceA",
       namespace: "",
+      generatedNamespace: "",
       methods: [method]
     )
     let expectedSwift =
@@ -339,15 +365,15 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       /// Documentation for ServiceA
       protocol ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for MethodA
-          func methodA(request: ServerRequest.Stream<ServiceA.Methods.methodA.Input>) async throws -> ServerResponse.Stream<ServiceA.Methods.methodA.Output>
+          func methodA(request: ServerRequest.Stream<ServiceA.Methods.MethodA.Input>) async throws -> ServerResponse.Stream<ServiceA.Methods.MethodA.Output>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       public extension ServiceA.StreamingServiceProtocol {
           func registerRPCs(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
-                  for: ServiceA.Methods.methodA.descriptor,
-                  deserializer: ProtobufDeserializer<ServiceA.Methods.methodA.Input>(),
-                  serializer: ProtobufSerializer<ServiceA.Methods.methodA.Output>(),
+                  for: ServiceA.Methods.MethodA.descriptor,
+                  deserializer: ProtobufDeserializer<ServiceA.Methods.MethodA.Input>(),
+                  serializer: ProtobufSerializer<ServiceA.Methods.MethodA.Output>(),
                   handler: { request in
                       try await self.methodA(request: request)
                   }
@@ -357,11 +383,11 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       /// Documentation for ServiceA
       protocol ServiceAServiceProtocol: ServiceA.StreamingServiceProtocol {
           /// Documentation for MethodA
-          func methodA(request: ServerRequest.Single<ServiceA.Methods.methodA.Input>) async throws -> ServerResponse.Single<ServiceA.Methods.methodA.Output>
+          func methodA(request: ServerRequest.Single<ServiceA.Methods.MethodA.Input>) async throws -> ServerResponse.Single<ServiceA.Methods.MethodA.Output>
       }
       /// Partial conformance to `ServiceAStreamingServiceProtocol`.
       public extension ServiceA.ServiceProtocol {
-          func methodA(request: ServerRequest.Stream<ServiceA.Methods.methodA.Input>) async throws -> ServerResponse.Stream<ServiceA.Methods.methodA.Output> {
+          func methodA(request: ServerRequest.Stream<ServiceA.Methods.MethodA.Input>) async throws -> ServerResponse.Stream<ServiceA.Methods.MethodA.Output> {
               let response = try await self.methodA(request: ServerRequest.Single(stream: request))
               return ServerResponse.Stream(single: response)
           }
@@ -378,38 +404,42 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     let serviceA = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
       name: "ServiceA",
+      generatedName: "ServiceA",
       namespace: "namespaceA",
+      generatedNamespace: "NamespaceA",
       methods: []
     )
     let serviceB = ServiceDescriptor(
       documentation: "Documentation for ServiceB",
       name: "ServiceB",
+      generatedName: "ServiceB",
       namespace: "namespaceA",
+      generatedNamespace: "NamespaceA",
       methods: []
     )
     let expectedSwift =
       """
       /// Documentation for ServiceA
-      protocol namespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {}
+      protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {}
       /// Conformance to `GRPCCore.RegistrableRPCService`.
-      public extension namespaceA.ServiceA.StreamingServiceProtocol {
+      public extension NamespaceA.ServiceA.StreamingServiceProtocol {
           func registerRPCs(with router: inout GRPCCore.RPCRouter) {}
       }
       /// Documentation for ServiceA
-      protocol namespaceA_ServiceAServiceProtocol: namespaceA.ServiceA.StreamingServiceProtocol {}
-      /// Partial conformance to `namespaceA_ServiceAStreamingServiceProtocol`.
-      public extension namespaceA.ServiceA.ServiceProtocol {
+      protocol NamespaceA_ServiceAServiceProtocol: NamespaceA.ServiceA.StreamingServiceProtocol {}
+      /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
+      public extension NamespaceA.ServiceA.ServiceProtocol {
       }
       /// Documentation for ServiceB
-      protocol namespaceA_ServiceBStreamingServiceProtocol: GRPCCore.RegistrableRPCService {}
+      protocol NamespaceA_ServiceBStreamingServiceProtocol: GRPCCore.RegistrableRPCService {}
       /// Conformance to `GRPCCore.RegistrableRPCService`.
-      public extension namespaceA.ServiceB.StreamingServiceProtocol {
+      public extension NamespaceA.ServiceB.StreamingServiceProtocol {
           func registerRPCs(with router: inout GRPCCore.RPCRouter) {}
       }
       /// Documentation for ServiceB
-      protocol namespaceA_ServiceBServiceProtocol: namespaceA.ServiceB.StreamingServiceProtocol {}
-      /// Partial conformance to `namespaceA_ServiceBStreamingServiceProtocol`.
-      public extension namespaceA.ServiceB.ServiceProtocol {
+      protocol NamespaceA_ServiceBServiceProtocol: NamespaceA.ServiceB.StreamingServiceProtocol {}
+      /// Partial conformance to `NamespaceA_ServiceBStreamingServiceProtocol`.
+      public extension NamespaceA.ServiceB.ServiceProtocol {
       }
       """
 

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
@@ -23,13 +23,12 @@ import XCTest
 final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
   typealias MethodDescriptor = GRPCCodeGen.CodeGenerationRequest.ServiceDescriptor.MethodDescriptor
   typealias ServiceDescriptor = GRPCCodeGen.CodeGenerationRequest.ServiceDescriptor
+  typealias Name = GRPCCodeGen.CodeGenerationRequest.Name
 
   func testServerCodeTranslatorUnaryMethod() throws {
     let method = MethodDescriptor(
       documentation: "Documentation for unaryMethod",
-      name: "UnaryMethod",
-      generatedName: "Unary",
-      signatureName: "unary",
+      name: Name(base: "UnaryMethod", generatedUpperCase: "Unary", generatedLowerCase: "unary"),
       isInputStreaming: false,
       isOutputStreaming: false,
       inputType: "NamespaceA_ServiceARequest",
@@ -37,10 +36,16 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     )
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
-      name: "AlongNameForServiceA",
-      generatedName: "ServiceA",
-      namespace: "namespaceA",
-      generatedNamespace: "NamespaceA",
+      name: Name(
+        base: "AlongNameForServiceA",
+        generatedUpperCase: "ServiceA",
+        generatedLowerCase: "serviceA"
+      ),
+      namespace: Name(
+        base: "namespaceA",
+        generatedUpperCase: "NamespaceA",
+        generatedLowerCase: "namespaceA"
+      ),
       methods: [method]
     )
     let expectedSwift =
@@ -86,9 +91,11 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
   func testServerCodeTranslatorInputStreamingMethod() throws {
     let method = MethodDescriptor(
       documentation: "Documentation for inputStreamingMethod",
-      name: "InputStreamingMethod",
-      generatedName: "InputStreaming",
-      signatureName: "inputStreaming",
+      name: Name(
+        base: "InputStreamingMethod",
+        generatedUpperCase: "InputStreaming",
+        generatedLowerCase: "inputStreaming"
+      ),
       isInputStreaming: true,
       isOutputStreaming: false,
       inputType: "NamespaceA_ServiceARequest",
@@ -96,10 +103,12 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     )
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
-      name: "ServiceA",
-      generatedName: "ServiceA",
-      namespace: "namespaceA",
-      generatedNamespace: "NamespaceA",
+      name: Name(base: "ServiceA", generatedUpperCase: "ServiceA", generatedLowerCase: "serviceA"),
+      namespace: Name(
+        base: "namespaceA",
+        generatedUpperCase: "NamespaceA",
+        generatedLowerCase: "namespaceA"
+      ),
       methods: [method]
     )
     let expectedSwift =
@@ -145,9 +154,11 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
   func testServerCodeTranslatorOutputStreamingMethod() throws {
     let method = MethodDescriptor(
       documentation: "Documentation for outputStreamingMethod",
-      name: "OutputStreamingMethod",
-      generatedName: "OutputStreaming",
-      signatureName: "outputStreaming",
+      name: Name(
+        base: "OutputStreamingMethod",
+        generatedUpperCase: "OutputStreaming",
+        generatedLowerCase: "outputStreaming"
+      ),
       isInputStreaming: false,
       isOutputStreaming: true,
       inputType: "NamespaceA_ServiceARequest",
@@ -155,10 +166,16 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     )
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
-      name: "ServiceATest",
-      generatedName: "ServiceA",
-      namespace: "namespaceA",
-      generatedNamespace: "NamespaceA",
+      name: Name(
+        base: "ServiceATest",
+        generatedUpperCase: "ServiceA",
+        generatedLowerCase: "serviceA"
+      ),
+      namespace: Name(
+        base: "namespaceA",
+        generatedUpperCase: "NamespaceA",
+        generatedLowerCase: "namespaceA"
+      ),
       methods: [method]
     )
     let expectedSwift =
@@ -204,9 +221,11 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
   func testServerCodeTranslatorBidirectionalStreamingMethod() throws {
     let method = MethodDescriptor(
       documentation: "Documentation for bidirectionalStreamingMethod",
-      name: "BidirectionalStreamingMethod",
-      generatedName: "BidirectionalStreaming",
-      signatureName: "bidirectionalStreaming",
+      name: Name(
+        base: "BidirectionalStreamingMethod",
+        generatedUpperCase: "BidirectionalStreaming",
+        generatedLowerCase: "bidirectionalStreaming"
+      ),
       isInputStreaming: true,
       isOutputStreaming: true,
       inputType: "NamespaceA_ServiceARequest",
@@ -214,10 +233,16 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     )
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
-      name: "ServiceATest",
-      generatedName: "ServiceA",
-      namespace: "namespaceA",
-      generatedNamespace: "NamespaceA",
+      name: Name(
+        base: "ServiceATest",
+        generatedUpperCase: "ServiceA",
+        generatedLowerCase: "serviceA"
+      ),
+      namespace: Name(
+        base: "namespaceA",
+        generatedUpperCase: "NamespaceA",
+        generatedLowerCase: "namespaceA"
+      ),
       methods: [method]
     )
     let expectedSwift =
@@ -259,9 +284,11 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
   func testServerCodeTranslatorMultipleMethods() throws {
     let inputStreamingMethod = MethodDescriptor(
       documentation: "Documentation for inputStreamingMethod",
-      name: "InputStreamingMethod",
-      generatedName: "InputStreaming",
-      signatureName: "inputStreaming",
+      name: Name(
+        base: "InputStreamingMethod",
+        generatedUpperCase: "InputStreaming",
+        generatedLowerCase: "inputStreaming"
+      ),
       isInputStreaming: true,
       isOutputStreaming: false,
       inputType: "NamespaceA_ServiceARequest",
@@ -269,9 +296,11 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     )
     let outputStreamingMethod = MethodDescriptor(
       documentation: "Documentation for outputStreamingMethod",
-      name: "outputStreamingMethod",
-      generatedName: "OutputStreaming",
-      signatureName: "outputStreaming",
+      name: Name(
+        base: "outputStreamingMethod",
+        generatedUpperCase: "OutputStreaming",
+        generatedLowerCase: "outputStreaming"
+      ),
       isInputStreaming: false,
       isOutputStreaming: true,
       inputType: "NamespaceA_ServiceARequest",
@@ -279,10 +308,16 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     )
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
-      name: "ServiceATest",
-      generatedName: "ServiceA",
-      namespace: "namespaceA",
-      generatedNamespace: "NamespaceA",
+      name: Name(
+        base: "ServiceATest",
+        generatedUpperCase: "ServiceA",
+        generatedLowerCase: "serviceA"
+      ),
+      namespace: Name(
+        base: "namespaceA",
+        generatedUpperCase: "NamespaceA",
+        generatedLowerCase: "namespaceA"
+      ),
       methods: [inputStreamingMethod, outputStreamingMethod]
     )
     let expectedSwift =
@@ -344,9 +379,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
   func testServerCodeTranslatorNoNamespaceService() throws {
     let method = MethodDescriptor(
       documentation: "Documentation for MethodA",
-      name: "methodA",
-      generatedName: "MethodA",
-      signatureName: "methodA",
+      name: Name(base: "methodA", generatedUpperCase: "MethodA", generatedLowerCase: "methodA"),
       isInputStreaming: false,
       isOutputStreaming: false,
       inputType: "NamespaceA_ServiceARequest",
@@ -354,10 +387,12 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     )
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
-      name: "ServiceATest",
-      generatedName: "ServiceA",
-      namespace: "",
-      generatedNamespace: "",
+      name: Name(
+        base: "ServiceATest",
+        generatedUpperCase: "ServiceA",
+        generatedLowerCase: "serviceA"
+      ),
+      namespace: Name(base: "", generatedUpperCase: "", generatedLowerCase: ""),
       methods: [method]
     )
     let expectedSwift =
@@ -403,18 +438,22 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
   func testServerCodeTranslatorMoreServicesOrder() throws {
     let serviceA = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
-      name: "ServiceA",
-      generatedName: "ServiceA",
-      namespace: "namespaceA",
-      generatedNamespace: "NamespaceA",
+      name: Name(base: "ServiceA", generatedUpperCase: "ServiceA", generatedLowerCase: "serviceA"),
+      namespace: Name(
+        base: "namespaceA",
+        generatedUpperCase: "NamespaceA",
+        generatedLowerCase: "namespaceA"
+      ),
       methods: []
     )
     let serviceB = ServiceDescriptor(
       documentation: "Documentation for ServiceB",
-      name: "ServiceB",
-      generatedName: "ServiceB",
-      namespace: "namespaceA",
-      generatedNamespace: "NamespaceA",
+      name: Name(base: "ServiceB", generatedUpperCase: "ServiceB", generatedLowerCase: "serviceB"),
+      namespace: Name(
+        base: "namespaceA",
+        generatedUpperCase: "NamespaceA",
+        generatedLowerCase: "namespaceA"
+      ),
       methods: []
     )
     let expectedSwift =

--- a/Tests/GRPCCodeGenTests/Internal/Translator/TypealiasTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/TypealiasTranslatorSnippetBasedTests.swift
@@ -23,13 +23,12 @@ import XCTest
 final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
   typealias MethodDescriptor = GRPCCodeGen.CodeGenerationRequest.ServiceDescriptor.MethodDescriptor
   typealias ServiceDescriptor = GRPCCodeGen.CodeGenerationRequest.ServiceDescriptor
+  typealias Name = GRPCCodeGen.CodeGenerationRequest.Name
 
   func testTypealiasTranslator() throws {
     let method = MethodDescriptor(
       documentation: "Documentation for MethodA",
-      name: "MethodA",
-      generatedName: "MethodA",
-      signatureName: "methodA",
+      name: Name(base: "MethodA", generatedUpperCase: "MethodA", generatedLowerCase: "methodA"),
       isInputStreaming: false,
       isOutputStreaming: false,
       inputType: "NamespaceA_ServiceARequest",
@@ -37,10 +36,12 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     )
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
-      name: "ServiceA",
-      generatedName: "ServiceA",
-      namespace: "namespaceA",
-      generatedNamespace: "NamespaceA",
+      name: Name(base: "ServiceA", generatedUpperCase: "ServiceA", generatedLowerCase: "serviceA"),
+      namespace: Name(
+        base: "namespaceA",
+        generatedUpperCase: "NamespaceA",
+        generatedLowerCase: "namespaceA"
+      ),
       methods: [method]
     )
     let expectedSwift =
@@ -79,10 +80,12 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
   func testTypealiasTranslatorNoMethodsServiceClientAndServer() throws {
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
-      name: "ServiceA",
-      generatedName: "ServiceA",
-      namespace: "namespaceA",
-      generatedNamespace: "NamespaceA",
+      name: Name(base: "ServiceA", generatedUpperCase: "ServiceA", generatedLowerCase: "serviceA"),
+      namespace: Name(
+        base: "namespaceA",
+        generatedUpperCase: "NamespaceA",
+        generatedLowerCase: "namespaceA"
+      ),
       methods: []
     )
     let expectedSwift =
@@ -110,10 +113,12 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
   func testTypealiasTranslatorServer() throws {
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
-      name: "ServiceA",
-      generatedName: "ServiceA",
-      namespace: "namespaceA",
-      generatedNamespace: "NamespaceA",
+      name: Name(base: "ServiceA", generatedUpperCase: "ServiceA", generatedLowerCase: "serviceA"),
+      namespace: Name(
+        base: "namespaceA",
+        generatedUpperCase: "NamespaceA",
+        generatedLowerCase: "namespaceA"
+      ),
       methods: []
     )
     let expectedSwift =
@@ -139,10 +144,12 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
   func testTypealiasTranslatorClient() throws {
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
-      name: "ServiceA",
-      generatedName: "ServiceA",
-      namespace: "namespaceA",
-      generatedNamespace: "NamespaceA",
+      name: Name(base: "ServiceA", generatedUpperCase: "ServiceA", generatedLowerCase: "serviceA"),
+      namespace: Name(
+        base: "namespaceA",
+        generatedUpperCase: "NamespaceA",
+        generatedLowerCase: "namespaceA"
+      ),
       methods: []
     )
     let expectedSwift =
@@ -168,10 +175,12 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
   func testTypealiasTranslatorNoClientNoServer() throws {
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
-      name: "ServiceA",
-      generatedName: "ServiceA",
-      namespace: "namespaceA",
-      generatedNamespace: "NamespaceA",
+      name: Name(base: "ServiceA", generatedUpperCase: "ServiceA", generatedLowerCase: "serviceA"),
+      namespace: Name(
+        base: "namespaceA",
+        generatedUpperCase: "NamespaceA",
+        generatedLowerCase: "namespaceA"
+      ),
       methods: []
     )
     let expectedSwift =
@@ -195,9 +204,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
   func testTypealiasTranslatorEmptyNamespace() throws {
     let method = MethodDescriptor(
       documentation: "Documentation for MethodA",
-      name: "MethodA",
-      generatedName: "MethodA",
-      signatureName: "methodA",
+      name: Name(base: "MethodA", generatedUpperCase: "MethodA", generatedLowerCase: "methodA"),
       isInputStreaming: false,
       isOutputStreaming: false,
       inputType: "ServiceARequest",
@@ -205,10 +212,8 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     )
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
-      name: "ServiceA",
-      generatedName: "ServiceA",
-      namespace: "",
-      generatedNamespace: "",
+      name: Name(base: "ServiceA", generatedUpperCase: "ServiceA", generatedLowerCase: "serviceA"),
+      namespace: Name(base: "", generatedUpperCase: "", generatedLowerCase: ""),
       methods: [method]
     )
     let expectedSwift =
@@ -245,9 +250,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
   func testTypealiasTranslatorCheckMethodsOrder() throws {
     let methodA = MethodDescriptor(
       documentation: "Documentation for MethodA",
-      name: "MethodA",
-      generatedName: "MethodA",
-      signatureName: "methodA",
+      name: Name(base: "MethodA", generatedUpperCase: "MethodA", generatedLowerCase: "methodA"),
       isInputStreaming: false,
       isOutputStreaming: false,
       inputType: "NamespaceA_ServiceARequest",
@@ -255,9 +258,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     )
     let methodB = MethodDescriptor(
       documentation: "Documentation for MethodB",
-      name: "MethodB",
-      generatedName: "MethodB",
-      signatureName: "methodB",
+      name: Name(base: "MethodB", generatedUpperCase: "MethodB", generatedLowerCase: "methodB"),
       isInputStreaming: false,
       isOutputStreaming: false,
       inputType: "NamespaceA_ServiceARequest",
@@ -265,10 +266,12 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     )
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
-      name: "ServiceA",
-      generatedName: "ServiceA",
-      namespace: "namespaceA",
-      generatedNamespace: "NamespaceA",
+      name: Name(base: "ServiceA", generatedUpperCase: "ServiceA", generatedLowerCase: "serviceA"),
+      namespace: Name(
+        base: "namespaceA",
+        generatedUpperCase: "NamespaceA",
+        generatedLowerCase: "namespaceA"
+      ),
       methods: [methodA, methodB]
     )
     let expectedSwift =
@@ -316,10 +319,12 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
   func testTypealiasTranslatorNoMethodsService() throws {
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
-      name: "ServiceA",
-      generatedName: "ServiceA",
-      namespace: "namespaceA",
-      generatedNamespace: "NamespaceA",
+      name: Name(base: "ServiceA", generatedUpperCase: "ServiceA", generatedLowerCase: "serviceA"),
+      namespace: Name(
+        base: "namespaceA",
+        generatedUpperCase: "NamespaceA",
+        generatedLowerCase: "namespaceA"
+      ),
       methods: []
     )
     let expectedSwift =
@@ -347,19 +352,23 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
   func testTypealiasTranslatorServiceAlphabeticalOrder() throws {
     let serviceB = ServiceDescriptor(
       documentation: "Documentation for BService",
-      name: "BService",
-      generatedName: "Bservice",
-      namespace: "namespaceA",
-      generatedNamespace: "NamespaceA",
+      name: Name(base: "BService", generatedUpperCase: "Bservice", generatedLowerCase: "bservice"),
+      namespace: Name(
+        base: "namespaceA",
+        generatedUpperCase: "NamespaceA",
+        generatedLowerCase: "namespaceA"
+      ),
       methods: []
     )
 
     let serviceA = ServiceDescriptor(
       documentation: "Documentation for AService",
-      name: "AService",
-      generatedName: "Aservice",
-      namespace: "namespaceA",
-      generatedNamespace: "NamespaceA",
+      name: Name(base: "AService", generatedUpperCase: "Aservice", generatedLowerCase: "aservice"),
+      namespace: Name(
+        base: "namespaceA",
+        generatedUpperCase: "NamespaceA",
+        generatedLowerCase: "namespaceA"
+      ),
       methods: []
     )
 
@@ -396,19 +405,15 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
   func testTypealiasTranslatorServiceAlphabeticalOrderNoNamespace() throws {
     let serviceB = ServiceDescriptor(
       documentation: "Documentation for BService",
-      name: "BService",
-      generatedName: "BService",
-      namespace: "",
-      generatedNamespace: "",
+      name: Name(base: "BService", generatedUpperCase: "BService", generatedLowerCase: "bservice"),
+      namespace: Name(base: "", generatedUpperCase: "", generatedLowerCase: ""),
       methods: []
     )
 
     let serviceA = ServiceDescriptor(
       documentation: "Documentation for AService",
-      name: "AService",
-      generatedName: "AService",
-      namespace: "",
-      generatedNamespace: "",
+      name: Name(base: "AService", generatedUpperCase: "AService", generatedLowerCase: "aservice"),
+      namespace: Name(base: "", generatedUpperCase: "", generatedLowerCase: ""),
       methods: []
     )
 
@@ -443,19 +448,23 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
   func testTypealiasTranslatorNamespaceAlphabeticalOrder() throws {
     let serviceB = ServiceDescriptor(
       documentation: "Documentation for BService",
-      name: "BService",
-      generatedName: "BService",
-      namespace: "bnamespace",
-      generatedNamespace: "Bnamespace",
+      name: Name(base: "BService", generatedUpperCase: "BService", generatedLowerCase: "bservice"),
+      namespace: Name(
+        base: "bnamespace",
+        generatedUpperCase: "Bnamespace",
+        generatedLowerCase: "bnamespace"
+      ),
       methods: []
     )
 
     let serviceA = ServiceDescriptor(
       documentation: "Documentation for AService",
-      name: "AService",
-      generatedName: "AService",
-      namespace: "anamespace",
-      generatedNamespace: "Anamespace",
+      name: Name(base: "AService", generatedUpperCase: "AService", generatedLowerCase: "aservice"),
+      namespace: Name(
+        base: "anamespace",
+        generatedUpperCase: "Anamespace",
+        generatedLowerCase: "anamespace"
+      ),
       methods: []
     )
 
@@ -494,18 +503,18 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
   func testTypealiasTranslatorNamespaceNoNamespaceOrder() throws {
     let serviceA = ServiceDescriptor(
       documentation: "Documentation for AService",
-      name: "AService",
-      generatedName: "AService",
-      namespace: "anamespace",
-      generatedNamespace: "Anamespace",
+      name: Name(base: "AService", generatedUpperCase: "AService", generatedLowerCase: "aService"),
+      namespace: Name(
+        base: "anamespace",
+        generatedUpperCase: "Anamespace",
+        generatedLowerCase: "anamespace"
+      ),
       methods: []
     )
     let serviceB = ServiceDescriptor(
       documentation: "Documentation for BService",
-      name: "BService",
-      generatedName: "BService",
-      namespace: "",
-      generatedNamespace: "",
+      name: Name(base: "BService", generatedUpperCase: "BService", generatedLowerCase: "bService"),
+      namespace: Name(base: "", generatedUpperCase: "", generatedLowerCase: ""),
       methods: []
     )
     let expectedSwift =

--- a/Tests/GRPCCodeGenTests/Internal/Translator/TypealiasTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/TypealiasTranslatorSnippetBasedTests.swift
@@ -28,6 +28,8 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let method = MethodDescriptor(
       documentation: "Documentation for MethodA",
       name: "MethodA",
+      generatedName: "MethodA",
+      signatureName: "methodA",
       isInputStreaming: false,
       isOutputStreaming: false,
       inputType: "NamespaceA_ServiceARequest",
@@ -36,12 +38,14 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
       name: "ServiceA",
+      generatedName: "ServiceA",
       namespace: "namespaceA",
+      generatedNamespace: "NamespaceA",
       methods: [method]
     )
     let expectedSwift =
       """
-      enum namespaceA {
+      enum NamespaceA {
           enum ServiceA {
               enum Methods {
                   enum MethodA {
@@ -56,10 +60,10 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               static let methods: [MethodDescriptor] = [
                   Methods.MethodA.descriptor
               ]
-              typealias StreamingServiceProtocol = namespaceA_ServiceAServiceStreamingProtocol
-              typealias ServiceProtocol = namespaceA_ServiceAServiceProtocol
-              typealias ClientProtocol = namespaceA_ServiceAClientProtocol
-              typealias Client = namespaceA_ServiceAClient
+              typealias StreamingServiceProtocol = NamespaceA_ServiceAServiceStreamingProtocol
+              typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
+              typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
+              typealias Client = NamespaceA_ServiceAClient
           }
       }
       """
@@ -76,19 +80,21 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
       name: "ServiceA",
+      generatedName: "ServiceA",
       namespace: "namespaceA",
+      generatedNamespace: "NamespaceA",
       methods: []
     )
     let expectedSwift =
       """
-      enum namespaceA {
+      enum NamespaceA {
           enum ServiceA {
               enum Methods {}
               static let methods: [MethodDescriptor] = []
-              typealias StreamingServiceProtocol = namespaceA_ServiceAServiceStreamingProtocol
-              typealias ServiceProtocol = namespaceA_ServiceAServiceProtocol
-              typealias ClientProtocol = namespaceA_ServiceAClientProtocol
-              typealias Client = namespaceA_ServiceAClient
+              typealias StreamingServiceProtocol = NamespaceA_ServiceAServiceStreamingProtocol
+              typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
+              typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
+              typealias Client = NamespaceA_ServiceAClient
           }
       }
       """
@@ -105,17 +111,19 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
       name: "ServiceA",
+      generatedName: "ServiceA",
       namespace: "namespaceA",
+      generatedNamespace: "NamespaceA",
       methods: []
     )
     let expectedSwift =
       """
-      enum namespaceA {
+      enum NamespaceA {
           enum ServiceA {
               enum Methods {}
               static let methods: [MethodDescriptor] = []
-              typealias StreamingServiceProtocol = namespaceA_ServiceAServiceStreamingProtocol
-              typealias ServiceProtocol = namespaceA_ServiceAServiceProtocol
+              typealias StreamingServiceProtocol = NamespaceA_ServiceAServiceStreamingProtocol
+              typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
           }
       }
       """
@@ -132,17 +140,19 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
       name: "ServiceA",
+      generatedName: "ServiceA",
       namespace: "namespaceA",
+      generatedNamespace: "NamespaceA",
       methods: []
     )
     let expectedSwift =
       """
-      enum namespaceA {
+      enum NamespaceA {
           enum ServiceA {
               enum Methods {}
               static let methods: [MethodDescriptor] = []
-              typealias ClientProtocol = namespaceA_ServiceAClientProtocol
-              typealias Client = namespaceA_ServiceAClient
+              typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
+              typealias Client = NamespaceA_ServiceAClient
           }
       }
       """
@@ -159,12 +169,14 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
       name: "ServiceA",
+      generatedName: "ServiceA",
       namespace: "namespaceA",
+      generatedNamespace: "NamespaceA",
       methods: []
     )
     let expectedSwift =
       """
-      enum namespaceA {
+      enum NamespaceA {
           enum ServiceA {
               enum Methods {}
               static let methods: [MethodDescriptor] = []
@@ -184,6 +196,8 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let method = MethodDescriptor(
       documentation: "Documentation for MethodA",
       name: "MethodA",
+      generatedName: "MethodA",
+      signatureName: "methodA",
       isInputStreaming: false,
       isOutputStreaming: false,
       inputType: "ServiceARequest",
@@ -192,7 +206,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
       name: "ServiceA",
+      generatedName: "ServiceA",
       namespace: "",
+      generatedNamespace: "",
       methods: [method]
     )
     let expectedSwift =
@@ -230,6 +246,8 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let methodA = MethodDescriptor(
       documentation: "Documentation for MethodA",
       name: "MethodA",
+      generatedName: "MethodA",
+      signatureName: "methodA",
       isInputStreaming: false,
       isOutputStreaming: false,
       inputType: "NamespaceA_ServiceARequest",
@@ -238,6 +256,8 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let methodB = MethodDescriptor(
       documentation: "Documentation for MethodB",
       name: "MethodB",
+      generatedName: "MethodB",
+      signatureName: "methodB",
       isInputStreaming: false,
       isOutputStreaming: false,
       inputType: "NamespaceA_ServiceARequest",
@@ -246,12 +266,14 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
       name: "ServiceA",
+      generatedName: "ServiceA",
       namespace: "namespaceA",
+      generatedNamespace: "NamespaceA",
       methods: [methodA, methodB]
     )
     let expectedSwift =
       """
-      enum namespaceA {
+      enum NamespaceA {
           enum ServiceA {
               enum Methods {
                   enum MethodA {
@@ -275,10 +297,10 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
                   Methods.MethodA.descriptor,
                   Methods.MethodB.descriptor
               ]
-              typealias StreamingServiceProtocol = namespaceA_ServiceAServiceStreamingProtocol
-              typealias ServiceProtocol = namespaceA_ServiceAServiceProtocol
-              typealias ClientProtocol = namespaceA_ServiceAClientProtocol
-              typealias Client = namespaceA_ServiceAClient
+              typealias StreamingServiceProtocol = NamespaceA_ServiceAServiceStreamingProtocol
+              typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
+              typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
+              typealias Client = NamespaceA_ServiceAClient
           }
       }
       """
@@ -295,19 +317,21 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let service = ServiceDescriptor(
       documentation: "Documentation for ServiceA",
       name: "ServiceA",
+      generatedName: "ServiceA",
       namespace: "namespaceA",
+      generatedNamespace: "NamespaceA",
       methods: []
     )
     let expectedSwift =
       """
-      enum namespaceA {
+      enum NamespaceA {
           enum ServiceA {
               enum Methods {}
               static let methods: [MethodDescriptor] = []
-              typealias StreamingServiceProtocol = namespaceA_ServiceAServiceStreamingProtocol
-              typealias ServiceProtocol = namespaceA_ServiceAServiceProtocol
-              typealias ClientProtocol = namespaceA_ServiceAClientProtocol
-              typealias Client = namespaceA_ServiceAClient
+              typealias StreamingServiceProtocol = NamespaceA_ServiceAServiceStreamingProtocol
+              typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
+              typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
+              typealias Client = NamespaceA_ServiceAClient
           }
       }
       """
@@ -324,35 +348,39 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let serviceB = ServiceDescriptor(
       documentation: "Documentation for BService",
       name: "BService",
-      namespace: "namespacea",
+      generatedName: "Bservice",
+      namespace: "namespaceA",
+      generatedNamespace: "NamespaceA",
       methods: []
     )
 
     let serviceA = ServiceDescriptor(
       documentation: "Documentation for AService",
       name: "AService",
-      namespace: "namespacea",
+      generatedName: "Aservice",
+      namespace: "namespaceA",
+      generatedNamespace: "NamespaceA",
       methods: []
     )
 
     let expectedSwift =
       """
-      enum namespacea {
-          enum AService {
+      enum NamespaceA {
+          enum Aservice {
               enum Methods {}
               static let methods: [MethodDescriptor] = []
-              typealias StreamingServiceProtocol = namespacea_AServiceServiceStreamingProtocol
-              typealias ServiceProtocol = namespacea_AServiceServiceProtocol
-              typealias ClientProtocol = namespacea_AServiceClientProtocol
-              typealias Client = namespacea_AServiceClient
+              typealias StreamingServiceProtocol = NamespaceA_AserviceServiceStreamingProtocol
+              typealias ServiceProtocol = NamespaceA_AserviceServiceProtocol
+              typealias ClientProtocol = NamespaceA_AserviceClientProtocol
+              typealias Client = NamespaceA_AserviceClient
           }
-          enum BService {
+          enum Bservice {
               enum Methods {}
               static let methods: [MethodDescriptor] = []
-              typealias StreamingServiceProtocol = namespacea_BServiceServiceStreamingProtocol
-              typealias ServiceProtocol = namespacea_BServiceServiceProtocol
-              typealias ClientProtocol = namespacea_BServiceClientProtocol
-              typealias Client = namespacea_BServiceClient
+              typealias StreamingServiceProtocol = NamespaceA_BserviceServiceStreamingProtocol
+              typealias ServiceProtocol = NamespaceA_BserviceServiceProtocol
+              typealias ClientProtocol = NamespaceA_BserviceClientProtocol
+              typealias Client = NamespaceA_BserviceClient
           }
       }
       """
@@ -369,14 +397,18 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let serviceB = ServiceDescriptor(
       documentation: "Documentation for BService",
       name: "BService",
+      generatedName: "BService",
       namespace: "",
+      generatedNamespace: "",
       methods: []
     )
 
     let serviceA = ServiceDescriptor(
       documentation: "Documentation for AService",
       name: "AService",
+      generatedName: "AService",
       namespace: "",
+      generatedNamespace: "",
       methods: []
     )
 
@@ -412,37 +444,41 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let serviceB = ServiceDescriptor(
       documentation: "Documentation for BService",
       name: "BService",
+      generatedName: "BService",
       namespace: "bnamespace",
+      generatedNamespace: "Bnamespace",
       methods: []
     )
 
     let serviceA = ServiceDescriptor(
       documentation: "Documentation for AService",
       name: "AService",
+      generatedName: "AService",
       namespace: "anamespace",
+      generatedNamespace: "Anamespace",
       methods: []
     )
 
     let expectedSwift =
       """
-      enum anamespace {
+      enum Anamespace {
           enum AService {
               enum Methods {}
               static let methods: [MethodDescriptor] = []
-              typealias StreamingServiceProtocol = anamespace_AServiceServiceStreamingProtocol
-              typealias ServiceProtocol = anamespace_AServiceServiceProtocol
-              typealias ClientProtocol = anamespace_AServiceClientProtocol
-              typealias Client = anamespace_AServiceClient
+              typealias StreamingServiceProtocol = Anamespace_AServiceServiceStreamingProtocol
+              typealias ServiceProtocol = Anamespace_AServiceServiceProtocol
+              typealias ClientProtocol = Anamespace_AServiceClientProtocol
+              typealias Client = Anamespace_AServiceClient
           }
       }
-      enum bnamespace {
+      enum Bnamespace {
           enum BService {
               enum Methods {}
               static let methods: [MethodDescriptor] = []
-              typealias StreamingServiceProtocol = bnamespace_BServiceServiceStreamingProtocol
-              typealias ServiceProtocol = bnamespace_BServiceServiceProtocol
-              typealias ClientProtocol = bnamespace_BServiceClientProtocol
-              typealias Client = bnamespace_BServiceClient
+              typealias StreamingServiceProtocol = Bnamespace_BServiceServiceStreamingProtocol
+              typealias ServiceProtocol = Bnamespace_BServiceServiceProtocol
+              typealias ClientProtocol = Bnamespace_BServiceClientProtocol
+              typealias Client = Bnamespace_BServiceClient
           }
       }
       """
@@ -459,13 +495,17 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let serviceA = ServiceDescriptor(
       documentation: "Documentation for AService",
       name: "AService",
+      generatedName: "AService",
       namespace: "anamespace",
+      generatedNamespace: "Anamespace",
       methods: []
     )
     let serviceB = ServiceDescriptor(
       documentation: "Documentation for BService",
       name: "BService",
+      generatedName: "BService",
       namespace: "",
+      generatedNamespace: "",
       methods: []
     )
     let expectedSwift =
@@ -478,14 +518,14 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           typealias ClientProtocol = BServiceClientProtocol
           typealias Client = BServiceClient
       }
-      enum anamespace {
+      enum Anamespace {
           enum AService {
               enum Methods {}
               static let methods: [MethodDescriptor] = []
-              typealias StreamingServiceProtocol = anamespace_AServiceServiceStreamingProtocol
-              typealias ServiceProtocol = anamespace_AServiceServiceProtocol
-              typealias ClientProtocol = anamespace_AServiceClientProtocol
-              typealias Client = anamespace_AServiceClient
+              typealias StreamingServiceProtocol = Anamespace_AServiceServiceStreamingProtocol
+              typealias ServiceProtocol = Anamespace_AServiceServiceProtocol
+              typealias ClientProtocol = Anamespace_AServiceClientProtocol
+              typealias Client = Anamespace_AServiceClient
           }
       }
       """


### PR DESCRIPTION
Motivation:

The names of the namespaces/service/methods used in the type names from the generated code can be different from the names identifying the namespaces/service/methods in the IDL. Methods also have a third name - for the function signatures.

Modifications:

- Created a Name struct that has 3 properties: the base name, the upper case name and the lower case name
- Added the new names properties in the ServiceDescriptor and MethodDescriptor from CodeGenerationRequest
- Modified the existing tests accordingly
- Added new validation methods verifying the generated names (or signature name)
- Added tests for the new checks

Result:

Users will be able to set an identifying name, a generated upper case and a generated lower case name for the namespaces, services and methods.