### PR TITLE
Update renderer-blank line after imports, delete blank line from docs

### DIFF
--- a/Sources/GRPCCodeGen/Internal/Renderer/TextBasedRenderer.swift
+++ b/Sources/GRPCCodeGen/Internal/Renderer/TextBasedRenderer.swift
@@ -136,8 +136,14 @@ struct TextBasedRenderer: RendererProtocol {
 
   /// Renders the specified Swift file.
   func renderFile(_ description: FileDescription) {
-    if let topComment = description.topComment { renderComment(topComment) }
-    if let imports = description.imports { renderImports(imports) }
+    if let topComment = description.topComment {
+      renderComment(topComment)
+      writer.writeLine("")
+    }
+    if let imports = description.imports {
+      renderImports(imports)
+      writer.writeLine("")
+    }
     for codeBlock in description.codeBlocks {
       renderCodeBlock(codeBlock)
       writer.writeLine("")
@@ -1052,7 +1058,6 @@ struct TextBasedRenderer: RendererProtocol {
     switch description {
     case .declaration(let declaration): renderDeclaration(declaration)
     case .expression(let expression): renderExpression(expression)
-    case .emptyLine: writer.nextLineAppendsToLastLine(false)
     }
   }
 

--- a/Sources/GRPCCodeGen/Internal/Renderer/TextBasedRenderer.swift
+++ b/Sources/GRPCCodeGen/Internal/Renderer/TextBasedRenderer.swift
@@ -98,10 +98,10 @@ final class StringCodeWriter {
   }
 
   /// Sets a flag on the writer so that the next call to `writeLine` continues
-  /// the last stored line or starts on a new line.
+  /// the last stored line instead of starting a new line.
   ///
   /// Safe to call repeatedly, it gets reset by `writeLine`.
-  func nextLineAppendsToLastLine(_ append: Bool = true) { nextWriteAppendsToLastLine = append }
+  func nextLineAppendsToLastLine() { nextWriteAppendsToLastLine = true }
 }
 
 /// A renderer that uses string interpolation and concatenation

--- a/Sources/GRPCCodeGen/Internal/Renderer/TextBasedRenderer.swift
+++ b/Sources/GRPCCodeGen/Internal/Renderer/TextBasedRenderer.swift
@@ -103,7 +103,7 @@ final class StringCodeWriter {
   /// Safe to call repeatedly, it gets reset by `writeLine`.
   func nextLineAppendsToLastLine() { nextWriteAppendsToLastLine = true }
 
-  /// Sets a flag on the writer so that the next call to `writeLine` starts a new line.
+  /// Sets a flag on the writer so that the next call to `writeLine` starts on a new line.
   ///
   /// Safe to call repeatedly, it gets reset by `writeLine`.
   func nextLineOnNewLine() { nextWriteAppendsToLastLine = false }

--- a/Sources/GRPCCodeGen/Internal/StructuredSwiftRepresentation.swift
+++ b/Sources/GRPCCodeGen/Internal/StructuredSwiftRepresentation.swift
@@ -1446,7 +1446,6 @@ extension CodeBlock {
   static func emptyLine() -> Self {
     CodeBlock(item: .emptyLine)
   }
-
 }
 
 extension Expression {

--- a/Sources/GRPCCodeGen/Internal/StructuredSwiftRepresentation.swift
+++ b/Sources/GRPCCodeGen/Internal/StructuredSwiftRepresentation.swift
@@ -1141,6 +1141,9 @@ enum CodeBlockItem: Equatable, Codable {
 
   /// An expression, such as a call of a declared function.
   case expression(Expression)
+
+  /// A blank line between code blocks.
+  case emptyLine
 }
 
 /// A code block, with an optional comment.
@@ -1437,6 +1440,13 @@ extension CodeBlock {
   static func expression(_ expression: Expression) -> Self {
     CodeBlock(item: .expression(expression))
   }
+
+  /// Returns a new code block wrapping an empty line.
+  /// - Returns: A new `CodeBlock` instance containing a blank line.
+  static func emptyLine() -> Self {
+    CodeBlock(item: .emptyLine)
+  }
+
 }
 
 extension Expression {

--- a/Sources/GRPCCodeGen/Internal/StructuredSwiftRepresentation.swift
+++ b/Sources/GRPCCodeGen/Internal/StructuredSwiftRepresentation.swift
@@ -1441,9 +1441,8 @@ extension CodeBlock {
     CodeBlock(item: .expression(expression))
   }
 
-  /// Returns a new code block wrapping an empty line.
-  /// - Returns: A new `CodeBlock` instance containing a blank line.
-  static func emptyLine() -> Self {
+  /// A new code block wrapping an empty line.
+  static var emptyLine: Self {
     CodeBlock(item: .emptyLine)
   }
 }

--- a/Sources/GRPCCodeGen/Internal/StructuredSwiftRepresentation.swift
+++ b/Sources/GRPCCodeGen/Internal/StructuredSwiftRepresentation.swift
@@ -1141,9 +1141,6 @@ enum CodeBlockItem: Equatable, Codable {
 
   /// An expression, such as a call of a declared function.
   case expression(Expression)
-
-  /// A blank line between code blocks.
-  case emptyLine
 }
 
 /// A code block, with an optional comment.
@@ -1439,11 +1436,6 @@ extension CodeBlock {
   /// - Returns: A new `CodeBlock` instance containing the provided declaration.
   static func expression(_ expression: Expression) -> Self {
     CodeBlock(item: .expression(expression))
-  }
-
-  /// A new code block wrapping an empty line.
-  static var emptyLine: Self {
-    CodeBlock(item: .emptyLine)
   }
 }
 

--- a/Sources/GRPCCodeGen/Internal/Translator/IDLToStructuredSwiftTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/IDLToStructuredSwiftTranslator.swift
@@ -38,7 +38,7 @@ struct IDLToStructuredSwiftTranslator: Translator {
       try partialResult.append(translateImport(dependency: newDependency))
     }
 
-    var codeBlocks: [CodeBlock] = []
+    var codeBlocks: [CodeBlock] = [.emptyLine]
     codeBlocks.append(
       contentsOf: try typealiasTranslator.translate(from: codeGenerationRequest)
     )

--- a/Sources/GRPCCodeGen/Internal/Translator/IDLToStructuredSwiftTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/IDLToStructuredSwiftTranslator.swift
@@ -38,7 +38,7 @@ struct IDLToStructuredSwiftTranslator: Translator {
       try partialResult.append(translateImport(dependency: newDependency))
     }
 
-    var codeBlocks: [CodeBlock] = [.emptyLine]
+    var codeBlocks = [CodeBlock]()
     codeBlocks.append(
       contentsOf: try typealiasTranslator.translate(from: codeGenerationRequest)
     )

--- a/Sources/GRPCCodeGen/Internal/Translator/TypealiasTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/TypealiasTranslator.swift
@@ -64,7 +64,7 @@ struct TypealiasTranslator: SpecializedTranslator {
   }
 
   func translate(from codeGenerationRequest: CodeGenerationRequest) throws -> [CodeBlock] {
-    var codeBlocks: [CodeBlock] = [.emptyLine()]
+    var codeBlocks = [CodeBlock]()
     let services = codeGenerationRequest.services
     let servicesByNamespace = Dictionary(
       grouping: services,

--- a/Sources/GRPCCodeGen/Internal/Translator/TypealiasTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/TypealiasTranslator.swift
@@ -64,7 +64,7 @@ struct TypealiasTranslator: SpecializedTranslator {
   }
 
   func translate(from codeGenerationRequest: CodeGenerationRequest) throws -> [CodeBlock] {
-    var codeBlocks: [CodeBlock] = []
+    var codeBlocks: [CodeBlock] = [.emptyLine()]
     let services = codeGenerationRequest.services
     let servicesByNamespace = Dictionary(
       grouping: services,

--- a/Tests/GRPCCodeGenTests/Internal/Renderer/TextBasedRendererTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Renderer/TextBasedRendererTests.swift
@@ -106,7 +106,6 @@ final class Test_TextBasedRenderer: XCTestCase {
       rendersAs: #"""
         import Foo
         import Bar
-
         """#
     )
     try _test(
@@ -114,7 +113,6 @@ final class Test_TextBasedRenderer: XCTestCase {
       renderedBy: TextBasedRenderer.renderImports,
       rendersAs: #"""
         @_spi(Secret) import Foo
-
         """#
     )
     try _test(
@@ -126,7 +124,6 @@ final class Test_TextBasedRenderer: XCTestCase {
         #else
         import Foo
         #endif
-
         """#
     )
     try _test(
@@ -138,7 +135,6 @@ final class Test_TextBasedRenderer: XCTestCase {
       rendersAs: #"""
         @preconcurrency import Foo
         @preconcurrency @_spi(Secret) import Bar
-
         """#
     )
 
@@ -193,7 +189,6 @@ final class Test_TextBasedRenderer: XCTestCase {
         import func Foo.Bak
         @_spi(Secret) import func Foo.SecretBar
         @preconcurrency import func Foo.PreconcurrencyBar
-
         """#
     )
   }
@@ -838,7 +833,6 @@ final class Test_TextBasedRenderer: XCTestCase {
       rendersAs: #"""
         // hi
         import Foo
-
         struct Bar {}
 
         """#
@@ -861,7 +855,6 @@ final class Test_TextBasedRenderer: XCTestCase {
       rendersAs: #"""
         // hi
         import Foo
-
         struct Bar {
           struct Baz {}
         }

--- a/Tests/GRPCCodeGenTests/Internal/Renderer/TextBasedRendererTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Renderer/TextBasedRendererTests.swift
@@ -372,16 +372,6 @@ final class Test_TextBasedRenderer: XCTestCase {
     )
   }
 
-  func testEmptyLine() throws {
-    try _test(
-      .emptyLine,
-      renderedBy: TextBasedRenderer.renderCodeBlockItem(_:),
-      rendersAs: #"""
-
-        """#
-    )
-  }
-
   func testFunctionKind() throws {
     try _test(
       .initializer,
@@ -851,7 +841,9 @@ final class Test_TextBasedRenderer: XCTestCase {
       renderedBy: TextBasedRenderer.renderFile,
       rendersAs: #"""
         // hi
+
         import Foo
+
         struct Bar {}
 
         """#
@@ -873,7 +865,9 @@ final class Test_TextBasedRenderer: XCTestCase {
       renderedBy: TextBasedRenderer.renderFile,
       rendersAs: #"""
         // hi
+
         import Foo
+
         struct Bar {
           struct Baz {}
         }

--- a/Tests/GRPCCodeGenTests/Internal/Renderer/TextBasedRendererTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Renderer/TextBasedRendererTests.swift
@@ -89,6 +89,13 @@ final class Test_TextBasedRenderer: XCTestCase {
         // Also, bar
         """#
     )
+    try _test(
+      .preFormatted("/// Lorem ipsum\n"),
+      renderedBy: TextBasedRenderer.renderComment,
+      rendersAs: """
+        /// Lorem ipsum
+        """
+    )
   }
 
   func testImports() throws {
@@ -99,6 +106,7 @@ final class Test_TextBasedRenderer: XCTestCase {
       rendersAs: #"""
         import Foo
         import Bar
+
         """#
     )
     try _test(
@@ -106,6 +114,7 @@ final class Test_TextBasedRenderer: XCTestCase {
       renderedBy: TextBasedRenderer.renderImports,
       rendersAs: #"""
         @_spi(Secret) import Foo
+
         """#
     )
     try _test(
@@ -117,6 +126,7 @@ final class Test_TextBasedRenderer: XCTestCase {
         #else
         import Foo
         #endif
+
         """#
     )
     try _test(
@@ -128,6 +138,7 @@ final class Test_TextBasedRenderer: XCTestCase {
       rendersAs: #"""
         @preconcurrency import Foo
         @preconcurrency @_spi(Secret) import Bar
+
         """#
     )
 
@@ -182,6 +193,7 @@ final class Test_TextBasedRenderer: XCTestCase {
         import func Foo.Bak
         @_spi(Secret) import func Foo.SecretBar
         @preconcurrency import func Foo.PreconcurrencyBar
+
         """#
     )
   }
@@ -826,6 +838,7 @@ final class Test_TextBasedRenderer: XCTestCase {
       rendersAs: #"""
         // hi
         import Foo
+
         struct Bar {}
 
         """#
@@ -848,6 +861,7 @@ final class Test_TextBasedRenderer: XCTestCase {
       rendersAs: #"""
         // hi
         import Foo
+
         struct Bar {
           struct Baz {}
         }

--- a/Tests/GRPCCodeGenTests/Internal/Renderer/TextBasedRendererTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Renderer/TextBasedRendererTests.swift
@@ -96,6 +96,15 @@ final class Test_TextBasedRenderer: XCTestCase {
         /// Lorem ipsum
         """
     )
+    try _test(
+      .preFormatted("/// Lorem ipsum\n\n/// Lorem ipsum\n"),
+      renderedBy: TextBasedRenderer.renderComment,
+      rendersAs: """
+        /// Lorem ipsum
+
+        /// Lorem ipsum
+        """
+    )
   }
 
   func testImports() throws {
@@ -359,6 +368,16 @@ final class Test_TextBasedRenderer: XCTestCase {
       renderedBy: TextBasedRenderer.renderDeclaration,
       rendersAs: #"""
         func foo() {}
+        """#
+    )
+  }
+
+  func testEmptyLine() throws {
+    try _test(
+      .emptyLine,
+      renderedBy: TextBasedRenderer.renderCodeBlockItem(_:),
+      rendersAs: #"""
+
         """#
     )
   }

--- a/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
@@ -56,6 +56,7 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Some really exciting license header 2023.
+
       import GRPCCore
       import Foo
       import typealias Foo.Bar
@@ -94,6 +95,7 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Some really exciting license header 2023.
+
       import GRPCCore
       @preconcurrency import Foo
       @preconcurrency import enum Foo.Bar
@@ -125,6 +127,7 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Some really exciting license header 2023.
+
       import GRPCCore
       @_spi(Secret) import Foo
       @_spi(Secret) import enum Foo.Bar
@@ -137,17 +140,84 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
     )
   }
 
+  func testGeneration() throws {
+    var dependencies = [CodeGenerationRequest.Dependency]()
+    dependencies.append(CodeGenerationRequest.Dependency(module: "Foo", spi: "Secret"))
+    dependencies.append(
+      CodeGenerationRequest.Dependency(
+        item: .init(kind: .enum, name: "Bar"),
+        module: "Foo",
+        spi: "Secret"
+      )
+    )
+
+    let serviceA = ServiceDescriptor(
+      documentation: "/// Documentation for AService\n",
+      name: Name(base: "ServiceA", generatedUpperCase: "ServiceA", generatedLowerCase: "serviceA"),
+      namespace: Name(
+        base: "namespaceA",
+        generatedUpperCase: "NamespaceA",
+        generatedLowerCase: "namespaceA"
+      ),
+      methods: []
+    )
+
+    let expectedSwift =
+      """
+      /// Some really exciting license header 2023.
+
+      import GRPCCore
+      @_spi(Secret) import Foo
+      @_spi(Secret) import enum Foo.Bar
+
+      public enum NamespaceA {
+          public enum ServiceA {
+              public enum Methods {}
+              public static let methods: [MethodDescriptor] = []
+              public typealias StreamingServiceProtocol = NamespaceA_ServiceAServiceStreamingProtocol
+              public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
+          }
+      }
+
+      /// Documentation for AService
+      public protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {}
+
+      /// Conformance to `GRPCCore.RegistrableRPCService`.
+      extension NamespaceA.ServiceA.StreamingServiceProtocol {
+          public func registerMethods(with router: inout GRPCCore.RPCRouter) {}
+      }
+
+      /// Documentation for AService
+      public protocol NamespaceA_ServiceAServiceProtocol: NamespaceA.ServiceA.StreamingServiceProtocol {}
+
+      /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
+      extension NamespaceA.ServiceA.ServiceProtocol {
+      }
+
+      """
+    try self.assertIDLToStructuredSwiftTranslation(
+      codeGenerationRequest: makeCodeGenerationRequest(
+        services: [serviceA],
+        dependencies: dependencies
+      ),
+      expectedSwift: expectedSwift,
+      accessLevel: .public,
+      server: true
+    )
+  }
+
   private func assertIDLToStructuredSwiftTranslation(
     codeGenerationRequest: CodeGenerationRequest,
     expectedSwift: String,
-    accessLevel: SourceGenerator.Configuration.AccessLevel
+    accessLevel: SourceGenerator.Configuration.AccessLevel,
+    server: Bool = false
   ) throws {
     let translator = IDLToStructuredSwiftTranslator()
     let structuredSwift = try translator.translate(
       codeGenerationRequest: codeGenerationRequest,
       accessLevel: accessLevel,
       client: false,
-      server: false
+      server: server
     )
     let renderer = TextBasedRenderer.default
     let sourceFile = try renderer.render(structured: structuredSwift)
@@ -265,7 +335,7 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
 
   func testSameGeneratedNameServicesSameNamespaceError() throws {
     let serviceA = ServiceDescriptor(
-      documentation: "Documentation for AService",
+      documentation: "/// Documentation for AService\n",
       name: Name(base: "AService", generatedUpperCase: "AService", generatedLowerCase: "aService"),
       namespace: Name(
         base: "namespacea",
@@ -275,7 +345,7 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
       methods: []
     )
     let serviceB = ServiceDescriptor(
-      documentation: "Documentation for BService",
+      documentation: "/// Documentation for BService\n",
       name: Name(base: "BService", generatedUpperCase: "AService", generatedLowerCase: "aService"),
       namespace: Name(
         base: "namespacea",

--- a/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
@@ -66,6 +66,7 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
       import let Foo.Baq
       import var Foo.Bag
       import func Foo.Bak
+
       """
     try self.assertIDLToStructuredSwiftTranslation(
       codeGenerationRequest: makeCodeGenerationRequest(dependencies: dependencies),
@@ -101,6 +102,7 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
       #else
       import Baz
       #endif
+
       """
     try self.assertIDLToStructuredSwiftTranslation(
       codeGenerationRequest: makeCodeGenerationRequest(dependencies: dependencies),
@@ -126,6 +128,7 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
       import GRPCCore
       @_spi(Secret) import Foo
       @_spi(Secret) import enum Foo.Bar
+
       """
     try self.assertIDLToStructuredSwiftTranslation(
       codeGenerationRequest: makeCodeGenerationRequest(dependencies: dependencies),

--- a/Tests/GRPCCodeGenTests/Internal/Translator/TestFunctions.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/TestFunctions.swift
@@ -72,30 +72,14 @@ internal func XCTAssertEqualWithDiff(
 }
 
 internal func makeCodeGenerationRequest(
-  services: [CodeGenerationRequest.ServiceDescriptor]
+  services: [CodeGenerationRequest.ServiceDescriptor] = [],
+  dependencies: [CodeGenerationRequest.Dependency] = []
 ) -> CodeGenerationRequest {
   return CodeGenerationRequest(
     fileName: "test.grpc",
-    leadingTrivia: "/// Some really exciting license header 2023.",
-    dependencies: [],
-    services: services,
-    lookupSerializer: {
-      "ProtobufSerializer<\($0)>()"
-    },
-    lookupDeserializer: {
-      "ProtobufDeserializer<\($0)>()"
-    }
-  )
-}
-
-internal func makeCodeGenerationRequest(
-  dependencies: [CodeGenerationRequest.Dependency]
-) -> CodeGenerationRequest {
-  return CodeGenerationRequest(
-    fileName: "test.grpc",
-    leadingTrivia: "/// Some really exciting license header 2023.",
+    leadingTrivia: "/// Some really exciting license header 2023.\n",
     dependencies: dependencies,
-    services: [],
+    services: services,
     lookupSerializer: {
       "ProtobufSerializer<\($0)>()"
     },


### PR DESCRIPTION
Motivation:

We want to have a blank line between the imports and the generated code and no blank line between the docs and the protocols/methods declarations.

Modifications:

Updated the TextBasedRenderer and the tests.

Result:

The generated code will have the right format.