### PR TITLE
Implement 'quit' and 'core count' RPCs on the worker service

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -250,7 +250,8 @@ extension Target {
     name: "performance-worker",
     dependencies: [
       .grpcCore,
-      .grpcProtobuf
+      .grpcProtobuf,
+      .nioCore
     ]
   )
     

--- a/Sources/performance-worker/WorkerService.swift
+++ b/Sources/performance-worker/WorkerService.swift
@@ -15,20 +15,54 @@
  */
 
 import GRPCCore
+import NIOConcurrencyHelpers
 import NIOCore
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-struct WorkerService: Grpc_Testing_WorkerService.ServiceProtocol {
-  var testClient: GRPCClient? = nil
-  var testServer: GRPCServer? = nil
+final class WorkerService: Grpc_Testing_WorkerService.ServiceProtocol, Sendable {
+  let state: NIOLockedValueBox<State>
+
+  init() {
+    let clientAndServer = State()
+    self.state = NIOLockedValueBox(clientAndServer)
+  }
+
+  struct State {
+    var role: Role?
+
+    enum Role {
+      case client(GRPCClient)
+      case server(GRPCServer)
+    }
+
+    init() {}
+
+    init(role: Role) {
+      self.role = role
+    }
+
+    init(server: GRPCServer) {
+      self.role = .server(server)
+    }
+
+    init(client: GRPCClient) {
+      self.role = .client(client)
+    }
+  }
 
   func quitWorker(
     request: ServerRequest.Single<Grpc_Testing_WorkerService.Method.QuitWorker.Input>
   ) async throws -> ServerResponse.Single<Grpc_Testing_WorkerService.Method.QuitWorker.Output> {
-    if let testClient = self.testClient {
-      testClient.close()
-    } else if let testServer = self.testServer {
-      testServer.stopListening()
+
+    if let role = self.state.withLockedValue({ $0.role }) {
+      switch role {
+      case .client(let client):
+        client.close()
+        self.state.withLockedValue({ $0.role = nil })
+      case .server(let server):
+        server.stopListening()
+        self.state.withLockedValue({ $0.role = nil })
+      }
     }
     return ServerResponse.Single(message: Grpc_Testing_WorkerService.Method.QuitWorker.Output())
   }

--- a/Sources/performance-worker/WorkerService.swift
+++ b/Sources/performance-worker/WorkerService.swift
@@ -20,14 +20,14 @@ import NIOCore
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 final class WorkerService: Grpc_Testing_WorkerService.ServiceProtocol, Sendable {
-  let state: NIOLockedValueBox<State>
+  private let state: NIOLockedValueBox<State>
 
   init() {
     let clientAndServer = State()
     self.state = NIOLockedValueBox(clientAndServer)
   }
 
-  struct State {
+  private struct State {
     var role: Role?
 
     enum Role {
@@ -54,16 +54,20 @@ final class WorkerService: Grpc_Testing_WorkerService.ServiceProtocol, Sendable 
     request: ServerRequest.Single<Grpc_Testing_WorkerService.Method.QuitWorker.Input>
   ) async throws -> ServerResponse.Single<Grpc_Testing_WorkerService.Method.QuitWorker.Output> {
 
-    if let role = self.state.withLockedValue({ $0.role }) {
+    let role = self.state.withLockedValue { state in
+      defer { state.role = nil }
+      return state.role
+    }
+
+    if let role = role {
       switch role {
       case .client(let client):
         client.close()
-        self.state.withLockedValue({ $0.role = nil })
       case .server(let server):
         server.stopListening()
-        self.state.withLockedValue({ $0.role = nil })
       }
     }
+
     return ServerResponse.Single(message: Grpc_Testing_WorkerService.Method.QuitWorker.Output())
   }
 

--- a/Sources/performance-worker/WorkerService.swift
+++ b/Sources/performance-worker/WorkerService.swift
@@ -26,11 +26,11 @@ struct WorkerService: Grpc_Testing_WorkerService.ServiceProtocol {
     request: ServerRequest.Single<Grpc_Testing_WorkerService.Method.QuitWorker.Input>
   ) async throws -> ServerResponse.Single<Grpc_Testing_WorkerService.Method.QuitWorker.Output> {
     if let testClient = self.testClient {
-      testClient?.close()
+      testClient.close()
     } else if let testServer = self.testServer {
       testServer.stopListening()
     }
-    return ServerResponse.Single(Grpc_Testing_WorkerService.Method.QuitWorker.Output())
+    return ServerResponse.Single(message: Grpc_Testing_WorkerService.Method.QuitWorker.Output())
   }
 
   func coreCount(
@@ -38,8 +38,8 @@ struct WorkerService: Grpc_Testing_WorkerService.ServiceProtocol {
   ) async throws -> ServerResponse.Single<Grpc_Testing_WorkerService.Method.CoreCount.Output> {
     let coreCount = System.coreCount
     return ServerResponse.Single(
-      Grpc_Testing_WorkerService.Method.CoreCount.Output.with {
-        $0.cores = coreCount
+      message: Grpc_Testing_WorkerService.Method.CoreCount.Output.with {
+        $0.cores = Int32(coreCount)
       }
     )
   }
@@ -49,7 +49,7 @@ struct WorkerService: Grpc_Testing_WorkerService.ServiceProtocol {
   ) async throws
     -> GRPCCore.ServerResponse.Stream<Grpc_Testing_WorkerService.Method.RunServer.Output>
   {
-    throw RPCError(status: .Code(.unimplemented))
+    throw RPCError(code: .unimplemented, message: "This RPC has not been implemented yet.")
   }
 
   func runClient(
@@ -57,6 +57,6 @@ struct WorkerService: Grpc_Testing_WorkerService.ServiceProtocol {
   ) async throws
     -> GRPCCore.ServerResponse.Stream<Grpc_Testing_WorkerService.Method.RunClient.Output>
   {
-    throw RPCError(status: .Code(.unimplemented))
+    throw RPCError(code: .unimplemented, message: "This RPC has not been implemented yet.")
   }
 }

--- a/Sources/performance-worker/WorkerService.swift
+++ b/Sources/performance-worker/WorkerService.swift
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import GRPCCore
+import NIOCore
+
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+struct WorkerService: Grpc_Testing_WorkerService.ServiceProtocol {
+  var testClient: GRPCClient? = nil
+  var testServer: GRPCServer? = nil
+
+  func quitWorker(
+    request: ServerRequest.Single<Grpc_Testing_WorkerService.Method.QuitWorker.Input>
+  ) async throws -> ServerResponse.Single<Grpc_Testing_WorkerService.Method.QuitWorker.Output> {
+    if let testClient = self.testClient {
+      testClient?.close()
+    } else if let testServer = self.testServer {
+      testServer.stopListening()
+    }
+    return ServerResponse.Single(Grpc_Testing_WorkerService.Method.QuitWorker.Output())
+  }
+
+  func coreCount(
+    request: ServerRequest.Single<Grpc_Testing_WorkerService.Method.CoreCount.Input>
+  ) async throws -> ServerResponse.Single<Grpc_Testing_WorkerService.Method.CoreCount.Output> {
+    let coreCount = System.coreCount
+    return ServerResponse.Single(
+      Grpc_Testing_WorkerService.Method.CoreCount.Output.with {
+        $0.cores = coreCount
+      }
+    )
+  }
+
+  func runServer(
+    request: GRPCCore.ServerRequest.Stream<Grpc_Testing_WorkerService.Method.RunServer.Input>
+  ) async throws
+    -> GRPCCore.ServerResponse.Stream<Grpc_Testing_WorkerService.Method.RunServer.Output>
+  {
+    throw RPCError(status: .Code(.unimplemented))
+  }
+
+  func runClient(
+    request: GRPCCore.ServerRequest.Stream<Grpc_Testing_WorkerService.Method.RunClient.Input>
+  ) async throws
+    -> GRPCCore.ServerResponse.Stream<Grpc_Testing_WorkerService.Method.RunClient.Output>
+  {
+    throw RPCError(status: .Code(.unimplemented))
+  }
+}


### PR DESCRIPTION
Motivation:

These are 2 of the RPCs on the worker service that we need for benchmarking.

Modifications:

- Created the WorkerService struct that has a GRPCClient and a GRPCServer property
- Implemented the 'coreCount' and 'quitWorker' RPCs

Result:

- The driver will be able to request 'quitWorker' and 'coreCount' from the workers