### PR TITLE
Add `GRPCMessageDeframer`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -128,6 +128,7 @@ extension Target.Dependency {
     name: "NIOTransportServices",
     package: "swift-nio-transport-services"
   )
+  static let nioTestUtils: Self = .product(name: "NIOTestUtils", package: "swift-nio")
   static let logging: Self = .product(name: "Logging", package: "swift-log")
   static let protobuf: Self = .product(name: "SwiftProtobuf", package: "swift-protobuf")
   static let protobufPluginLibrary: Self = .product(
@@ -312,6 +313,7 @@ extension Target {
       .nioCore,
       .nioHTTP2,
       .nioEmbedded,
+      .nioTestUtils,
     ]
   )
   

--- a/Sources/GRPCHTTP2Core/GRPCMessageDeframer.swift
+++ b/Sources/GRPCHTTP2Core/GRPCMessageDeframer.swift
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import NIOCore
 import GRPCCore
+import NIOCore
 
 /// A ``GRPCMessageDeframer`` helps with the deframing of gRPC data frames:
 /// - It reads the frame's metadata to know whether the message payload is compressed or not, and its length
@@ -27,13 +27,13 @@ struct GRPCMessageDeframer: NIOSingleStepByteToMessageDecoder {
   static let defaultMaximumPayloadSize = Int.max
 
   typealias InboundOut = [UInt8]
-  
+
   private let decompressor: Zlib.Decompressor?
   private let maximumPayloadSize: Int?
   private var effectiveMaximumPayloadSize: Int {
     self.maximumPayloadSize ?? Self.defaultMaximumPayloadSize
   }
-  
+
   /// Create a new ``GRPCMessageDeframer``.
   /// - Parameters:
   ///   - maximumPayloadSize: The maximum size a message payload can be.
@@ -44,7 +44,7 @@ struct GRPCMessageDeframer: NIOSingleStepByteToMessageDecoder {
     self.maximumPayloadSize = maximumPayloadSize
     self.decompressor = decompressor
   }
-  
+
   mutating func decode(buffer: inout ByteBuffer) throws -> InboundOut? {
     guard buffer.readableBytes >= Self.metadataLength else {
       // If we cannot read enough bytes to cover the metadata's length, then we
@@ -65,7 +65,7 @@ struct GRPCMessageDeframer: NIOSingleStepByteToMessageDecoder {
       buffer.moveReaderIndex(to: originalReaderIndex)
       return nil
     }
-    
+
     if isMessageCompressed {
       guard let decompressor = self.decompressor else {
         // We cannot decompress the payload - discard the message.
@@ -76,13 +76,14 @@ struct GRPCMessageDeframer: NIOSingleStepByteToMessageDecoder {
       if message.readableBytes > self.effectiveMaximumPayloadSize {
         throw RPCError(
           code: .resourceExhausted,
-          message: "Message has exceeded the configured maximum payload size (max: \(self.effectiveMaximumPayloadSize), actual: \(message.readableBytes))"
+          message:
+            "Message has exceeded the configured maximum payload size (max: \(self.effectiveMaximumPayloadSize), actual: \(message.readableBytes))"
         )
       }
       return Array(buffer: message)
     }
   }
-  
+
   mutating func decodeLast(buffer: inout ByteBuffer, seenEOF: Bool) throws -> InboundOut? {
     try self.decode(buffer: &buffer)
   }

--- a/Sources/GRPCHTTP2Core/GRPCMessageDeframer.swift
+++ b/Sources/GRPCHTTP2Core/GRPCMessageDeframer.swift
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import NIOCore
+import GRPCCore
+
+/// A ``GRPCMessageDeframer`` helps with the deframing of gRPC data frames:
+/// - It reads the frame's metadata to know whether the message payload is compressed or not, and its length
+/// - It reads and decompresses the payload, if compressed
+/// - It helps put together frames that have been split across multiple `ByteBuffers` by the underlying transport
+struct GRPCMessageDeframer: NIOSingleStepByteToMessageDecoder {
+  /// Length of the gRPC message header (1 compression byte, 4 bytes for the length).
+  static let metadataLength = 5
+  static let defaultMaximumPayloadSize = Int.max
+
+  typealias InboundOut = [UInt8]
+  
+  private let decompressor: Zlib.Decompressor?
+  private let maximumPayloadSize: Int?
+  private var effectiveMaximumPayloadSize: Int {
+    self.maximumPayloadSize ?? Self.defaultMaximumPayloadSize
+  }
+  
+  /// Create a new ``GRPCMessageDeframer``.
+  /// - Parameters:
+  ///   - maximumPayloadSize: The maximum size a message payload can be.
+  ///   - decompressor: A `Zlib.Decompressor` to use when decompressing compressed gRPC messages.
+  /// - Important: You must call `end()` on the `decompressor` when you're done using it, to clean
+  /// up any resources allocated by `Zlib`.
+  init(maximumPayloadSize: Int? = nil, decompressor: Zlib.Decompressor? = nil) {
+    self.maximumPayloadSize = maximumPayloadSize
+    self.decompressor = decompressor
+  }
+  
+  mutating func decode(buffer: inout ByteBuffer) throws -> InboundOut? {
+    guard buffer.readableBytes >= Self.metadataLength else {
+      // If we cannot read enough bytes to cover the metadata's length, then we
+      // need to wait for more bytes to become available to us.
+      return nil
+    }
+
+    // Store the current reader index in case we don't yet have enough
+    // bytes in the buffer to decode a full frame, and need to reset it.
+    let originalReaderIndex = buffer.readerIndex
+    let isMessageCompressed = buffer.readInteger(as: UInt8.self)! == 1
+
+    guard var message = buffer.readLengthPrefixedSlice(as: UInt32.self) else {
+      // We have moved the reader index, but we don't have enough bytes to
+      // read the full message payload, so reset it to its previous, original
+      // position for now, and return. We'll try decoding again, once more
+      // bytes become available in our buffer.
+      buffer.moveReaderIndex(to: originalReaderIndex)
+      return nil
+    }
+    
+    if isMessageCompressed {
+      guard let decompressor = self.decompressor else {
+        // We cannot decompress the payload - discard the message.
+        return nil
+      }
+      return try decompressor.decompress(&message, limit: self.effectiveMaximumPayloadSize)
+    } else {
+      if message.readableBytes > self.effectiveMaximumPayloadSize {
+        throw RPCError(
+          code: .resourceExhausted,
+          message: "Message has exceeded the configured maximum payload size (max: \(self.effectiveMaximumPayloadSize), actual: \(message.readableBytes))"
+        )
+      }
+      return Array(buffer: message)
+    }
+  }
+  
+  mutating func decodeLast(buffer: inout ByteBuffer, seenEOF: Bool) throws -> InboundOut? {
+    try self.decode(buffer: &buffer)
+  }
+}

--- a/Tests/GRPCHTTP2CoreTests/GRPCMessageDeframerTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/GRPCMessageDeframerTests.swift
@@ -23,52 +23,58 @@ final class GRPCMessageDeframerTests: XCTestCase {
   func testReadMultipleMessagesWithoutCompression() throws {
     let deframer = GRPCMessageDeframer()
     let processor = NIOSingleStepByteToMessageProcessor(deframer)
-    
+
     var buffer = ByteBuffer()
     buffer.writeInteger(UInt8(0))
     buffer.writeInteger(UInt32(16))
     buffer.writeRepeatingByte(42, count: 16)
-    
+
     buffer.writeInteger(UInt8(0))
     buffer.writeInteger(UInt32(8))
     buffer.writeRepeatingByte(43, count: 8)
-    
+
     var messages = [[UInt8]]()
     try processor.process(buffer: buffer) { message in
       messages.append(message)
     }
-    
-    XCTAssertEqual(messages, [
-      Array(repeating: 42, count: 16),
-      Array(repeating: 43, count: 8)
-    ])
+
+    XCTAssertEqual(
+      messages,
+      [
+        Array(repeating: 42, count: 16),
+        Array(repeating: 43, count: 8),
+      ]
+    )
   }
-  
+
   func testReadMessageOverSizeLimitWithoutCompression() throws {
     let deframer = GRPCMessageDeframer(maximumPayloadSize: 100)
     let processor = NIOSingleStepByteToMessageProcessor(deframer)
-    
+
     var buffer = ByteBuffer()
     buffer.writeInteger(UInt8(0))
     buffer.writeInteger(UInt32(101))
     buffer.writeRepeatingByte(42, count: 101)
-    
-    XCTAssertThrowsRPCError (
+
+    XCTAssertThrowsRPCError(
       try processor.process(buffer: buffer) { _ in
         XCTFail("No message should be produced.")
       }
     ) { error in
       XCTAssertEqual(error.code, .resourceExhausted)
-      XCTAssertEqual(error.message, "Message has exceeded the configured maximum payload size (max: 100, actual: 101)")
+      XCTAssertEqual(
+        error.message,
+        "Message has exceeded the configured maximum payload size (max: 100, actual: 101)"
+      )
     }
   }
-  
+
   func testReadSingleMessageWithoutCompressionSplitAcrossMultipleBuffers() throws {
     let deframer = GRPCMessageDeframer()
     let processor = NIOSingleStepByteToMessageProcessor(deframer)
-    
+
     var buffer = ByteBuffer()
-    
+
     // We want to write the following gRPC frame:
     // - Compression flag unset
     // - Message length = 120
@@ -79,7 +85,7 @@ final class GRPCMessageDeframerTests: XCTestCase {
     // the rest of the message bytes in a third buffer.
     // The purpose of this test is to make sure that we are correctly stitching
     // together the frame.
-    
+
     // Write compression flag (unset)
     buffer.writeInteger(UInt8(0))
     // Write the first two bytes of the length field
@@ -88,7 +94,7 @@ final class GRPCMessageDeframerTests: XCTestCase {
     try processor.process(buffer: buffer) { message in
       XCTAssertNil(message)
     }
-    
+
     buffer.clear()
     // Write the next two bytes of the length field
     buffer.writeInteger(UInt16(120))
@@ -99,11 +105,11 @@ final class GRPCMessageDeframerTests: XCTestCase {
     try processor.process(buffer: buffer) { message in
       XCTAssertNil(message)
     }
-    
+
     buffer.clear()
     // Write remaining 60 bytes of the message.
     buffer.writeRepeatingByte(43, count: 60)
-    
+
     // Now we should be reading the full message.
     var messages = [[UInt8]]()
     try processor.process(buffer: buffer) { message in
@@ -116,45 +122,48 @@ final class GRPCMessageDeframerTests: XCTestCase {
     }()
     XCTAssertEqual(messages, [expectedMessage])
   }
-  
+
   func testReadMultipleMessagesWithCompression() throws {
     let decompressor = Zlib.Decompressor(method: .deflate)
     let deframer = GRPCMessageDeframer(maximumPayloadSize: 1000, decompressor: decompressor)
     let processor = NIOSingleStepByteToMessageProcessor(deframer)
     let compressor = Zlib.Compressor(method: .deflate)
     var framer = GRPCMessageFramer()
-    
+
     framer.append(Array(repeating: 42, count: 100))
     var framedMessage = try framer.next(compressor: compressor)!
-    
+
     var messages = [[UInt8]]()
     try processor.process(buffer: framedMessage) { message in
       messages.append(message)
     }
-    
+
     framer.append(Array(repeating: 43, count: 110))
     framedMessage = try framer.next(compressor: compressor)!
     try processor.process(buffer: framedMessage) { message in
       messages.append(message)
     }
-    
-    XCTAssertEqual(messages, [
-      Array(repeating: 42, count: 100),
-      Array(repeating: 43, count: 110)
-    ])
+
+    XCTAssertEqual(
+      messages,
+      [
+        Array(repeating: 42, count: 100),
+        Array(repeating: 43, count: 110),
+      ]
+    )
   }
-  
+
   func testReadMessageOverSizeLimitWithCompression() throws {
     let decompressor = Zlib.Decompressor(method: .deflate)
     let deframer = GRPCMessageDeframer(maximumPayloadSize: 100, decompressor: decompressor)
     let processor = NIOSingleStepByteToMessageProcessor(deframer)
-    
+
     let compressor = Zlib.Compressor(method: .deflate)
     var framer = GRPCMessageFramer()
     framer.append(Array(repeating: 42, count: 101))
     var framedMessage = try framer.next(compressor: compressor)!
-    
-    XCTAssertThrowsRPCError (
+
+    XCTAssertThrowsRPCError(
       try processor.process(buffer: framedMessage) { _ in
         XCTFail("No message should be produced.")
       }
@@ -163,21 +172,21 @@ final class GRPCMessageDeframerTests: XCTestCase {
       XCTAssertEqual(error.message, "Message is too large to decompress.")
     }
   }
-  
+
   func testReadSingleMessageWithCompressionSplitAcrossMultipleBuffers() throws {
     let decompressor = Zlib.Decompressor(method: .deflate)
     let deframer = GRPCMessageDeframer(maximumPayloadSize: 100, decompressor: decompressor)
     let processor = NIOSingleStepByteToMessageProcessor(deframer)
     let compressor = Zlib.Compressor(method: .deflate)
     var framer = GRPCMessageFramer()
-    
+
     framer.append(Array(repeating: 42, count: 100))
     var framedMessage = try framer.next(compressor: compressor)!
     var firstBuffer = ByteBuffer(buffer: framedMessage.readSlice(length: 3)!)
     var secondBuffer = ByteBuffer(buffer: framedMessage.readSlice(length: 3)!)
     var thirdBuffer = ByteBuffer(buffer: framedMessage)
     framedMessage.moveReaderIndex(to: 0)
-    
+
     // Make sure we don't produce a message, since we've got incomplete data.
     try processor.process(buffer: firstBuffer) { message in
       XCTFail("No message should be produced.")
@@ -188,7 +197,7 @@ final class GRPCMessageDeframerTests: XCTestCase {
     try processor.process(buffer: secondBuffer) { message in
       XCTFail("No message should be produced.")
     }
-    
+
     // Now we should be reading the full message.
     var messages = [[UInt8]]()
     try processor.process(buffer: thirdBuffer) { message in

--- a/Tests/GRPCHTTP2CoreTests/GRPCMessageDeframerTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/GRPCMessageDeframerTests.swift
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import NIOCore
+import XCTest
+
+@testable import GRPCHTTP2Core
+
+final class GRPCMessageDeframerTests: XCTestCase {
+  func testReadMultipleMessagesWithoutCompression() throws {
+    let deframer = GRPCMessageDeframer()
+    let processor = NIOSingleStepByteToMessageProcessor(deframer)
+    
+    var buffer = ByteBuffer()
+    buffer.writeInteger(UInt8(0))
+    buffer.writeInteger(UInt32(16))
+    buffer.writeRepeatingByte(42, count: 16)
+    
+    buffer.writeInteger(UInt8(0))
+    buffer.writeInteger(UInt32(8))
+    buffer.writeRepeatingByte(43, count: 8)
+    
+    var messages = [[UInt8]]()
+    try processor.process(buffer: buffer) { message in
+      messages.append(message)
+    }
+    
+    XCTAssertEqual(messages, [
+      Array(repeating: 42, count: 16),
+      Array(repeating: 43, count: 8)
+    ])
+  }
+  
+  func testReadMessageOverSizeLimitWithoutCompression() throws {
+    let deframer = GRPCMessageDeframer(maximumPayloadSize: 100)
+    let processor = NIOSingleStepByteToMessageProcessor(deframer)
+    
+    var buffer = ByteBuffer()
+    buffer.writeInteger(UInt8(0))
+    buffer.writeInteger(UInt32(101))
+    buffer.writeRepeatingByte(42, count: 101)
+    
+    XCTAssertThrowsRPCError (
+      try processor.process(buffer: buffer) { _ in
+        XCTFail("No message should be produced.")
+      }
+    ) { error in
+      XCTAssertEqual(error.code, .resourceExhausted)
+      XCTAssertEqual(error.message, "Message has exceeded the configured maximum payload size (max: 100, actual: 101)")
+    }
+  }
+  
+  func testReadSingleMessageWithoutCompressionSplitAcrossMultipleBuffers() throws {
+    let deframer = GRPCMessageDeframer()
+    let processor = NIOSingleStepByteToMessageProcessor(deframer)
+    
+    var buffer = ByteBuffer()
+    
+    // We want to write the following gRPC frame:
+    // - Compression flag unset
+    // - Message length = 120
+    // - 120 bytes of data for the message
+    // The header will be split in two (the first 3 bytes in a buffer, the
+    // remaining 2 in another one); the first chunk of the message will follow
+    // the second part of the metadata in the second buffer; and finally
+    // the rest of the message bytes in a third buffer.
+    // The purpose of this test is to make sure that we are correctly stitching
+    // together the frame.
+    
+    // Write compression flag (unset)
+    buffer.writeInteger(UInt8(0))
+    // Write the first two bytes of the length field
+    buffer.writeInteger(UInt16(0))
+    // Make sure we don't produce a message, since we've got incomplete data.
+    try processor.process(buffer: buffer) { message in
+      XCTAssertNil(message)
+    }
+    
+    buffer.clear()
+    // Write the next two bytes of the length field
+    buffer.writeInteger(UInt16(120))
+    // Write the first half of the message data
+    buffer.writeRepeatingByte(42, count: 60)
+    // Again, make sure we don't produce a message, since we don't have enough
+    // message bytes to read (only have 60 so far, but need 120).
+    try processor.process(buffer: buffer) { message in
+      XCTAssertNil(message)
+    }
+    
+    buffer.clear()
+    // Write remaining 60 bytes of the message.
+    buffer.writeRepeatingByte(43, count: 60)
+    
+    // Now we should be reading the full message.
+    var messages = [[UInt8]]()
+    try processor.process(buffer: buffer) { message in
+      messages.append(message)
+    }
+    let expectedMessage = {
+      var firstHalf = Array(repeating: UInt8(42), count: 60)
+      firstHalf.append(contentsOf: Array(repeating: 43, count: 60))
+      return firstHalf
+    }()
+    XCTAssertEqual(messages, [expectedMessage])
+  }
+  
+  func testReadMultipleMessagesWithCompression() throws {
+    let decompressor = Zlib.Decompressor(method: .deflate)
+    let deframer = GRPCMessageDeframer(maximumPayloadSize: 1000, decompressor: decompressor)
+    let processor = NIOSingleStepByteToMessageProcessor(deframer)
+    let compressor = Zlib.Compressor(method: .deflate)
+    var framer = GRPCMessageFramer()
+    
+    framer.append(Array(repeating: 42, count: 100))
+    var framedMessage = try framer.next(compressor: compressor)!
+    
+    var messages = [[UInt8]]()
+    try processor.process(buffer: framedMessage) { message in
+      messages.append(message)
+    }
+    
+    framer.append(Array(repeating: 43, count: 110))
+    framedMessage = try framer.next(compressor: compressor)!
+    try processor.process(buffer: framedMessage) { message in
+      messages.append(message)
+    }
+    
+    XCTAssertEqual(messages, [
+      Array(repeating: 42, count: 100),
+      Array(repeating: 43, count: 110)
+    ])
+  }
+  
+  func testReadMessageOverSizeLimitWithCompression() throws {
+    let decompressor = Zlib.Decompressor(method: .deflate)
+    let deframer = GRPCMessageDeframer(maximumPayloadSize: 100, decompressor: decompressor)
+    let processor = NIOSingleStepByteToMessageProcessor(deframer)
+    
+    let compressor = Zlib.Compressor(method: .deflate)
+    var framer = GRPCMessageFramer()
+    framer.append(Array(repeating: 42, count: 101))
+    var framedMessage = try framer.next(compressor: compressor)!
+    
+    XCTAssertThrowsRPCError (
+      try processor.process(buffer: framedMessage) { _ in
+        XCTFail("No message should be produced.")
+      }
+    ) { error in
+      XCTAssertEqual(error.code, .resourceExhausted)
+      XCTAssertEqual(error.message, "Message is too large to decompress.")
+    }
+  }
+  
+  func testReadSingleMessageWithCompressionSplitAcrossMultipleBuffers() throws {
+    let decompressor = Zlib.Decompressor(method: .deflate)
+    let deframer = GRPCMessageDeframer(maximumPayloadSize: 100, decompressor: decompressor)
+    let processor = NIOSingleStepByteToMessageProcessor(deframer)
+    let compressor = Zlib.Compressor(method: .deflate)
+    var framer = GRPCMessageFramer()
+    
+    framer.append(Array(repeating: 42, count: 100))
+    var framedMessage = try framer.next(compressor: compressor)!
+    var firstBuffer = ByteBuffer(buffer: framedMessage.readSlice(length: 3)!)
+    var secondBuffer = ByteBuffer(buffer: framedMessage.readSlice(length: 3)!)
+    var thirdBuffer = ByteBuffer(buffer: framedMessage)
+    framedMessage.moveReaderIndex(to: 0)
+    
+    // Make sure we don't produce a message, since we've got incomplete data.
+    try processor.process(buffer: firstBuffer) { message in
+      XCTFail("No message should be produced.")
+    }
+
+    // Again, make sure we don't produce a message, since we don't have enough
+    // message bytes to read.
+    try processor.process(buffer: secondBuffer) { message in
+      XCTFail("No message should be produced.")
+    }
+    
+    // Now we should be reading the full message.
+    var messages = [[UInt8]]()
+    try processor.process(buffer: thirdBuffer) { message in
+      messages.append(message)
+    }
+    // Assert the retrieved message matches the uncompressed original message.
+    XCTAssertEqual(messages, [Array(repeating: 42, count: 100)])
+  }
+}

--- a/Tests/GRPCHTTP2CoreTests/Test Utilities/XCTest+Utilities.swift
+++ b/Tests/GRPCHTTP2CoreTests/Test Utilities/XCTest+Utilities.swift
@@ -28,16 +28,3 @@ func XCTAssertThrowsError<T, E: Error>(
     errorHandler(error)
   }
 }
-
-func XCTAssertThrowsRPCError<T>(
-  _ expression: @autoclosure () throws -> T,
-  _ errorHandler: (RPCError) -> Void
-) {
-  XCTAssertThrowsError(try expression()) { error in
-    guard let error = error as? RPCError else {
-      return XCTFail("Error had unexpected type '\(type(of: error))'")
-    }
-
-    errorHandler(error)
-  }
-}

--- a/Tests/GRPCHTTP2CoreTests/Test Utilities/XCTest+Utilities.swift
+++ b/Tests/GRPCHTTP2CoreTests/Test Utilities/XCTest+Utilities.swift
@@ -28,3 +28,16 @@ func XCTAssertThrowsError<T, E: Error>(
     errorHandler(error)
   }
 }
+
+func XCTAssertThrowsRPCError<T>(
+  _ expression: @autoclosure () throws -> T,
+  _ errorHandler: (RPCError) -> Void
+) {
+  XCTAssertThrowsError(try expression()) { error in
+    guard let error = error as? RPCError else {
+      return XCTFail("Error had unexpected type '\(type(of: error))'")
+    }
+
+    errorHandler(error)
+  }
+}


### PR DESCRIPTION
## Motivation
We need a helper to deframe gRPC messages for the HTTP2 transport implementation we're carrying out.
This is the counterpart to https://github.com/grpc/grpc-swift/pull/1768

## Modifications
Added a `GRPCMessageDeframer`. This implementation conforms to NIO's `NIOSingleStepByteToMessageDecoder` to reuse the logic of stitching together multiple frames.

## Result
We've got a usable gRPC deframer now.