### PR TITLE
[CodeGenLib] Remove namespace enum generation

### DIFF
--- a/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
@@ -141,7 +141,7 @@ extension ClientCodeTranslator {
     }
     let clientProtocolExtension = Declaration.extension(
       ExtensionDescription(
-        onType: "\(service.namespacedTypealiasGeneratedName).ClientProtocol",
+        onType: "\(service.namespacedGeneratedName).ClientProtocol",
         declarations: methods
       )
     )
@@ -344,7 +344,7 @@ extension ClientCodeTranslator {
         StructDescription(
           accessModifier: self.accessModifier,
           name: "\(service.namespacedGeneratedName)Client",
-          conformances: ["\(service.namespacedTypealiasGeneratedName).ClientProtocol"],
+          conformances: ["\(service.namespacedGeneratedName).ClientProtocol"],
           members: [clientProperty, initializer] + methods
         )
       )
@@ -408,7 +408,7 @@ extension ClientCodeTranslator {
         .init(
           label: "descriptor",
           expression: .identifierPattern(
-            "\(service.namespacedTypealiasGeneratedName).Method.\(method.name.generatedUpperCase).descriptor"
+            "\(service.namespacedGeneratedName).Method.\(method.name.generatedUpperCase).descriptor"
           )
         ),
         .init(label: "serializer", expression: .identifierPattern("serializer")),
@@ -448,7 +448,7 @@ extension ClientCodeTranslator {
     type: InputOutputType
   ) -> String {
     var components: String =
-      "\(service.namespacedTypealiasGeneratedName).Method.\(method.name.generatedUpperCase)"
+      "\(service.namespacedGeneratedName).Method.\(method.name.generatedUpperCase)"
 
     switch type {
     case .input:

--- a/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
@@ -479,7 +479,7 @@ extension ServerCodeTranslator {
     type: InputOutputType
   ) -> String {
     var components: String =
-      "\(service.namespacedTypealiasGeneratedName).Method.\(method.name.generatedUpperCase)"
+      "\(service.namespacedGeneratedName).Method.\(method.name.generatedUpperCase)"
 
     switch type {
     case .input:
@@ -497,7 +497,7 @@ extension ServerCodeTranslator {
     service: CodeGenerationRequest.ServiceDescriptor
   ) -> String {
     return
-      "\(service.namespacedTypealiasGeneratedName).Method.\(method.name.generatedUpperCase).descriptor"
+      "\(service.namespacedGeneratedName).Method.\(method.name.generatedUpperCase).descriptor"
   }
 
   /// Generates the fully qualified name of the type alias for a service protocol.
@@ -506,9 +506,9 @@ extension ServerCodeTranslator {
     streaming: Bool
   ) -> String {
     if streaming {
-      return "\(service.namespacedTypealiasGeneratedName).StreamingServiceProtocol"
+      return "\(service.namespacedGeneratedName).StreamingServiceProtocol"
     }
-    return "\(service.namespacedTypealiasGeneratedName).ServiceProtocol"
+    return "\(service.namespacedGeneratedName).ServiceProtocol"
   }
 
   /// Generates the name of a service protocol.

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
@@ -47,29 +47,29 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       public protocol NamespaceA_ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
-              request: ClientRequest.Single<NamespaceA.ServiceA.Method.MethodA.Input>,
-              serializer: some MessageSerializer<NamespaceA.ServiceA.Method.MethodA.Input>,
-              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Method.MethodA.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
+              request: ClientRequest.Single<NamespaceA_ServiceA.Method.MethodA.Input>,
+              serializer: some MessageSerializer<NamespaceA_ServiceA.Method.MethodA.Input>,
+              deserializer: some MessageDeserializer<NamespaceA_ServiceA.Method.MethodA.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable
       }
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-      extension NamespaceA.ServiceA.ClientProtocol {
+      extension NamespaceA_ServiceA.ClientProtocol {
           public func methodA<R>(
-              request: ClientRequest.Single<NamespaceA.ServiceA.Method.MethodA.Input>,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
+              request: ClientRequest.Single<NamespaceA_ServiceA.Method.MethodA.Input>,
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.methodA(
                   request: request,
-                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Method.MethodA.Input>(),
-                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Method.MethodA.Output>(),
+                  serializer: ProtobufSerializer<NamespaceA_ServiceA.Method.MethodA.Input>(),
+                  deserializer: ProtobufDeserializer<NamespaceA_ServiceA.Method.MethodA.Output>(),
                   body
               )
           }
       }
       /// Documentation for ServiceA
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-      public struct NamespaceA_ServiceAClient: NamespaceA.ServiceA.ClientProtocol {
+      public struct NamespaceA_ServiceAClient: NamespaceA_ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
           public init(client: GRPCCore.GRPCClient) {
@@ -78,14 +78,14 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           
           /// Documentation for MethodA
           public func methodA<R>(
-              request: ClientRequest.Single<NamespaceA.ServiceA.Method.MethodA.Input>,
-              serializer: some MessageSerializer<NamespaceA.ServiceA.Method.MethodA.Input>,
-              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Method.MethodA.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
+              request: ClientRequest.Single<NamespaceA_ServiceA.Method.MethodA.Input>,
+              serializer: some MessageSerializer<NamespaceA_ServiceA.Method.MethodA.Input>,
+              deserializer: some MessageDeserializer<NamespaceA_ServiceA.Method.MethodA.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.client.unary(
                   request: request,
-                  descriptor: NamespaceA.ServiceA.Method.MethodA.descriptor,
+                  descriptor: NamespaceA_ServiceA.Method.MethodA.descriptor,
                   serializer: serializer,
                   deserializer: deserializer,
                   handler: body
@@ -123,29 +123,29 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       public protocol NamespaceA_ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
-              request: ClientRequest.Stream<NamespaceA.ServiceA.Method.MethodA.Input>,
-              serializer: some MessageSerializer<NamespaceA.ServiceA.Method.MethodA.Input>,
-              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Method.MethodA.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
+              request: ClientRequest.Stream<NamespaceA_ServiceA.Method.MethodA.Input>,
+              serializer: some MessageSerializer<NamespaceA_ServiceA.Method.MethodA.Input>,
+              deserializer: some MessageDeserializer<NamespaceA_ServiceA.Method.MethodA.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable
       }
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-      extension NamespaceA.ServiceA.ClientProtocol {
+      extension NamespaceA_ServiceA.ClientProtocol {
           public func methodA<R>(
-              request: ClientRequest.Stream<NamespaceA.ServiceA.Method.MethodA.Input>,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
+              request: ClientRequest.Stream<NamespaceA_ServiceA.Method.MethodA.Input>,
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.methodA(
                   request: request,
-                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Method.MethodA.Input>(),
-                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Method.MethodA.Output>(),
+                  serializer: ProtobufSerializer<NamespaceA_ServiceA.Method.MethodA.Input>(),
+                  deserializer: ProtobufDeserializer<NamespaceA_ServiceA.Method.MethodA.Output>(),
                   body
               )
           }
       }
       /// Documentation for ServiceA
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-      public struct NamespaceA_ServiceAClient: NamespaceA.ServiceA.ClientProtocol {
+      public struct NamespaceA_ServiceAClient: NamespaceA_ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
           public init(client: GRPCCore.GRPCClient) {
@@ -154,14 +154,14 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           
           /// Documentation for MethodA
           public func methodA<R>(
-              request: ClientRequest.Stream<NamespaceA.ServiceA.Method.MethodA.Input>,
-              serializer: some MessageSerializer<NamespaceA.ServiceA.Method.MethodA.Input>,
-              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Method.MethodA.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
+              request: ClientRequest.Stream<NamespaceA_ServiceA.Method.MethodA.Input>,
+              serializer: some MessageSerializer<NamespaceA_ServiceA.Method.MethodA.Input>,
+              deserializer: some MessageDeserializer<NamespaceA_ServiceA.Method.MethodA.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.client.clientStreaming(
                   request: request,
-                  descriptor: NamespaceA.ServiceA.Method.MethodA.descriptor,
+                  descriptor: NamespaceA_ServiceA.Method.MethodA.descriptor,
                   serializer: serializer,
                   deserializer: deserializer,
                   handler: body
@@ -199,29 +199,29 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       public protocol NamespaceA_ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
-              request: ClientRequest.Single<NamespaceA.ServiceA.Method.MethodA.Input>,
-              serializer: some MessageSerializer<NamespaceA.ServiceA.Method.MethodA.Input>,
-              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Method.MethodA.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
+              request: ClientRequest.Single<NamespaceA_ServiceA.Method.MethodA.Input>,
+              serializer: some MessageSerializer<NamespaceA_ServiceA.Method.MethodA.Input>,
+              deserializer: some MessageDeserializer<NamespaceA_ServiceA.Method.MethodA.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA_ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable
       }
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-      extension NamespaceA.ServiceA.ClientProtocol {
+      extension NamespaceA_ServiceA.ClientProtocol {
           public func methodA<R>(
-              request: ClientRequest.Single<NamespaceA.ServiceA.Method.MethodA.Input>,
-              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
+              request: ClientRequest.Single<NamespaceA_ServiceA.Method.MethodA.Input>,
+              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA_ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.methodA(
                   request: request,
-                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Method.MethodA.Input>(),
-                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Method.MethodA.Output>(),
+                  serializer: ProtobufSerializer<NamespaceA_ServiceA.Method.MethodA.Input>(),
+                  deserializer: ProtobufDeserializer<NamespaceA_ServiceA.Method.MethodA.Output>(),
                   body
               )
           }
       }
       /// Documentation for ServiceA
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-      public struct NamespaceA_ServiceAClient: NamespaceA.ServiceA.ClientProtocol {
+      public struct NamespaceA_ServiceAClient: NamespaceA_ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
           public init(client: GRPCCore.GRPCClient) {
@@ -230,14 +230,14 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           
           /// Documentation for MethodA
           public func methodA<R>(
-              request: ClientRequest.Single<NamespaceA.ServiceA.Method.MethodA.Input>,
-              serializer: some MessageSerializer<NamespaceA.ServiceA.Method.MethodA.Input>,
-              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Method.MethodA.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
+              request: ClientRequest.Single<NamespaceA_ServiceA.Method.MethodA.Input>,
+              serializer: some MessageSerializer<NamespaceA_ServiceA.Method.MethodA.Input>,
+              deserializer: some MessageDeserializer<NamespaceA_ServiceA.Method.MethodA.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA_ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.client.serverStreaming(
                   request: request,
-                  descriptor: NamespaceA.ServiceA.Method.MethodA.descriptor,
+                  descriptor: NamespaceA_ServiceA.Method.MethodA.descriptor,
                   serializer: serializer,
                   deserializer: deserializer,
                   handler: body
@@ -275,29 +275,29 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       public protocol NamespaceA_ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
-              request: ClientRequest.Stream<NamespaceA.ServiceA.Method.MethodA.Input>,
-              serializer: some MessageSerializer<NamespaceA.ServiceA.Method.MethodA.Input>,
-              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Method.MethodA.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
+              request: ClientRequest.Stream<NamespaceA_ServiceA.Method.MethodA.Input>,
+              serializer: some MessageSerializer<NamespaceA_ServiceA.Method.MethodA.Input>,
+              deserializer: some MessageDeserializer<NamespaceA_ServiceA.Method.MethodA.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA_ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable
       }
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-      extension NamespaceA.ServiceA.ClientProtocol {
+      extension NamespaceA_ServiceA.ClientProtocol {
           public func methodA<R>(
-              request: ClientRequest.Stream<NamespaceA.ServiceA.Method.MethodA.Input>,
-              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
+              request: ClientRequest.Stream<NamespaceA_ServiceA.Method.MethodA.Input>,
+              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA_ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.methodA(
                   request: request,
-                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Method.MethodA.Input>(),
-                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Method.MethodA.Output>(),
+                  serializer: ProtobufSerializer<NamespaceA_ServiceA.Method.MethodA.Input>(),
+                  deserializer: ProtobufDeserializer<NamespaceA_ServiceA.Method.MethodA.Output>(),
                   body
               )
           }
       }
       /// Documentation for ServiceA
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-      public struct NamespaceA_ServiceAClient: NamespaceA.ServiceA.ClientProtocol {
+      public struct NamespaceA_ServiceAClient: NamespaceA_ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
           public init(client: GRPCCore.GRPCClient) {
@@ -306,14 +306,14 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           
           /// Documentation for MethodA
           public func methodA<R>(
-              request: ClientRequest.Stream<NamespaceA.ServiceA.Method.MethodA.Input>,
-              serializer: some MessageSerializer<NamespaceA.ServiceA.Method.MethodA.Input>,
-              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Method.MethodA.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
+              request: ClientRequest.Stream<NamespaceA_ServiceA.Method.MethodA.Input>,
+              serializer: some MessageSerializer<NamespaceA_ServiceA.Method.MethodA.Input>,
+              deserializer: some MessageDeserializer<NamespaceA_ServiceA.Method.MethodA.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA_ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.client.bidirectionalStreaming(
                   request: request,
-                  descriptor: NamespaceA.ServiceA.Method.MethodA.descriptor,
+                  descriptor: NamespaceA_ServiceA.Method.MethodA.descriptor,
                   serializer: serializer,
                   deserializer: deserializer,
                   handler: body
@@ -359,49 +359,49 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       package protocol NamespaceA_ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
-              request: ClientRequest.Stream<NamespaceA.ServiceA.Method.MethodA.Input>,
-              serializer: some MessageSerializer<NamespaceA.ServiceA.Method.MethodA.Input>,
-              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Method.MethodA.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
+              request: ClientRequest.Stream<NamespaceA_ServiceA.Method.MethodA.Input>,
+              serializer: some MessageSerializer<NamespaceA_ServiceA.Method.MethodA.Input>,
+              deserializer: some MessageDeserializer<NamespaceA_ServiceA.Method.MethodA.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable
           
           /// Documentation for MethodB
           func methodB<R>(
-              request: ClientRequest.Single<NamespaceA.ServiceA.Method.MethodB.Input>,
-              serializer: some MessageSerializer<NamespaceA.ServiceA.Method.MethodB.Input>,
-              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Method.MethodB.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Method.MethodB.Output>) async throws -> R
+              request: ClientRequest.Single<NamespaceA_ServiceA.Method.MethodB.Input>,
+              serializer: some MessageSerializer<NamespaceA_ServiceA.Method.MethodB.Input>,
+              deserializer: some MessageDeserializer<NamespaceA_ServiceA.Method.MethodB.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA_ServiceA.Method.MethodB.Output>) async throws -> R
           ) async throws -> R where R: Sendable
       }
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-      extension NamespaceA.ServiceA.ClientProtocol {
+      extension NamespaceA_ServiceA.ClientProtocol {
           package func methodA<R>(
-              request: ClientRequest.Stream<NamespaceA.ServiceA.Method.MethodA.Input>,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
+              request: ClientRequest.Stream<NamespaceA_ServiceA.Method.MethodA.Input>,
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.methodA(
                   request: request,
-                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Method.MethodA.Input>(),
-                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Method.MethodA.Output>(),
+                  serializer: ProtobufSerializer<NamespaceA_ServiceA.Method.MethodA.Input>(),
+                  deserializer: ProtobufDeserializer<NamespaceA_ServiceA.Method.MethodA.Output>(),
                   body
               )
           }
           
           package func methodB<R>(
-              request: ClientRequest.Single<NamespaceA.ServiceA.Method.MethodB.Input>,
-              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Method.MethodB.Output>) async throws -> R
+              request: ClientRequest.Single<NamespaceA_ServiceA.Method.MethodB.Input>,
+              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA_ServiceA.Method.MethodB.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.methodB(
                   request: request,
-                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Method.MethodB.Input>(),
-                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Method.MethodB.Output>(),
+                  serializer: ProtobufSerializer<NamespaceA_ServiceA.Method.MethodB.Input>(),
+                  deserializer: ProtobufDeserializer<NamespaceA_ServiceA.Method.MethodB.Output>(),
                   body
               )
           }
       }
       /// Documentation for ServiceA
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-      package struct NamespaceA_ServiceAClient: NamespaceA.ServiceA.ClientProtocol {
+      package struct NamespaceA_ServiceAClient: NamespaceA_ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
           package init(client: GRPCCore.GRPCClient) {
@@ -410,14 +410,14 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           
           /// Documentation for MethodA
           package func methodA<R>(
-              request: ClientRequest.Stream<NamespaceA.ServiceA.Method.MethodA.Input>,
-              serializer: some MessageSerializer<NamespaceA.ServiceA.Method.MethodA.Input>,
-              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Method.MethodA.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA.ServiceA.Method.MethodA.Output>) async throws -> R
+              request: ClientRequest.Stream<NamespaceA_ServiceA.Method.MethodA.Input>,
+              serializer: some MessageSerializer<NamespaceA_ServiceA.Method.MethodA.Input>,
+              deserializer: some MessageDeserializer<NamespaceA_ServiceA.Method.MethodA.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceA.Method.MethodA.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.client.clientStreaming(
                   request: request,
-                  descriptor: NamespaceA.ServiceA.Method.MethodA.descriptor,
+                  descriptor: NamespaceA_ServiceA.Method.MethodA.descriptor,
                   serializer: serializer,
                   deserializer: deserializer,
                   handler: body
@@ -426,14 +426,14 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           
           /// Documentation for MethodB
           package func methodB<R>(
-              request: ClientRequest.Single<NamespaceA.ServiceA.Method.MethodB.Input>,
-              serializer: some MessageSerializer<NamespaceA.ServiceA.Method.MethodB.Input>,
-              deserializer: some MessageDeserializer<NamespaceA.ServiceA.Method.MethodB.Output>,
-              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA.ServiceA.Method.MethodB.Output>) async throws -> R
+              request: ClientRequest.Single<NamespaceA_ServiceA.Method.MethodB.Input>,
+              serializer: some MessageSerializer<NamespaceA_ServiceA.Method.MethodB.Input>,
+              deserializer: some MessageDeserializer<NamespaceA_ServiceA.Method.MethodB.Output>,
+              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA_ServiceA.Method.MethodB.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.client.serverStreaming(
                   request: request,
-                  descriptor: NamespaceA.ServiceA.Method.MethodB.descriptor,
+                  descriptor: NamespaceA_ServiceA.Method.MethodB.descriptor,
                   serializer: serializer,
                   deserializer: deserializer,
                   handler: body
@@ -552,11 +552,11 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       public protocol NamespaceA_ServiceAClientProtocol: Sendable {}
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-      extension NamespaceA.ServiceA.ClientProtocol {
+      extension NamespaceA_ServiceA.ClientProtocol {
       }
       /// Documentation for ServiceA
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-      public struct NamespaceA_ServiceAClient: NamespaceA.ServiceA.ClientProtocol {
+      public struct NamespaceA_ServiceAClient: NamespaceA_ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
           public init(client: GRPCCore.GRPCClient) {

--- a/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
@@ -170,16 +170,14 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
       @_spi(Secret) import Foo
       @_spi(Secret) import enum Foo.Bar
 
-      public enum NamespaceA {
-          public enum ServiceA {
-              public enum Method {
-                  public static let descriptors: [MethodDescriptor] = []
-              }
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              public typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
+      public enum NamespaceA_ServiceA {
+          public enum Method {
+              public static let descriptors: [MethodDescriptor] = []
           }
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          public typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
       }
 
       /// Documentation for AService
@@ -188,18 +186,18 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
 
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-      extension NamespaceA.ServiceA.StreamingServiceProtocol {
+      extension NamespaceA_ServiceA.StreamingServiceProtocol {
           @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {}
       }
 
       /// Documentation for AService
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-      public protocol NamespaceA_ServiceAServiceProtocol: NamespaceA.ServiceA.StreamingServiceProtocol {}
+      public protocol NamespaceA_ServiceAServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {}
 
       /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-      extension NamespaceA.ServiceA.ServiceProtocol {
+      extension NamespaceA_ServiceA.ServiceProtocol {
       }
       """
     try self.assertIDLToStructuredSwiftTranslation(
@@ -379,8 +377,8 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
         CodeGenError(
           code: .nonUniqueServiceName,
           message: """
-            Services within the same namespace must have unique generated upper case names. \
-            AService is used as a generated upper case name for multiple services in the namespacea namespace.
+            There must be a unique (namespace, service_name) pair for each service. \
+            NamespaceA_AService is used as a <namespace>_<service_name> construction for multiple services.
             """
         )
       )
@@ -541,7 +539,11 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
   func testSameGeneratedNameNoNamespaceServiceAndNamespaceError() throws {
     let serviceA = ServiceDescriptor(
       documentation: "Documentation for SameName service with no namespace",
-      name: Name(base: "SameName", generatedUpperCase: "SameName", generatedLowerCase: "sameName"),
+      name: Name(
+        base: "SameName",
+        generatedUpperCase: "SameName_BService",
+        generatedLowerCase: "sameName"
+      ),
       namespace: Name(base: "", generatedUpperCase: "", generatedLowerCase: ""),
       methods: []
     )
@@ -572,8 +574,8 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
         CodeGenError(
           code: .nonUniqueServiceName,
           message: """
-            Services with no namespace must not have the same generated upper case names as the namespaces. \
-            SameName is used as a generated upper case name for a service with no namespace and a namespace.
+            There must be a unique (namespace, service_name) pair for each service. \
+            SameName_BService is used as a <namespace>_<service_name> construction for multiple services.
             """
         )
       )

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
@@ -54,17 +54,17 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       public protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for unaryMethod
-          func unary(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.Unary.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.Unary.Output>
+          func unary(request: ServerRequest.Stream<NamespaceA_ServiceA.Method.Unary.Input>) async throws -> ServerResponse.Stream<NamespaceA_ServiceA.Method.Unary.Output>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-      extension NamespaceA.ServiceA.StreamingServiceProtocol {
+      extension NamespaceA_ServiceA.StreamingServiceProtocol {
           @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
-                  forMethod: NamespaceA.ServiceA.Method.Unary.descriptor,
-                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Method.Unary.Input>(),
-                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Method.Unary.Output>(),
+                  forMethod: NamespaceA_ServiceA.Method.Unary.descriptor,
+                  deserializer: ProtobufDeserializer<NamespaceA_ServiceA.Method.Unary.Input>(),
+                  serializer: ProtobufSerializer<NamespaceA_ServiceA.Method.Unary.Output>(),
                   handler: { request in
                       try await self.unary(request: request)
                   }
@@ -73,14 +73,14 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       }
       /// Documentation for ServiceA
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-      public protocol NamespaceA_ServiceAServiceProtocol: NamespaceA.ServiceA.StreamingServiceProtocol {
+      public protocol NamespaceA_ServiceAServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
           /// Documentation for unaryMethod
-          func unary(request: ServerRequest.Single<NamespaceA.ServiceA.Method.Unary.Input>) async throws -> ServerResponse.Single<NamespaceA.ServiceA.Method.Unary.Output>
+          func unary(request: ServerRequest.Single<NamespaceA_ServiceA.Method.Unary.Input>) async throws -> ServerResponse.Single<NamespaceA_ServiceA.Method.Unary.Output>
       }
       /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-      extension NamespaceA.ServiceA.ServiceProtocol {
-          public func unary(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.Unary.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.Unary.Output> {
+      extension NamespaceA_ServiceA.ServiceProtocol {
+          public func unary(request: ServerRequest.Stream<NamespaceA_ServiceA.Method.Unary.Input>) async throws -> ServerResponse.Stream<NamespaceA_ServiceA.Method.Unary.Output> {
               let response = try await self.unary(request: ServerRequest.Single(stream: request))
               return ServerResponse.Stream(single: response)
           }
@@ -123,17 +123,17 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       package protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for inputStreamingMethod
-          func inputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.InputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.InputStreaming.Output>
+          func inputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceA.Method.InputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA_ServiceA.Method.InputStreaming.Output>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-      extension NamespaceA.ServiceA.StreamingServiceProtocol {
+      extension NamespaceA_ServiceA.StreamingServiceProtocol {
           @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           package func registerMethods(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
-                  forMethod: NamespaceA.ServiceA.Method.InputStreaming.descriptor,
-                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Method.InputStreaming.Input>(),
-                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Method.InputStreaming.Output>(),
+                  forMethod: NamespaceA_ServiceA.Method.InputStreaming.descriptor,
+                  deserializer: ProtobufDeserializer<NamespaceA_ServiceA.Method.InputStreaming.Input>(),
+                  serializer: ProtobufSerializer<NamespaceA_ServiceA.Method.InputStreaming.Output>(),
                   handler: { request in
                       try await self.inputStreaming(request: request)
                   }
@@ -142,14 +142,14 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       }
       /// Documentation for ServiceA
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-      package protocol NamespaceA_ServiceAServiceProtocol: NamespaceA.ServiceA.StreamingServiceProtocol {
+      package protocol NamespaceA_ServiceAServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
           /// Documentation for inputStreamingMethod
-          func inputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.InputStreaming.Input>) async throws -> ServerResponse.Single<NamespaceA.ServiceA.Method.InputStreaming.Output>
+          func inputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceA.Method.InputStreaming.Input>) async throws -> ServerResponse.Single<NamespaceA_ServiceA.Method.InputStreaming.Output>
       }
       /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-      extension NamespaceA.ServiceA.ServiceProtocol {
-          package func inputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.InputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.InputStreaming.Output> {
+      extension NamespaceA_ServiceA.ServiceProtocol {
+          package func inputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceA.Method.InputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA_ServiceA.Method.InputStreaming.Output> {
               let response = try await self.inputStreaming(request: request)
               return ServerResponse.Stream(single: response)
           }
@@ -196,17 +196,17 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       public protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for outputStreamingMethod
-          func outputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.OutputStreaming.Output>
+          func outputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceA.Method.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA_ServiceA.Method.OutputStreaming.Output>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-      extension NamespaceA.ServiceA.StreamingServiceProtocol {
+      extension NamespaceA_ServiceA.StreamingServiceProtocol {
           @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
-                  forMethod: NamespaceA.ServiceA.Method.OutputStreaming.descriptor,
-                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Method.OutputStreaming.Input>(),
-                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Method.OutputStreaming.Output>(),
+                  forMethod: NamespaceA_ServiceA.Method.OutputStreaming.descriptor,
+                  deserializer: ProtobufDeserializer<NamespaceA_ServiceA.Method.OutputStreaming.Input>(),
+                  serializer: ProtobufSerializer<NamespaceA_ServiceA.Method.OutputStreaming.Output>(),
                   handler: { request in
                       try await self.outputStreaming(request: request)
                   }
@@ -215,14 +215,14 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       }
       /// Documentation for ServiceA
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-      public protocol NamespaceA_ServiceAServiceProtocol: NamespaceA.ServiceA.StreamingServiceProtocol {
+      public protocol NamespaceA_ServiceAServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
           /// Documentation for outputStreamingMethod
-          func outputStreaming(request: ServerRequest.Single<NamespaceA.ServiceA.Method.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.OutputStreaming.Output>
+          func outputStreaming(request: ServerRequest.Single<NamespaceA_ServiceA.Method.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA_ServiceA.Method.OutputStreaming.Output>
       }
       /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-      extension NamespaceA.ServiceA.ServiceProtocol {
-          public func outputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.OutputStreaming.Output> {
+      extension NamespaceA_ServiceA.ServiceProtocol {
+          public func outputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceA.Method.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA_ServiceA.Method.OutputStreaming.Output> {
               let response = try await self.outputStreaming(request: ServerRequest.Single(stream: request))
               return response
           }
@@ -269,17 +269,17 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       package protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for bidirectionalStreamingMethod
-          func bidirectionalStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.BidirectionalStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.BidirectionalStreaming.Output>
+          func bidirectionalStreaming(request: ServerRequest.Stream<NamespaceA_ServiceA.Method.BidirectionalStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA_ServiceA.Method.BidirectionalStreaming.Output>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-      extension NamespaceA.ServiceA.StreamingServiceProtocol {
+      extension NamespaceA_ServiceA.StreamingServiceProtocol {
           @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           package func registerMethods(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
-                  forMethod: NamespaceA.ServiceA.Method.BidirectionalStreaming.descriptor,
-                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Method.BidirectionalStreaming.Input>(),
-                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Method.BidirectionalStreaming.Output>(),
+                  forMethod: NamespaceA_ServiceA.Method.BidirectionalStreaming.descriptor,
+                  deserializer: ProtobufDeserializer<NamespaceA_ServiceA.Method.BidirectionalStreaming.Input>(),
+                  serializer: ProtobufSerializer<NamespaceA_ServiceA.Method.BidirectionalStreaming.Output>(),
                   handler: { request in
                       try await self.bidirectionalStreaming(request: request)
                   }
@@ -288,13 +288,13 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       }
       /// Documentation for ServiceA
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-      package protocol NamespaceA_ServiceAServiceProtocol: NamespaceA.ServiceA.StreamingServiceProtocol {
+      package protocol NamespaceA_ServiceAServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
           /// Documentation for bidirectionalStreamingMethod
-          func bidirectionalStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.BidirectionalStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.BidirectionalStreaming.Output>
+          func bidirectionalStreaming(request: ServerRequest.Stream<NamespaceA_ServiceA.Method.BidirectionalStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA_ServiceA.Method.BidirectionalStreaming.Output>
       }
       /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-      extension NamespaceA.ServiceA.ServiceProtocol {
+      extension NamespaceA_ServiceA.ServiceProtocol {
       }
       """
 
@@ -350,28 +350,28 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       internal protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for inputStreamingMethod
-          func inputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.InputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.InputStreaming.Output>
+          func inputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceA.Method.InputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA_ServiceA.Method.InputStreaming.Output>
           
           /// Documentation for outputStreamingMethod
-          func outputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.OutputStreaming.Output>
+          func outputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceA.Method.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA_ServiceA.Method.OutputStreaming.Output>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-      extension NamespaceA.ServiceA.StreamingServiceProtocol {
+      extension NamespaceA_ServiceA.StreamingServiceProtocol {
           @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           internal func registerMethods(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
-                  forMethod: NamespaceA.ServiceA.Method.InputStreaming.descriptor,
-                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Method.InputStreaming.Input>(),
-                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Method.InputStreaming.Output>(),
+                  forMethod: NamespaceA_ServiceA.Method.InputStreaming.descriptor,
+                  deserializer: ProtobufDeserializer<NamespaceA_ServiceA.Method.InputStreaming.Input>(),
+                  serializer: ProtobufSerializer<NamespaceA_ServiceA.Method.InputStreaming.Output>(),
                   handler: { request in
                       try await self.inputStreaming(request: request)
                   }
               )
               router.registerHandler(
-                  forMethod: NamespaceA.ServiceA.Method.OutputStreaming.descriptor,
-                  deserializer: ProtobufDeserializer<NamespaceA.ServiceA.Method.OutputStreaming.Input>(),
-                  serializer: ProtobufSerializer<NamespaceA.ServiceA.Method.OutputStreaming.Output>(),
+                  forMethod: NamespaceA_ServiceA.Method.OutputStreaming.descriptor,
+                  deserializer: ProtobufDeserializer<NamespaceA_ServiceA.Method.OutputStreaming.Input>(),
+                  serializer: ProtobufSerializer<NamespaceA_ServiceA.Method.OutputStreaming.Output>(),
                   handler: { request in
                       try await self.outputStreaming(request: request)
                   }
@@ -380,22 +380,22 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       }
       /// Documentation for ServiceA
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-      internal protocol NamespaceA_ServiceAServiceProtocol: NamespaceA.ServiceA.StreamingServiceProtocol {
+      internal protocol NamespaceA_ServiceAServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
           /// Documentation for inputStreamingMethod
-          func inputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.InputStreaming.Input>) async throws -> ServerResponse.Single<NamespaceA.ServiceA.Method.InputStreaming.Output>
+          func inputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceA.Method.InputStreaming.Input>) async throws -> ServerResponse.Single<NamespaceA_ServiceA.Method.InputStreaming.Output>
           
           /// Documentation for outputStreamingMethod
-          func outputStreaming(request: ServerRequest.Single<NamespaceA.ServiceA.Method.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.OutputStreaming.Output>
+          func outputStreaming(request: ServerRequest.Single<NamespaceA_ServiceA.Method.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA_ServiceA.Method.OutputStreaming.Output>
       }
       /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-      extension NamespaceA.ServiceA.ServiceProtocol {
-          internal func inputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.InputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.InputStreaming.Output> {
+      extension NamespaceA_ServiceA.ServiceProtocol {
+          internal func inputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceA.Method.InputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA_ServiceA.Method.InputStreaming.Output> {
               let response = try await self.inputStreaming(request: request)
               return ServerResponse.Stream(single: response)
           }
           
-          internal func outputStreaming(request: ServerRequest.Stream<NamespaceA.ServiceA.Method.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA.ServiceA.Method.OutputStreaming.Output> {
+          internal func outputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceA.Method.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA_ServiceA.Method.OutputStreaming.Output> {
               let response = try await self.outputStreaming(request: ServerRequest.Single(stream: request))
               return response
           }
@@ -502,32 +502,32 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       public protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {}
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-      extension NamespaceA.ServiceA.StreamingServiceProtocol {
+      extension NamespaceA_ServiceA.StreamingServiceProtocol {
           @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {}
       }
       /// Documentation for ServiceA
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-      public protocol NamespaceA_ServiceAServiceProtocol: NamespaceA.ServiceA.StreamingServiceProtocol {}
+      public protocol NamespaceA_ServiceAServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {}
       /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-      extension NamespaceA.ServiceA.ServiceProtocol {
+      extension NamespaceA_ServiceA.ServiceProtocol {
       }
       /// Documentation for ServiceB
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       public protocol NamespaceA_ServiceBStreamingServiceProtocol: GRPCCore.RegistrableRPCService {}
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-      extension NamespaceA.ServiceB.StreamingServiceProtocol {
+      extension NamespaceA_ServiceB.StreamingServiceProtocol {
           @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {}
       }
       /// Documentation for ServiceB
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-      public protocol NamespaceA_ServiceBServiceProtocol: NamespaceA.ServiceB.StreamingServiceProtocol {}
+      public protocol NamespaceA_ServiceBServiceProtocol: NamespaceA_ServiceB.StreamingServiceProtocol {}
       /// Partial conformance to `NamespaceA_ServiceBStreamingServiceProtocol`.
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-      extension NamespaceA.ServiceB.ServiceProtocol {
+      extension NamespaceA_ServiceB.ServiceProtocol {
       }
       """
 

--- a/Tests/GRPCCodeGenTests/Internal/Translator/TypealiasTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/TypealiasTranslatorSnippetBasedTests.swift
@@ -46,30 +46,28 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     )
     let expectedSwift =
       """
-      public enum NamespaceA {
-          public enum ServiceA {
-              public enum Method {
-                  public enum MethodA {
-                      public typealias Input = NamespaceA_ServiceARequest
-                      public typealias Output = NamespaceA_ServiceAResponse
-                      public static let descriptor = MethodDescriptor(
-                          service: "namespaceA.ServiceA",
-                          method: "MethodA"
-                      )
-                  }
-                  public static let descriptors: [MethodDescriptor] = [
-                      MethodA.descriptor
-                  ]
+      public enum NamespaceA_ServiceA {
+          public enum Method {
+              public enum MethodA {
+                  public typealias Input = NamespaceA_ServiceARequest
+                  public typealias Output = NamespaceA_ServiceAResponse
+                  public static let descriptor = MethodDescriptor(
+                      service: "namespaceA.ServiceA",
+                      method: "MethodA"
+                  )
               }
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              public typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              public typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              public typealias Client = NamespaceA_ServiceAClient
+              public static let descriptors: [MethodDescriptor] = [
+                  MethodA.descriptor
+              ]
           }
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          public typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          public typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          public typealias Client = NamespaceA_ServiceAClient
       }
       """
 
@@ -95,20 +93,18 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     )
     let expectedSwift =
       """
-      public enum NamespaceA {
-          public enum ServiceA {
-              public enum Method {
-                  public static let descriptors: [MethodDescriptor] = []
-              }
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              public typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              public typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              public typealias Client = NamespaceA_ServiceAClient
+      public enum NamespaceA_ServiceA {
+          public enum Method {
+              public static let descriptors: [MethodDescriptor] = []
           }
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          public typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          public typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          public typealias Client = NamespaceA_ServiceAClient
       }
       """
 
@@ -134,16 +130,14 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     )
     let expectedSwift =
       """
-      public enum NamespaceA {
-          public enum ServiceA {
-              public enum Method {
-                  public static let descriptors: [MethodDescriptor] = []
-              }
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              public typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
+      public enum NamespaceA_ServiceA {
+          public enum Method {
+              public static let descriptors: [MethodDescriptor] = []
           }
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          public typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
       }
       """
 
@@ -169,16 +163,14 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     )
     let expectedSwift =
       """
-      public enum NamespaceA {
-          public enum ServiceA {
-              public enum Method {
-                  public static let descriptors: [MethodDescriptor] = []
-              }
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              public typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              public typealias Client = NamespaceA_ServiceAClient
+      public enum NamespaceA_ServiceA {
+          public enum Method {
+              public static let descriptors: [MethodDescriptor] = []
           }
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          public typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          public typealias Client = NamespaceA_ServiceAClient
       }
       """
 
@@ -204,11 +196,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     )
     let expectedSwift =
       """
-      public enum NamespaceA {
-          public enum ServiceA {
-              public enum Method {
-                  public static let descriptors: [MethodDescriptor] = []
-              }
+      public enum NamespaceA_ServiceA {
+          public enum Method {
+              public static let descriptors: [MethodDescriptor] = []
           }
       }
       """
@@ -302,39 +292,37 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     )
     let expectedSwift =
       """
-      public enum NamespaceA {
-          public enum ServiceA {
-              public enum Method {
-                  public enum MethodA {
-                      public typealias Input = NamespaceA_ServiceARequest
-                      public typealias Output = NamespaceA_ServiceAResponse
-                      public static let descriptor = MethodDescriptor(
-                          service: "namespaceA.ServiceA",
-                          method: "MethodA"
-                      )
-                  }
-                  public enum MethodB {
-                      public typealias Input = NamespaceA_ServiceARequest
-                      public typealias Output = NamespaceA_ServiceAResponse
-                      public static let descriptor = MethodDescriptor(
-                          service: "namespaceA.ServiceA",
-                          method: "MethodB"
-                      )
-                  }
-                  public static let descriptors: [MethodDescriptor] = [
-                      MethodA.descriptor,
-                      MethodB.descriptor
-                  ]
+      public enum NamespaceA_ServiceA {
+          public enum Method {
+              public enum MethodA {
+                  public typealias Input = NamespaceA_ServiceARequest
+                  public typealias Output = NamespaceA_ServiceAResponse
+                  public static let descriptor = MethodDescriptor(
+                      service: "namespaceA.ServiceA",
+                      method: "MethodA"
+                  )
               }
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              public typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              public typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              public typealias Client = NamespaceA_ServiceAClient
+              public enum MethodB {
+                  public typealias Input = NamespaceA_ServiceARequest
+                  public typealias Output = NamespaceA_ServiceAResponse
+                  public static let descriptor = MethodDescriptor(
+                      service: "namespaceA.ServiceA",
+                      method: "MethodB"
+                  )
+              }
+              public static let descriptors: [MethodDescriptor] = [
+                  MethodA.descriptor,
+                  MethodB.descriptor
+              ]
           }
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          public typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          public typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          public typealias Client = NamespaceA_ServiceAClient
       }
       """
 
@@ -360,20 +348,18 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     )
     let expectedSwift =
       """
-      package enum NamespaceA {
-          package enum ServiceA {
-              package enum Method {
-                  package static let descriptors: [MethodDescriptor] = []
-              }
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              package typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              package typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              package typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              package typealias Client = NamespaceA_ServiceAClient
+      package enum NamespaceA_ServiceA {
+          package enum Method {
+              package static let descriptors: [MethodDescriptor] = []
           }
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          package typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          package typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          package typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          package typealias Client = NamespaceA_ServiceAClient
       }
       """
 
@@ -411,33 +397,31 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
 
     let expectedSwift =
       """
-      public enum NamespaceA {
-          public enum Aservice {
-              public enum Method {
-                  public static let descriptors: [MethodDescriptor] = []
-              }
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              public typealias StreamingServiceProtocol = NamespaceA_AserviceStreamingServiceProtocol
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              public typealias ServiceProtocol = NamespaceA_AserviceServiceProtocol
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              public typealias ClientProtocol = NamespaceA_AserviceClientProtocol
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              public typealias Client = NamespaceA_AserviceClient
+      public enum NamespaceA_Aservice {
+          public enum Method {
+              public static let descriptors: [MethodDescriptor] = []
           }
-          public enum Bservice {
-              public enum Method {
-                  public static let descriptors: [MethodDescriptor] = []
-              }
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              public typealias StreamingServiceProtocol = NamespaceA_BserviceStreamingServiceProtocol
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              public typealias ServiceProtocol = NamespaceA_BserviceServiceProtocol
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              public typealias ClientProtocol = NamespaceA_BserviceClientProtocol
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              public typealias Client = NamespaceA_BserviceClient
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          public typealias StreamingServiceProtocol = NamespaceA_AserviceStreamingServiceProtocol
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          public typealias ServiceProtocol = NamespaceA_AserviceServiceProtocol
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          public typealias ClientProtocol = NamespaceA_AserviceClientProtocol
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          public typealias Client = NamespaceA_AserviceClient
+      }
+      public enum NamespaceA_Bservice {
+          public enum Method {
+              public static let descriptors: [MethodDescriptor] = []
           }
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          public typealias StreamingServiceProtocol = NamespaceA_BserviceStreamingServiceProtocol
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          public typealias ServiceProtocol = NamespaceA_BserviceServiceProtocol
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          public typealias ClientProtocol = NamespaceA_BserviceClientProtocol
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          public typealias Client = NamespaceA_BserviceClient
       }
       """
 
@@ -529,35 +513,31 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
 
     let expectedSwift =
       """
-      internal enum Anamespace {
-          internal enum AService {
-              internal enum Method {
-                  internal static let descriptors: [MethodDescriptor] = []
-              }
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              internal typealias StreamingServiceProtocol = Anamespace_AServiceStreamingServiceProtocol
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              internal typealias ServiceProtocol = Anamespace_AServiceServiceProtocol
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              internal typealias ClientProtocol = Anamespace_AServiceClientProtocol
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              internal typealias Client = Anamespace_AServiceClient
+      internal enum Anamespace_AService {
+          internal enum Method {
+              internal static let descriptors: [MethodDescriptor] = []
           }
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          internal typealias StreamingServiceProtocol = Anamespace_AServiceStreamingServiceProtocol
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          internal typealias ServiceProtocol = Anamespace_AServiceServiceProtocol
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          internal typealias ClientProtocol = Anamespace_AServiceClientProtocol
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          internal typealias Client = Anamespace_AServiceClient
       }
-      internal enum Bnamespace {
-          internal enum BService {
-              internal enum Method {
-                  internal static let descriptors: [MethodDescriptor] = []
-              }
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              internal typealias StreamingServiceProtocol = Bnamespace_BServiceStreamingServiceProtocol
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              internal typealias ServiceProtocol = Bnamespace_BServiceServiceProtocol
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              internal typealias ClientProtocol = Bnamespace_BServiceClientProtocol
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              internal typealias Client = Bnamespace_BServiceClient
+      internal enum Bnamespace_BService {
+          internal enum Method {
+              internal static let descriptors: [MethodDescriptor] = []
           }
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          internal typealias StreamingServiceProtocol = Bnamespace_BServiceStreamingServiceProtocol
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          internal typealias ServiceProtocol = Bnamespace_BServiceServiceProtocol
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          internal typealias ClientProtocol = Bnamespace_BServiceClientProtocol
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          internal typealias Client = Bnamespace_BServiceClient
       }
       """
 
@@ -589,6 +569,19 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     )
     let expectedSwift =
       """
+      public enum Anamespace_AService {
+          public enum Method {
+              public static let descriptors: [MethodDescriptor] = []
+          }
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          public typealias StreamingServiceProtocol = Anamespace_AServiceStreamingServiceProtocol
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          public typealias ServiceProtocol = Anamespace_AServiceServiceProtocol
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          public typealias ClientProtocol = Anamespace_AServiceClientProtocol
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          public typealias Client = Anamespace_AServiceClient
+      }
       public enum BService {
           public enum Method {
               public static let descriptors: [MethodDescriptor] = []
@@ -601,21 +594,6 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public typealias ClientProtocol = BServiceClientProtocol
           @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           public typealias Client = BServiceClient
-      }
-      public enum Anamespace {
-          public enum AService {
-              public enum Method {
-                  public static let descriptors: [MethodDescriptor] = []
-              }
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              public typealias StreamingServiceProtocol = Anamespace_AServiceStreamingServiceProtocol
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              public typealias ServiceProtocol = Anamespace_AServiceServiceProtocol
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              public typealias ClientProtocol = Anamespace_AServiceClientProtocol
-              @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-              public typealias Client = Anamespace_AServiceClient
-          }
       }
       """
 

--- a/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGeneratorTests.swift
+++ b/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGeneratorTests.swift
@@ -58,26 +58,24 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         import DifferentModule
         import ExtraModule
 
-        internal enum Helloworld {
-            internal enum Greeter {
-                internal enum Method {
-                    internal enum SayHello {
-                        internal typealias Input = Helloworld_HelloRequest
-                        internal typealias Output = Helloworld_HelloReply
-                        internal static let descriptor = MethodDescriptor(
-                            service: "helloworld.Greeter",
-                            method: "SayHello"
-                        )
-                    }
-                    internal static let descriptors: [MethodDescriptor] = [
-                        SayHello.descriptor
-                    ]
+        internal enum Helloworld_Greeter {
+            internal enum Method {
+                internal enum SayHello {
+                    internal typealias Input = Helloworld_HelloRequest
+                    internal typealias Output = Helloworld_HelloReply
+                    internal static let descriptor = MethodDescriptor(
+                        service: "helloworld.Greeter",
+                        method: "SayHello"
+                    )
                 }
-                @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-                internal typealias ClientProtocol = Helloworld_GreeterClientProtocol
-                @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-                internal typealias Client = Helloworld_GreeterClient
+                internal static let descriptors: [MethodDescriptor] = [
+                    SayHello.descriptor
+                ]
             }
+            @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+            internal typealias ClientProtocol = Helloworld_GreeterClientProtocol
+            @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+            internal typealias Client = Helloworld_GreeterClient
         }
 
         /// The greeting service definition.
@@ -85,23 +83,23 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         internal protocol Helloworld_GreeterClientProtocol: Sendable {
             /// Sends a greeting.
             func sayHello<R>(
-                request: ClientRequest.Single<Helloworld.Greeter.Method.SayHello.Input>,
-                serializer: some MessageSerializer<Helloworld.Greeter.Method.SayHello.Input>,
-                deserializer: some MessageDeserializer<Helloworld.Greeter.Method.SayHello.Output>,
-                _ body: @Sendable @escaping (ClientResponse.Single<Helloworld.Greeter.Method.SayHello.Output>) async throws -> R
+                request: ClientRequest.Single<Helloworld_Greeter.Method.SayHello.Input>,
+                serializer: some MessageSerializer<Helloworld_Greeter.Method.SayHello.Input>,
+                deserializer: some MessageDeserializer<Helloworld_Greeter.Method.SayHello.Output>,
+                _ body: @Sendable @escaping (ClientResponse.Single<Helloworld_Greeter.Method.SayHello.Output>) async throws -> R
             ) async throws -> R where R: Sendable
         }
 
         @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-        extension Helloworld.Greeter.ClientProtocol {
+        extension Helloworld_Greeter.ClientProtocol {
             internal func sayHello<R>(
-                request: ClientRequest.Single<Helloworld.Greeter.Method.SayHello.Input>,
-                _ body: @Sendable @escaping (ClientResponse.Single<Helloworld.Greeter.Method.SayHello.Output>) async throws -> R
+                request: ClientRequest.Single<Helloworld_Greeter.Method.SayHello.Input>,
+                _ body: @Sendable @escaping (ClientResponse.Single<Helloworld_Greeter.Method.SayHello.Output>) async throws -> R
             ) async throws -> R where R: Sendable {
                 try await self.sayHello(
                     request: request,
-                    serializer: ProtobufSerializer<Helloworld.Greeter.Method.SayHello.Input>(),
-                    deserializer: ProtobufDeserializer<Helloworld.Greeter.Method.SayHello.Output>(),
+                    serializer: ProtobufSerializer<Helloworld_Greeter.Method.SayHello.Input>(),
+                    deserializer: ProtobufDeserializer<Helloworld_Greeter.Method.SayHello.Output>(),
                     body
                 )
             }
@@ -109,7 +107,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
 
         /// The greeting service definition.
         @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-        internal struct Helloworld_GreeterClient: Helloworld.Greeter.ClientProtocol {
+        internal struct Helloworld_GreeterClient: Helloworld_Greeter.ClientProtocol {
             private let client: GRPCCore.GRPCClient
             
             internal init(client: GRPCCore.GRPCClient) {
@@ -118,14 +116,14 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
             
             /// Sends a greeting.
             internal func sayHello<R>(
-                request: ClientRequest.Single<Helloworld.Greeter.Method.SayHello.Input>,
-                serializer: some MessageSerializer<Helloworld.Greeter.Method.SayHello.Input>,
-                deserializer: some MessageDeserializer<Helloworld.Greeter.Method.SayHello.Output>,
-                _ body: @Sendable @escaping (ClientResponse.Single<Helloworld.Greeter.Method.SayHello.Output>) async throws -> R
+                request: ClientRequest.Single<Helloworld_Greeter.Method.SayHello.Input>,
+                serializer: some MessageSerializer<Helloworld_Greeter.Method.SayHello.Input>,
+                deserializer: some MessageDeserializer<Helloworld_Greeter.Method.SayHello.Output>,
+                _ body: @Sendable @escaping (ClientResponse.Single<Helloworld_Greeter.Method.SayHello.Output>) async throws -> R
             ) async throws -> R where R: Sendable {
                 try await self.client.unary(
                     request: request,
-                    descriptor: Helloworld.Greeter.Method.SayHello.descriptor,
+                    descriptor: Helloworld_Greeter.Method.SayHello.descriptor,
                     serializer: serializer,
                     deserializer: deserializer,
                     handler: body
@@ -169,44 +167,42 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         import DifferentModule
         import ExtraModule
 
-        public enum Helloworld {
-          public enum Greeter {
-            public enum Method {
-              public enum SayHello {
-                public typealias Input = Helloworld_HelloRequest
-                public typealias Output = Helloworld_HelloReply
-                public static let descriptor = MethodDescriptor(
-                  service: "helloworld.Greeter",
-                  method: "SayHello"
-                )
-              }
-              public static let descriptors: [MethodDescriptor] = [
-                SayHello.descriptor
-              ]
+        public enum Helloworld_Greeter {
+          public enum Method {
+            public enum SayHello {
+              public typealias Input = Helloworld_HelloRequest
+              public typealias Output = Helloworld_HelloReply
+              public static let descriptor = MethodDescriptor(
+                service: "helloworld.Greeter",
+                method: "SayHello"
+              )
             }
-            @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-            public typealias StreamingServiceProtocol = Helloworld_GreeterStreamingServiceProtocol
-            @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-            public typealias ServiceProtocol = Helloworld_GreeterServiceProtocol
+            public static let descriptors: [MethodDescriptor] = [
+              SayHello.descriptor
+            ]
           }
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          public typealias StreamingServiceProtocol = Helloworld_GreeterStreamingServiceProtocol
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          public typealias ServiceProtocol = Helloworld_GreeterServiceProtocol
         }
 
         /// The greeting service definition.
         @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
         public protocol Helloworld_GreeterStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Sends a greeting.
-          func sayHello(request: ServerRequest.Stream<Helloworld.Greeter.Method.SayHello.Input>) async throws -> ServerResponse.Stream<Helloworld.Greeter.Method.SayHello.Output>
+          func sayHello(request: ServerRequest.Stream<Helloworld_Greeter.Method.SayHello.Input>) async throws -> ServerResponse.Stream<Helloworld_Greeter.Method.SayHello.Output>
         }
 
         /// Conformance to `GRPCCore.RegistrableRPCService`.
         @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-        extension Helloworld.Greeter.StreamingServiceProtocol {
+        extension Helloworld_Greeter.StreamingServiceProtocol {
           @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {
             router.registerHandler(
-              forMethod: Helloworld.Greeter.Method.SayHello.descriptor,
-              deserializer: ProtobufDeserializer<Helloworld.Greeter.Method.SayHello.Input>(),
-              serializer: ProtobufSerializer<Helloworld.Greeter.Method.SayHello.Output>(),
+              forMethod: Helloworld_Greeter.Method.SayHello.descriptor,
+              deserializer: ProtobufDeserializer<Helloworld_Greeter.Method.SayHello.Input>(),
+              serializer: ProtobufSerializer<Helloworld_Greeter.Method.SayHello.Output>(),
               handler: { request in
                 try await self.sayHello(request: request)
               }
@@ -216,15 +212,15 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
 
         /// The greeting service definition.
         @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-        public protocol Helloworld_GreeterServiceProtocol: Helloworld.Greeter.StreamingServiceProtocol {
+        public protocol Helloworld_GreeterServiceProtocol: Helloworld_Greeter.StreamingServiceProtocol {
           /// Sends a greeting.
-          func sayHello(request: ServerRequest.Single<Helloworld.Greeter.Method.SayHello.Input>) async throws -> ServerResponse.Single<Helloworld.Greeter.Method.SayHello.Output>
+          func sayHello(request: ServerRequest.Single<Helloworld_Greeter.Method.SayHello.Input>) async throws -> ServerResponse.Single<Helloworld_Greeter.Method.SayHello.Output>
         }
 
         /// Partial conformance to `Helloworld_GreeterStreamingServiceProtocol`.
         @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-        extension Helloworld.Greeter.ServiceProtocol {
-          public func sayHello(request: ServerRequest.Stream<Helloworld.Greeter.Method.SayHello.Input>) async throws -> ServerResponse.Stream<Helloworld.Greeter.Method.SayHello.Output> {
+        extension Helloworld_Greeter.ServiceProtocol {
+          public func sayHello(request: ServerRequest.Stream<Helloworld_Greeter.Method.SayHello.Input>) async throws -> ServerResponse.Stream<Helloworld_Greeter.Method.SayHello.Output> {
             let response = try await self.sayHello(request: ServerRequest.Single(stream: request))
             return ServerResponse.Stream(single: response)
           }
@@ -265,48 +261,46 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         import DifferentModule
         import ExtraModule
 
-        package enum Helloworld {
-          package enum Greeter {
-            package enum Method {
-              package enum SayHello {
-                package typealias Input = Helloworld_HelloRequest
-                package typealias Output = Helloworld_HelloReply
-                package static let descriptor = MethodDescriptor(
-                  service: "helloworld.Greeter",
-                  method: "SayHello"
-                )
-              }
-              package static let descriptors: [MethodDescriptor] = [
-                SayHello.descriptor
-              ]
+        package enum Helloworld_Greeter {
+          package enum Method {
+            package enum SayHello {
+              package typealias Input = Helloworld_HelloRequest
+              package typealias Output = Helloworld_HelloReply
+              package static let descriptor = MethodDescriptor(
+                service: "helloworld.Greeter",
+                method: "SayHello"
+              )
             }
-            @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-            package typealias StreamingServiceProtocol = Helloworld_GreeterStreamingServiceProtocol
-            @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-            package typealias ServiceProtocol = Helloworld_GreeterServiceProtocol
-            @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-            package typealias ClientProtocol = Helloworld_GreeterClientProtocol
-            @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-            package typealias Client = Helloworld_GreeterClient
+            package static let descriptors: [MethodDescriptor] = [
+              SayHello.descriptor
+            ]
           }
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          package typealias StreamingServiceProtocol = Helloworld_GreeterStreamingServiceProtocol
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          package typealias ServiceProtocol = Helloworld_GreeterServiceProtocol
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          package typealias ClientProtocol = Helloworld_GreeterClientProtocol
+          @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+          package typealias Client = Helloworld_GreeterClient
         }
 
         /// The greeting service definition.
         @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
         package protocol Helloworld_GreeterStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Sends a greeting.
-          func sayHello(request: ServerRequest.Stream<Helloworld.Greeter.Method.SayHello.Input>) async throws -> ServerResponse.Stream<Helloworld.Greeter.Method.SayHello.Output>
+          func sayHello(request: ServerRequest.Stream<Helloworld_Greeter.Method.SayHello.Input>) async throws -> ServerResponse.Stream<Helloworld_Greeter.Method.SayHello.Output>
         }
 
         /// Conformance to `GRPCCore.RegistrableRPCService`.
         @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-        extension Helloworld.Greeter.StreamingServiceProtocol {
+        extension Helloworld_Greeter.StreamingServiceProtocol {
           @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
           package func registerMethods(with router: inout GRPCCore.RPCRouter) {
             router.registerHandler(
-              forMethod: Helloworld.Greeter.Method.SayHello.descriptor,
-              deserializer: ProtobufDeserializer<Helloworld.Greeter.Method.SayHello.Input>(),
-              serializer: ProtobufSerializer<Helloworld.Greeter.Method.SayHello.Output>(),
+              forMethod: Helloworld_Greeter.Method.SayHello.descriptor,
+              deserializer: ProtobufDeserializer<Helloworld_Greeter.Method.SayHello.Input>(),
+              serializer: ProtobufSerializer<Helloworld_Greeter.Method.SayHello.Output>(),
               handler: { request in
                 try await self.sayHello(request: request)
               }
@@ -316,15 +310,15 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
 
         /// The greeting service definition.
         @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-        package protocol Helloworld_GreeterServiceProtocol: Helloworld.Greeter.StreamingServiceProtocol {
+        package protocol Helloworld_GreeterServiceProtocol: Helloworld_Greeter.StreamingServiceProtocol {
           /// Sends a greeting.
-          func sayHello(request: ServerRequest.Single<Helloworld.Greeter.Method.SayHello.Input>) async throws -> ServerResponse.Single<Helloworld.Greeter.Method.SayHello.Output>
+          func sayHello(request: ServerRequest.Single<Helloworld_Greeter.Method.SayHello.Input>) async throws -> ServerResponse.Single<Helloworld_Greeter.Method.SayHello.Output>
         }
 
         /// Partial conformance to `Helloworld_GreeterStreamingServiceProtocol`.
         @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-        extension Helloworld.Greeter.ServiceProtocol {
-          package func sayHello(request: ServerRequest.Stream<Helloworld.Greeter.Method.SayHello.Input>) async throws -> ServerResponse.Stream<Helloworld.Greeter.Method.SayHello.Output> {
+        extension Helloworld_Greeter.ServiceProtocol {
+          package func sayHello(request: ServerRequest.Stream<Helloworld_Greeter.Method.SayHello.Input>) async throws -> ServerResponse.Stream<Helloworld_Greeter.Method.SayHello.Output> {
             let response = try await self.sayHello(request: ServerRequest.Single(stream: request))
             return ServerResponse.Stream(single: response)
           }
@@ -335,23 +329,23 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         package protocol Helloworld_GreeterClientProtocol: Sendable {
           /// Sends a greeting.
           func sayHello<R>(
-            request: ClientRequest.Single<Helloworld.Greeter.Method.SayHello.Input>,
-            serializer: some MessageSerializer<Helloworld.Greeter.Method.SayHello.Input>,
-            deserializer: some MessageDeserializer<Helloworld.Greeter.Method.SayHello.Output>,
-            _ body: @Sendable @escaping (ClientResponse.Single<Helloworld.Greeter.Method.SayHello.Output>) async throws -> R
+            request: ClientRequest.Single<Helloworld_Greeter.Method.SayHello.Input>,
+            serializer: some MessageSerializer<Helloworld_Greeter.Method.SayHello.Input>,
+            deserializer: some MessageDeserializer<Helloworld_Greeter.Method.SayHello.Output>,
+            _ body: @Sendable @escaping (ClientResponse.Single<Helloworld_Greeter.Method.SayHello.Output>) async throws -> R
           ) async throws -> R where R: Sendable
         }
 
         @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-        extension Helloworld.Greeter.ClientProtocol {
+        extension Helloworld_Greeter.ClientProtocol {
           package func sayHello<R>(
-            request: ClientRequest.Single<Helloworld.Greeter.Method.SayHello.Input>,
-            _ body: @Sendable @escaping (ClientResponse.Single<Helloworld.Greeter.Method.SayHello.Output>) async throws -> R
+            request: ClientRequest.Single<Helloworld_Greeter.Method.SayHello.Input>,
+            _ body: @Sendable @escaping (ClientResponse.Single<Helloworld_Greeter.Method.SayHello.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
             try await self.sayHello(
               request: request,
-              serializer: ProtobufSerializer<Helloworld.Greeter.Method.SayHello.Input>(),
-              deserializer: ProtobufDeserializer<Helloworld.Greeter.Method.SayHello.Output>(),
+              serializer: ProtobufSerializer<Helloworld_Greeter.Method.SayHello.Input>(),
+              deserializer: ProtobufDeserializer<Helloworld_Greeter.Method.SayHello.Output>(),
               body
             )
           }
@@ -359,7 +353,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
 
         /// The greeting service definition.
         @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-        package struct Helloworld_GreeterClient: Helloworld.Greeter.ClientProtocol {
+        package struct Helloworld_GreeterClient: Helloworld_Greeter.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
           package init(client: GRPCCore.GRPCClient) {
@@ -368,14 +362,14 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
           
           /// Sends a greeting.
           package func sayHello<R>(
-            request: ClientRequest.Single<Helloworld.Greeter.Method.SayHello.Input>,
-            serializer: some MessageSerializer<Helloworld.Greeter.Method.SayHello.Input>,
-            deserializer: some MessageDeserializer<Helloworld.Greeter.Method.SayHello.Output>,
-            _ body: @Sendable @escaping (ClientResponse.Single<Helloworld.Greeter.Method.SayHello.Output>) async throws -> R
+            request: ClientRequest.Single<Helloworld_Greeter.Method.SayHello.Input>,
+            serializer: some MessageSerializer<Helloworld_Greeter.Method.SayHello.Input>,
+            deserializer: some MessageDeserializer<Helloworld_Greeter.Method.SayHello.Output>,
+            _ body: @Sendable @escaping (ClientResponse.Single<Helloworld_Greeter.Method.SayHello.Output>) async throws -> R
           ) async throws -> R where R: Sendable {
             try await self.client.unary(
               request: request,
-              descriptor: Helloworld.Greeter.Method.SayHello.descriptor,
+              descriptor: Helloworld_Greeter.Method.SayHello.descriptor,
               serializer: serializer,
               deserializer: deserializer,
               handler: body


### PR DESCRIPTION
Motivation:

Having a namespace enum in the generated code leads to redeclaration of the package enum when we generate code for .proto files within the same package. Thus, we cannot generate the namespace enums anymore, so we need to generate service enums that contain the namespace in their names.

Modifications:

- Changed the typealias translator to generate the service enums with namespace prefixed names
- Deleted the namespace enum generation
- Modified the CodeGenerationRequest validation function for service names
- Updated tests accordingly

Result:

Redeclaration of the same enum will be avoided when generating code using CodeGenLib.