### PR TITLE
Add compression logic to `GRPCMessageFramer`

### DIFF
--- a/Sources/GRPCHTTP2Core/Compression/Zlib.swift
+++ b/Sources/GRPCHTTP2Core/Compression/Zlib.swift
@@ -38,6 +38,9 @@ extension Zlib {
   /// Creates a new compressor for the given compression format.
   ///
   /// This compressor is only suitable for compressing whole messages at a time.
+  ///
+  /// - Important: ``Compressor/end()`` must be called when the compressor is not needed
+  /// anymore, to deallocate any resources allocated by `Zlib`.
   struct Compressor {
     // TODO: Make this ~Copyable when 5.9 is the lowest supported Swift version.
 
@@ -86,6 +89,9 @@ extension Zlib {
   /// Creates a new decompressor for the given compression format.
   ///
   /// This decompressor is only suitable for compressing whole messages at a time.
+  ///
+  /// - Important: ``Decompressor/end()`` must be called when the compressor is not needed
+  /// anymore, to deallocate any resources allocated by `Zlib`.
   struct Decompressor {
     // TODO: Make this ~Copyable when 5.9 is the lowest supported Swift version.
 

--- a/Sources/GRPCHTTP2Core/GRPCMessageFramer.swift
+++ b/Sources/GRPCHTTP2Core/GRPCMessageFramer.swift
@@ -35,7 +35,7 @@ struct GRPCMessageFramer {
   private var pendingMessages: OneOrManyQueue<[UInt8]>
 
   private var writeBuffer: ByteBuffer
-  
+
   private var compressor: Zlib.Compressor?
 
   /// Create a new ``GRPCMessageFramer``.
@@ -46,14 +46,14 @@ struct GRPCMessageFramer {
     self.writeBuffer = ByteBuffer()
     self.compressor = compressor
   }
-  
+
   /// Set a compressor on this ``GRPCMessageFramer``.
   /// - Parameter compressor: An optional compressor to use when compressing messages.
   /// - Important: The `compressor` must have been `initialized()`.
   mutating func setCompressor(_ compressor: Zlib.Compressor?) {
     self.compressor = compressor
   }
-  
+
   mutating func initialize() {
     self.compressor?.initialize()
   }
@@ -97,14 +97,14 @@ struct GRPCMessageFramer {
   private mutating func encode(_ message: [UInt8]) throws {
     if self.compressor != nil {
       self.writeBuffer.writeInteger(UInt8(1))  // Set compression flag
-      
+
       // Write zeroes as length - we'll write the actual compressed size after compression.
       let lengthIndex = self.writeBuffer.writerIndex
       self.writeBuffer.writeInteger(UInt32(0))
-      
+
       // This force-unwrap is safe, because we know `self.compressor` is not `nil`.
       let writtenBytes = try self.compressor!.compress(message, into: &self.writeBuffer)
-      
+
       self.writeBuffer.setInteger(UInt32(writtenBytes), at: lengthIndex)
     } else {
       self.writeBuffer.writeMultipleIntegers(

--- a/Sources/GRPCHTTP2Core/GRPCMessageFramer.swift
+++ b/Sources/GRPCHTTP2Core/GRPCMessageFramer.swift
@@ -54,10 +54,6 @@ struct GRPCMessageFramer {
     self.compressor = compressor
   }
 
-  mutating func initialize() {
-    self.compressor?.initialize()
-  }
-
   /// Queue the given bytes to be framed and potentially coalesced alongside other messages in a `ByteBuffer`.
   /// The resulting data will be returned when calling ``GRPCMessageFramer/next()``.
   mutating func append(_ bytes: [UInt8]) {

--- a/Tests/GRPCHTTP2CoreTests/GRPCMessageFramerTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/GRPCMessageFramerTests.swift
@@ -20,9 +20,10 @@ import XCTest
 @testable import GRPCHTTP2Core
 
 final class GRPCMessageFramerTests: XCTestCase {
+  
   func testSingleWrite() throws {
     var framer = GRPCMessageFramer()
-    framer.append(Array(repeating: 42, count: 128), compress: false)
+    framer.append(Array(repeating: 42, count: 128))
 
     var buffer = try XCTUnwrap(framer.next())
     let (compressed, length) = try XCTUnwrap(buffer.readMessageHeader())
@@ -34,13 +35,45 @@ final class GRPCMessageFramerTests: XCTestCase {
     // No more bufers.
     XCTAssertNil(try framer.next())
   }
+    
+  private func testSingleWrite(compressionMethod: Zlib.Method) throws {
+    var framer = GRPCMessageFramer(compressor: Zlib.Compressor(method: compressionMethod))
+    framer.initialize()
+
+    let message = [UInt8](repeating: 42, count: 128)
+    framer.append(message)
+    
+    var buffer = ByteBuffer()
+    var testCompressor = Zlib.Compressor(method: compressionMethod)
+    testCompressor.initialize()
+    let compressedSize = try testCompressor.compress(message, into: &buffer)
+    let compressedMessage = buffer.readSlice(length: compressedSize)
+
+    buffer = try XCTUnwrap(framer.next())
+    let (compressed, length) = try XCTUnwrap(buffer.readMessageHeader())
+    XCTAssertTrue(compressed)
+    XCTAssertEqual(length, UInt32(compressedSize))
+    XCTAssertEqual(buffer.readSlice(length: Int(length)), compressedMessage)
+    XCTAssertEqual(buffer.readableBytes, 0)
+
+    // No more bufers.
+    XCTAssertNil(try framer.next())
+  }
+  
+  func testSingleWriteDeflateCompressed() throws {
+    try self.testSingleWrite(compressionMethod: .deflate)
+  }
+  
+  func testSingleWriteGZIPCompressed() throws {
+    try self.testSingleWrite(compressionMethod: .gzip)
+  }
 
   func testMultipleWrites() throws {
     var framer = GRPCMessageFramer()
 
     let messages = 100
     for _ in 0 ..< messages {
-      framer.append(Array(repeating: 42, count: 128), compress: false)
+      framer.append(Array(repeating: 42, count: 128))
     }
 
     var buffer = try XCTUnwrap(framer.next())
@@ -56,6 +89,8 @@ final class GRPCMessageFramerTests: XCTestCase {
     // No more bufers.
     XCTAssertNil(try framer.next())
   }
+    
+    
 }
 
 extension ByteBuffer {

--- a/Tests/GRPCHTTP2CoreTests/GRPCMessageFramerTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/GRPCMessageFramerTests.swift
@@ -20,7 +20,7 @@ import XCTest
 @testable import GRPCHTTP2Core
 
 final class GRPCMessageFramerTests: XCTestCase {
-  
+
   func testSingleWrite() throws {
     var framer = GRPCMessageFramer()
     framer.append(Array(repeating: 42, count: 128))
@@ -35,14 +35,14 @@ final class GRPCMessageFramerTests: XCTestCase {
     // No more bufers.
     XCTAssertNil(try framer.next())
   }
-    
+
   private func testSingleWrite(compressionMethod: Zlib.Method) throws {
     var framer = GRPCMessageFramer(compressor: Zlib.Compressor(method: compressionMethod))
     framer.initialize()
 
     let message = [UInt8](repeating: 42, count: 128)
     framer.append(message)
-    
+
     var buffer = ByteBuffer()
     var testCompressor = Zlib.Compressor(method: compressionMethod)
     testCompressor.initialize()
@@ -59,11 +59,11 @@ final class GRPCMessageFramerTests: XCTestCase {
     // No more bufers.
     XCTAssertNil(try framer.next())
   }
-  
+
   func testSingleWriteDeflateCompressed() throws {
     try self.testSingleWrite(compressionMethod: .deflate)
   }
-  
+
   func testSingleWriteGZIPCompressed() throws {
     try self.testSingleWrite(compressionMethod: .gzip)
   }
@@ -89,8 +89,7 @@ final class GRPCMessageFramerTests: XCTestCase {
     // No more bufers.
     XCTAssertNil(try framer.next())
   }
-    
-    
+
 }
 
 extension ByteBuffer {

--- a/Tests/GRPCHTTP2CoreTests/GRPCMessageFramerTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/GRPCMessageFramerTests.swift
@@ -20,7 +20,6 @@ import XCTest
 @testable import GRPCHTTP2Core
 
 final class GRPCMessageFramerTests: XCTestCase {
-
   func testSingleWrite() throws {
     var framer = GRPCMessageFramer()
     framer.append(Array(repeating: 42, count: 128))
@@ -41,7 +40,7 @@ final class GRPCMessageFramerTests: XCTestCase {
     defer {
       compressor.end()
     }
-    var framer = GRPCMessageFramer(compressor: compressor)
+    var framer = GRPCMessageFramer()
 
     let message = [UInt8](repeating: 42, count: 128)
     framer.append(message)
@@ -54,7 +53,7 @@ final class GRPCMessageFramerTests: XCTestCase {
       testCompressor.end()
     }
 
-    buffer = try XCTUnwrap(framer.next())
+    buffer = try XCTUnwrap(framer.next(compressor: compressor))
     let (compressed, length) = try XCTUnwrap(buffer.readMessageHeader())
     XCTAssertTrue(compressed)
     XCTAssertEqual(length, UInt32(compressedSize))


### PR DESCRIPTION
## Motivation
In https://github.com/grpc/grpc-swift/pull/1768 we added a `GRPCMessageFramer` to frame messages with gRPC's metadata. This type should also take care of compressing the payloads, if so configured.

## Modifications
This PR adds compression logic to the `GRPCMessageFramer`.

## Result
If set up to do so, payloads will now be compressed by the `GRPCMessageFramer`.