### PR TITLE
Fix failing build on some platforms

### DIFF
--- a/Tests/GRPCInterceptorsTests/TracingTestsUtilities.swift
+++ b/Tests/GRPCInterceptorsTests/TracingTestsUtilities.swift
@@ -149,6 +149,7 @@ extension ServiceContext {
   }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 struct TestWriter<WriterElement>: RPCWriterProtocol {
   typealias Element = WriterElement
 


### PR DESCRIPTION
An availability guard was missing - this PR adds it.