### PR TITLE
Update `swift-nio-http2` version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let packageDependencies: [Package.Dependency] = [
   ),
   .package(
     url: "https://github.com/apple/swift-nio-http2.git",
-    from: "1.24.1"
+    from: "1.28.1"
   ),
   .package(
     url: "https://github.com/apple/swift-nio-transport-services.git",


### PR DESCRIPTION
## Context

[A vulnerability has been found](https://github.com/advisories/GHSA-qppj-fm5r-hxr3) in `swift-nio-http2`.  
The affected versions were < 1.28.0, and the patched version is 1.28.0.

## Changes

Update the minimum version to `1.28.1`