### PR TITLE
Update formatting script

### DIFF
--- a/Plugins/GRPCSwiftPlugin/plugin.swift
+++ b/Plugins/GRPCSwiftPlugin/plugin.swift
@@ -36,9 +36,9 @@ struct GRPCSwiftPlugin {
         return "The input file '\(path)' does not have a '.proto' extension."
       case let .noConfigFound(path):
         return """
-        No configuration file found named '\(path)'. The file must not be listed in the \
-        'exclude:' argument for the target in Package.swift.
-        """
+          No configuration file found named '\(path)'. The file must not be listed in the \
+          'exclude:' argument for the target in Package.swift.
+          """
       }
     }
   }
@@ -99,11 +99,13 @@ struct GRPCSwiftPlugin {
     sourceFiles: FileList,
     tool: (String) throws -> PackagePlugin.PluginContext.Tool
   ) throws -> [Command] {
-    guard let configurationFilePath = sourceFiles.first(
-      where: {
-        $0.path.lastComponent == Self.configurationFileName
-      }
-    )?.path else {
+    guard
+      let configurationFilePath = sourceFiles.first(
+        where: {
+          $0.path.lastComponent == Self.configurationFileName
+        }
+      )?.path
+    else {
       throw PluginError.noConfigFound(Self.configurationFileName)
     }
 

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -56,7 +56,7 @@ THIS_SCRIPT=$0
 HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 REPO="$HERE/.."
 SWIFTFORMAT_DIR="$HERE/.swift-format-source"
-SWIFTFORMAT_VERSION=509.0.0
+SWIFTFORMAT_VERSION=510.0.0
 
 # Clone SwiftFormat if we don't already have it.
 if [ ! -d "$SWIFTFORMAT_DIR" ]; then
@@ -91,7 +91,9 @@ fi
 if "$lint"; then
   "${SWIFTFORMAT_BIN}" lint \
     --parallel --recursive --strict \
-    "${REPO}/Sources" "${REPO}/Tests" \
+    "${REPO}/Sources" \
+    "${REPO}/Tests" \
+    "${REPO}/Plugins" \
     && SWIFT_FORMAT_RC=$? || SWIFT_FORMAT_RC=$?
 
   if [[ "${SWIFT_FORMAT_RC}" -ne 0 ]]; then
@@ -108,7 +110,9 @@ if "$lint"; then
 elif "$format"; then
   "${SWIFTFORMAT_BIN}" format \
     --parallel --recursive --in-place \
-    "${REPO}/Sources" "${REPO}/Tests" \
+    "${REPO}/Sources" \
+    "${REPO}/Tests" \
+    "${REPO}/Plugins" \
     && SWIFT_FORMAT_RC=$? || SWIFT_FORMAT_RC=$?
 
   if [[ "${SWIFT_FORMAT_RC}" -ne 0 ]]; then


### PR DESCRIPTION
Motivation:

The formatting script only checks Sources and Tests. The Plugins directory is currently not checked. Moreover the formatter is using the 5.9 version.

Modifications:

- Update the formatter to use 5.10
- Upadte the formatting script to check Plugins

Result:

Formatting checks more places