### PR TITLE
Make Zlib.Compressor/Decompressor classes

### DIFF
--- a/Tests/GRPCHTTP2CoreTests/Server/Compression/ZlibTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Server/Compression/ZlibTests.swift
@@ -31,10 +31,7 @@ final class ZlibTests: XCTestCase {
     """
 
   private func compress(_ input: [UInt8], method: Zlib.Method) throws -> ByteBuffer {
-    var compressor = Zlib.Compressor(method: method)
-    compressor.initialize()
-    defer { compressor.end() }
-
+    let compressor = Zlib.Compressor(method: method)
     var buffer = ByteBuffer()
     try compressor.compress(input, into: &buffer)
     return buffer
@@ -45,10 +42,7 @@ final class ZlibTests: XCTestCase {
     method: Zlib.Method,
     limit: Int = .max
   ) throws -> [UInt8] {
-    var decompressor = Zlib.Decompressor(method: method)
-    decompressor.initialize()
-    defer { decompressor.end() }
-
+    let decompressor = Zlib.Decompressor(method: method)
     var input = input
     return try decompressor.decompress(&input, limit: limit)
   }
@@ -69,9 +63,7 @@ final class ZlibTests: XCTestCase {
 
   func testRepeatedCompresses() throws {
     let original = Array(self.text.utf8)
-    var compressor = Zlib.Compressor(method: .deflate)
-    compressor.initialize()
-    defer { compressor.end() }
+    let compressor = Zlib.Compressor(method: .deflate)
 
     var compressed = ByteBuffer()
     let bytesWritten = try compressor.compress(original, into: &compressed)
@@ -86,9 +78,7 @@ final class ZlibTests: XCTestCase {
 
   func testRepeatedDecompresses() throws {
     let original = Array(self.text.utf8)
-    var decompressor = Zlib.Decompressor(method: .deflate)
-    decompressor.initialize()
-    defer { decompressor.end() }
+    let decompressor = Zlib.Decompressor(method: .deflate)
 
     let compressed = try self.compress(original, method: .deflate)
     var input = compressed
@@ -123,9 +113,7 @@ final class ZlibTests: XCTestCase {
   }
 
   func testCompressAppendsToBuffer() throws {
-    var compressor = Zlib.Compressor(method: .deflate)
-    compressor.initialize()
-    defer { compressor.end() }
+    let compressor = Zlib.Compressor(method: .deflate)
 
     var buffer = ByteBuffer()
     try compressor.compress(Array(repeating: 0, count: 1024), into: &buffer)


### PR DESCRIPTION
Motivation:

z_stream stores a pointer to itself in its internal state which it checks against in inflate/deflate. As we hold these within structs, and call through to C functions which take a pointer to a z_stream, this address can change as the struct is copied about. This results in errors when calling deflate/inflate.

Modifications:

- Make Compressor/Decompressor classes
- Move the initialize call to init and the end call to deinit.

Result:

Harder to misue compressor/decompressor