### PR TITLE
[CodeGen Protobuf support] Message serializer and deserializer

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -89,6 +89,7 @@ extension Target.Dependency {
   static let protocGenGRPCSwift: Self = .target(name: "protoc-gen-grpc-swift")
   static let reflectionService: Self = .target(name: "GRPCReflectionService")
   static let grpcCodeGen: Self = .target(name: "GRPCCodeGen")
+  static let grpcProtobuf: Self = .target(name: "GRPCProtobuf")
 
   // Target dependencies; internal
   static let grpcSampleData: Self = .target(name: "GRPCSampleData")
@@ -306,6 +307,15 @@ extension Target {
     ]
   )
 
+  static let grpcProtobufTests: Target = .testTarget(
+    name: "GRPCProtobufTests",
+    dependencies: [
+      .grpcCore,
+      .grpcProtobuf,
+      .echoModel
+    ]
+  )
+  
   static let interopTestModels: Target = .target(
     name: "GRPCInteroperabilityTestModels",
     dependencies: [
@@ -555,6 +565,15 @@ extension Target {
     name: "GRPCCodeGen",
     path: "Sources/GRPCCodeGen"
   )
+  
+  static let grpcProtobuf: Target = .target(
+    name: "GRPCProtobuf",
+    dependencies: [
+      .grpcCore,
+      .protobuf
+    ],
+    path: "Sources/GRPCProtobuf"
+  )
 }
 
 // MARK: - Products
@@ -641,6 +660,7 @@ let package = Package(
     .grpcHTTP2Core,
     .grpcHTTP2TransportNIOPosix,
     .grpcHTTP2TransportNIOTransportServices,
+    .grpcProtobuf,
 
     // v2 tests
     .grpcCoreTests,
@@ -648,7 +668,8 @@ let package = Package(
     .grpcCodeGenTests,
     .grpcHTTP2CoreTests,
     .grpcHTTP2TransportNIOPosixTests,
-    .grpcHTTP2TransportNIOTransportServicesTests
+    .grpcHTTP2TransportNIOTransportServicesTests,
+    .grpcProtobufTests
   ]
 )
 

--- a/Package.swift
+++ b/Package.swift
@@ -312,7 +312,7 @@ extension Target {
     dependencies: [
       .grpcCore,
       .grpcProtobuf,
-      .echoModel
+      .protobuf
     ]
   )
   

--- a/Sources/GRPCProtobuf/Coding.swift
+++ b/Sources/GRPCProtobuf/Coding.swift
@@ -22,7 +22,7 @@ import SwiftProtobuf
 public struct ProtobufSerializer<Message: SwiftProtobuf.Message>: GRPCCore.MessageSerializer {
   public init() {}
 
-  /// Serializes a ``SwiftProtobuf.Message`` into a sequence of bytes.
+  /// Serializes a ``Message`` into a sequence of bytes.
   ///
   /// - Parameter message: The message to serialize.
   /// - Returns: An array of serialized bytes representing the message.
@@ -44,7 +44,7 @@ public struct ProtobufSerializer<Message: SwiftProtobuf.Message>: GRPCCore.Messa
 public struct ProtobufDeserializer<Message: SwiftProtobuf.Message>: GRPCCore.MessageDeserializer {
   public init() {}
 
-  /// Deserializes a sequence of bytes into a ``SwiftProtobuf.Message``.
+  /// Deserializes a sequence of bytes into a ``Message``.
   ///
   /// - Parameter serializedMessageBytes: The array of bytes to deserialize.
   /// - Returns: The deserialized message.

--- a/Sources/GRPCProtobuf/Coding.swift
+++ b/Sources/GRPCProtobuf/Coding.swift
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+import GRPCCore
+import SwiftProtobuf
+
+/// Serializes a Protobuf message into a sequence of bytes.
+public struct ProtobufSerializer<Message: SwiftProtobuf.Message>: GRPCCore.MessageSerializer {
+  /// Serializes a ``SwiftProtobuf.Message`` into a sequence of bytes.
+  ///
+  /// - Parameter message: The message to serialize.
+  /// - Returns: An array of serialized bytes representing the message.
+  public func serialize(_ message: Message) throws -> [UInt8] {
+    do {
+      let data = try message.serializedData()
+      return Array(data)
+    } catch let error {
+      throw RPCError(
+        code: .invalidArgument,
+        message: "The message could not be serialized.",
+        cause: error
+      )
+    }
+  }
+
+  public init() {}
+}
+
+/// Deserializes a sequence of bytes into a Protobuf message.
+public struct ProtobufDeserializer<Message: SwiftProtobuf.Message>: GRPCCore.MessageDeserializer {
+  /// Deserializes a sequence of bytes into a ``SwiftProtobuf.Message``.
+  ///
+  /// - Parameter serializedMessageBytes: The array of bytes to deserialize.
+  /// - Returns: The deserialized message.
+  public func deserialize(_ serializedMessageBytes: [UInt8]) throws -> Message {
+    do {
+      let data = Data(serializedMessageBytes)
+      let message = try Message(serializedData: data)
+      return message
+    } catch let error {
+      throw RPCError(
+        code: .invalidArgument,
+        message: "The data could not be deserialized into a Message.",
+        cause: error
+      )
+    }
+  }
+
+  public init() {}
+}

--- a/Sources/GRPCProtobuf/Coding.swift
+++ b/Sources/GRPCProtobuf/Coding.swift
@@ -20,6 +20,8 @@ import SwiftProtobuf
 
 /// Serializes a Protobuf message into a sequence of bytes.
 public struct ProtobufSerializer<Message: SwiftProtobuf.Message>: GRPCCore.MessageSerializer {
+  public init() {}
+
   /// Serializes a ``SwiftProtobuf.Message`` into a sequence of bytes.
   ///
   /// - Parameter message: The message to serialize.
@@ -31,34 +33,31 @@ public struct ProtobufSerializer<Message: SwiftProtobuf.Message>: GRPCCore.Messa
     } catch let error {
       throw RPCError(
         code: .invalidArgument,
-        message: "The message could not be serialized.",
+        message: "Can't serialize message of type \(type(of: message)).",
         cause: error
       )
     }
   }
-
-  public init() {}
 }
 
 /// Deserializes a sequence of bytes into a Protobuf message.
 public struct ProtobufDeserializer<Message: SwiftProtobuf.Message>: GRPCCore.MessageDeserializer {
+  public init() {}
+
   /// Deserializes a sequence of bytes into a ``SwiftProtobuf.Message``.
   ///
   /// - Parameter serializedMessageBytes: The array of bytes to deserialize.
   /// - Returns: The deserialized message.
   public func deserialize(_ serializedMessageBytes: [UInt8]) throws -> Message {
     do {
-      let data = Data(serializedMessageBytes)
-      let message = try Message(serializedData: data)
+      let message = try Message(contiguousBytes: serializedMessageBytes)
       return message
     } catch let error {
       throw RPCError(
         code: .invalidArgument,
-        message: "The data could not be deserialized into a Message.",
+        message: "Can't deserialize to message of type \(Message.self)",
         cause: error
       )
     }
   }
-
-  public init() {}
 }

--- a/Tests/GRPCProtobufTests/CodingTests.swift
+++ b/Tests/GRPCProtobufTests/CodingTests.swift
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import EchoModel
+import GRPCCore
+import GRPCProtobuf
+import SwiftProtobuf
+import XCTest
+
+final class CodingTests: XCTestCase {
+  func testSerializeDeserializeRoundtrip() throws {
+    let message = TestMessage.with {
+      $0.text = "TestText"
+    }
+
+    let serializer = ProtobufSerializer<TestMessage>()
+    let deserializer = ProtobufDeserializer<TestMessage>()
+
+    let bytes = try serializer.serialize(message)
+    let roundTrip = try deserializer.deserialize(bytes)
+    XCTAssertEqual(roundTrip, message)
+  }
+
+  func testSerializerError() throws {
+    let message = TestMessage()
+    let serializer = ProtobufSerializer<TestMessage>()
+
+    XCTAssertThrowsError(
+      try serializer.serialize(message)
+    ) { error in
+      XCTAssertEqual(
+        error as? RPCError,
+        RPCError(
+          code: .invalidArgument,
+          message:
+            """
+            The message could not be serialized.
+            """
+        )
+      )
+    }
+  }
+
+  func testDeserializerError() throws {
+    let invalidData = "%%%%%££££".data(using: .utf8)
+    let bytes = [UInt8](invalidData!)
+    let deserializer = ProtobufDeserializer<TestMessage>()
+    XCTAssertThrowsError(
+      try deserializer.deserialize(bytes)
+    ) { error in
+      XCTAssertEqual(
+        error as? RPCError,
+        RPCError(
+          code: .invalidArgument,
+          message:
+            """
+            The data could not be deserialized into a Message.
+            """
+        )
+      )
+    }
+  }
+}
+
+struct TestMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+
+  var text: String = ""
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+  static var protoMessageName: String = "Test" + ".ServiceRequest"
+  init() {}
+
+  mutating func decodeMessage<D>(decoder: inout D) throws where D: SwiftProtobuf.Decoder {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.text) }()
+      default: break
+      }
+    }
+  }
+
+  func traverse<V>(visitor: inout V) throws where V: SwiftProtobuf.Visitor {
+    if !self.text.isEmpty {
+      try visitor.visitSingularStringField(value: self.text, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func == (lhs: TestMessage, rhs: TestMessage) -> Bool {
+    if lhs.text != rhs.text { return false }
+    if lhs.unknownFields != rhs.unknownFields { return false }
+    return true
+  }
+
+  public var isInitialized: Bool {
+    if self.text.isEmpty { return false }
+    return true
+  }
+}


### PR DESCRIPTION
Motivation:

In the generated code we are specifying types for a serializer and deserializer. As we want to support SwiftProtobuf, we need to implement the generic serializer and deserializer for Protobuf messages, which will be the default if the user doesn't specify other IDL serializer and deserializer.

Modifications:

Created the serializer and deserializer structs conforming to `GRPCCore.MessageSerializer` and `GRPCCOre.MessageDeserializer` respectively and implemented their `serialize()` and `deserialize()` functions. Added tests for them.

Result:

The generated code can reference protobuf serializer and deserializer types, as they will be supported in GRPC.