### PR TITLE
Handle write promises correctly

### DIFF
--- a/Sources/GRPCHTTP2Core/Client/GRPCClientStreamHandler.swift
+++ b/Sources/GRPCHTTP2Core/Client/GRPCClientStreamHandler.swift
@@ -143,23 +143,16 @@ extension GRPCClientStreamHandler {
       do {
         self.flushPending = true
         let headers = try self.stateMachine.send(metadata: metadata)
-        context.write(self.wrapOutboundOut(.headers(.init(headers: headers))), promise: nil)
-        // TODO: move the promise handling into the state machine
-        promise?.succeed()
+        context.write(self.wrapOutboundOut(.headers(.init(headers: headers))), promise: promise)
       } catch {
         context.fireErrorCaught(error)
-        // TODO: move the promise handling into the state machine
-        promise?.fail(error)
       }
 
     case .message(let message):
       do {
-        try self.stateMachine.send(message: message)
-        // TODO: move the promise handling into the state machine
-        promise?.succeed()
+        try self.stateMachine.send(message: message, promise: promise)
       } catch {
         context.fireErrorCaught(error)
-        // TODO: move the promise handling into the state machine
         promise?.fail(error)
       }
     }
@@ -198,11 +191,11 @@ extension GRPCClientStreamHandler {
     do {
       loop: while true {
         switch try self.stateMachine.nextOutboundMessage() {
-        case .sendMessage(let byteBuffer):
+        case .sendMessage(let byteBuffer, let promise):
           self.flushPending = true
           context.write(
             self.wrapOutboundOut(.data(.init(data: .byteBuffer(byteBuffer)))),
-            promise: nil
+            promise: promise
           )
 
         case .noMoreMessages:

--- a/Sources/GRPCHTTP2Core/Client/GRPCClientStreamHandler.swift
+++ b/Sources/GRPCHTTP2Core/Client/GRPCClientStreamHandler.swift
@@ -145,6 +145,7 @@ extension GRPCClientStreamHandler {
         let headers = try self.stateMachine.send(metadata: metadata)
         context.write(self.wrapOutboundOut(.headers(.init(headers: headers))), promise: promise)
       } catch {
+        promise?.fail(error)
         context.fireErrorCaught(error)
       }
 
@@ -152,8 +153,8 @@ extension GRPCClientStreamHandler {
       do {
         try self.stateMachine.send(message: message, promise: promise)
       } catch {
-        context.fireErrorCaught(error)
         promise?.fail(error)
+        context.fireErrorCaught(error)
       }
     }
   }

--- a/Sources/GRPCHTTP2Core/Client/GRPCClientStreamHandler.swift
+++ b/Sources/GRPCHTTP2Core/Client/GRPCClientStreamHandler.swift
@@ -190,8 +190,8 @@ extension GRPCClientStreamHandler {
   private func _flush(context: ChannelHandlerContext) {
     do {
       loop: while true {
-        switch try self.stateMachine.nextOutboundMessage() {
-        case .sendMessage(let byteBuffer, let promise):
+        switch try self.stateMachine.nextOutboundFrame() {
+        case .sendFrame(let byteBuffer, let promise):
           self.flushPending = true
           context.write(
             self.wrapOutboundOut(.data(.init(data: .byteBuffer(byteBuffer)))),

--- a/Sources/GRPCHTTP2Core/GRPCMessageFramer.swift
+++ b/Sources/GRPCHTTP2Core/GRPCMessageFramer.swift
@@ -48,17 +48,14 @@ struct GRPCMessageFramer {
     self.pendingMessages.append((bytes, promise))
   }
 
-  struct DataFrame {
-    let bytes: ByteBuffer
-    let promise: EventLoopPromise<Void>?
-  }
-
   /// If there are pending messages to be framed, a `ByteBuffer` will be returned with the framed data.
   /// Data may also be compressed (if configured) and multiple frames may be coalesced into the same `ByteBuffer`.
   /// - Parameter compressor: An optional compressor: if present, payloads will be compressed; otherwise
   /// they'll be framed as-is.
   /// - Throws: If an error is encountered, such as a compression failure, an error will be thrown.
-  mutating func next(compressor: Zlib.Compressor? = nil) throws -> DataFrame? {
+  mutating func next(
+    compressor: Zlib.Compressor? = nil
+  ) throws -> (bytes: ByteBuffer, promise: EventLoopPromise<Void>?)? {
     if self.pendingMessages.isEmpty {
       // Nothing pending: exit early.
       return nil
@@ -88,7 +85,7 @@ struct GRPCMessageFramer {
       }
     }
 
-    return DataFrame(bytes: self.writeBuffer, promise: pendingWritePromise)
+    return (bytes: self.writeBuffer, promise: pendingWritePromise)
   }
 
   private mutating func encode(_ message: [UInt8], compressor: Zlib.Compressor?) throws {

--- a/Sources/GRPCHTTP2Core/GRPCMessageFramer.swift
+++ b/Sources/GRPCHTTP2Core/GRPCMessageFramer.swift
@@ -32,7 +32,7 @@ struct GRPCMessageFramer {
   /// reserves capacity in powers of 2. This way, we can take advantage of the whole buffer.
   static let maximumWriteBufferLength = 65_536
 
-  private var pendingMessages: OneOrManyQueue<[UInt8]>
+  private var pendingMessages: OneOrManyQueue<(bytes: [UInt8], promise: EventLoopPromise<Void>?)>
 
   private var writeBuffer: ByteBuffer
 
@@ -44,8 +44,13 @@ struct GRPCMessageFramer {
 
   /// Queue the given bytes to be framed and potentially coalesced alongside other messages in a `ByteBuffer`.
   /// The resulting data will be returned when calling ``GRPCMessageFramer/next()``.
-  mutating func append(_ bytes: [UInt8]) {
-    self.pendingMessages.append(bytes)
+  mutating func append(_ bytes: [UInt8], promise: EventLoopPromise<Void>?) {
+    self.pendingMessages.append((bytes, promise))
+  }
+
+  struct DataFrame {
+    let bytes: ByteBuffer
+    let promise: EventLoopPromise<Void>?
   }
 
   /// If there are pending messages to be framed, a `ByteBuffer` will be returned with the framed data.
@@ -53,7 +58,7 @@ struct GRPCMessageFramer {
   /// - Parameter compressor: An optional compressor: if present, payloads will be compressed; otherwise
   /// they'll be framed as-is.
   /// - Throws: If an error is encountered, such as a compression failure, an error will be thrown.
-  mutating func next(compressor: Zlib.Compressor? = nil) throws -> ByteBuffer? {
+  mutating func next(compressor: Zlib.Compressor? = nil) throws -> DataFrame? {
     if self.pendingMessages.isEmpty {
       // Nothing pending: exit early.
       return nil
@@ -69,15 +74,21 @@ struct GRPCMessageFramer {
 
     var requiredCapacity = 0
     for message in self.pendingMessages {
-      requiredCapacity += message.count + Self.metadataLength
+      requiredCapacity += message.bytes.count + Self.metadataLength
     }
     self.writeBuffer.clear(minimumCapacity: requiredCapacity)
 
+    var pendingWritePromise: EventLoopPromise<Void>?
     while let message = self.pendingMessages.pop() {
-      try self.encode(message, compressor: compressor)
+      try self.encode(message.bytes, compressor: compressor)
+      if pendingWritePromise == nil {
+        pendingWritePromise = message.promise
+      } else {
+        pendingWritePromise?.futureResult.cascade(to: message.promise)
+      }
     }
 
-    return self.writeBuffer
+    return DataFrame(bytes: self.writeBuffer, promise: pendingWritePromise)
   }
 
   private mutating func encode(_ message: [UInt8], compressor: Zlib.Compressor?) throws {

--- a/Sources/GRPCHTTP2Core/GRPCMessageFramer.swift
+++ b/Sources/GRPCHTTP2Core/GRPCMessageFramer.swift
@@ -78,10 +78,10 @@ struct GRPCMessageFramer {
     var pendingWritePromise: EventLoopPromise<Void>?
     while let message = self.pendingMessages.pop() {
       try self.encode(message.bytes, compressor: compressor)
-      if pendingWritePromise == nil {
-        pendingWritePromise = message.promise
+      if let existingPendingWritePromise = pendingWritePromise {
+        existingPendingWritePromise.futureResult.cascade(to: message.promise)
       } else {
-        pendingWritePromise?.futureResult.cascade(to: message.promise)
+        pendingWritePromise = message.promise
       }
     }
 

--- a/Sources/GRPCHTTP2Core/GRPCStreamStateMachine.swift
+++ b/Sources/GRPCHTTP2Core/GRPCStreamStateMachine.swift
@@ -325,12 +325,12 @@ struct GRPCStreamStateMachine {
     }
   }
 
-  mutating func send(message: [UInt8]) throws {
+  mutating func send(message: [UInt8], promise: EventLoopPromise<Void>?) throws {
     switch self.configuration {
     case .client:
-      try self.clientSend(message: message)
+      try self.clientSend(message: message, promise: promise)
     case .server:
-      try self.serverSend(message: message)
+      try self.serverSend(message: message, promise: promise)
     }
   }
 
@@ -398,14 +398,17 @@ struct GRPCStreamStateMachine {
   }
 
   /// The result of requesting the next outbound message.
-  enum OnNextOutboundMessage: Equatable {
+  enum OnNextOutboundMessage {
     /// Either the receiving party is closed, so we shouldn't send any more messages; or the sender is done
     /// writing messages (i.e. we are now closed).
     case noMoreMessages
     /// There isn't a message ready to be sent, but we could still receive more, so keep trying.
     case awaitMoreMessages
     /// A message is ready to be sent.
-    case sendMessage(ByteBuffer)
+    case sendMessage(
+      message: ByteBuffer,
+      promise: EventLoopPromise<Void>?
+    )
   }
 
   mutating func nextOutboundMessage() throws -> OnNextOutboundMessage {
@@ -540,15 +543,15 @@ extension GRPCStreamStateMachine {
     }
   }
 
-  private mutating func clientSend(message: [UInt8]) throws {
+  private mutating func clientSend(message: [UInt8], promise: EventLoopPromise<Void>?) throws {
     switch self.state {
     case .clientIdleServerIdle:
       try self.invalidState("Client not yet open.")
     case .clientOpenServerIdle(var state):
-      state.framer.append(message)
+      state.framer.append(message, promise: promise)
       self.state = .clientOpenServerIdle(state)
     case .clientOpenServerOpen(var state):
-      state.framer.append(message)
+      state.framer.append(message, promise: promise)
       self.state = .clientOpenServerOpen(state)
     case .clientOpenServerClosed:
       // The server has closed, so it makes no sense to send the rest of the request.
@@ -584,16 +587,18 @@ extension GRPCStreamStateMachine {
     case .clientOpenServerIdle(var state):
       let request = try state.framer.next(compressor: state.compressor)
       self.state = .clientOpenServerIdle(state)
-      return request.map { .sendMessage($0) } ?? .awaitMoreMessages
+      return request.map { .sendMessage(message: $0.bytes, promise: $0.promise) }
+        ?? .awaitMoreMessages
     case .clientOpenServerOpen(var state):
       let request = try state.framer.next(compressor: state.compressor)
       self.state = .clientOpenServerOpen(state)
-      return request.map { .sendMessage($0) } ?? .awaitMoreMessages
+      return request.map { .sendMessage(message: $0.bytes, promise: $0.promise) }
+        ?? .awaitMoreMessages
     case .clientClosedServerIdle(var state):
       let request = try state.framer.next(compressor: state.compressor)
       self.state = .clientClosedServerIdle(state)
       if let request {
-        return .sendMessage(request)
+        return .sendMessage(message: request.bytes, promise: request.promise)
       } else {
         return .noMoreMessages
       }
@@ -601,7 +606,7 @@ extension GRPCStreamStateMachine {
       let request = try state.framer.next(compressor: state.compressor)
       self.state = .clientClosedServerOpen(state)
       if let request {
-        return .sendMessage(request)
+        return .sendMessage(message: request.bytes, promise: request.promise)
       } else {
         return .noMoreMessages
       }
@@ -1003,17 +1008,17 @@ extension GRPCStreamStateMachine {
     }
   }
 
-  private mutating func serverSend(message: [UInt8]) throws {
+  private mutating func serverSend(message: [UInt8], promise: EventLoopPromise<Void>?) throws {
     switch self.state {
     case .clientIdleServerIdle, .clientOpenServerIdle, .clientClosedServerIdle:
       try self.invalidState(
         "Server must have sent initial metadata before sending a message."
       )
     case .clientOpenServerOpen(var state):
-      state.framer.append(message)
+      state.framer.append(message, promise: promise)
       self.state = .clientOpenServerOpen(state)
     case .clientClosedServerOpen(var state):
-      state.framer.append(message)
+      state.framer.append(message, promise: promise)
       self.state = .clientClosedServerOpen(state)
     case .clientOpenServerClosed, .clientClosedServerClosed:
       try self.invalidState(
@@ -1358,16 +1363,18 @@ extension GRPCStreamStateMachine {
     case .clientOpenServerOpen(var state):
       let response = try state.framer.next(compressor: state.compressor)
       self.state = .clientOpenServerOpen(state)
-      return response.map { .sendMessage($0) } ?? .awaitMoreMessages
+      return response.map { .sendMessage(message: $0.bytes, promise: $0.promise) }
+        ?? .awaitMoreMessages
     case .clientClosedServerOpen(var state):
       let response = try state.framer.next(compressor: state.compressor)
       self.state = .clientClosedServerOpen(state)
-      return response.map { .sendMessage($0) } ?? .awaitMoreMessages
+      return response.map { .sendMessage(message: $0.bytes, promise: $0.promise) }
+        ?? .awaitMoreMessages
     case .clientOpenServerClosed(var state):
       let response = try state.framer?.next(compressor: state.compressor)
       self.state = .clientOpenServerClosed(state)
       if let response {
-        return .sendMessage(response)
+        return .sendMessage(message: response.bytes, promise: response.promise)
       } else {
         return .noMoreMessages
       }
@@ -1375,7 +1382,7 @@ extension GRPCStreamStateMachine {
       let response = try state.framer?.next(compressor: state.compressor)
       self.state = .clientClosedServerClosed(state)
       if let response {
-        return .sendMessage(response)
+        return .sendMessage(message: response.bytes, promise: response.promise)
       } else {
         return .noMoreMessages
       }

--- a/Sources/GRPCHTTP2Core/GRPCStreamStateMachine.swift
+++ b/Sources/GRPCHTTP2Core/GRPCStreamStateMachine.swift
@@ -397,26 +397,26 @@ struct GRPCStreamStateMachine {
     }
   }
 
-  /// The result of requesting the next outbound message.
-  enum OnNextOutboundMessage {
-    /// Either the receiving party is closed, so we shouldn't send any more messages; or the sender is done
+  /// The result of requesting the next outbound frame, which may contain multiple messages.
+  enum OnNextOutboundFrame {
+    /// Either the receiving party is closed, so we shouldn't send any more frames; or the sender is done
     /// writing messages (i.e. we are now closed).
     case noMoreMessages
-    /// There isn't a message ready to be sent, but we could still receive more, so keep trying.
+    /// There isn't a frame ready to be sent, but we could still receive more messages, so keep trying.
     case awaitMoreMessages
-    /// A message is ready to be sent.
-    case sendMessage(
-      message: ByteBuffer,
+    /// A frame is ready to be sent.
+    case sendFrame(
+      frame: ByteBuffer,
       promise: EventLoopPromise<Void>?
     )
   }
 
-  mutating func nextOutboundMessage() throws -> OnNextOutboundMessage {
+  mutating func nextOutboundFrame() throws -> OnNextOutboundFrame {
     switch self.configuration {
     case .client:
-      return try self.clientNextOutboundMessage()
+      return try self.clientNextOutboundFrame()
     case .server:
-      return try self.serverNextOutboundMessage()
+      return try self.serverNextOutboundFrame()
     }
   }
 
@@ -580,25 +580,25 @@ extension GRPCStreamStateMachine {
 
   /// Returns the client's next request to the server.
   /// - Returns: The request to be made to the server.
-  private mutating func clientNextOutboundMessage() throws -> OnNextOutboundMessage {
+  private mutating func clientNextOutboundFrame() throws -> OnNextOutboundFrame {
     switch self.state {
     case .clientIdleServerIdle:
       try self.invalidState("Client is not open yet.")
     case .clientOpenServerIdle(var state):
       let request = try state.framer.next(compressor: state.compressor)
       self.state = .clientOpenServerIdle(state)
-      return request.map { .sendMessage(message: $0.bytes, promise: $0.promise) }
+      return request.map { .sendFrame(frame: $0.bytes, promise: $0.promise) }
         ?? .awaitMoreMessages
     case .clientOpenServerOpen(var state):
       let request = try state.framer.next(compressor: state.compressor)
       self.state = .clientOpenServerOpen(state)
-      return request.map { .sendMessage(message: $0.bytes, promise: $0.promise) }
+      return request.map { .sendFrame(frame: $0.bytes, promise: $0.promise) }
         ?? .awaitMoreMessages
     case .clientClosedServerIdle(var state):
       let request = try state.framer.next(compressor: state.compressor)
       self.state = .clientClosedServerIdle(state)
       if let request {
-        return .sendMessage(message: request.bytes, promise: request.promise)
+        return .sendFrame(frame: request.bytes, promise: request.promise)
       } else {
         return .noMoreMessages
       }
@@ -606,7 +606,7 @@ extension GRPCStreamStateMachine {
       let request = try state.framer.next(compressor: state.compressor)
       self.state = .clientClosedServerOpen(state)
       if let request {
-        return .sendMessage(message: request.bytes, promise: request.promise)
+        return .sendFrame(frame: request.bytes, promise: request.promise)
       } else {
         return .noMoreMessages
       }
@@ -1356,25 +1356,25 @@ extension GRPCStreamStateMachine {
     }
   }
 
-  private mutating func serverNextOutboundMessage() throws -> OnNextOutboundMessage {
+  private mutating func serverNextOutboundFrame() throws -> OnNextOutboundFrame {
     switch self.state {
     case .clientIdleServerIdle, .clientOpenServerIdle, .clientClosedServerIdle:
       try self.invalidState("Server is not open yet.")
     case .clientOpenServerOpen(var state):
       let response = try state.framer.next(compressor: state.compressor)
       self.state = .clientOpenServerOpen(state)
-      return response.map { .sendMessage(message: $0.bytes, promise: $0.promise) }
+      return response.map { .sendFrame(frame: $0.bytes, promise: $0.promise) }
         ?? .awaitMoreMessages
     case .clientClosedServerOpen(var state):
       let response = try state.framer.next(compressor: state.compressor)
       self.state = .clientClosedServerOpen(state)
-      return response.map { .sendMessage(message: $0.bytes, promise: $0.promise) }
+      return response.map { .sendFrame(frame: $0.bytes, promise: $0.promise) }
         ?? .awaitMoreMessages
     case .clientOpenServerClosed(var state):
       let response = try state.framer?.next(compressor: state.compressor)
       self.state = .clientOpenServerClosed(state)
       if let response {
-        return .sendMessage(message: response.bytes, promise: response.promise)
+        return .sendFrame(frame: response.bytes, promise: response.promise)
       } else {
         return .noMoreMessages
       }
@@ -1382,7 +1382,7 @@ extension GRPCStreamStateMachine {
       let response = try state.framer?.next(compressor: state.compressor)
       self.state = .clientClosedServerClosed(state)
       if let response {
-        return .sendMessage(message: response.bytes, promise: response.promise)
+        return .sendFrame(frame: response.bytes, promise: response.promise)
       } else {
         return .noMoreMessages
       }

--- a/Sources/GRPCHTTP2Core/Server/GRPCServerStreamHandler.swift
+++ b/Sources/GRPCHTTP2Core/Server/GRPCServerStreamHandler.swift
@@ -164,6 +164,7 @@ extension GRPCServerStreamHandler {
         self.pendingTrailersPromise = promise
       } catch {
         context.fireErrorCaught(error)
+        promise?.fail(error)
       }
     }
   }

--- a/Sources/GRPCHTTP2Core/Server/GRPCServerStreamHandler.swift
+++ b/Sources/GRPCHTTP2Core/Server/GRPCServerStreamHandler.swift
@@ -177,8 +177,8 @@ extension GRPCServerStreamHandler {
 
     do {
       loop: while true {
-        switch try self.stateMachine.nextOutboundMessage() {
-        case .sendMessage(let byteBuffer, let promise):
+        switch try self.stateMachine.nextOutboundFrame() {
+        case .sendFrame(let byteBuffer, let promise):
           self.flushPending = true
           context.write(
             self.wrapOutboundOut(.data(.init(data: .byteBuffer(byteBuffer)))),

--- a/Sources/GRPCHTTP2Core/Server/GRPCServerStreamHandler.swift
+++ b/Sources/GRPCHTTP2Core/Server/GRPCServerStreamHandler.swift
@@ -145,14 +145,15 @@ extension GRPCServerStreamHandler {
         let headers = try self.stateMachine.send(metadata: metadata)
         context.write(self.wrapOutboundOut(.headers(.init(headers: headers))), promise: promise)
       } catch {
-        context.fireErrorCaught(error)
         promise?.fail(error)
+        context.fireErrorCaught(error)
       }
 
     case .message(let message):
       do {
         try self.stateMachine.send(message: message, promise: promise)
       } catch {
+        promise?.fail(error)
         context.fireErrorCaught(error)
       }
 
@@ -162,8 +163,8 @@ extension GRPCServerStreamHandler {
         let response = HTTP2Frame.FramePayload.headers(.init(headers: headers, endStream: true))
         self.pendingTrailers = (response, promise)
       } catch {
-        context.fireErrorCaught(error)
         promise?.fail(error)
+        context.fireErrorCaught(error)
       }
     }
   }

--- a/Tests/GRPCHTTP2CoreTests/GRPCMessageFramerTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/GRPCMessageFramerTests.swift
@@ -22,9 +22,9 @@ import XCTest
 final class GRPCMessageFramerTests: XCTestCase {
   func testSingleWrite() throws {
     var framer = GRPCMessageFramer()
-    framer.append(Array(repeating: 42, count: 128))
+    framer.append(Array(repeating: 42, count: 128), promise: nil)
 
-    var buffer = try XCTUnwrap(framer.next())
+    var buffer = try XCTUnwrap(framer.next()).bytes
     let (compressed, length) = try XCTUnwrap(buffer.readMessageHeader())
     XCTAssertFalse(compressed)
     XCTAssertEqual(length, 128)
@@ -43,7 +43,7 @@ final class GRPCMessageFramerTests: XCTestCase {
     var framer = GRPCMessageFramer()
 
     let message = [UInt8](repeating: 42, count: 128)
-    framer.append(message)
+    framer.append(message, promise: nil)
 
     var buffer = ByteBuffer()
     let testCompressor = Zlib.Compressor(method: compressionMethod)
@@ -53,7 +53,7 @@ final class GRPCMessageFramerTests: XCTestCase {
       testCompressor.end()
     }
 
-    buffer = try XCTUnwrap(framer.next(compressor: compressor))
+    buffer = try XCTUnwrap(framer.next(compressor: compressor)).bytes
     let (compressed, length) = try XCTUnwrap(buffer.readMessageHeader())
     XCTAssertTrue(compressed)
     XCTAssertEqual(length, UInt32(compressedSize))
@@ -77,10 +77,10 @@ final class GRPCMessageFramerTests: XCTestCase {
 
     let messages = 100
     for _ in 0 ..< messages {
-      framer.append(Array(repeating: 42, count: 128))
+      framer.append(Array(repeating: 42, count: 128), promise: nil)
     }
 
-    var buffer = try XCTUnwrap(framer.next())
+    var buffer = try XCTUnwrap(framer.next()).bytes
     for _ in 0 ..< messages {
       let (compressed, length) = try XCTUnwrap(buffer.readMessageHeader())
       XCTAssertFalse(compressed)


### PR DESCRIPTION
We're not currently handling write promises correctly in the server and client stream handlers. 

This PR adds proper handling by storing promises linked to each write, and chaining them when they're framed together in a single frame, which can be passed onto the `context/write` call on `flush()`.