### PR TITLE
Server Stats Collection

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let includeNIOSSL = ProcessInfo.processInfo.environment["GRPC_NO_NIO_SSL"] == ni
 let packageDependencies: [Package.Dependency] = [
   .package(
     url: "https://github.com/apple/swift-nio.git",
-    from: "2.58.0"
+    from: "2.64.0"
   ),
   .package(
     url: "https://github.com/apple/swift-nio-http2.git",
@@ -132,6 +132,7 @@ extension Target.Dependency {
     package: "swift-nio-transport-services"
   )
   static let nioTestUtils: Self = .product(name: "NIOTestUtils", package: "swift-nio")
+  static let nioFileSystem: Self = .product(name: "_NIOFileSystem", package: "swift-nio")
   static let logging: Self = .product(name: "Logging", package: "swift-log")
   static let protobuf: Self = .product(name: "SwiftProtobuf", package: "swift-protobuf")
   static let protobufPluginLibrary: Self = .product(
@@ -251,7 +252,8 @@ extension Target {
     dependencies: [
       .grpcCore,
       .grpcProtobuf,
-      .nioCore
+      .nioCore,
+      .nioFileSystem
     ]
   )
     

--- a/Sources/performance-worker/ServerStats.swift
+++ b/Sources/performance-worker/ServerStats.swift
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Dispatch
+import NIOCore
+import NIOFileSystem
+
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import Darwin
+#elseif os(Linux) || os(FreeBSD) || os(Android)
+import Glibc
+#else
+let badOS = { fatalError("unsupported OS") }()
+#endif
+
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+private let OUR_RUSAGE_SELF: Int32 = RUSAGE_SELF
+#elseif os(Linux) || os(FreeBSD) || os(Android)
+private let OUR_RUSAGE_SELF: Int32 = RUSAGE_SELF.rawValue
+#endif
+
+/// Current server stats.
+internal struct ServerStats: Sendable {
+  let time: Double
+  let userTime: Double
+  let systemTime: Double
+  let totalCpuTime: UInt64
+  let idleCpuTime: UInt64
+
+  init(
+    time: Double,
+    userTime: Double,
+    systemTime: Double,
+    totalCpuTime: UInt64,
+    idleCPuTime: UInt64
+  ) {
+    self.time = time
+    self.userTime = userTime
+    self.systemTime = systemTime
+    self.totalCpuTime = totalCpuTime
+    self.idleCpuTime = idleCPuTime
+  }
+
+  init() async throws {
+    self.time = Double(DispatchTime.now().uptimeNanoseconds) * 1e-9
+    var usage = rusage()
+    if getrusage(OUR_RUSAGE_SELF, &usage) == 0 {
+      // Adding the seconds with the microseconds transformed into seconds to get the
+      // real number of seconds as a `Double`.
+      self.userTime = Double(usage.ru_utime.tv_sec) + Double(usage.ru_utime.tv_usec) * 1e-6
+      self.systemTime = Double(usage.ru_stime.tv_sec) + Double(usage.ru_stime.tv_usec) * 1e-6
+    } else {
+      self.userTime = 0
+      self.systemTime = 0
+    }
+    if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
+      let (totalCpuTime, idleCpuTime) = try await getTotalAndIdleCpuTime()
+      self.totalCpuTime = totalCpuTime
+      self.idleCpuTime = idleCpuTime
+    } else {
+      self.idleCpuTime = 0
+      self.totalCpuTime = 0
+    }
+  }
+}
+
+internal func changeInStats(initialStats: ServerStats, currentStats: ServerStats) -> ServerStats {
+  return ServerStats(
+    time: currentStats.time - initialStats.time,
+    userTime: currentStats.userTime - initialStats.userTime,
+    systemTime: currentStats.systemTime - initialStats.systemTime,
+    totalCpuTime: currentStats.totalCpuTime - initialStats.totalCpuTime,
+    idleCPuTime: currentStats.idleCpuTime - initialStats.idleCpuTime
+  )
+}
+
+/// Computes the total and idle CPU time after extracting stats from the first line of '/proc/stat'.
+///
+/// The first line in '/proc/stat' file looks as follows:
+/// cpu [user] [nice] [system] [idle] [iowait] [irq] [softirq]
+/// The totalCpuTime is computed as follows:
+/// total = user + nice + system + idle
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+private func getTotalAndIdleCpuTime() async throws -> (UInt64, UInt64) {
+  #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(Android)
+  do {
+    let contents = try await ByteBuffer(
+      contentsOf: "/proc/stat",
+      maximumSizeAllowed: .kilobytes(20)
+    )
+
+    guard let index = contents.readableBytesView.firstIndex(where: { $0 == UInt8("\n") }) else {
+      return (0, 0)
+    }
+
+    guard let firstLine = contents.getString(at: 0, length: index) else {
+      return (0, 0)
+    }
+
+    let lineComponents = firstLine.components(separatedBy: " ")
+    if lineComponents.count < 5 || lineComponents[0] != "cpu" {
+      return (0, 0)
+    }
+
+    let cpuTime: [UInt64] = lineComponents[1 ... 4].compactMap { UInt64($0) }
+    if cpuTime.count < 4 {
+      return (0, 0)
+    }
+
+    let totalCpuTime = cpuTime.reduce(0, +)
+    return (totalCpuTime, cpuTime[3])
+  } catch {
+    return (0, 0)
+  }
+  #else
+  return (0, 0)
+  #endif
+}

--- a/Sources/performance-worker/ServerStats.swift
+++ b/Sources/performance-worker/ServerStats.swift
@@ -35,6 +35,7 @@ private let OUR_RUSAGE_SELF: Int32 = RUSAGE_SELF.rawValue
 #endif
 
 /// Current server stats.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 internal struct ServerStats: Sendable {
   var time: Double
   var userTime: Double
@@ -68,14 +69,9 @@ internal struct ServerStats: Sendable {
       self.userTime = 0
       self.systemTime = 0
     }
-    if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
-      let (totalCPUTime, idleCPUTime) = try await ServerStats.getTotalAndIdleCPUTime()
-      self.totalCPUTime = totalCPUTime
-      self.idleCPUTime = idleCPUTime
-    } else {
-      self.idleCPUTime = 0
-      self.totalCPUTime = 0
-    }
+    let (totalCPUTime, idleCPUTime) = try await ServerStats.getTotalAndIdleCPUTime()
+    self.totalCPUTime = totalCPUTime
+    self.idleCPUTime = idleCPUTime
   }
 
   internal func difference(to stats: ServerStats) -> ServerStats {
@@ -94,7 +90,6 @@ internal struct ServerStats: Sendable {
   /// CPU [user] [nice] [system] [idle] [iowait] [irq] [softirq]
   /// The totalCPUTime is computed as follows:
   /// total = user + nice + system + idle
-  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
   private static func getTotalAndIdleCPUTime() async throws -> (
     totalCPUTime: UInt64, idleCPUTime: UInt64
   ) {


### PR DESCRIPTION
Motivation:

In order to implement the 'runServer' RPC on the WorkerService we need to capture a snapshot with the resorces usage for the server and compute the difference between 2 of these snapshots.

Modifications:

- Created the ServerStats struct that contains all stats needed in the QPS benchmarking from the server
- Implemented the init() that collects all these stats
- Implemented the function that computes the differences between 2 snapshots of ServerStats

Result:

We will be able to implement the `runServer` RPC.