### PR TITLE
Better waiter errors with NIOTS

### DIFF
--- a/Sources/GRPC/ConnectionPool/ConnectionPool.swift
+++ b/Sources/GRPC/ConnectionPool/ConnectionPool.swift
@@ -857,6 +857,12 @@ extension ConnectionPool {
       self.pool.eventLoop.assertInEventLoop()
       return self.pool._connections.values.reduce(0) { $0 + $1.reservedStreams }
     }
+
+    /// Updates the most recent connection error.
+    internal func updateMostRecentError(_ error: Error) {
+      self.pool.eventLoop.assertInEventLoop()
+      self.pool.updateMostRecentError(error)
+    }
   }
 
   internal var sync: Sync {

--- a/Sources/GRPC/ConnectionPool/PooledChannel.swift
+++ b/Sources/GRPC/ConnectionPool/PooledChannel.swift
@@ -87,6 +87,7 @@ internal final class PooledChannel: GRPCChannel {
       tlsConfiguration: configuration.transportSecurity.tlsConfiguration,
       httpTargetWindowSize: configuration.http2.targetWindowSize,
       httpMaxFrameSize: configuration.http2.maxFrameSize,
+      waitsForConnectivity: configuration.networkFrameworkWaitForConnectivity,
       errorDelegate: configuration.errorDelegate,
       debugChannelInitializer: configuration.debugChannelInitializer
     )

--- a/Sources/GRPC/ConnectionPool/PooledChannel.swift
+++ b/Sources/GRPC/ConnectionPool/PooledChannel.swift
@@ -87,7 +87,6 @@ internal final class PooledChannel: GRPCChannel {
       tlsConfiguration: configuration.transportSecurity.tlsConfiguration,
       httpTargetWindowSize: configuration.http2.targetWindowSize,
       httpMaxFrameSize: configuration.http2.maxFrameSize,
-      waitsForConnectivity: configuration.networkFrameworkWaitForConnectivity,
       errorDelegate: configuration.errorDelegate,
       debugChannelInitializer: configuration.debugChannelInitializer
     )

--- a/Sources/GRPC/GRPCIdleHandler.swift
+++ b/Sources/GRPC/GRPCIdleHandler.swift
@@ -288,11 +288,13 @@ internal final class GRPCIdleHandler: ChannelInboundHandler {
       )
       context.fireUserInboundEventTriggered(event)
     } else {
+      #if canImport(Network)
       if #available(macOS 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *) {
         if let waitsForConnectivity = event as? NIOTSNetworkEvents.WaitingForConnectivity {
           self.mode.connectionManager?.channelError(waitsForConnectivity.transientError)
         }
       }
+      #endif
 
       context.fireUserInboundEventTriggered(event)
     }

--- a/Sources/GRPC/GRPCIdleHandler.swift
+++ b/Sources/GRPC/GRPCIdleHandler.swift
@@ -17,6 +17,7 @@ import Logging
 import NIOCore
 import NIOHTTP2
 import NIOTLS
+import NIOTransportServices
 
 internal final class GRPCIdleHandler: ChannelInboundHandler {
   typealias InboundIn = HTTP2Frame
@@ -287,6 +288,12 @@ internal final class GRPCIdleHandler: ChannelInboundHandler {
       )
       context.fireUserInboundEventTriggered(event)
     } else {
+      if #available(macOS 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *) {
+        if let waitsForConnectivity = event as? NIOTSNetworkEvents.WaitingForConnectivity {
+          self.mode.connectionManager?.channelError(waitsForConnectivity.transientError)
+        }
+      }
+
       context.fireUserInboundEventTriggered(event)
     }
   }

--- a/Tests/GRPCTests/GRPCNetworkFrameworkTests.swift
+++ b/Tests/GRPCTests/GRPCNetworkFrameworkTests.swift
@@ -24,6 +24,7 @@ import NIOCore
 import NIOPosix
 import NIOSSL
 import NIOTransportServices
+import GRPCSampleData
 import Security
 import XCTest
 
@@ -207,6 +208,63 @@ final class GRPCNetworkFrameworkTests: GRPCTestCase {
     self.startClient(clientBuilder)
 
     XCTAssertNoThrow(try self.doEchoGet())
+  }
+
+  func testWaiterPicksUpNWError(
+    _ configure: (inout GRPCChannelPool.Configuration) -> Void
+  ) async throws {
+    let builder = Server.usingTLSBackedByNIOSSL(
+      on: self.group,
+      certificateChain: [SampleCertificate.server.certificate],
+      privateKey: SamplePrivateKey.server
+    )
+
+    let server = try await builder.bind(host: "127.0.0.1", port: 0).get()
+    defer { try? server.close().wait() }
+
+    let client = try GRPCChannelPool.with(
+      target: .hostAndPort("127.0.0.1", server.channel.localAddress!.port!),
+      transportSecurity: .tls(.makeClientConfigurationBackedByNetworkFramework()),
+      eventLoopGroup: self.tsGroup
+    ) {
+      configure(&$0)
+    }
+
+    let echo = Echo_EchoAsyncClient(channel: client)
+    do {
+      let _ = try await echo.get(.with { $0.text = "ignored" })
+    } catch let error as GRPCConnectionPoolError {
+      XCTAssertEqual(error.code, .deadlineExceeded)
+      print(error)
+      XCTAssert(error.underlyingError is NWError)
+    } catch {
+      XCTFail("Expected GRPCConnectionPoolError")
+    }
+
+    let promise = self.group.next().makePromise(of: Void.self)
+    client.closeGracefully(deadline: .now() + .seconds(1), promise: promise)
+    try await promise.futureResult.get()
+  }
+
+  func testErrorPickedUpBeforeConnectTimeout() async throws {
+    try await self.testWaiterPicksUpNWError {
+      // Configure the wait time to be less than the connect timeout, the waiter
+      // should fail with the appropriate NWError before the connect times out.
+      $0.connectionPool.maxWaitTime = .milliseconds(500)
+      $0.connectionBackoff.minimumConnectionTimeout = 1.0
+    }
+  }
+
+  func testNotWaitingForConnectivity() async throws {
+    try await self.testWaiterPicksUpNWError {
+      // The minimum connect time is still high, but setting wait for activity to false
+      // means it fails on entering the waiting state rather than seeing out the connect
+      // timeout.
+      $0.connectionPool.maxWaitTime = .milliseconds(500)
+      $0.debugChannelInitializer = { channel in
+        channel.setOption(NIOTSChannelOptions.waitForActivity, value: false)
+      }
+    }
   }
 }
 

--- a/Tests/GRPCTests/GRPCNetworkFrameworkTests.swift
+++ b/Tests/GRPCTests/GRPCNetworkFrameworkTests.swift
@@ -235,7 +235,6 @@ final class GRPCNetworkFrameworkTests: GRPCTestCase {
       let _ = try await echo.get(.with { $0.text = "ignored" })
     } catch let error as GRPCConnectionPoolError {
       XCTAssertEqual(error.code, .deadlineExceeded)
-      print(error)
       XCTAssert(error.underlyingError is NWError)
     } catch {
       XCTFail("Expected GRPCConnectionPoolError")


### PR DESCRIPTION
Motivation:

When establishing a connection using NIOTS, Network.framework may enter a 'waiting' state because of a transient error. This is surfaced as a user inbound event.

In many cases the connect call won't resolve until the connect timeout passes (defaults to 20 seconds). Attempts to start a call on this connection during this time will fail with a timeout at the connection pool layer (where the max wait time defaults to 5 seconds) and users will see a 'deadline exceeded' error without any more context. However, we can provide more information by passing up the transient error from Network.framework to the connection pool.

This isn't currently possible as events flow up on state changes, in this case from connecting to transient failure when the connect times out.

Modifications:

- Catch the `WaitingForConnectivity` event and bubble up its error though the idle handler to the connection pool

Result:

Better errors on connect timeouts in some situations