### PR TITLE
Generated code fixtures: availability guards and descriptor paths

### DIFF
--- a/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
@@ -22,6 +22,7 @@
 /// a representation for the following generated code:
 ///
 /// ```swift
+/// @available(macOS 13.0, *)
 /// public protocol Foo_BarClientProtocol: Sendable {
 ///   func baz<R: Sendable>(
 ///     request: ClientRequest.Single<foo.Bar.Method.baz.Input>,
@@ -30,6 +31,7 @@
 ///     _ body: @Sendable @escaping (ClientResponse.Single<foo.Bar.Method.Baz.Output>) async throws -> R
 ///   ) async throws -> ServerResponse.Stream<foo.Bar.Method.Baz.Output>
 /// }
+/// @available(macOS 13.0, *)
 /// extension Foo.Bar.ClientProtocol {
 ///   public func get<R: Sendable>(
 ///     request: ClientRequest.Single<Foo.Bar.Method.Baz.Input>,
@@ -42,6 +44,7 @@
 ///       body
 ///     )
 /// }
+/// @available(macOS 13.0, *)
 /// public struct foo_BarClient: foo.Bar.ClientProtocol {
 ///   private let client: GRPCCore.GRPCClient
 ///   public init(client: GRPCCore.GRPCClient) {
@@ -120,7 +123,7 @@ extension ClientCodeTranslator {
         members: methods
       )
     )
-    return clientProtocol
+    return .guarded(.init(osVersions: [.init(os: .macOS, version: "13.0")]), clientProtocol)
   }
 
   private func makeExtensionProtocol(
@@ -142,7 +145,10 @@ extension ClientCodeTranslator {
         declarations: methods
       )
     )
-    return clientProtocolExtension
+    return .guarded(
+      .init(osVersions: [.init(os: .macOS, version: "13.0")]),
+      clientProtocolExtension
+    )
   }
 
   private func makeClientProtocolMethod(

--- a/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
@@ -22,7 +22,7 @@
 /// a representation for the following generated code:
 ///
 /// ```swift
-/// @available(macOS 13.0, *)
+/// @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 /// public protocol Foo_BarClientProtocol: Sendable {
 ///   func baz<R: Sendable>(
 ///     request: ClientRequest.Single<foo.Bar.Method.baz.Input>,
@@ -31,7 +31,7 @@
 ///     _ body: @Sendable @escaping (ClientResponse.Single<foo.Bar.Method.Baz.Output>) async throws -> R
 ///   ) async throws -> ServerResponse.Stream<foo.Bar.Method.Baz.Output>
 /// }
-/// @available(macOS 13.0, *)
+/// @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 /// extension Foo.Bar.ClientProtocol {
 ///   public func get<R: Sendable>(
 ///     request: ClientRequest.Single<Foo.Bar.Method.Baz.Input>,
@@ -44,7 +44,7 @@
 ///       body
 ///     )
 /// }
-/// @available(macOS 13.0, *)
+/// @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 /// public struct foo_BarClient: foo.Bar.ClientProtocol {
 ///   private let client: GRPCCore.GRPCClient
 ///   public init(client: GRPCCore.GRPCClient) {
@@ -123,7 +123,7 @@ extension ClientCodeTranslator {
         members: methods
       )
     )
-    return .guarded(.init(osVersions: [.init(os: .macOS, version: "13.0")]), clientProtocol)
+    return .guarded(self.availabilityGuard, clientProtocol)
   }
 
   private func makeExtensionProtocol(
@@ -146,7 +146,7 @@ extension ClientCodeTranslator {
       )
     )
     return .guarded(
-      .init(osVersions: [.init(os: .macOS, version: "13.0")]),
+      self.availabilityGuard,
       clientProtocolExtension
     )
   }

--- a/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
@@ -173,7 +173,7 @@ extension ServerCodeTranslator {
     let streamingProtocol = self.protocolNameTypealias(service: service, streaming: true)
     let registerRPCMethod = self.makeRegisterRPCsMethod(for: service, in: codeGenerationRequest)
     return .guarded(
-      .init(osVersions: [.init(os: .macOS, version: "13.0")]),
+      self.availabilityGuard,
       .extension(
         onType: streamingProtocol,
         declarations: [registerRPCMethod]
@@ -305,7 +305,7 @@ extension ServerCodeTranslator {
     return .commentable(
       .preFormatted(service.documentation),
       .guarded(
-        .init(osVersions: [.init(os: .macOS, version: "13.0")]),
+        self.availabilityGuard,
         .protocol(
           ProtocolDescription(
             accessModifier: self.accessModifier,
@@ -374,7 +374,7 @@ extension ServerCodeTranslator {
 
     let protocolName = self.protocolNameTypealias(service: service, streaming: false)
     return .guarded(
-      .init(osVersions: [.init(os: .macOS, version: "13.0")]),
+      self.availabilityGuard,
       .extension(
         onType: protocolName,
         declarations: methods

--- a/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
@@ -22,14 +22,14 @@
 /// a representation for the following generated code:
 ///
 /// ```swift
-/// @available(macOS 13.0, *)
+/// @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 /// public protocol foo_BarServiceStreamingProtocol: GRPCCore.RegistrableRPCService {
 ///   func baz(
 ///     request: ServerRequest.Stream<foo.Method.baz.Input>
 ///   ) async throws -> ServerResponse.Stream<foo.Method.baz.Output>
 /// }
 /// // Generated conformance to `RegistrableRPCService`.
-/// @available(macOS 13.0, *)
+/// @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 /// extension foo.Bar.StreamingServiceProtocol {
 ///   public func registerRPCs(with router: inout RPCRouter) {
 ///     router.registerHandler(
@@ -40,14 +40,14 @@
 ///     )
 ///   }
 /// }
-/// @available(macOS 13.0, *)
+/// @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 /// public protocol foo_BarServiceProtocol: foo.Bar.StreamingServiceProtocol {
 ///   func baz(
 ///     request: ServerRequest.Single<foo.Bar.Method.baz.Input>
 ///   ) async throws -> ServerResponse.Single<foo.Bar.Method.baz.Output>
 /// }
 /// // Generated partial conformance to `foo_BarStreamingServiceProtocol`.
-/// @available(macOS 13.0, *)
+/// @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 /// extension foo.Bar.ServiceProtocol {
 ///   public func baz(
 ///     request: ServerRequest.Stream<foo.Bar.Method.baz.Input>

--- a/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
@@ -22,12 +22,14 @@
 /// a representation for the following generated code:
 ///
 /// ```swift
+/// @available(macOS 13.0, *)
 /// public protocol foo_BarServiceStreamingProtocol: GRPCCore.RegistrableRPCService {
 ///   func baz(
 ///     request: ServerRequest.Stream<foo.Method.baz.Input>
 ///   ) async throws -> ServerResponse.Stream<foo.Method.baz.Output>
 /// }
 /// // Generated conformance to `RegistrableRPCService`.
+/// @available(macOS 13.0, *)
 /// extension foo.Bar.StreamingServiceProtocol {
 ///   public func registerRPCs(with router: inout RPCRouter) {
 ///     router.registerHandler(
@@ -38,12 +40,14 @@
 ///     )
 ///   }
 /// }
+/// @available(macOS 13.0, *)
 /// public protocol foo_BarServiceProtocol: foo.Bar.StreamingServiceProtocol {
 ///   func baz(
 ///     request: ServerRequest.Single<foo.Bar.Method.baz.Input>
 ///   ) async throws -> ServerResponse.Single<foo.Bar.Method.baz.Output>
 /// }
 /// // Generated partial conformance to `foo_BarStreamingServiceProtocol`.
+/// @available(macOS 13.0, *)
 /// extension foo.Bar.ServiceProtocol {
 ///   public func baz(
 ///     request: ServerRequest.Stream<foo.Bar.Method.baz.Input>
@@ -168,9 +172,12 @@ extension ServerCodeTranslator {
   ) -> Declaration {
     let streamingProtocol = self.protocolNameTypealias(service: service, streaming: true)
     let registerRPCMethod = self.makeRegisterRPCsMethod(for: service, in: codeGenerationRequest)
-    return .extension(
-      onType: streamingProtocol,
-      declarations: [registerRPCMethod]
+    return .guarded(
+      .init(osVersions: [.init(os: .macOS, version: "13.0")]),
+      .extension(
+        onType: streamingProtocol,
+        declarations: [registerRPCMethod]
+      )
     )
   }
 
@@ -297,12 +304,15 @@ extension ServerCodeTranslator {
 
     return .commentable(
       .preFormatted(service.documentation),
-      .protocol(
-        ProtocolDescription(
-          accessModifier: self.accessModifier,
-          name: protocolName,
-          conformances: [streamingProtocol],
-          members: methods
+      .guarded(
+        .init(osVersions: [.init(os: .macOS, version: "13.0")]),
+        .protocol(
+          ProtocolDescription(
+            accessModifier: self.accessModifier,
+            name: protocolName,
+            conformances: [streamingProtocol],
+            members: methods
+          )
         )
       )
     )
@@ -363,9 +373,12 @@ extension ServerCodeTranslator {
     }
 
     let protocolName = self.protocolNameTypealias(service: service, streaming: false)
-    return .extension(
-      onType: protocolName,
-      declarations: methods
+    return .guarded(
+      .init(osVersions: [.init(os: .macOS, version: "13.0")]),
+      .extension(
+        onType: protocolName,
+        declarations: methods
+      )
     )
   }
 

--- a/Sources/GRPCCodeGen/Internal/Translator/TypealiasTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/TypealiasTranslator.swift
@@ -259,11 +259,11 @@ extension TypealiasTranslator {
 
     return [
       .guarded(
-        .init(osVersions: [(.init(os: .macOS, version: "13.0"))]),
+        self.availabilityGuard,
         streamingServiceProtocolTypealias
       ),
       .guarded(
-        .init(osVersions: [(.init(os: .macOS, version: "13.0"))]),
+        self.availabilityGuard,
         serviceProtocolTypealias
       ),
     ]
@@ -273,7 +273,7 @@ extension TypealiasTranslator {
     for service: CodeGenerationRequest.ServiceDescriptor
   ) -> Declaration {
     return .guarded(
-      .init(osVersions: [(.init(os: .macOS, version: "13.0"))]),
+      self.availabilityGuard,
       .typealias(
         accessModifier: self.accessModifier,
         name: "ClientProtocol",
@@ -286,7 +286,7 @@ extension TypealiasTranslator {
     for service: CodeGenerationRequest.ServiceDescriptor
   ) -> Declaration {
     return .guarded(
-      .init(osVersions: [(.init(os: .macOS, version: "13.0"))]),
+      self.availabilityGuard,
       .typealias(
         accessModifier: self.accessModifier,
         name: "Client",

--- a/Sources/GRPCCodeGen/Internal/Translator/TypealiasTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/TypealiasTranslator.swift
@@ -38,13 +38,15 @@
 ///       // ...
 ///
 ///       public static let descriptors: [MethodDescriptor] = [
-///         Echo.Echo.Method.Get.descriptor,
-///         Echo.Echo.Method.Collect.descriptor,
+///         Get.descriptor,
+///         Collect.descriptor,
 ///         // ...
 ///       ]
 ///     }
 ///
+///     @available(macOS 13.0, *)
 ///     public typealias StreamingServiceProtocol = echo_EchoServiceStreamingProtocol
+///     @available(macOS 13.0, *)
 ///     public typealias ServiceProtocol = echo_EchoServiceProtocol
 ///
 ///   }
@@ -223,7 +225,7 @@ extension TypealiasTranslator {
       let methodDescriptorPath = Expression.memberAccess(
         MemberAccessDescription(
           left: .identifierType(
-            .member([service.namespacedTypealiasGeneratedName, "Method", methodName])
+            .member([methodName])
           ),
           right: "descriptor"
         )
@@ -255,26 +257,41 @@ extension TypealiasTranslator {
       existingType: .member("\(service.namespacedGeneratedName)ServiceProtocol")
     )
 
-    return [streamingServiceProtocolTypealias, serviceProtocolTypealias]
+    return [
+      .guarded(
+        .init(osVersions: [(.init(os: .macOS, version: "13.0"))]),
+        streamingServiceProtocolTypealias
+      ),
+      .guarded(
+        .init(osVersions: [(.init(os: .macOS, version: "13.0"))]),
+        serviceProtocolTypealias
+      ),
+    ]
   }
 
   private func makeClientProtocolTypealias(
     for service: CodeGenerationRequest.ServiceDescriptor
   ) -> Declaration {
-    return .typealias(
-      accessModifier: self.accessModifier,
-      name: "ClientProtocol",
-      existingType: .member("\(service.namespacedGeneratedName)ClientProtocol")
+    return .guarded(
+      .init(osVersions: [(.init(os: .macOS, version: "13.0"))]),
+      .typealias(
+        accessModifier: self.accessModifier,
+        name: "ClientProtocol",
+        existingType: .member("\(service.namespacedGeneratedName)ClientProtocol")
+      )
     )
   }
 
   private func makeClientStructTypealias(
     for service: CodeGenerationRequest.ServiceDescriptor
   ) -> Declaration {
-    return .typealias(
-      accessModifier: self.accessModifier,
-      name: "Client",
-      existingType: .member("\(service.namespacedGeneratedName)Client")
+    return .guarded(
+      .init(osVersions: [(.init(os: .macOS, version: "13.0"))]),
+      .typealias(
+        accessModifier: self.accessModifier,
+        name: "Client",
+        existingType: .member("\(service.namespacedGeneratedName)Client")
+      )
     )
   }
 }

--- a/Sources/GRPCCodeGen/Internal/Translator/TypealiasTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/TypealiasTranslator.swift
@@ -44,9 +44,9 @@
 ///       ]
 ///     }
 ///
-///     @available(macOS 13.0, *)
+///     @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 ///     public typealias StreamingServiceProtocol = echo_EchoServiceStreamingProtocol
-///     @available(macOS 13.0, *)
+///     @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 ///     public typealias ServiceProtocol = echo_EchoServiceProtocol
 ///
 ///   }

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
@@ -43,7 +43,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       public protocol NamespaceA_ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
@@ -53,7 +53,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable
       }
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       extension NamespaceA.ServiceA.ClientProtocol {
           public func methodA<R>(
               request: ClientRequest.Single<NamespaceA.ServiceA.Method.MethodA.Input>,
@@ -119,7 +119,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       public protocol NamespaceA_ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
@@ -129,7 +129,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable
       }
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       extension NamespaceA.ServiceA.ClientProtocol {
           public func methodA<R>(
               request: ClientRequest.Stream<NamespaceA.ServiceA.Method.MethodA.Input>,
@@ -195,7 +195,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       public protocol NamespaceA_ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
@@ -205,7 +205,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable
       }
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       extension NamespaceA.ServiceA.ClientProtocol {
           public func methodA<R>(
               request: ClientRequest.Single<NamespaceA.ServiceA.Method.MethodA.Input>,
@@ -271,7 +271,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       public protocol NamespaceA_ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
@@ -281,7 +281,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable
       }
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       extension NamespaceA.ServiceA.ClientProtocol {
           public func methodA<R>(
               request: ClientRequest.Stream<NamespaceA.ServiceA.Method.MethodA.Input>,
@@ -355,7 +355,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       package protocol NamespaceA_ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
@@ -373,7 +373,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Method.MethodB.Output>) async throws -> R
           ) async throws -> R where R: Sendable
       }
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       extension NamespaceA.ServiceA.ClientProtocol {
           package func methodA<R>(
               request: ClientRequest.Stream<NamespaceA.ServiceA.Method.MethodA.Input>,
@@ -467,7 +467,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       internal protocol ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
@@ -477,7 +477,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               _ body: @Sendable @escaping (ClientResponse.Single<ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable
       }
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       extension ServiceA.ClientProtocol {
           internal func methodA<R>(
               request: ClientRequest.Single<ServiceA.Method.MethodA.Input>,
@@ -549,9 +549,9 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       public protocol NamespaceA_ServiceAClientProtocol: Sendable {}
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       extension NamespaceA.ServiceA.ClientProtocol {
       }
       /// Documentation for ServiceA
@@ -566,9 +566,9 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       /// Documentation for ServiceB
       ///
       /// Line 2
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       public protocol ServiceBClientProtocol: Sendable {}
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       extension ServiceB.ClientProtocol {
       }
       /// Documentation for ServiceB

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
@@ -43,6 +43,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
+      @available(macOS 13.0, *)
       public protocol NamespaceA_ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
@@ -52,6 +53,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable
       }
+      @available(macOS 13.0, *)
       extension NamespaceA.ServiceA.ClientProtocol {
           public func methodA<R>(
               request: ClientRequest.Single<NamespaceA.ServiceA.Method.MethodA.Input>,
@@ -117,6 +119,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
+      @available(macOS 13.0, *)
       public protocol NamespaceA_ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
@@ -126,6 +129,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable
       }
+      @available(macOS 13.0, *)
       extension NamespaceA.ServiceA.ClientProtocol {
           public func methodA<R>(
               request: ClientRequest.Stream<NamespaceA.ServiceA.Method.MethodA.Input>,
@@ -191,6 +195,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
+      @available(macOS 13.0, *)
       public protocol NamespaceA_ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
@@ -200,6 +205,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable
       }
+      @available(macOS 13.0, *)
       extension NamespaceA.ServiceA.ClientProtocol {
           public func methodA<R>(
               request: ClientRequest.Single<NamespaceA.ServiceA.Method.MethodA.Input>,
@@ -265,6 +271,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
+      @available(macOS 13.0, *)
       public protocol NamespaceA_ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
@@ -274,6 +281,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable
       }
+      @available(macOS 13.0, *)
       extension NamespaceA.ServiceA.ClientProtocol {
           public func methodA<R>(
               request: ClientRequest.Stream<NamespaceA.ServiceA.Method.MethodA.Input>,
@@ -347,6 +355,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
+      @available(macOS 13.0, *)
       package protocol NamespaceA_ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
@@ -364,6 +373,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Method.MethodB.Output>) async throws -> R
           ) async throws -> R where R: Sendable
       }
+      @available(macOS 13.0, *)
       extension NamespaceA.ServiceA.ClientProtocol {
           package func methodA<R>(
               request: ClientRequest.Stream<NamespaceA.ServiceA.Method.MethodA.Input>,
@@ -457,6 +467,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
+      @available(macOS 13.0, *)
       internal protocol ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
@@ -466,6 +477,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               _ body: @Sendable @escaping (ClientResponse.Single<ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable
       }
+      @available(macOS 13.0, *)
       extension ServiceA.ClientProtocol {
           internal func methodA<R>(
               request: ClientRequest.Single<ServiceA.Method.MethodA.Input>,
@@ -537,7 +549,9 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
+      @available(macOS 13.0, *)
       public protocol NamespaceA_ServiceAClientProtocol: Sendable {}
+      @available(macOS 13.0, *)
       extension NamespaceA.ServiceA.ClientProtocol {
       }
       /// Documentation for ServiceA
@@ -552,7 +566,9 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       /// Documentation for ServiceB
       ///
       /// Line 2
+      @available(macOS 13.0, *)
       public protocol ServiceBClientProtocol: Sendable {}
+      @available(macOS 13.0, *)
       extension ServiceB.ClientProtocol {
       }
       /// Documentation for ServiceB

--- a/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
@@ -175,9 +175,9 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
               public enum Method {
                   public static let descriptors: [MethodDescriptor] = []
               }
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               public typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
           }
       }
@@ -187,18 +187,18 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
       public protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {}
 
       /// Conformance to `GRPCCore.RegistrableRPCService`.
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       extension NamespaceA.ServiceA.StreamingServiceProtocol {
           @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {}
       }
 
       /// Documentation for AService
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       public protocol NamespaceA_ServiceAServiceProtocol: NamespaceA.ServiceA.StreamingServiceProtocol {}
 
       /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       extension NamespaceA.ServiceA.ServiceProtocol {
       }
       """

--- a/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
@@ -175,7 +175,9 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
               public enum Method {
                   public static let descriptors: [MethodDescriptor] = []
               }
+              @available(macOS 13.0, *)
               public typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
+              @available(macOS 13.0, *)
               public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
           }
       }
@@ -185,15 +187,18 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
       public protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {}
 
       /// Conformance to `GRPCCore.RegistrableRPCService`.
+      @available(macOS 13.0, *)
       extension NamespaceA.ServiceA.StreamingServiceProtocol {
           @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {}
       }
 
       /// Documentation for AService
+      @available(macOS 13.0, *)
       public protocol NamespaceA_ServiceAServiceProtocol: NamespaceA.ServiceA.StreamingServiceProtocol {}
 
       /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
+      @available(macOS 13.0, *)
       extension NamespaceA.ServiceA.ServiceProtocol {
       }
       """

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
@@ -57,6 +57,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           func unary(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.Unary.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.Unary.Output>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
+      @available(macOS 13.0, *)
       extension NamespaceA.ServiceA.StreamingServiceProtocol {
           @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {
@@ -71,11 +72,13 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           }
       }
       /// Documentation for ServiceA
+      @available(macOS 13.0, *)
       public protocol NamespaceA_ServiceAServiceProtocol: NamespaceA.ServiceA.StreamingServiceProtocol {
           /// Documentation for unaryMethod
           func unary(request: ServerRequest.Single<NamespaceA.ServiceA.Method.Unary.Input>) async throws -> ServerResponse.Single<NamespaceA.ServiceA.Method.Unary.Output>
       }
       /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
+      @available(macOS 13.0, *)
       extension NamespaceA.ServiceA.ServiceProtocol {
           public func unary(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.Unary.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.Unary.Output> {
               let response = try await self.unary(request: ServerRequest.Single(stream: request))
@@ -123,6 +126,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           func inputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.InputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.InputStreaming.Output>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
+      @available(macOS 13.0, *)
       extension NamespaceA.ServiceA.StreamingServiceProtocol {
           @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           package func registerMethods(with router: inout GRPCCore.RPCRouter) {
@@ -137,11 +141,13 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           }
       }
       /// Documentation for ServiceA
+      @available(macOS 13.0, *)
       package protocol NamespaceA_ServiceAServiceProtocol: NamespaceA.ServiceA.StreamingServiceProtocol {
           /// Documentation for inputStreamingMethod
           func inputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.InputStreaming.Input>) async throws -> ServerResponse.Single<NamespaceA.ServiceA.Method.InputStreaming.Output>
       }
       /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
+      @available(macOS 13.0, *)
       extension NamespaceA.ServiceA.ServiceProtocol {
           package func inputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.InputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.InputStreaming.Output> {
               let response = try await self.inputStreaming(request: request)
@@ -193,6 +199,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           func outputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.OutputStreaming.Output>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
+      @available(macOS 13.0, *)
       extension NamespaceA.ServiceA.StreamingServiceProtocol {
           @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {
@@ -207,11 +214,13 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           }
       }
       /// Documentation for ServiceA
+      @available(macOS 13.0, *)
       public protocol NamespaceA_ServiceAServiceProtocol: NamespaceA.ServiceA.StreamingServiceProtocol {
           /// Documentation for outputStreamingMethod
           func outputStreaming(request: ServerRequest.Single<NamespaceA.ServiceA.Method.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.OutputStreaming.Output>
       }
       /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
+      @available(macOS 13.0, *)
       extension NamespaceA.ServiceA.ServiceProtocol {
           public func outputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.OutputStreaming.Output> {
               let response = try await self.outputStreaming(request: ServerRequest.Single(stream: request))
@@ -263,6 +272,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           func bidirectionalStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.BidirectionalStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.BidirectionalStreaming.Output>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
+      @available(macOS 13.0, *)
       extension NamespaceA.ServiceA.StreamingServiceProtocol {
           @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           package func registerMethods(with router: inout GRPCCore.RPCRouter) {
@@ -277,11 +287,13 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           }
       }
       /// Documentation for ServiceA
+      @available(macOS 13.0, *)
       package protocol NamespaceA_ServiceAServiceProtocol: NamespaceA.ServiceA.StreamingServiceProtocol {
           /// Documentation for bidirectionalStreamingMethod
           func bidirectionalStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.BidirectionalStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.BidirectionalStreaming.Output>
       }
       /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
+      @available(macOS 13.0, *)
       extension NamespaceA.ServiceA.ServiceProtocol {
       }
       """
@@ -344,6 +356,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           func outputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.OutputStreaming.Output>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
+      @available(macOS 13.0, *)
       extension NamespaceA.ServiceA.StreamingServiceProtocol {
           @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           internal func registerMethods(with router: inout GRPCCore.RPCRouter) {
@@ -366,6 +379,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           }
       }
       /// Documentation for ServiceA
+      @available(macOS 13.0, *)
       internal protocol NamespaceA_ServiceAServiceProtocol: NamespaceA.ServiceA.StreamingServiceProtocol {
           /// Documentation for inputStreamingMethod
           func inputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.InputStreaming.Input>) async throws -> ServerResponse.Single<NamespaceA.ServiceA.Method.InputStreaming.Output>
@@ -374,6 +388,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           func outputStreaming(request: ServerRequest.Single<NamespaceA.ServiceA.Method.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.OutputStreaming.Output>
       }
       /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
+      @available(macOS 13.0, *)
       extension NamespaceA.ServiceA.ServiceProtocol {
           internal func inputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.InputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.InputStreaming.Output> {
               let response = try await self.inputStreaming(request: request)
@@ -422,6 +437,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           func methodA(request: ServerRequest.Stream<ServiceA.Method.MethodA.Input>) async throws -> ServerResponse.Stream<ServiceA.Method.MethodA.Output>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
+      @available(macOS 13.0, *)
       extension ServiceA.StreamingServiceProtocol {
           @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           internal func registerMethods(with router: inout GRPCCore.RPCRouter) {
@@ -436,11 +452,13 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           }
       }
       /// Documentation for ServiceA
+      @available(macOS 13.0, *)
       internal protocol ServiceAServiceProtocol: ServiceA.StreamingServiceProtocol {
           /// Documentation for MethodA
           func methodA(request: ServerRequest.Single<ServiceA.Method.MethodA.Input>) async throws -> ServerResponse.Single<ServiceA.Method.MethodA.Output>
       }
       /// Partial conformance to `ServiceAStreamingServiceProtocol`.
+      @available(macOS 13.0, *)
       extension ServiceA.ServiceProtocol {
           internal func methodA(request: ServerRequest.Stream<ServiceA.Method.MethodA.Input>) async throws -> ServerResponse.Stream<ServiceA.Method.MethodA.Output> {
               let response = try await self.methodA(request: ServerRequest.Single(stream: request))
@@ -483,26 +501,32 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       public protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {}
       /// Conformance to `GRPCCore.RegistrableRPCService`.
+      @available(macOS 13.0, *)
       extension NamespaceA.ServiceA.StreamingServiceProtocol {
           @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {}
       }
       /// Documentation for ServiceA
+      @available(macOS 13.0, *)
       public protocol NamespaceA_ServiceAServiceProtocol: NamespaceA.ServiceA.StreamingServiceProtocol {}
       /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
+      @available(macOS 13.0, *)
       extension NamespaceA.ServiceA.ServiceProtocol {
       }
       /// Documentation for ServiceB
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       public protocol NamespaceA_ServiceBStreamingServiceProtocol: GRPCCore.RegistrableRPCService {}
       /// Conformance to `GRPCCore.RegistrableRPCService`.
+      @available(macOS 13.0, *)
       extension NamespaceA.ServiceB.StreamingServiceProtocol {
           @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {}
       }
       /// Documentation for ServiceB
+      @available(macOS 13.0, *)
       public protocol NamespaceA_ServiceBServiceProtocol: NamespaceA.ServiceB.StreamingServiceProtocol {}
       /// Partial conformance to `NamespaceA_ServiceBStreamingServiceProtocol`.
+      @available(macOS 13.0, *)
       extension NamespaceA.ServiceB.ServiceProtocol {
       }
       """

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
@@ -57,7 +57,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           func unary(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.Unary.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.Unary.Output>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       extension NamespaceA.ServiceA.StreamingServiceProtocol {
           @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {
@@ -72,13 +72,13 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           }
       }
       /// Documentation for ServiceA
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       public protocol NamespaceA_ServiceAServiceProtocol: NamespaceA.ServiceA.StreamingServiceProtocol {
           /// Documentation for unaryMethod
           func unary(request: ServerRequest.Single<NamespaceA.ServiceA.Method.Unary.Input>) async throws -> ServerResponse.Single<NamespaceA.ServiceA.Method.Unary.Output>
       }
       /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       extension NamespaceA.ServiceA.ServiceProtocol {
           public func unary(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.Unary.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.Unary.Output> {
               let response = try await self.unary(request: ServerRequest.Single(stream: request))
@@ -126,7 +126,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           func inputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.InputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.InputStreaming.Output>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       extension NamespaceA.ServiceA.StreamingServiceProtocol {
           @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           package func registerMethods(with router: inout GRPCCore.RPCRouter) {
@@ -141,13 +141,13 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           }
       }
       /// Documentation for ServiceA
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       package protocol NamespaceA_ServiceAServiceProtocol: NamespaceA.ServiceA.StreamingServiceProtocol {
           /// Documentation for inputStreamingMethod
           func inputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.InputStreaming.Input>) async throws -> ServerResponse.Single<NamespaceA.ServiceA.Method.InputStreaming.Output>
       }
       /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       extension NamespaceA.ServiceA.ServiceProtocol {
           package func inputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.InputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.InputStreaming.Output> {
               let response = try await self.inputStreaming(request: request)
@@ -199,7 +199,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           func outputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.OutputStreaming.Output>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       extension NamespaceA.ServiceA.StreamingServiceProtocol {
           @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {
@@ -214,13 +214,13 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           }
       }
       /// Documentation for ServiceA
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       public protocol NamespaceA_ServiceAServiceProtocol: NamespaceA.ServiceA.StreamingServiceProtocol {
           /// Documentation for outputStreamingMethod
           func outputStreaming(request: ServerRequest.Single<NamespaceA.ServiceA.Method.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.OutputStreaming.Output>
       }
       /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       extension NamespaceA.ServiceA.ServiceProtocol {
           public func outputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.OutputStreaming.Output> {
               let response = try await self.outputStreaming(request: ServerRequest.Single(stream: request))
@@ -272,7 +272,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           func bidirectionalStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.BidirectionalStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.BidirectionalStreaming.Output>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       extension NamespaceA.ServiceA.StreamingServiceProtocol {
           @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           package func registerMethods(with router: inout GRPCCore.RPCRouter) {
@@ -287,13 +287,13 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           }
       }
       /// Documentation for ServiceA
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       package protocol NamespaceA_ServiceAServiceProtocol: NamespaceA.ServiceA.StreamingServiceProtocol {
           /// Documentation for bidirectionalStreamingMethod
           func bidirectionalStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.BidirectionalStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.BidirectionalStreaming.Output>
       }
       /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       extension NamespaceA.ServiceA.ServiceProtocol {
       }
       """
@@ -356,7 +356,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           func outputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.OutputStreaming.Output>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       extension NamespaceA.ServiceA.StreamingServiceProtocol {
           @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           internal func registerMethods(with router: inout GRPCCore.RPCRouter) {
@@ -379,7 +379,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           }
       }
       /// Documentation for ServiceA
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       internal protocol NamespaceA_ServiceAServiceProtocol: NamespaceA.ServiceA.StreamingServiceProtocol {
           /// Documentation for inputStreamingMethod
           func inputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.InputStreaming.Input>) async throws -> ServerResponse.Single<NamespaceA.ServiceA.Method.InputStreaming.Output>
@@ -388,7 +388,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           func outputStreaming(request: ServerRequest.Single<NamespaceA.ServiceA.Method.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.OutputStreaming.Output>
       }
       /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       extension NamespaceA.ServiceA.ServiceProtocol {
           internal func inputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.InputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.InputStreaming.Output> {
               let response = try await self.inputStreaming(request: request)
@@ -437,7 +437,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           func methodA(request: ServerRequest.Stream<ServiceA.Method.MethodA.Input>) async throws -> ServerResponse.Stream<ServiceA.Method.MethodA.Output>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       extension ServiceA.StreamingServiceProtocol {
           @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           internal func registerMethods(with router: inout GRPCCore.RPCRouter) {
@@ -452,13 +452,13 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           }
       }
       /// Documentation for ServiceA
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       internal protocol ServiceAServiceProtocol: ServiceA.StreamingServiceProtocol {
           /// Documentation for MethodA
           func methodA(request: ServerRequest.Single<ServiceA.Method.MethodA.Input>) async throws -> ServerResponse.Single<ServiceA.Method.MethodA.Output>
       }
       /// Partial conformance to `ServiceAStreamingServiceProtocol`.
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       extension ServiceA.ServiceProtocol {
           internal func methodA(request: ServerRequest.Stream<ServiceA.Method.MethodA.Input>) async throws -> ServerResponse.Stream<ServiceA.Method.MethodA.Output> {
               let response = try await self.methodA(request: ServerRequest.Single(stream: request))
@@ -501,32 +501,32 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       public protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {}
       /// Conformance to `GRPCCore.RegistrableRPCService`.
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       extension NamespaceA.ServiceA.StreamingServiceProtocol {
           @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {}
       }
       /// Documentation for ServiceA
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       public protocol NamespaceA_ServiceAServiceProtocol: NamespaceA.ServiceA.StreamingServiceProtocol {}
       /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       extension NamespaceA.ServiceA.ServiceProtocol {
       }
       /// Documentation for ServiceB
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       public protocol NamespaceA_ServiceBStreamingServiceProtocol: GRPCCore.RegistrableRPCService {}
       /// Conformance to `GRPCCore.RegistrableRPCService`.
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       extension NamespaceA.ServiceB.StreamingServiceProtocol {
           @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {}
       }
       /// Documentation for ServiceB
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       public protocol NamespaceA_ServiceBServiceProtocol: NamespaceA.ServiceB.StreamingServiceProtocol {}
       /// Partial conformance to `NamespaceA_ServiceBStreamingServiceProtocol`.
-      @available(macOS 13.0, *)
+      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       extension NamespaceA.ServiceB.ServiceProtocol {
       }
       """

--- a/Tests/GRPCCodeGenTests/Internal/Translator/TypealiasTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/TypealiasTranslatorSnippetBasedTests.swift
@@ -61,13 +61,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
                       MethodA.descriptor
                   ]
               }
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               public typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               public typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               public typealias Client = NamespaceA_ServiceAClient
           }
       }
@@ -100,13 +100,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               public enum Method {
                   public static let descriptors: [MethodDescriptor] = []
               }
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               public typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               public typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               public typealias Client = NamespaceA_ServiceAClient
           }
       }
@@ -139,9 +139,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               public enum Method {
                   public static let descriptors: [MethodDescriptor] = []
               }
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               public typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
           }
       }
@@ -174,9 +174,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               public enum Method {
                   public static let descriptors: [MethodDescriptor] = []
               }
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               public typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               public typealias Client = NamespaceA_ServiceAClient
           }
       }
@@ -253,13 +253,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
                   MethodA.descriptor
               ]
           }
-          @available(macOS 13.0, *)
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           public typealias StreamingServiceProtocol = ServiceAStreamingServiceProtocol
-          @available(macOS 13.0, *)
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           public typealias ServiceProtocol = ServiceAServiceProtocol
-          @available(macOS 13.0, *)
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           public typealias ClientProtocol = ServiceAClientProtocol
-          @available(macOS 13.0, *)
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           public typealias Client = ServiceAClient
       }
       """
@@ -326,13 +326,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
                       MethodB.descriptor
                   ]
               }
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               public typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               public typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               public typealias Client = NamespaceA_ServiceAClient
           }
       }
@@ -365,13 +365,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               package enum Method {
                   package static let descriptors: [MethodDescriptor] = []
               }
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               package typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               package typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               package typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               package typealias Client = NamespaceA_ServiceAClient
           }
       }
@@ -416,26 +416,26 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               public enum Method {
                   public static let descriptors: [MethodDescriptor] = []
               }
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               public typealias StreamingServiceProtocol = NamespaceA_AserviceStreamingServiceProtocol
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               public typealias ServiceProtocol = NamespaceA_AserviceServiceProtocol
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               public typealias ClientProtocol = NamespaceA_AserviceClientProtocol
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               public typealias Client = NamespaceA_AserviceClient
           }
           public enum Bservice {
               public enum Method {
                   public static let descriptors: [MethodDescriptor] = []
               }
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               public typealias StreamingServiceProtocol = NamespaceA_BserviceStreamingServiceProtocol
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               public typealias ServiceProtocol = NamespaceA_BserviceServiceProtocol
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               public typealias ClientProtocol = NamespaceA_BserviceClientProtocol
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               public typealias Client = NamespaceA_BserviceClient
           }
       }
@@ -471,26 +471,26 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           package enum Method {
               package static let descriptors: [MethodDescriptor] = []
           }
-          @available(macOS 13.0, *)
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           package typealias StreamingServiceProtocol = AServiceStreamingServiceProtocol
-          @available(macOS 13.0, *)
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           package typealias ServiceProtocol = AServiceServiceProtocol
-          @available(macOS 13.0, *)
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           package typealias ClientProtocol = AServiceClientProtocol
-          @available(macOS 13.0, *)
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           package typealias Client = AServiceClient
       }
       package enum BService {
           package enum Method {
               package static let descriptors: [MethodDescriptor] = []
           }
-          @available(macOS 13.0, *)
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           package typealias StreamingServiceProtocol = BServiceStreamingServiceProtocol
-          @available(macOS 13.0, *)
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           package typealias ServiceProtocol = BServiceServiceProtocol
-          @available(macOS 13.0, *)
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           package typealias ClientProtocol = BServiceClientProtocol
-          @available(macOS 13.0, *)
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           package typealias Client = BServiceClient
       }
       """
@@ -534,13 +534,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               internal enum Method {
                   internal static let descriptors: [MethodDescriptor] = []
               }
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               internal typealias StreamingServiceProtocol = Anamespace_AServiceStreamingServiceProtocol
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               internal typealias ServiceProtocol = Anamespace_AServiceServiceProtocol
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               internal typealias ClientProtocol = Anamespace_AServiceClientProtocol
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               internal typealias Client = Anamespace_AServiceClient
           }
       }
@@ -549,13 +549,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               internal enum Method {
                   internal static let descriptors: [MethodDescriptor] = []
               }
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               internal typealias StreamingServiceProtocol = Bnamespace_BServiceStreamingServiceProtocol
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               internal typealias ServiceProtocol = Bnamespace_BServiceServiceProtocol
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               internal typealias ClientProtocol = Bnamespace_BServiceClientProtocol
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               internal typealias Client = Bnamespace_BServiceClient
           }
       }
@@ -593,13 +593,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public enum Method {
               public static let descriptors: [MethodDescriptor] = []
           }
-          @available(macOS 13.0, *)
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           public typealias StreamingServiceProtocol = BServiceStreamingServiceProtocol
-          @available(macOS 13.0, *)
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           public typealias ServiceProtocol = BServiceServiceProtocol
-          @available(macOS 13.0, *)
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           public typealias ClientProtocol = BServiceClientProtocol
-          @available(macOS 13.0, *)
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           public typealias Client = BServiceClient
       }
       public enum Anamespace {
@@ -607,13 +607,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               public enum Method {
                   public static let descriptors: [MethodDescriptor] = []
               }
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               public typealias StreamingServiceProtocol = Anamespace_AServiceStreamingServiceProtocol
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               public typealias ServiceProtocol = Anamespace_AServiceServiceProtocol
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               public typealias ClientProtocol = Anamespace_AServiceClientProtocol
-              @available(macOS 13.0, *)
+              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
               public typealias Client = Anamespace_AServiceClient
           }
       }

--- a/Tests/GRPCCodeGenTests/Internal/Translator/TypealiasTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/TypealiasTranslatorSnippetBasedTests.swift
@@ -58,12 +58,16 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
                       )
                   }
                   public static let descriptors: [MethodDescriptor] = [
-                      NamespaceA.ServiceA.Method.MethodA.descriptor
+                      MethodA.descriptor
                   ]
               }
+              @available(macOS 13.0, *)
               public typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
+              @available(macOS 13.0, *)
               public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
+              @available(macOS 13.0, *)
               public typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
+              @available(macOS 13.0, *)
               public typealias Client = NamespaceA_ServiceAClient
           }
       }
@@ -96,9 +100,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               public enum Method {
                   public static let descriptors: [MethodDescriptor] = []
               }
+              @available(macOS 13.0, *)
               public typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
+              @available(macOS 13.0, *)
               public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
+              @available(macOS 13.0, *)
               public typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
+              @available(macOS 13.0, *)
               public typealias Client = NamespaceA_ServiceAClient
           }
       }
@@ -131,7 +139,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               public enum Method {
                   public static let descriptors: [MethodDescriptor] = []
               }
+              @available(macOS 13.0, *)
               public typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
+              @available(macOS 13.0, *)
               public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
           }
       }
@@ -164,7 +174,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               public enum Method {
                   public static let descriptors: [MethodDescriptor] = []
               }
+              @available(macOS 13.0, *)
               public typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
+              @available(macOS 13.0, *)
               public typealias Client = NamespaceA_ServiceAClient
           }
       }
@@ -238,12 +250,16 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
                   )
               }
               public static let descriptors: [MethodDescriptor] = [
-                  ServiceA.Method.MethodA.descriptor
+                  MethodA.descriptor
               ]
           }
+          @available(macOS 13.0, *)
           public typealias StreamingServiceProtocol = ServiceAStreamingServiceProtocol
+          @available(macOS 13.0, *)
           public typealias ServiceProtocol = ServiceAServiceProtocol
+          @available(macOS 13.0, *)
           public typealias ClientProtocol = ServiceAClientProtocol
+          @available(macOS 13.0, *)
           public typealias Client = ServiceAClient
       }
       """
@@ -306,13 +322,17 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
                       )
                   }
                   public static let descriptors: [MethodDescriptor] = [
-                      NamespaceA.ServiceA.Method.MethodA.descriptor,
-                      NamespaceA.ServiceA.Method.MethodB.descriptor
+                      MethodA.descriptor,
+                      MethodB.descriptor
                   ]
               }
+              @available(macOS 13.0, *)
               public typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
+              @available(macOS 13.0, *)
               public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
+              @available(macOS 13.0, *)
               public typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
+              @available(macOS 13.0, *)
               public typealias Client = NamespaceA_ServiceAClient
           }
       }
@@ -345,9 +365,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               package enum Method {
                   package static let descriptors: [MethodDescriptor] = []
               }
+              @available(macOS 13.0, *)
               package typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
+              @available(macOS 13.0, *)
               package typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
+              @available(macOS 13.0, *)
               package typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
+              @available(macOS 13.0, *)
               package typealias Client = NamespaceA_ServiceAClient
           }
       }
@@ -392,18 +416,26 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               public enum Method {
                   public static let descriptors: [MethodDescriptor] = []
               }
+              @available(macOS 13.0, *)
               public typealias StreamingServiceProtocol = NamespaceA_AserviceStreamingServiceProtocol
+              @available(macOS 13.0, *)
               public typealias ServiceProtocol = NamespaceA_AserviceServiceProtocol
+              @available(macOS 13.0, *)
               public typealias ClientProtocol = NamespaceA_AserviceClientProtocol
+              @available(macOS 13.0, *)
               public typealias Client = NamespaceA_AserviceClient
           }
           public enum Bservice {
               public enum Method {
                   public static let descriptors: [MethodDescriptor] = []
               }
+              @available(macOS 13.0, *)
               public typealias StreamingServiceProtocol = NamespaceA_BserviceStreamingServiceProtocol
+              @available(macOS 13.0, *)
               public typealias ServiceProtocol = NamespaceA_BserviceServiceProtocol
+              @available(macOS 13.0, *)
               public typealias ClientProtocol = NamespaceA_BserviceClientProtocol
+              @available(macOS 13.0, *)
               public typealias Client = NamespaceA_BserviceClient
           }
       }
@@ -439,18 +471,26 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           package enum Method {
               package static let descriptors: [MethodDescriptor] = []
           }
+          @available(macOS 13.0, *)
           package typealias StreamingServiceProtocol = AServiceStreamingServiceProtocol
+          @available(macOS 13.0, *)
           package typealias ServiceProtocol = AServiceServiceProtocol
+          @available(macOS 13.0, *)
           package typealias ClientProtocol = AServiceClientProtocol
+          @available(macOS 13.0, *)
           package typealias Client = AServiceClient
       }
       package enum BService {
           package enum Method {
               package static let descriptors: [MethodDescriptor] = []
           }
+          @available(macOS 13.0, *)
           package typealias StreamingServiceProtocol = BServiceStreamingServiceProtocol
+          @available(macOS 13.0, *)
           package typealias ServiceProtocol = BServiceServiceProtocol
+          @available(macOS 13.0, *)
           package typealias ClientProtocol = BServiceClientProtocol
+          @available(macOS 13.0, *)
           package typealias Client = BServiceClient
       }
       """
@@ -494,9 +534,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               internal enum Method {
                   internal static let descriptors: [MethodDescriptor] = []
               }
+              @available(macOS 13.0, *)
               internal typealias StreamingServiceProtocol = Anamespace_AServiceStreamingServiceProtocol
+              @available(macOS 13.0, *)
               internal typealias ServiceProtocol = Anamespace_AServiceServiceProtocol
+              @available(macOS 13.0, *)
               internal typealias ClientProtocol = Anamespace_AServiceClientProtocol
+              @available(macOS 13.0, *)
               internal typealias Client = Anamespace_AServiceClient
           }
       }
@@ -505,9 +549,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               internal enum Method {
                   internal static let descriptors: [MethodDescriptor] = []
               }
+              @available(macOS 13.0, *)
               internal typealias StreamingServiceProtocol = Bnamespace_BServiceStreamingServiceProtocol
+              @available(macOS 13.0, *)
               internal typealias ServiceProtocol = Bnamespace_BServiceServiceProtocol
+              @available(macOS 13.0, *)
               internal typealias ClientProtocol = Bnamespace_BServiceClientProtocol
+              @available(macOS 13.0, *)
               internal typealias Client = Bnamespace_BServiceClient
           }
       }
@@ -545,9 +593,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public enum Method {
               public static let descriptors: [MethodDescriptor] = []
           }
+          @available(macOS 13.0, *)
           public typealias StreamingServiceProtocol = BServiceStreamingServiceProtocol
+          @available(macOS 13.0, *)
           public typealias ServiceProtocol = BServiceServiceProtocol
+          @available(macOS 13.0, *)
           public typealias ClientProtocol = BServiceClientProtocol
+          @available(macOS 13.0, *)
           public typealias Client = BServiceClient
       }
       public enum Anamespace {
@@ -555,9 +607,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               public enum Method {
                   public static let descriptors: [MethodDescriptor] = []
               }
+              @available(macOS 13.0, *)
               public typealias StreamingServiceProtocol = Anamespace_AServiceStreamingServiceProtocol
+              @available(macOS 13.0, *)
               public typealias ServiceProtocol = Anamespace_AServiceServiceProtocol
+              @available(macOS 13.0, *)
               public typealias ClientProtocol = Anamespace_AServiceClientProtocol
+              @available(macOS 13.0, *)
               public typealias Client = Anamespace_AServiceClient
           }
       }

--- a/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGeneratorTests.swift
+++ b/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGeneratorTests.swift
@@ -71,15 +71,15 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
                         SayHello.descriptor
                     ]
                 }
-                @available(macOS 13.0, *)
+                @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
                 internal typealias ClientProtocol = Helloworld_GreeterClientProtocol
-                @available(macOS 13.0, *)
+                @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
                 internal typealias Client = Helloworld_GreeterClient
             }
         }
 
         /// The greeting service definition.
-        @available(macOS 13.0, *)
+        @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
         internal protocol Helloworld_GreeterClientProtocol: Sendable {
             /// Sends a greeting.
             func sayHello<R>(
@@ -90,7 +90,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
             ) async throws -> R where R: Sendable
         }
 
-        @available(macOS 13.0, *)
+        @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
         extension Helloworld.Greeter.ClientProtocol {
             internal func sayHello<R>(
                 request: ClientRequest.Single<Helloworld.Greeter.Method.SayHello.Input>,
@@ -180,9 +180,9 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
                 SayHello.descriptor
               ]
             }
-            @available(macOS 13.0, *)
+            @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
             public typealias StreamingServiceProtocol = Helloworld_GreeterStreamingServiceProtocol
-            @available(macOS 13.0, *)
+            @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
             public typealias ServiceProtocol = Helloworld_GreeterServiceProtocol
           }
         }
@@ -195,7 +195,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         }
 
         /// Conformance to `GRPCCore.RegistrableRPCService`.
-        @available(macOS 13.0, *)
+        @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
         extension Helloworld.Greeter.StreamingServiceProtocol {
           @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {
@@ -211,14 +211,14 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         }
 
         /// The greeting service definition.
-        @available(macOS 13.0, *)
+        @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
         public protocol Helloworld_GreeterServiceProtocol: Helloworld.Greeter.StreamingServiceProtocol {
           /// Sends a greeting.
           func sayHello(request: ServerRequest.Single<Helloworld.Greeter.Method.SayHello.Input>) async throws -> ServerResponse.Single<Helloworld.Greeter.Method.SayHello.Output>
         }
 
         /// Partial conformance to `Helloworld_GreeterStreamingServiceProtocol`.
-        @available(macOS 13.0, *)
+        @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
         extension Helloworld.Greeter.ServiceProtocol {
           public func sayHello(request: ServerRequest.Stream<Helloworld.Greeter.Method.SayHello.Input>) async throws -> ServerResponse.Stream<Helloworld.Greeter.Method.SayHello.Output> {
             let response = try await self.sayHello(request: ServerRequest.Single(stream: request))
@@ -274,13 +274,13 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
                 SayHello.descriptor
               ]
             }
-            @available(macOS 13.0, *)
+            @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
             package typealias StreamingServiceProtocol = Helloworld_GreeterStreamingServiceProtocol
-            @available(macOS 13.0, *)
+            @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
             package typealias ServiceProtocol = Helloworld_GreeterServiceProtocol
-            @available(macOS 13.0, *)
+            @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
             package typealias ClientProtocol = Helloworld_GreeterClientProtocol
-            @available(macOS 13.0, *)
+            @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
             package typealias Client = Helloworld_GreeterClient
           }
         }
@@ -293,7 +293,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         }
 
         /// Conformance to `GRPCCore.RegistrableRPCService`.
-        @available(macOS 13.0, *)
+        @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
         extension Helloworld.Greeter.StreamingServiceProtocol {
           @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           package func registerMethods(with router: inout GRPCCore.RPCRouter) {
@@ -309,14 +309,14 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         }
 
         /// The greeting service definition.
-        @available(macOS 13.0, *)
+        @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
         package protocol Helloworld_GreeterServiceProtocol: Helloworld.Greeter.StreamingServiceProtocol {
           /// Sends a greeting.
           func sayHello(request: ServerRequest.Single<Helloworld.Greeter.Method.SayHello.Input>) async throws -> ServerResponse.Single<Helloworld.Greeter.Method.SayHello.Output>
         }
 
         /// Partial conformance to `Helloworld_GreeterStreamingServiceProtocol`.
-        @available(macOS 13.0, *)
+        @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
         extension Helloworld.Greeter.ServiceProtocol {
           package func sayHello(request: ServerRequest.Stream<Helloworld.Greeter.Method.SayHello.Input>) async throws -> ServerResponse.Stream<Helloworld.Greeter.Method.SayHello.Output> {
             let response = try await self.sayHello(request: ServerRequest.Single(stream: request))
@@ -325,7 +325,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         }
 
         /// The greeting service definition.
-        @available(macOS 13.0, *)
+        @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
         package protocol Helloworld_GreeterClientProtocol: Sendable {
           /// Sends a greeting.
           func sayHello<R>(
@@ -336,7 +336,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
           ) async throws -> R where R: Sendable
         }
 
-        @available(macOS 13.0, *)
+        @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
         extension Helloworld.Greeter.ClientProtocol {
           package func sayHello<R>(
             request: ClientRequest.Single<Helloworld.Greeter.Method.SayHello.Input>,

--- a/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGeneratorTests.swift
+++ b/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGeneratorTests.swift
@@ -68,15 +68,18 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
                         )
                     }
                     internal static let descriptors: [MethodDescriptor] = [
-                        Helloworld.Greeter.Method.SayHello.descriptor
+                        SayHello.descriptor
                     ]
                 }
+                @available(macOS 13.0, *)
                 internal typealias ClientProtocol = Helloworld_GreeterClientProtocol
+                @available(macOS 13.0, *)
                 internal typealias Client = Helloworld_GreeterClient
             }
         }
 
         /// The greeting service definition.
+        @available(macOS 13.0, *)
         internal protocol Helloworld_GreeterClientProtocol: Sendable {
             /// Sends a greeting.
             func sayHello<R>(
@@ -87,6 +90,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
             ) async throws -> R where R: Sendable
         }
 
+        @available(macOS 13.0, *)
         extension Helloworld.Greeter.ClientProtocol {
             internal func sayHello<R>(
                 request: ClientRequest.Single<Helloworld.Greeter.Method.SayHello.Input>,
@@ -173,10 +177,12 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
                 )
               }
               public static let descriptors: [MethodDescriptor] = [
-                Helloworld.Greeter.Method.SayHello.descriptor
+                SayHello.descriptor
               ]
             }
+            @available(macOS 13.0, *)
             public typealias StreamingServiceProtocol = Helloworld_GreeterStreamingServiceProtocol
+            @available(macOS 13.0, *)
             public typealias ServiceProtocol = Helloworld_GreeterServiceProtocol
           }
         }
@@ -189,6 +195,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         }
 
         /// Conformance to `GRPCCore.RegistrableRPCService`.
+        @available(macOS 13.0, *)
         extension Helloworld.Greeter.StreamingServiceProtocol {
           @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {
@@ -204,12 +211,14 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         }
 
         /// The greeting service definition.
+        @available(macOS 13.0, *)
         public protocol Helloworld_GreeterServiceProtocol: Helloworld.Greeter.StreamingServiceProtocol {
           /// Sends a greeting.
           func sayHello(request: ServerRequest.Single<Helloworld.Greeter.Method.SayHello.Input>) async throws -> ServerResponse.Single<Helloworld.Greeter.Method.SayHello.Output>
         }
 
         /// Partial conformance to `Helloworld_GreeterStreamingServiceProtocol`.
+        @available(macOS 13.0, *)
         extension Helloworld.Greeter.ServiceProtocol {
           public func sayHello(request: ServerRequest.Stream<Helloworld.Greeter.Method.SayHello.Input>) async throws -> ServerResponse.Stream<Helloworld.Greeter.Method.SayHello.Output> {
             let response = try await self.sayHello(request: ServerRequest.Single(stream: request))
@@ -262,12 +271,16 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
                 )
               }
               package static let descriptors: [MethodDescriptor] = [
-                Helloworld.Greeter.Method.SayHello.descriptor
+                SayHello.descriptor
               ]
             }
+            @available(macOS 13.0, *)
             package typealias StreamingServiceProtocol = Helloworld_GreeterStreamingServiceProtocol
+            @available(macOS 13.0, *)
             package typealias ServiceProtocol = Helloworld_GreeterServiceProtocol
+            @available(macOS 13.0, *)
             package typealias ClientProtocol = Helloworld_GreeterClientProtocol
+            @available(macOS 13.0, *)
             package typealias Client = Helloworld_GreeterClient
           }
         }
@@ -280,6 +293,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         }
 
         /// Conformance to `GRPCCore.RegistrableRPCService`.
+        @available(macOS 13.0, *)
         extension Helloworld.Greeter.StreamingServiceProtocol {
           @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           package func registerMethods(with router: inout GRPCCore.RPCRouter) {
@@ -295,12 +309,14 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         }
 
         /// The greeting service definition.
+        @available(macOS 13.0, *)
         package protocol Helloworld_GreeterServiceProtocol: Helloworld.Greeter.StreamingServiceProtocol {
           /// Sends a greeting.
           func sayHello(request: ServerRequest.Single<Helloworld.Greeter.Method.SayHello.Input>) async throws -> ServerResponse.Single<Helloworld.Greeter.Method.SayHello.Output>
         }
 
         /// Partial conformance to `Helloworld_GreeterStreamingServiceProtocol`.
+        @available(macOS 13.0, *)
         extension Helloworld.Greeter.ServiceProtocol {
           package func sayHello(request: ServerRequest.Stream<Helloworld.Greeter.Method.SayHello.Input>) async throws -> ServerResponse.Stream<Helloworld.Greeter.Method.SayHello.Output> {
             let response = try await self.sayHello(request: ServerRequest.Single(stream: request))
@@ -309,6 +325,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         }
 
         /// The greeting service definition.
+        @available(macOS 13.0, *)
         package protocol Helloworld_GreeterClientProtocol: Sendable {
           /// Sends a greeting.
           func sayHello<R>(
@@ -319,6 +336,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
           ) async throws -> R where R: Sendable
         }
 
+        @available(macOS 13.0, *)
         extension Helloworld.Greeter.ClientProtocol {
           package func sayHello<R>(
             request: ClientRequest.Single<Helloworld.Greeter.Method.SayHello.Input>,


### PR DESCRIPTION
Motivation:

The generated code must contain the availability guards on top of all protocols, extensions and typealiases for protocols in order to be compiled. The full descriptor paths caused errors for namespaces and services with the same name, so we will use the relative paths to them in the descriptors array from the 'Method' enum.

Modifications:

- added the availability guards in the translators
- modified the descriptors path in the typealias translator (for the descriptors array)
- modified all tests accordingly

Result:

The generated code will be compiled.