### PR TITLE
Add a closeOutbound func to GRPCStreamStateMachine and remove endStream param from send(message:)

### DIFF
--- a/Sources/GRPCHTTP2Core/Server/GRPCServerStreamHandler.swift
+++ b/Sources/GRPCHTTP2Core/Server/GRPCServerStreamHandler.swift
@@ -153,7 +153,7 @@ extension GRPCServerStreamHandler {
 
     case .message(let message):
       do {
-        try self.stateMachine.send(message: message, endStream: false)
+        try self.stateMachine.send(message: message)
         // TODO: move the promise handling into the state machine
         promise?.succeed()
       } catch {


### PR DESCRIPTION
This change is necessary to decouple the sending messages from closing the outbound side of the channel.
It will simplify the implementation of the `GRPCClientStreamHandler`.