### PR TITLE
[CodeGenLib] Change location of method descriptor array in generated code

### DIFF
--- a/Sources/GRPCCodeGen/Internal/Translator/TypealiasTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/TypealiasTranslator.swift
@@ -38,10 +38,10 @@
 ///       // ...
 ///
 ///       public static let descriptors: [MethodDescriptor] = [
-///       echo.Echo.Get.descriptor,
-///       echo.Echo.Collect.descriptor,
-///       // ...
-///     ]
+///         echo.Echo.Get.descriptor,
+///         echo.Echo.Collect.descriptor,
+///         // ...
+///       ]
 ///     }
 ///
 ///     public typealias StreamingServiceProtocol = echo_EchoServiceStreamingProtocol

--- a/Sources/GRPCCodeGen/Internal/Translator/TypealiasTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/TypealiasTranslator.swift
@@ -23,7 +23,7 @@
 /// ```swift
 /// public enum Echo {
 ///   public enum Echo {
-///     public enum Methods {
+///     public enum Method {
 ///       public enum Get {
 ///         public typealias Input = Echo_EchoRequest
 ///         public typealias Output = Echo_EchoResponse
@@ -36,12 +36,13 @@
 ///         public static let descriptor = MethodDescriptor(service: "echo.Echo", method: "Collect")
 ///       }
 ///       // ...
-///     }
-///     public static let methods: [MethodDescriptor] = [
+///
+///       public static let descriptors: [MethodDescriptor] = [
 ///       echo.Echo.Get.descriptor,
 ///       echo.Echo.Collect.descriptor,
 ///       // ...
 ///     ]
+///     }
 ///
 ///     public typealias StreamingServiceProtocol = echo_EchoServiceStreamingProtocol
 ///     public typealias ServiceProtocol = echo_EchoServiceProtocol
@@ -119,7 +120,7 @@ extension TypealiasTranslator {
       accessModifier: self.accessModifier,
       name: service.name.generatedUpperCase
     )
-    var methodsEnum = EnumDescription(accessModifier: self.accessModifier, name: "Methods")
+    var methodsEnum = EnumDescription(accessModifier: self.accessModifier, name: "Method")
     let methods = service.methods
 
     // Create the method specific enums.
@@ -127,11 +128,12 @@ extension TypealiasTranslator {
       let methodEnum = self.makeMethodEnum(from: method, in: service)
       methodsEnum.members.append(methodEnum)
     }
-    serviceEnum.members.append(.enum(methodsEnum))
 
     // Create the method descriptor array.
     let methodDescriptorsDeclaration = self.makeMethodDescriptors(for: service)
-    serviceEnum.members.append(methodDescriptorsDeclaration)
+    methodsEnum.members.append(methodDescriptorsDeclaration)
+
+    serviceEnum.members.append(.enum(methodsEnum))
 
     if self.server {
       // Create the streaming and non-streaming service protocol type aliases.
@@ -231,7 +233,7 @@ extension TypealiasTranslator {
       accessModifier: self.accessModifier,
       isStatic: true,
       kind: .let,
-      left: .identifier(.pattern("methods")),
+      left: .identifier(.pattern("descriptors")),
       type: .array(.member("MethodDescriptor")),
       right: .literal(.array(methodDescriptors))
     )

--- a/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
@@ -172,8 +172,9 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
 
       public enum NamespaceA {
           public enum ServiceA {
-              public enum Methods {}
-              public static let methods: [MethodDescriptor] = []
+              public enum Method {
+                  public static let descriptors: [MethodDescriptor] = []
+              }
               public typealias StreamingServiceProtocol = NamespaceA_ServiceAServiceStreamingProtocol
               public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
           }

--- a/Tests/GRPCCodeGenTests/Internal/Translator/TypealiasTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/TypealiasTranslatorSnippetBasedTests.swift
@@ -48,7 +48,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
       """
       public enum NamespaceA {
           public enum ServiceA {
-              public enum Methods {
+              public enum Method {
                   public enum MethodA {
                       public typealias Input = NamespaceA_ServiceARequest
                       public typealias Output = NamespaceA_ServiceAResponse
@@ -57,10 +57,10 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
                           method: "MethodA"
                       )
                   }
+                  public static let descriptors: [MethodDescriptor] = [
+                      Methods.MethodA.descriptor
+                  ]
               }
-              public static let methods: [MethodDescriptor] = [
-                  Methods.MethodA.descriptor
-              ]
               public typealias StreamingServiceProtocol = NamespaceA_ServiceAServiceStreamingProtocol
               public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
               public typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
@@ -93,8 +93,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
       """
       public enum NamespaceA {
           public enum ServiceA {
-              public enum Methods {}
-              public static let methods: [MethodDescriptor] = []
+              public enum Method {
+                  public static let descriptors: [MethodDescriptor] = []
+              }
               public typealias StreamingServiceProtocol = NamespaceA_ServiceAServiceStreamingProtocol
               public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
               public typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
@@ -127,8 +128,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
       """
       public enum NamespaceA {
           public enum ServiceA {
-              public enum Methods {}
-              public static let methods: [MethodDescriptor] = []
+              public enum Method {
+                  public static let descriptors: [MethodDescriptor] = []
+              }
               public typealias StreamingServiceProtocol = NamespaceA_ServiceAServiceStreamingProtocol
               public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
           }
@@ -159,8 +161,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
       """
       public enum NamespaceA {
           public enum ServiceA {
-              public enum Methods {}
-              public static let methods: [MethodDescriptor] = []
+              public enum Method {
+                  public static let descriptors: [MethodDescriptor] = []
+              }
               public typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
               public typealias Client = NamespaceA_ServiceAClient
           }
@@ -191,8 +194,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
       """
       public enum NamespaceA {
           public enum ServiceA {
-              public enum Methods {}
-              public static let methods: [MethodDescriptor] = []
+              public enum Method {
+                  public static let descriptors: [MethodDescriptor] = []
+              }
           }
       }
       """
@@ -224,7 +228,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum ServiceA {
-          public enum Methods {
+          public enum Method {
               public enum MethodA {
                   public typealias Input = ServiceARequest
                   public typealias Output = ServiceAResponse
@@ -233,10 +237,10 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
                       method: "MethodA"
                   )
               }
+              public static let descriptors: [MethodDescriptor] = [
+                  Methods.MethodA.descriptor
+              ]
           }
-          public static let methods: [MethodDescriptor] = [
-              Methods.MethodA.descriptor
-          ]
           public typealias StreamingServiceProtocol = ServiceAServiceStreamingProtocol
           public typealias ServiceProtocol = ServiceAServiceProtocol
           public typealias ClientProtocol = ServiceAClientProtocol
@@ -284,7 +288,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
       """
       public enum NamespaceA {
           public enum ServiceA {
-              public enum Methods {
+              public enum Method {
                   public enum MethodA {
                       public typealias Input = NamespaceA_ServiceARequest
                       public typealias Output = NamespaceA_ServiceAResponse
@@ -301,11 +305,11 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
                           method: "MethodB"
                       )
                   }
+                  public static let descriptors: [MethodDescriptor] = [
+                      Methods.MethodA.descriptor,
+                      Methods.MethodB.descriptor
+                  ]
               }
-              public static let methods: [MethodDescriptor] = [
-                  Methods.MethodA.descriptor,
-                  Methods.MethodB.descriptor
-              ]
               public typealias StreamingServiceProtocol = NamespaceA_ServiceAServiceStreamingProtocol
               public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
               public typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
@@ -338,8 +342,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
       """
       package enum NamespaceA {
           package enum ServiceA {
-              package enum Methods {}
-              package static let methods: [MethodDescriptor] = []
+              package enum Method {
+                  package static let descriptors: [MethodDescriptor] = []
+              }
               package typealias StreamingServiceProtocol = NamespaceA_ServiceAServiceStreamingProtocol
               package typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
               package typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
@@ -384,16 +389,18 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
       """
       public enum NamespaceA {
           public enum Aservice {
-              public enum Methods {}
-              public static let methods: [MethodDescriptor] = []
+              public enum Method {
+                  public static let descriptors: [MethodDescriptor] = []
+              }
               public typealias StreamingServiceProtocol = NamespaceA_AserviceServiceStreamingProtocol
               public typealias ServiceProtocol = NamespaceA_AserviceServiceProtocol
               public typealias ClientProtocol = NamespaceA_AserviceClientProtocol
               public typealias Client = NamespaceA_AserviceClient
           }
           public enum Bservice {
-              public enum Methods {}
-              public static let methods: [MethodDescriptor] = []
+              public enum Method {
+                  public static let descriptors: [MethodDescriptor] = []
+              }
               public typealias StreamingServiceProtocol = NamespaceA_BserviceServiceStreamingProtocol
               public typealias ServiceProtocol = NamespaceA_BserviceServiceProtocol
               public typealias ClientProtocol = NamespaceA_BserviceClientProtocol
@@ -429,16 +436,18 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       package enum AService {
-          package enum Methods {}
-          package static let methods: [MethodDescriptor] = []
+          package enum Method {
+              package static let descriptors: [MethodDescriptor] = []
+          }
           package typealias StreamingServiceProtocol = AServiceServiceStreamingProtocol
           package typealias ServiceProtocol = AServiceServiceProtocol
           package typealias ClientProtocol = AServiceClientProtocol
           package typealias Client = AServiceClient
       }
       package enum BService {
-          package enum Methods {}
-          package static let methods: [MethodDescriptor] = []
+          package enum Method {
+              package static let descriptors: [MethodDescriptor] = []
+          }
           package typealias StreamingServiceProtocol = BServiceServiceStreamingProtocol
           package typealias ServiceProtocol = BServiceServiceProtocol
           package typealias ClientProtocol = BServiceClientProtocol
@@ -482,8 +491,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
       """
       internal enum Anamespace {
           internal enum AService {
-              internal enum Methods {}
-              internal static let methods: [MethodDescriptor] = []
+              internal enum Method {
+                  internal static let descriptors: [MethodDescriptor] = []
+              }
               internal typealias StreamingServiceProtocol = Anamespace_AServiceServiceStreamingProtocol
               internal typealias ServiceProtocol = Anamespace_AServiceServiceProtocol
               internal typealias ClientProtocol = Anamespace_AServiceClientProtocol
@@ -492,8 +502,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
       }
       internal enum Bnamespace {
           internal enum BService {
-              internal enum Methods {}
-              internal static let methods: [MethodDescriptor] = []
+              internal enum Method {
+                  internal static let descriptors: [MethodDescriptor] = []
+              }
               internal typealias StreamingServiceProtocol = Bnamespace_BServiceServiceStreamingProtocol
               internal typealias ServiceProtocol = Bnamespace_BServiceServiceProtocol
               internal typealias ClientProtocol = Bnamespace_BServiceClientProtocol
@@ -531,8 +542,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum BService {
-          public enum Methods {}
-          public static let methods: [MethodDescriptor] = []
+          public enum Method {
+              public static let descriptors: [MethodDescriptor] = []
+          }
           public typealias StreamingServiceProtocol = BServiceServiceStreamingProtocol
           public typealias ServiceProtocol = BServiceServiceProtocol
           public typealias ClientProtocol = BServiceClientProtocol
@@ -540,8 +552,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
       }
       public enum Anamespace {
           public enum AService {
-              public enum Methods {}
-              public static let methods: [MethodDescriptor] = []
+              public enum Method {
+                  public static let descriptors: [MethodDescriptor] = []
+              }
               public typealias StreamingServiceProtocol = Anamespace_AServiceServiceStreamingProtocol
               public typealias ServiceProtocol = Anamespace_AServiceServiceProtocol
               public typealias ClientProtocol = Anamespace_AServiceClientProtocol

--- a/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGeneratorTests.swift
+++ b/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGeneratorTests.swift
@@ -58,7 +58,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
 
         internal enum Helloworld {
             internal enum Greeter {
-                internal enum Methods {
+                internal enum Method {
                     internal enum SayHello {
                         internal typealias Input = HelloRequest
                         internal typealias Output = HelloReply
@@ -67,10 +67,10 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
                             method: "SayHello"
                         )
                     }
+                    internal static let descriptors: [MethodDescriptor] = [
+                        Methods.SayHello.descriptor
+                    ]
                 }
-                internal static let methods: [MethodDescriptor] = [
-                    Methods.SayHello.descriptor
-                ]
                 internal typealias ClientProtocol = Helloworld_GreeterClientProtocol
                 internal typealias Client = Helloworld_GreeterClient
             }
@@ -162,7 +162,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
 
         public enum Helloworld {
           public enum Greeter {
-            public enum Methods {
+            public enum Method {
               public enum SayHello {
                 public typealias Input = HelloRequest
                 public typealias Output = HelloReply
@@ -171,10 +171,10 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
                   method: "SayHello"
                 )
               }
+              public static let descriptors: [MethodDescriptor] = [
+                Methods.SayHello.descriptor
+              ]
             }
-            public static let methods: [MethodDescriptor] = [
-              Methods.SayHello.descriptor
-            ]
             public typealias StreamingServiceProtocol = Helloworld_GreeterServiceStreamingProtocol
             public typealias ServiceProtocol = Helloworld_GreeterServiceProtocol
           }
@@ -249,7 +249,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
 
         package enum Helloworld {
           package enum Greeter {
-            package enum Methods {
+            package enum Method {
               package enum SayHello {
                 package typealias Input = HelloRequest
                 package typealias Output = HelloReply
@@ -258,10 +258,10 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
                   method: "SayHello"
                 )
               }
+              package static let descriptors: [MethodDescriptor] = [
+                Methods.SayHello.descriptor
+              ]
             }
-            package static let methods: [MethodDescriptor] = [
-              Methods.SayHello.descriptor
-            ]
             package typealias StreamingServiceProtocol = Helloworld_GreeterServiceStreamingProtocol
             package typealias ServiceProtocol = Helloworld_GreeterServiceProtocol
             package typealias ClientProtocol = Helloworld_GreeterClientProtocol


### PR DESCRIPTION
Motivation:

The method descriptor array should reside inside the Methods enum (which should be called Method).

Modifications:

- added the descriptor array as a member of the Methods enum
- chenged the Methods enum name to Method
- changed the tests accordingly

Result:

Better organized generated code.