### PR TITLE
[InteropTests] Create test framework

### DIFF
--- a/Sources/InteroperabilityTests/AssertionFailure.swift
+++ b/Sources/InteroperabilityTests/AssertionFailure.swift
@@ -1,0 +1,37 @@
+///*
+// * Copyright 2024, gRPC Authors All rights reserved.
+// *
+// * Licensed under the Apache License, Version 2.0 (the "License");
+// * you may not use this file except in compliance with the License.
+// * You may obtain a copy of the License at
+// *
+// *     http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS,
+// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// * See the License for the specific language governing permissions and
+// * limitations under the License.
+// */
+//
+
+/// Failure assertion for interoperability testing.
+///
+/// This is required because the tests must be able to run without XCTest.
+public struct AssertionFailure: Error {
+  public var message: String
+  public var file: String
+  public var line: Int
+}
+
+/// Asserts that the value of an expression is `true`.
+public func assertTrue(
+  _ expression: @autoclosure () throws -> Bool,
+  _ message: String = "The statement is not true.",
+  file: String = #fileID,
+  line: Int = #line
+) throws {
+  guard try expression() else {
+    throw AssertionFailure(message: message, file: file, line: line)
+  }
+}

--- a/Sources/InteroperabilityTests/AssertionFailure.swift
+++ b/Sources/InteroperabilityTests/AssertionFailure.swift
@@ -1,19 +1,18 @@
-///*
-// * Copyright 2024, gRPC Authors All rights reserved.
-// *
-// * Licensed under the Apache License, Version 2.0 (the "License");
-// * you may not use this file except in compliance with the License.
-// * You may obtain a copy of the License at
-// *
-// *     http://www.apache.org/licenses/LICENSE-2.0
-// *
-// * Unless required by applicable law or agreed to in writing, software
-// * distributed under the License is distributed on an "AS IS" BASIS,
-// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// * See the License for the specific language governing permissions and
-// * limitations under the License.
-// */
-//
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 /// Failure assertion for interoperability testing.
 ///


### PR DESCRIPTION
Motivation:

We can’t use XCTest for the interoperability tests because we need to be able to run them as an executable target. However, we need to be able to write tests which assert various things.

Modifications:

Implemented an AssertionFailure struct and a function that checks if the result of an expression is true. From this function we can build up any other assertion functions depending on what we will need for the interop tests.

Result:

We will have a basic test framework for the interp tests.