### PR TITLE
[CodeGenLib] Fixtures for the generated code

### DIFF
--- a/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
@@ -24,21 +24,21 @@
 /// ```swift
 /// public protocol Foo_BarClientProtocol: Sendable {
 ///   func baz<R: Sendable>(
-///     request: ClientRequest.Single<foo.Bar.Methods.baz.Input>,
-///     serializer: some MessageSerializer<foo.Bar.Methods.baz.Input>,
-///     deserializer: some MessageDeserializer<foo.Bar.Methods.baz.Output>,
-///     _ body: @Sendable @escaping (ClientResponse.Single<foo.Bar.Methods.Baz.Output>) async throws -> R
-///   ) async throws -> ServerResponse.Stream<foo.Bar.Methods.Baz.Output>
+///     request: ClientRequest.Single<foo.Bar.Method.baz.Input>,
+///     serializer: some MessageSerializer<foo.Bar.Method.baz.Input>,
+///     deserializer: some MessageDeserializer<foo.Bar.Method.baz.Output>,
+///     _ body: @Sendable @escaping (ClientResponse.Single<foo.Bar.Method.Baz.Output>) async throws -> R
+///   ) async throws -> ServerResponse.Stream<foo.Bar.Method.Baz.Output>
 /// }
 /// extension Foo.Bar.ClientProtocol {
 ///   public func get<R: Sendable>(
-///     request: ClientRequest.Single<Foo.Bar.Methods.Baz.Input>,
-///     _ body: @Sendable @escaping (ClientResponse.Single<Foo.Bar.Methods.Baz.Output>) async throws -> R
+///     request: ClientRequest.Single<Foo.Bar.Method.Baz.Input>,
+///     _ body: @Sendable @escaping (ClientResponse.Single<Foo.Bar.Method.Baz.Output>) async throws -> R
 ///   ) async rethrows -> R {
 ///     try await self.baz(
 ///       request: request,
-///       serializer: ProtobufSerializer<Foo.Bar.Methods.Baz.Input>(),
-///       deserializer: ProtobufDeserializer<Foo.Bar.Methods.Baz.Output>(),
+///       serializer: ProtobufSerializer<Foo.Bar.Method.Baz.Input>(),
+///       deserializer: ProtobufDeserializer<Foo.Bar.Method.Baz.Output>(),
 ///       body
 ///     )
 /// }
@@ -48,14 +48,14 @@
 ///     self.client = client
 ///   }
 ///   public func methodA<R: Sendable>(
-///     request: ClientRequest.Stream<namespaceA.ServiceA.Methods.methodA.Input>,
-///     serializer: some MessageSerializer<namespaceA.ServiceA.Methods.methodA.Input>,
-///     deserializer: some MessageDeserializer<namespaceA.ServiceA.Methods.methodA.Output>,
-///     _ body: @Sendable @escaping (ClientResponse.Single<namespaceA.ServiceA.Methods.methodA.Output>) async throws -> R
+///     request: ClientRequest.Stream<namespaceA.ServiceA.Method.methodA.Input>,
+///     serializer: some MessageSerializer<namespaceA.ServiceA.Method.methodA.Input>,
+///     deserializer: some MessageDeserializer<namespaceA.ServiceA.Method.methodA.Output>,
+///     _ body: @Sendable @escaping (ClientResponse.Single<namespaceA.ServiceA.Method.methodA.Output>) async throws -> R
 ///   ) async rethrows -> R {
 ///    try await self.client.clientStreaming(
 ///      request: request,
-///      descriptor: NamespaceA.ServiceA.Methods.MethodA.descriptor,
+///      descriptor: NamespaceA.ServiceA.Method.MethodA.descriptor,
 ///      serializer: serializer,
 ///      deserializer: deserializer,
 ///      handler: body
@@ -399,7 +399,7 @@ extension ClientCodeTranslator {
         .init(
           label: "descriptor",
           expression: .identifierPattern(
-            "\(service.namespacedTypealiasGeneratedName).Methods.\(method.name.generatedUpperCase).descriptor"
+            "\(service.namespacedTypealiasGeneratedName).Method.\(method.name.generatedUpperCase).descriptor"
           )
         ),
         .init(label: "serializer", expression: .identifierPattern("serializer")),
@@ -439,7 +439,7 @@ extension ClientCodeTranslator {
     type: InputOutputType
   ) -> String {
     var components: String =
-      "\(service.namespacedTypealiasGeneratedName).Methods.\(method.name.generatedUpperCase)"
+      "\(service.namespacedTypealiasGeneratedName).Method.\(method.name.generatedUpperCase)"
 
     switch type {
     case .input:

--- a/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
@@ -31,23 +31,23 @@
 /// extension foo.Bar.StreamingServiceProtocol {
 ///   public func registerRPCs(with router: inout RPCRouter) {
 ///     router.registerHandler(
-///       for: foo.Method.baz.descriptor,
-///       deserializer: ProtobufDeserializer<foo.Methods.baz.Input>(),
-///       serializer: ProtobufSerializer<foo.Methods.baz.Output>(),
+///       forMethod: foo.Method.baz.descriptor,
+///       deserializer: ProtobufDeserializer<foo.Method.baz.Input>(),
+///       serializer: ProtobufSerializer<foo.Method.baz.Output>(),
 ///       handler: { request in try await self.baz(request: request) }
 ///     )
 ///   }
 /// }
 /// public protocol foo_BarServiceProtocol: foo.Bar.StreamingServiceProtocol {
 ///   func baz(
-///     request: ServerRequest.Single<foo.Bar.Methods.baz.Input>
-///   ) async throws -> ServerResponse.Single<foo.Bar.Methods.baz.Output>
+///     request: ServerRequest.Single<foo.Bar.Method.baz.Input>
+///   ) async throws -> ServerResponse.Single<foo.Bar.Method.baz.Output>
 /// }
 /// // Generated partial conformance to `foo_BarStreamingServiceProtocol`.
 /// extension foo.Bar.ServiceProtocol {
 ///   public func baz(
-///     request: ServerRequest.Stream<foo.Bar.Methods.baz.Input>
-///   ) async throws -> ServerResponse.Stream<foo.Bar.Methods.baz.Output> {
+///     request: ServerRequest.Stream<foo.Bar.Method.baz.Input>
+///   ) async throws -> ServerResponse.Stream<foo.Bar.Method.baz.Output> {
 ///     let response = try await self.baz(request: ServerRequest.Single(stream: request)
 ///     return ServerResponse.Stream(single: response)
 ///   }
@@ -221,7 +221,7 @@ extension ServerCodeTranslator {
     var arguments = [FunctionArgumentDescription]()
     arguments.append(
       .init(
-        label: "for",
+        label: "forMethod",
         expression: .identifierPattern(
           self.methodDescriptorPath(for: method, service: service)
         )
@@ -460,7 +460,7 @@ extension ServerCodeTranslator {
     type: InputOutputType
   ) -> String {
     var components: String =
-      "\(service.namespacedTypealiasGeneratedName).Methods.\(method.name.generatedUpperCase)"
+      "\(service.namespacedTypealiasGeneratedName).Method.\(method.name.generatedUpperCase)"
 
     switch type {
     case .input:
@@ -478,7 +478,7 @@ extension ServerCodeTranslator {
     service: CodeGenerationRequest.ServiceDescriptor
   ) -> String {
     return
-      "\(service.namespacedTypealiasGeneratedName).Methods.\(method.name.generatedUpperCase).descriptor"
+      "\(service.namespacedTypealiasGeneratedName).Method.\(method.name.generatedUpperCase).descriptor"
   }
 
   /// Generates the fully qualified name of the type alias for a service protocol.

--- a/Sources/GRPCCodeGen/Internal/Translator/TypealiasTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/TypealiasTranslator.swift
@@ -38,8 +38,8 @@
 ///       // ...
 ///
 ///       public static let descriptors: [MethodDescriptor] = [
-///         echo.Echo.Get.descriptor,
-///         echo.Echo.Collect.descriptor,
+///         Echo.Echo.Method.Get.descriptor,
+///         Echo.Echo.Method.Collect.descriptor,
 ///         // ...
 ///       ]
 ///     }
@@ -222,7 +222,9 @@ extension TypealiasTranslator {
     for methodName in methodNames {
       let methodDescriptorPath = Expression.memberAccess(
         MemberAccessDescription(
-          left: .identifierType(.member(["Methods", methodName])),
+          left: .identifierType(
+            .member([service.namespacedTypealiasGeneratedName, "Method", methodName])
+          ),
           right: "descriptor"
         )
       )
@@ -245,7 +247,7 @@ extension TypealiasTranslator {
     let streamingServiceProtocolTypealias = Declaration.typealias(
       accessModifier: self.accessModifier,
       name: "StreamingServiceProtocol",
-      existingType: .member("\(service.namespacedGeneratedName)ServiceStreamingProtocol")
+      existingType: .member("\(service.namespacedGeneratedName)StreamingServiceProtocol")
     )
     let serviceProtocolTypealias = Declaration.typealias(
       accessModifier: self.accessModifier,

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
@@ -46,21 +46,21 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       public protocol NamespaceA_ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
-              request: ClientRequest.Single<NamespaceA.ServiceA.Methods.MethodA.Input>,
-              serializer: some MessageSerializer<NamespaceA.ServiceA.Methods.MethodA.Input>,
-              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Methods.MethodA.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Methods.MethodA.Output>) async throws -> R
+              request: ClientRequest.Single<NamespaceA.ServiceA.Method.MethodA.Input>,
+              serializer: some MessageSerializer<NamespaceA.ServiceA.Method.MethodA.Input>,
+              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Method.MethodA.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable
       }
       extension NamespaceA.ServiceA.ClientProtocol {
           public func methodA<R>(
-              request: ClientRequest.Single<NamespaceA.ServiceA.Methods.MethodA.Input>,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Methods.MethodA.Output>) async throws -> R
+              request: ClientRequest.Single<NamespaceA.ServiceA.Method.MethodA.Input>,
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.methodA(
                   request: request,
-                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Methods.MethodA.Input>(),
-                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Methods.MethodA.Output>(),
+                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Method.MethodA.Input>(),
+                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Method.MethodA.Output>(),
                   body
               )
           }
@@ -75,14 +75,14 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           
           /// Documentation for MethodA
           public func methodA<R>(
-              request: ClientRequest.Single<NamespaceA.ServiceA.Methods.MethodA.Input>,
-              serializer: some MessageSerializer<NamespaceA.ServiceA.Methods.MethodA.Input>,
-              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Methods.MethodA.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Methods.MethodA.Output>) async throws -> R
+              request: ClientRequest.Single<NamespaceA.ServiceA.Method.MethodA.Input>,
+              serializer: some MessageSerializer<NamespaceA.ServiceA.Method.MethodA.Input>,
+              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Method.MethodA.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.client.unary(
                   request: request,
-                  descriptor: NamespaceA.ServiceA.Methods.MethodA.descriptor,
+                  descriptor: NamespaceA.ServiceA.Method.MethodA.descriptor,
                   serializer: serializer,
                   deserializer: deserializer,
                   handler: body
@@ -119,21 +119,21 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       public protocol NamespaceA_ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
-              request: ClientRequest.Stream<NamespaceA.ServiceA.Methods.MethodA.Input>,
-              serializer: some MessageSerializer<NamespaceA.ServiceA.Methods.MethodA.Input>,
-              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Methods.MethodA.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Methods.MethodA.Output>) async throws -> R
+              request: ClientRequest.Stream<NamespaceA.ServiceA.Method.MethodA.Input>,
+              serializer: some MessageSerializer<NamespaceA.ServiceA.Method.MethodA.Input>,
+              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Method.MethodA.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable
       }
       extension NamespaceA.ServiceA.ClientProtocol {
           public func methodA<R>(
-              request: ClientRequest.Stream<NamespaceA.ServiceA.Methods.MethodA.Input>,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Methods.MethodA.Output>) async throws -> R
+              request: ClientRequest.Stream<NamespaceA.ServiceA.Method.MethodA.Input>,
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.methodA(
                   request: request,
-                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Methods.MethodA.Input>(),
-                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Methods.MethodA.Output>(),
+                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Method.MethodA.Input>(),
+                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Method.MethodA.Output>(),
                   body
               )
           }
@@ -148,14 +148,14 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           
           /// Documentation for MethodA
           public func methodA<R>(
-              request: ClientRequest.Stream<NamespaceA.ServiceA.Methods.MethodA.Input>,
-              serializer: some MessageSerializer<NamespaceA.ServiceA.Methods.MethodA.Input>,
-              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Methods.MethodA.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Methods.MethodA.Output>) async throws -> R
+              request: ClientRequest.Stream<NamespaceA.ServiceA.Method.MethodA.Input>,
+              serializer: some MessageSerializer<NamespaceA.ServiceA.Method.MethodA.Input>,
+              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Method.MethodA.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.client.clientStreaming(
                   request: request,
-                  descriptor: NamespaceA.ServiceA.Methods.MethodA.descriptor,
+                  descriptor: NamespaceA.ServiceA.Method.MethodA.descriptor,
                   serializer: serializer,
                   deserializer: deserializer,
                   handler: body
@@ -192,21 +192,21 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       public protocol NamespaceA_ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
-              request: ClientRequest.Single<NamespaceA.ServiceA.Methods.MethodA.Input>,
-              serializer: some MessageSerializer<NamespaceA.ServiceA.Methods.MethodA.Input>,
-              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Methods.MethodA.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Methods.MethodA.Output>) async throws -> R
+              request: ClientRequest.Single<NamespaceA.ServiceA.Method.MethodA.Input>,
+              serializer: some MessageSerializer<NamespaceA.ServiceA.Method.MethodA.Input>,
+              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Method.MethodA.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable
       }
       extension NamespaceA.ServiceA.ClientProtocol {
           public func methodA<R>(
-              request: ClientRequest.Single<NamespaceA.ServiceA.Methods.MethodA.Input>,
-              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Methods.MethodA.Output>) async throws -> R
+              request: ClientRequest.Single<NamespaceA.ServiceA.Method.MethodA.Input>,
+              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.methodA(
                   request: request,
-                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Methods.MethodA.Input>(),
-                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Methods.MethodA.Output>(),
+                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Method.MethodA.Input>(),
+                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Method.MethodA.Output>(),
                   body
               )
           }
@@ -221,14 +221,14 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           
           /// Documentation for MethodA
           public func methodA<R>(
-              request: ClientRequest.Single<NamespaceA.ServiceA.Methods.MethodA.Input>,
-              serializer: some MessageSerializer<NamespaceA.ServiceA.Methods.MethodA.Input>,
-              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Methods.MethodA.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Methods.MethodA.Output>) async throws -> R
+              request: ClientRequest.Single<NamespaceA.ServiceA.Method.MethodA.Input>,
+              serializer: some MessageSerializer<NamespaceA.ServiceA.Method.MethodA.Input>,
+              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Method.MethodA.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.client.serverStreaming(
                   request: request,
-                  descriptor: NamespaceA.ServiceA.Methods.MethodA.descriptor,
+                  descriptor: NamespaceA.ServiceA.Method.MethodA.descriptor,
                   serializer: serializer,
                   deserializer: deserializer,
                   handler: body
@@ -265,21 +265,21 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       public protocol NamespaceA_ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
-              request: ClientRequest.Stream<NamespaceA.ServiceA.Methods.MethodA.Input>,
-              serializer: some MessageSerializer<NamespaceA.ServiceA.Methods.MethodA.Input>,
-              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Methods.MethodA.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Methods.MethodA.Output>) async throws -> R
+              request: ClientRequest.Stream<NamespaceA.ServiceA.Method.MethodA.Input>,
+              serializer: some MessageSerializer<NamespaceA.ServiceA.Method.MethodA.Input>,
+              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Method.MethodA.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable
       }
       extension NamespaceA.ServiceA.ClientProtocol {
           public func methodA<R>(
-              request: ClientRequest.Stream<NamespaceA.ServiceA.Methods.MethodA.Input>,
-              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Methods.MethodA.Output>) async throws -> R
+              request: ClientRequest.Stream<NamespaceA.ServiceA.Method.MethodA.Input>,
+              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.methodA(
                   request: request,
-                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Methods.MethodA.Input>(),
-                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Methods.MethodA.Output>(),
+                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Method.MethodA.Input>(),
+                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Method.MethodA.Output>(),
                   body
               )
           }
@@ -294,14 +294,14 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           
           /// Documentation for MethodA
           public func methodA<R>(
-              request: ClientRequest.Stream<NamespaceA.ServiceA.Methods.MethodA.Input>,
-              serializer: some MessageSerializer<NamespaceA.ServiceA.Methods.MethodA.Input>,
-              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Methods.MethodA.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Methods.MethodA.Output>) async throws -> R
+              request: ClientRequest.Stream<NamespaceA.ServiceA.Method.MethodA.Input>,
+              serializer: some MessageSerializer<NamespaceA.ServiceA.Method.MethodA.Input>,
+              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Method.MethodA.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.client.bidirectionalStreaming(
                   request: request,
-                  descriptor: NamespaceA.ServiceA.Methods.MethodA.descriptor,
+                  descriptor: NamespaceA.ServiceA.Method.MethodA.descriptor,
                   serializer: serializer,
                   deserializer: deserializer,
                   handler: body
@@ -317,7 +317,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     )
   }
 
-  func testClientCodeTranslatorMultipleMethods() throws {
+  func testClientCodeTranslatorMultipleMethod() throws {
     let methodA = MethodDescriptor(
       documentation: "/// Documentation for MethodA",
       name: Name(base: "MethodA", generatedUpperCase: "MethodA", generatedLowerCase: "methodA"),
@@ -346,41 +346,41 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       package protocol NamespaceA_ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
-              request: ClientRequest.Stream<NamespaceA.ServiceA.Methods.MethodA.Input>,
-              serializer: some MessageSerializer<NamespaceA.ServiceA.Methods.MethodA.Input>,
-              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Methods.MethodA.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Methods.MethodA.Output>) async throws -> R
+              request: ClientRequest.Stream<NamespaceA.ServiceA.Method.MethodA.Input>,
+              serializer: some MessageSerializer<NamespaceA.ServiceA.Method.MethodA.Input>,
+              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Method.MethodA.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable
           
           /// Documentation for MethodB
           func methodB<R>(
-              request: ClientRequest.Single<NamespaceA.ServiceA.Methods.MethodB.Input>,
-              serializer: some MessageSerializer<NamespaceA.ServiceA.Methods.MethodB.Input>,
-              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Methods.MethodB.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Methods.MethodB.Output>) async throws -> R
+              request: ClientRequest.Single<NamespaceA.ServiceA.Method.MethodB.Input>,
+              serializer: some MessageSerializer<NamespaceA.ServiceA.Method.MethodB.Input>,
+              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Method.MethodB.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Method.MethodB.Output>) async throws -> R
           ) async throws -> R where R: Sendable
       }
       extension NamespaceA.ServiceA.ClientProtocol {
           package func methodA<R>(
-              request: ClientRequest.Stream<NamespaceA.ServiceA.Methods.MethodA.Input>,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Methods.MethodA.Output>) async throws -> R
+              request: ClientRequest.Stream<NamespaceA.ServiceA.Method.MethodA.Input>,
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.methodA(
                   request: request,
-                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Methods.MethodA.Input>(),
-                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Methods.MethodA.Output>(),
+                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Method.MethodA.Input>(),
+                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Method.MethodA.Output>(),
                   body
               )
           }
           
           package func methodB<R>(
-              request: ClientRequest.Single<NamespaceA.ServiceA.Methods.MethodB.Input>,
-              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Methods.MethodB.Output>) async throws -> R
+              request: ClientRequest.Single<NamespaceA.ServiceA.Method.MethodB.Input>,
+              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Method.MethodB.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.methodB(
                   request: request,
-                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Methods.MethodB.Input>(),
-                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Methods.MethodB.Output>(),
+                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Method.MethodB.Input>(),
+                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Method.MethodB.Output>(),
                   body
               )
           }
@@ -395,14 +395,14 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           
           /// Documentation for MethodA
           package func methodA<R>(
-              request: ClientRequest.Stream<NamespaceA.ServiceA.Methods.MethodA.Input>,
-              serializer: some MessageSerializer<NamespaceA.ServiceA.Methods.MethodA.Input>,
-              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Methods.MethodA.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Methods.MethodA.Output>) async throws -> R
+              request: ClientRequest.Stream<NamespaceA.ServiceA.Method.MethodA.Input>,
+              serializer: some MessageSerializer<NamespaceA.ServiceA.Method.MethodA.Input>,
+              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Method.MethodA.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.client.clientStreaming(
                   request: request,
-                  descriptor: NamespaceA.ServiceA.Methods.MethodA.descriptor,
+                  descriptor: NamespaceA.ServiceA.Method.MethodA.descriptor,
                   serializer: serializer,
                   deserializer: deserializer,
                   handler: body
@@ -411,14 +411,14 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           
           /// Documentation for MethodB
           package func methodB<R>(
-              request: ClientRequest.Single<NamespaceA.ServiceA.Methods.MethodB.Input>,
-              serializer: some MessageSerializer<NamespaceA.ServiceA.Methods.MethodB.Input>,
-              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Methods.MethodB.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Methods.MethodB.Output>) async throws -> R
+              request: ClientRequest.Single<NamespaceA.ServiceA.Method.MethodB.Input>,
+              serializer: some MessageSerializer<NamespaceA.ServiceA.Method.MethodB.Input>,
+              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Method.MethodB.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Method.MethodB.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.client.serverStreaming(
                   request: request,
-                  descriptor: NamespaceA.ServiceA.Methods.MethodB.descriptor,
+                  descriptor: NamespaceA.ServiceA.Method.MethodB.descriptor,
                   serializer: serializer,
                   deserializer: deserializer,
                   handler: body
@@ -455,21 +455,21 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       internal protocol ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
-              request: ClientRequest.Single<ServiceA.Methods.MethodA.Input>,
-              serializer: some MessageSerializer<ServiceA.Methods.MethodA.Input>,
-              deserializer: some MessageDeserializer<ServiceA.Methods.MethodA.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Single<ServiceA.Methods.MethodA.Output>) async throws -> R
+              request: ClientRequest.Single<ServiceA.Method.MethodA.Input>,
+              serializer: some MessageSerializer<ServiceA.Method.MethodA.Input>,
+              deserializer: some MessageDeserializer<ServiceA.Method.MethodA.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Single<ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable
       }
       extension ServiceA.ClientProtocol {
           internal func methodA<R>(
-              request: ClientRequest.Single<ServiceA.Methods.MethodA.Input>,
-              _ body: @Sendable @escaping (ClientResponse.Single<ServiceA.Methods.MethodA.Output>) async throws -> R
+              request: ClientRequest.Single<ServiceA.Method.MethodA.Input>,
+              _ body: @Sendable @escaping (ClientResponse.Single<ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.methodA(
                   request: request,
-                  serializer: ProtobufSerializer<ServiceA.Methods.MethodA.Input>(),
-                  deserializer: ProtobufDeserializer<ServiceA.Methods.MethodA.Output>(),
+                  serializer: ProtobufSerializer<ServiceA.Method.MethodA.Input>(),
+                  deserializer: ProtobufDeserializer<ServiceA.Method.MethodA.Output>(),
                   body
               )
           }
@@ -484,14 +484,14 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           
           /// Documentation for MethodA
           internal func methodA<R>(
-              request: ClientRequest.Single<ServiceA.Methods.MethodA.Input>,
-              serializer: some MessageSerializer<ServiceA.Methods.MethodA.Input>,
-              deserializer: some MessageDeserializer<ServiceA.Methods.MethodA.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Single<ServiceA.Methods.MethodA.Output>) async throws -> R
+              request: ClientRequest.Single<ServiceA.Method.MethodA.Input>,
+              serializer: some MessageSerializer<ServiceA.Method.MethodA.Input>,
+              deserializer: some MessageDeserializer<ServiceA.Method.MethodA.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Single<ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.client.unary(
                   request: request,
-                  descriptor: ServiceA.Methods.MethodA.descriptor,
+                  descriptor: ServiceA.Method.MethodA.descriptor,
                   serializer: serializer,
                   deserializer: deserializer,
                   handler: body

--- a/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
@@ -175,7 +175,7 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
               public enum Method {
                   public static let descriptors: [MethodDescriptor] = []
               }
-              public typealias StreamingServiceProtocol = NamespaceA_ServiceAServiceStreamingProtocol
+              public typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
               public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
           }
       }

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
@@ -53,15 +53,15 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       /// Documentation for ServiceA
       public protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for unaryMethod
-          func unary(request: ServerRequest.Stream<NamespaceA.ServiceA.Methods.Unary.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Methods.Unary.Output>
+          func unary(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.Unary.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.Unary.Output>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       extension NamespaceA.ServiceA.StreamingServiceProtocol {
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
-                  for: NamespaceA.ServiceA.Methods.Unary.descriptor,
-                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Methods.Unary.Input>(),
-                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Methods.Unary.Output>(),
+                  forMethod: NamespaceA.ServiceA.Method.Unary.descriptor,
+                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Method.Unary.Input>(),
+                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Method.Unary.Output>(),
                   handler: { request in
                       try await self.unary(request: request)
                   }
@@ -71,11 +71,11 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       /// Documentation for ServiceA
       public protocol NamespaceA_ServiceAServiceProtocol: NamespaceA.ServiceA.StreamingServiceProtocol {
           /// Documentation for unaryMethod
-          func unary(request: ServerRequest.Single<NamespaceA.ServiceA.Methods.Unary.Input>) async throws -> ServerResponse.Single<NamespaceA.ServiceA.Methods.Unary.Output>
+          func unary(request: ServerRequest.Single<NamespaceA.ServiceA.Method.Unary.Input>) async throws -> ServerResponse.Single<NamespaceA.ServiceA.Method.Unary.Output>
       }
       /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
       extension NamespaceA.ServiceA.ServiceProtocol {
-          public func unary(request: ServerRequest.Stream<NamespaceA.ServiceA.Methods.Unary.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Methods.Unary.Output> {
+          public func unary(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.Unary.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.Unary.Output> {
               let response = try await self.unary(request: ServerRequest.Single(stream: request))
               return ServerResponse.Stream(single: response)
           }
@@ -117,15 +117,15 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       /// Documentation for ServiceA
       package protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for inputStreamingMethod
-          func inputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Methods.InputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Methods.InputStreaming.Output>
+          func inputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.InputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.InputStreaming.Output>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       extension NamespaceA.ServiceA.StreamingServiceProtocol {
           package func registerMethods(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
-                  for: NamespaceA.ServiceA.Methods.InputStreaming.descriptor,
-                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Methods.InputStreaming.Input>(),
-                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Methods.InputStreaming.Output>(),
+                  forMethod: NamespaceA.ServiceA.Method.InputStreaming.descriptor,
+                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Method.InputStreaming.Input>(),
+                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Method.InputStreaming.Output>(),
                   handler: { request in
                       try await self.inputStreaming(request: request)
                   }
@@ -135,11 +135,11 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       /// Documentation for ServiceA
       package protocol NamespaceA_ServiceAServiceProtocol: NamespaceA.ServiceA.StreamingServiceProtocol {
           /// Documentation for inputStreamingMethod
-          func inputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Methods.InputStreaming.Input>) async throws -> ServerResponse.Single<NamespaceA.ServiceA.Methods.InputStreaming.Output>
+          func inputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.InputStreaming.Input>) async throws -> ServerResponse.Single<NamespaceA.ServiceA.Method.InputStreaming.Output>
       }
       /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
       extension NamespaceA.ServiceA.ServiceProtocol {
-          package func inputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Methods.InputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Methods.InputStreaming.Output> {
+          package func inputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.InputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.InputStreaming.Output> {
               let response = try await self.inputStreaming(request: request)
               return ServerResponse.Stream(single: response)
           }
@@ -185,15 +185,15 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       /// Documentation for ServiceA
       public protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for outputStreamingMethod
-          func outputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Methods.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Methods.OutputStreaming.Output>
+          func outputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.OutputStreaming.Output>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       extension NamespaceA.ServiceA.StreamingServiceProtocol {
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
-                  for: NamespaceA.ServiceA.Methods.OutputStreaming.descriptor,
-                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Methods.OutputStreaming.Input>(),
-                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Methods.OutputStreaming.Output>(),
+                  forMethod: NamespaceA.ServiceA.Method.OutputStreaming.descriptor,
+                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Method.OutputStreaming.Input>(),
+                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Method.OutputStreaming.Output>(),
                   handler: { request in
                       try await self.outputStreaming(request: request)
                   }
@@ -203,11 +203,11 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       /// Documentation for ServiceA
       public protocol NamespaceA_ServiceAServiceProtocol: NamespaceA.ServiceA.StreamingServiceProtocol {
           /// Documentation for outputStreamingMethod
-          func outputStreaming(request: ServerRequest.Single<NamespaceA.ServiceA.Methods.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Methods.OutputStreaming.Output>
+          func outputStreaming(request: ServerRequest.Single<NamespaceA.ServiceA.Method.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.OutputStreaming.Output>
       }
       /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
       extension NamespaceA.ServiceA.ServiceProtocol {
-          public func outputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Methods.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Methods.OutputStreaming.Output> {
+          public func outputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.OutputStreaming.Output> {
               let response = try await self.outputStreaming(request: ServerRequest.Single(stream: request))
               return response
           }
@@ -253,15 +253,15 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       /// Documentation for ServiceA
       package protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for bidirectionalStreamingMethod
-          func bidirectionalStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Methods.BidirectionalStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Methods.BidirectionalStreaming.Output>
+          func bidirectionalStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.BidirectionalStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.BidirectionalStreaming.Output>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       extension NamespaceA.ServiceA.StreamingServiceProtocol {
           package func registerMethods(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
-                  for: NamespaceA.ServiceA.Methods.BidirectionalStreaming.descriptor,
-                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Methods.BidirectionalStreaming.Input>(),
-                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Methods.BidirectionalStreaming.Output>(),
+                  forMethod: NamespaceA.ServiceA.Method.BidirectionalStreaming.descriptor,
+                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Method.BidirectionalStreaming.Input>(),
+                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Method.BidirectionalStreaming.Output>(),
                   handler: { request in
                       try await self.bidirectionalStreaming(request: request)
                   }
@@ -271,7 +271,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       /// Documentation for ServiceA
       package protocol NamespaceA_ServiceAServiceProtocol: NamespaceA.ServiceA.StreamingServiceProtocol {
           /// Documentation for bidirectionalStreamingMethod
-          func bidirectionalStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Methods.BidirectionalStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Methods.BidirectionalStreaming.Output>
+          func bidirectionalStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.BidirectionalStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.BidirectionalStreaming.Output>
       }
       /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
       extension NamespaceA.ServiceA.ServiceProtocol {
@@ -329,26 +329,26 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       /// Documentation for ServiceA
       internal protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for inputStreamingMethod
-          func inputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Methods.InputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Methods.InputStreaming.Output>
+          func inputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.InputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.InputStreaming.Output>
           
           /// Documentation for outputStreamingMethod
-          func outputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Methods.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Methods.OutputStreaming.Output>
+          func outputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.OutputStreaming.Output>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       extension NamespaceA.ServiceA.StreamingServiceProtocol {
           internal func registerMethods(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
-                  for: NamespaceA.ServiceA.Methods.InputStreaming.descriptor,
-                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Methods.InputStreaming.Input>(),
-                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Methods.InputStreaming.Output>(),
+                  forMethod: NamespaceA.ServiceA.Method.InputStreaming.descriptor,
+                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Method.InputStreaming.Input>(),
+                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Method.InputStreaming.Output>(),
                   handler: { request in
                       try await self.inputStreaming(request: request)
                   }
               )
               router.registerHandler(
-                  for: NamespaceA.ServiceA.Methods.OutputStreaming.descriptor,
-                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Methods.OutputStreaming.Input>(),
-                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Methods.OutputStreaming.Output>(),
+                  forMethod: NamespaceA.ServiceA.Method.OutputStreaming.descriptor,
+                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Method.OutputStreaming.Input>(),
+                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Method.OutputStreaming.Output>(),
                   handler: { request in
                       try await self.outputStreaming(request: request)
                   }
@@ -358,19 +358,19 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       /// Documentation for ServiceA
       internal protocol NamespaceA_ServiceAServiceProtocol: NamespaceA.ServiceA.StreamingServiceProtocol {
           /// Documentation for inputStreamingMethod
-          func inputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Methods.InputStreaming.Input>) async throws -> ServerResponse.Single<NamespaceA.ServiceA.Methods.InputStreaming.Output>
+          func inputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.InputStreaming.Input>) async throws -> ServerResponse.Single<NamespaceA.ServiceA.Method.InputStreaming.Output>
           
           /// Documentation for outputStreamingMethod
-          func outputStreaming(request: ServerRequest.Single<NamespaceA.ServiceA.Methods.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Methods.OutputStreaming.Output>
+          func outputStreaming(request: ServerRequest.Single<NamespaceA.ServiceA.Method.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.OutputStreaming.Output>
       }
       /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
       extension NamespaceA.ServiceA.ServiceProtocol {
-          internal func inputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Methods.InputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Methods.InputStreaming.Output> {
+          internal func inputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.InputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.InputStreaming.Output> {
               let response = try await self.inputStreaming(request: request)
               return ServerResponse.Stream(single: response)
           }
           
-          internal func outputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Methods.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Methods.OutputStreaming.Output> {
+          internal func outputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.OutputStreaming.Output> {
               let response = try await self.outputStreaming(request: ServerRequest.Single(stream: request))
               return response
           }
@@ -408,15 +408,15 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       /// Documentation for ServiceA
       internal protocol ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for MethodA
-          func methodA(request: ServerRequest.Stream<ServiceA.Methods.MethodA.Input>) async throws -> ServerResponse.Stream<ServiceA.Methods.MethodA.Output>
+          func methodA(request: ServerRequest.Stream<ServiceA.Method.MethodA.Input>) async throws -> ServerResponse.Stream<ServiceA.Method.MethodA.Output>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       extension ServiceA.StreamingServiceProtocol {
           internal func registerMethods(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
-                  for: ServiceA.Methods.MethodA.descriptor,
-                  deserializer: ProtobufDeserializer<ServiceA.Methods.MethodA.Input>(),
-                  serializer: ProtobufSerializer<ServiceA.Methods.MethodA.Output>(),
+                  forMethod: ServiceA.Method.MethodA.descriptor,
+                  deserializer: ProtobufDeserializer<ServiceA.Method.MethodA.Input>(),
+                  serializer: ProtobufSerializer<ServiceA.Method.MethodA.Output>(),
                   handler: { request in
                       try await self.methodA(request: request)
                   }
@@ -426,11 +426,11 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       /// Documentation for ServiceA
       internal protocol ServiceAServiceProtocol: ServiceA.StreamingServiceProtocol {
           /// Documentation for MethodA
-          func methodA(request: ServerRequest.Single<ServiceA.Methods.MethodA.Input>) async throws -> ServerResponse.Single<ServiceA.Methods.MethodA.Output>
+          func methodA(request: ServerRequest.Single<ServiceA.Method.MethodA.Input>) async throws -> ServerResponse.Single<ServiceA.Method.MethodA.Output>
       }
       /// Partial conformance to `ServiceAStreamingServiceProtocol`.
       extension ServiceA.ServiceProtocol {
-          internal func methodA(request: ServerRequest.Stream<ServiceA.Methods.MethodA.Input>) async throws -> ServerResponse.Stream<ServiceA.Methods.MethodA.Output> {
+          internal func methodA(request: ServerRequest.Stream<ServiceA.Method.MethodA.Input>) async throws -> ServerResponse.Stream<ServiceA.Method.MethodA.Output> {
               let response = try await self.methodA(request: ServerRequest.Single(stream: request))
               return ServerResponse.Stream(single: response)
           }

--- a/Tests/GRPCCodeGenTests/Internal/Translator/TypealiasTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/TypealiasTranslatorSnippetBasedTests.swift
@@ -58,10 +58,10 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
                       )
                   }
                   public static let descriptors: [MethodDescriptor] = [
-                      Methods.MethodA.descriptor
+                      NamespaceA.ServiceA.Method.MethodA.descriptor
                   ]
               }
-              public typealias StreamingServiceProtocol = NamespaceA_ServiceAServiceStreamingProtocol
+              public typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
               public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
               public typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
               public typealias Client = NamespaceA_ServiceAClient
@@ -96,7 +96,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               public enum Method {
                   public static let descriptors: [MethodDescriptor] = []
               }
-              public typealias StreamingServiceProtocol = NamespaceA_ServiceAServiceStreamingProtocol
+              public typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
               public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
               public typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
               public typealias Client = NamespaceA_ServiceAClient
@@ -131,7 +131,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               public enum Method {
                   public static let descriptors: [MethodDescriptor] = []
               }
-              public typealias StreamingServiceProtocol = NamespaceA_ServiceAServiceStreamingProtocol
+              public typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
               public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
           }
       }
@@ -238,10 +238,10 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
                   )
               }
               public static let descriptors: [MethodDescriptor] = [
-                  Methods.MethodA.descriptor
+                  ServiceA.Method.MethodA.descriptor
               ]
           }
-          public typealias StreamingServiceProtocol = ServiceAServiceStreamingProtocol
+          public typealias StreamingServiceProtocol = ServiceAStreamingServiceProtocol
           public typealias ServiceProtocol = ServiceAServiceProtocol
           public typealias ClientProtocol = ServiceAClientProtocol
           public typealias Client = ServiceAClient
@@ -306,11 +306,11 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
                       )
                   }
                   public static let descriptors: [MethodDescriptor] = [
-                      Methods.MethodA.descriptor,
-                      Methods.MethodB.descriptor
+                      NamespaceA.ServiceA.Method.MethodA.descriptor,
+                      NamespaceA.ServiceA.Method.MethodB.descriptor
                   ]
               }
-              public typealias StreamingServiceProtocol = NamespaceA_ServiceAServiceStreamingProtocol
+              public typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
               public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
               public typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
               public typealias Client = NamespaceA_ServiceAClient
@@ -345,7 +345,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               package enum Method {
                   package static let descriptors: [MethodDescriptor] = []
               }
-              package typealias StreamingServiceProtocol = NamespaceA_ServiceAServiceStreamingProtocol
+              package typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
               package typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
               package typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
               package typealias Client = NamespaceA_ServiceAClient
@@ -392,7 +392,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               public enum Method {
                   public static let descriptors: [MethodDescriptor] = []
               }
-              public typealias StreamingServiceProtocol = NamespaceA_AserviceServiceStreamingProtocol
+              public typealias StreamingServiceProtocol = NamespaceA_AserviceStreamingServiceProtocol
               public typealias ServiceProtocol = NamespaceA_AserviceServiceProtocol
               public typealias ClientProtocol = NamespaceA_AserviceClientProtocol
               public typealias Client = NamespaceA_AserviceClient
@@ -401,7 +401,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               public enum Method {
                   public static let descriptors: [MethodDescriptor] = []
               }
-              public typealias StreamingServiceProtocol = NamespaceA_BserviceServiceStreamingProtocol
+              public typealias StreamingServiceProtocol = NamespaceA_BserviceStreamingServiceProtocol
               public typealias ServiceProtocol = NamespaceA_BserviceServiceProtocol
               public typealias ClientProtocol = NamespaceA_BserviceClientProtocol
               public typealias Client = NamespaceA_BserviceClient
@@ -439,7 +439,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           package enum Method {
               package static let descriptors: [MethodDescriptor] = []
           }
-          package typealias StreamingServiceProtocol = AServiceServiceStreamingProtocol
+          package typealias StreamingServiceProtocol = AServiceStreamingServiceProtocol
           package typealias ServiceProtocol = AServiceServiceProtocol
           package typealias ClientProtocol = AServiceClientProtocol
           package typealias Client = AServiceClient
@@ -448,7 +448,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           package enum Method {
               package static let descriptors: [MethodDescriptor] = []
           }
-          package typealias StreamingServiceProtocol = BServiceServiceStreamingProtocol
+          package typealias StreamingServiceProtocol = BServiceStreamingServiceProtocol
           package typealias ServiceProtocol = BServiceServiceProtocol
           package typealias ClientProtocol = BServiceClientProtocol
           package typealias Client = BServiceClient
@@ -494,7 +494,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               internal enum Method {
                   internal static let descriptors: [MethodDescriptor] = []
               }
-              internal typealias StreamingServiceProtocol = Anamespace_AServiceServiceStreamingProtocol
+              internal typealias StreamingServiceProtocol = Anamespace_AServiceStreamingServiceProtocol
               internal typealias ServiceProtocol = Anamespace_AServiceServiceProtocol
               internal typealias ClientProtocol = Anamespace_AServiceClientProtocol
               internal typealias Client = Anamespace_AServiceClient
@@ -505,7 +505,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               internal enum Method {
                   internal static let descriptors: [MethodDescriptor] = []
               }
-              internal typealias StreamingServiceProtocol = Bnamespace_BServiceServiceStreamingProtocol
+              internal typealias StreamingServiceProtocol = Bnamespace_BServiceStreamingServiceProtocol
               internal typealias ServiceProtocol = Bnamespace_BServiceServiceProtocol
               internal typealias ClientProtocol = Bnamespace_BServiceClientProtocol
               internal typealias Client = Bnamespace_BServiceClient
@@ -545,7 +545,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public enum Method {
               public static let descriptors: [MethodDescriptor] = []
           }
-          public typealias StreamingServiceProtocol = BServiceServiceStreamingProtocol
+          public typealias StreamingServiceProtocol = BServiceStreamingServiceProtocol
           public typealias ServiceProtocol = BServiceServiceProtocol
           public typealias ClientProtocol = BServiceClientProtocol
           public typealias Client = BServiceClient
@@ -555,7 +555,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               public enum Method {
                   public static let descriptors: [MethodDescriptor] = []
               }
-              public typealias StreamingServiceProtocol = Anamespace_AServiceServiceStreamingProtocol
+              public typealias StreamingServiceProtocol = Anamespace_AServiceStreamingServiceProtocol
               public typealias ServiceProtocol = Anamespace_AServiceServiceProtocol
               public typealias ClientProtocol = Anamespace_AServiceClientProtocol
               public typealias Client = Anamespace_AServiceClient

--- a/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGeneratorTests.swift
+++ b/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGeneratorTests.swift
@@ -68,7 +68,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
                         )
                     }
                     internal static let descriptors: [MethodDescriptor] = [
-                        Methods.SayHello.descriptor
+                        Helloworld.Greeter.Method.SayHello.descriptor
                     ]
                 }
                 internal typealias ClientProtocol = Helloworld_GreeterClientProtocol
@@ -80,22 +80,22 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         internal protocol Helloworld_GreeterClientProtocol: Sendable {
             /// Sends a greeting.
             func sayHello<R>(
-                request: ClientRequest.Single<Helloworld.Greeter.Methods.SayHello.Input>,
-                serializer: some MessageSerializer<Helloworld.Greeter.Methods.SayHello.Input>,
-                deserializer: some MessageDeserializer<Helloworld.Greeter.Methods.SayHello.Output>,
-                _ body: @Sendable @escaping (ClientResponse.Single<Helloworld.Greeter.Methods.SayHello.Output>) async throws -> R
+                request: ClientRequest.Single<Helloworld.Greeter.Method.SayHello.Input>,
+                serializer: some MessageSerializer<Helloworld.Greeter.Method.SayHello.Input>,
+                deserializer: some MessageDeserializer<Helloworld.Greeter.Method.SayHello.Output>,
+                _ body: @Sendable @escaping (ClientResponse.Single<Helloworld.Greeter.Method.SayHello.Output>) async throws -> R
             ) async throws -> R where R: Sendable
         }
 
         extension Helloworld.Greeter.ClientProtocol {
             internal func sayHello<R>(
-                request: ClientRequest.Single<Helloworld.Greeter.Methods.SayHello.Input>,
-                _ body: @Sendable @escaping (ClientResponse.Single<Helloworld.Greeter.Methods.SayHello.Output>) async throws -> R
+                request: ClientRequest.Single<Helloworld.Greeter.Method.SayHello.Input>,
+                _ body: @Sendable @escaping (ClientResponse.Single<Helloworld.Greeter.Method.SayHello.Output>) async throws -> R
             ) async throws -> R where R: Sendable {
                 try await self.sayHello(
                     request: request,
-                    serializer: ProtobufSerializer<Helloworld.Greeter.Methods.SayHello.Input>(),
-                    deserializer: ProtobufDeserializer<Helloworld.Greeter.Methods.SayHello.Output>(),
+                    serializer: ProtobufSerializer<Helloworld.Greeter.Method.SayHello.Input>(),
+                    deserializer: ProtobufDeserializer<Helloworld.Greeter.Method.SayHello.Output>(),
                     body
                 )
             }
@@ -111,14 +111,14 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
             
             /// Sends a greeting.
             internal func sayHello<R>(
-                request: ClientRequest.Single<Helloworld.Greeter.Methods.SayHello.Input>,
-                serializer: some MessageSerializer<Helloworld.Greeter.Methods.SayHello.Input>,
-                deserializer: some MessageDeserializer<Helloworld.Greeter.Methods.SayHello.Output>,
-                _ body: @Sendable @escaping (ClientResponse.Single<Helloworld.Greeter.Methods.SayHello.Output>) async throws -> R
+                request: ClientRequest.Single<Helloworld.Greeter.Method.SayHello.Input>,
+                serializer: some MessageSerializer<Helloworld.Greeter.Method.SayHello.Input>,
+                deserializer: some MessageDeserializer<Helloworld.Greeter.Method.SayHello.Output>,
+                _ body: @Sendable @escaping (ClientResponse.Single<Helloworld.Greeter.Method.SayHello.Output>) async throws -> R
             ) async throws -> R where R: Sendable {
                 try await self.client.unary(
                     request: request,
-                    descriptor: Helloworld.Greeter.Methods.SayHello.descriptor,
+                    descriptor: Helloworld.Greeter.Method.SayHello.descriptor,
                     serializer: serializer,
                     deserializer: deserializer,
                     handler: body
@@ -172,10 +172,10 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
                 )
               }
               public static let descriptors: [MethodDescriptor] = [
-                Methods.SayHello.descriptor
+                Helloworld.Greeter.Method.SayHello.descriptor
               ]
             }
-            public typealias StreamingServiceProtocol = Helloworld_GreeterServiceStreamingProtocol
+            public typealias StreamingServiceProtocol = Helloworld_GreeterStreamingServiceProtocol
             public typealias ServiceProtocol = Helloworld_GreeterServiceProtocol
           }
         }
@@ -183,16 +183,16 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         /// The greeting service definition.
         public protocol Helloworld_GreeterStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Sends a greeting.
-          func sayHello(request: ServerRequest.Stream<Helloworld.Greeter.Methods.SayHello.Input>) async throws -> ServerResponse.Stream<Helloworld.Greeter.Methods.SayHello.Output>
+          func sayHello(request: ServerRequest.Stream<Helloworld.Greeter.Method.SayHello.Input>) async throws -> ServerResponse.Stream<Helloworld.Greeter.Method.SayHello.Output>
         }
 
         /// Conformance to `GRPCCore.RegistrableRPCService`.
         extension Helloworld.Greeter.StreamingServiceProtocol {
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {
             router.registerHandler(
-              for: Helloworld.Greeter.Methods.SayHello.descriptor,
-              deserializer: ProtobufDeserializer<Helloworld.Greeter.Methods.SayHello.Input>(),
-              serializer: ProtobufSerializer<Helloworld.Greeter.Methods.SayHello.Output>(),
+              forMethod: Helloworld.Greeter.Method.SayHello.descriptor,
+              deserializer: ProtobufDeserializer<Helloworld.Greeter.Method.SayHello.Input>(),
+              serializer: ProtobufSerializer<Helloworld.Greeter.Method.SayHello.Output>(),
               handler: { request in
                 try await self.sayHello(request: request)
               }
@@ -203,12 +203,12 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         /// The greeting service definition.
         public protocol Helloworld_GreeterServiceProtocol: Helloworld.Greeter.StreamingServiceProtocol {
           /// Sends a greeting.
-          func sayHello(request: ServerRequest.Single<Helloworld.Greeter.Methods.SayHello.Input>) async throws -> ServerResponse.Single<Helloworld.Greeter.Methods.SayHello.Output>
+          func sayHello(request: ServerRequest.Single<Helloworld.Greeter.Method.SayHello.Input>) async throws -> ServerResponse.Single<Helloworld.Greeter.Method.SayHello.Output>
         }
 
         /// Partial conformance to `Helloworld_GreeterStreamingServiceProtocol`.
         extension Helloworld.Greeter.ServiceProtocol {
-          public func sayHello(request: ServerRequest.Stream<Helloworld.Greeter.Methods.SayHello.Input>) async throws -> ServerResponse.Stream<Helloworld.Greeter.Methods.SayHello.Output> {
+          public func sayHello(request: ServerRequest.Stream<Helloworld.Greeter.Method.SayHello.Input>) async throws -> ServerResponse.Stream<Helloworld.Greeter.Method.SayHello.Output> {
             let response = try await self.sayHello(request: ServerRequest.Single(stream: request))
             return ServerResponse.Stream(single: response)
           }
@@ -259,10 +259,10 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
                 )
               }
               package static let descriptors: [MethodDescriptor] = [
-                Methods.SayHello.descriptor
+                Helloworld.Greeter.Method.SayHello.descriptor
               ]
             }
-            package typealias StreamingServiceProtocol = Helloworld_GreeterServiceStreamingProtocol
+            package typealias StreamingServiceProtocol = Helloworld_GreeterStreamingServiceProtocol
             package typealias ServiceProtocol = Helloworld_GreeterServiceProtocol
             package typealias ClientProtocol = Helloworld_GreeterClientProtocol
             package typealias Client = Helloworld_GreeterClient
@@ -272,16 +272,16 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         /// The greeting service definition.
         package protocol Helloworld_GreeterStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Sends a greeting.
-          func sayHello(request: ServerRequest.Stream<Helloworld.Greeter.Methods.SayHello.Input>) async throws -> ServerResponse.Stream<Helloworld.Greeter.Methods.SayHello.Output>
+          func sayHello(request: ServerRequest.Stream<Helloworld.Greeter.Method.SayHello.Input>) async throws -> ServerResponse.Stream<Helloworld.Greeter.Method.SayHello.Output>
         }
 
         /// Conformance to `GRPCCore.RegistrableRPCService`.
         extension Helloworld.Greeter.StreamingServiceProtocol {
           package func registerMethods(with router: inout GRPCCore.RPCRouter) {
             router.registerHandler(
-              for: Helloworld.Greeter.Methods.SayHello.descriptor,
-              deserializer: ProtobufDeserializer<Helloworld.Greeter.Methods.SayHello.Input>(),
-              serializer: ProtobufSerializer<Helloworld.Greeter.Methods.SayHello.Output>(),
+              forMethod: Helloworld.Greeter.Method.SayHello.descriptor,
+              deserializer: ProtobufDeserializer<Helloworld.Greeter.Method.SayHello.Input>(),
+              serializer: ProtobufSerializer<Helloworld.Greeter.Method.SayHello.Output>(),
               handler: { request in
                 try await self.sayHello(request: request)
               }
@@ -292,12 +292,12 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         /// The greeting service definition.
         package protocol Helloworld_GreeterServiceProtocol: Helloworld.Greeter.StreamingServiceProtocol {
           /// Sends a greeting.
-          func sayHello(request: ServerRequest.Single<Helloworld.Greeter.Methods.SayHello.Input>) async throws -> ServerResponse.Single<Helloworld.Greeter.Methods.SayHello.Output>
+          func sayHello(request: ServerRequest.Single<Helloworld.Greeter.Method.SayHello.Input>) async throws -> ServerResponse.Single<Helloworld.Greeter.Method.SayHello.Output>
         }
 
         /// Partial conformance to `Helloworld_GreeterStreamingServiceProtocol`.
         extension Helloworld.Greeter.ServiceProtocol {
-          package func sayHello(request: ServerRequest.Stream<Helloworld.Greeter.Methods.SayHello.Input>) async throws -> ServerResponse.Stream<Helloworld.Greeter.Methods.SayHello.Output> {
+          package func sayHello(request: ServerRequest.Stream<Helloworld.Greeter.Method.SayHello.Input>) async throws -> ServerResponse.Stream<Helloworld.Greeter.Method.SayHello.Output> {
             let response = try await self.sayHello(request: ServerRequest.Single(stream: request))
             return ServerResponse.Stream(single: response)
           }
@@ -307,22 +307,22 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         package protocol Helloworld_GreeterClientProtocol: Sendable {
           /// Sends a greeting.
           func sayHello<R>(
-            request: ClientRequest.Single<Helloworld.Greeter.Methods.SayHello.Input>,
-            serializer: some MessageSerializer<Helloworld.Greeter.Methods.SayHello.Input>,
-            deserializer: some MessageDeserializer<Helloworld.Greeter.Methods.SayHello.Output>,
-            _ body: @Sendable @escaping (ClientResponse.Single<Helloworld.Greeter.Methods.SayHello.Output>) async throws -> R
+            request: ClientRequest.Single<Helloworld.Greeter.Method.SayHello.Input>,
+            serializer: some MessageSerializer<Helloworld.Greeter.Method.SayHello.Input>,
+            deserializer: some MessageDeserializer<Helloworld.Greeter.Method.SayHello.Output>,
+            _ body: @Sendable @escaping (ClientResponse.Single<Helloworld.Greeter.Method.SayHello.Output>) async throws -> R
           ) async throws -> R where R: Sendable
         }
 
         extension Helloworld.Greeter.ClientProtocol {
           package func sayHello<R>(
-            request: ClientRequest.Single<Helloworld.Greeter.Methods.SayHello.Input>,
-            _ body: @Sendable @escaping (ClientResponse.Single<Helloworld.Greeter.Methods.SayHello.Output>) async throws -> R
+            request: ClientRequest.Single<Helloworld.Greeter.Method.SayHello.Input>,
+            _ body: @Sendable @escaping (ClientResponse.Single<Helloworld.Greeter.Method.SayHello.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
             try await self.sayHello(
               request: request,
-              serializer: ProtobufSerializer<Helloworld.Greeter.Methods.SayHello.Input>(),
-              deserializer: ProtobufDeserializer<Helloworld.Greeter.Methods.SayHello.Output>(),
+              serializer: ProtobufSerializer<Helloworld.Greeter.Method.SayHello.Input>(),
+              deserializer: ProtobufDeserializer<Helloworld.Greeter.Method.SayHello.Output>(),
               body
             )
           }
@@ -338,14 +338,14 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
           
           /// Sends a greeting.
           package func sayHello<R>(
-            request: ClientRequest.Single<Helloworld.Greeter.Methods.SayHello.Input>,
-            serializer: some MessageSerializer<Helloworld.Greeter.Methods.SayHello.Input>,
-            deserializer: some MessageDeserializer<Helloworld.Greeter.Methods.SayHello.Output>,
-            _ body: @Sendable @escaping (ClientResponse.Single<Helloworld.Greeter.Methods.SayHello.Output>) async throws -> R
+            request: ClientRequest.Single<Helloworld.Greeter.Method.SayHello.Input>,
+            serializer: some MessageSerializer<Helloworld.Greeter.Method.SayHello.Input>,
+            deserializer: some MessageDeserializer<Helloworld.Greeter.Method.SayHello.Output>,
+            _ body: @Sendable @escaping (ClientResponse.Single<Helloworld.Greeter.Method.SayHello.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
             try await self.client.unary(
               request: request,
-              descriptor: Helloworld.Greeter.Methods.SayHello.descriptor,
+              descriptor: Helloworld.Greeter.Method.SayHello.descriptor,
               serializer: serializer,
               deserializer: deserializer,
               handler: body


### PR DESCRIPTION
Motivation:

- the protocol name for the streaming service used in the typealias does not match the actual streaming service protocol name
- we have already replaced the Methods enum name with "Method" so this change has to be reflected in all places where properties of the enum are used
- the first argument label of the registerHandler() method is "forMethod" and not "for"

Modifications:

Modified all the translators that handle these methods or names and their tests.

Result:

The generated code will be compiled.