### PR TITLE
Update `release` GitHub workflow action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,9 @@ jobs:
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
       - name: Build the plugins
-        run: make plugins
+        run: |
+          swift build --build-path=./.build --configuration=release --product protoc-gen-swift
+          swift build --build-path=./.build --configuration=release --product protoc-gen-grpc-swift
 
       - name: Zip the plugins
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,10 @@ jobs:
 
       - name: Build the plugins
         run: |
-          swift build --build-path=./.build --configuration=release --product protoc-gen-swift
-          swift build --build-path=./.build --configuration=release --product protoc-gen-grpc-swift
+          swift build --configuration=release --product protoc-gen-swift
+          cp ./.build/release/protoc-gen-swift .
+          swift build --configuration=release --product protoc-gen-grpc-swift
+          cp ./.build/release/protoc-gen-grpc-swift .
 
       - name: Zip the plugins
         run: |

--- a/Sources/GRPC/Docs.docc/index.md
+++ b/Sources/GRPC/Docs.docc/index.md
@@ -63,8 +63,14 @@ dependencies: [
 Binary releases of `protoc`, the Protocol Buffer Compiler, are available on
 [GitHub][protobuf-releases].
 
-To build the plugins, run `make plugins` in the main directory. This uses the
-Swift Package Manager to build both of the necessary plugins:
+To build the plugins, run the following in the main directory:
+
+```sh
+$ swift build --product protoc-gen-swift
+$ swift build --product protoc-gen-grpc-swift
+```
+
+This uses the Swift Package Manager to build both of the necessary plugins:
 `protoc-gen-swift`, which generates Protocol Buffer support code and
 `protoc-gen-grpc-swift`, which generates gRPC interface code.
 

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -5,14 +5,7 @@ compiler `protoc` to generate classes for clients and services.
 
 ## Building the Plugin
 
-The `protoc-gen-grpc-swift` plugin can be built by using the Makefile in the
-top-level directory:
-
-```sh
-$ make plugins
-```
-
-The Swift Package Manager may also be invoked directly to build the plugin:
+The `protoc-gen-grpc-swift` plugin can be built using the Swift Package Manager:
 
 ```sh
 $ swift build --product protoc-gen-grpc-swift


### PR DESCRIPTION
The `release` GH workflow action was still using the `plugins` Makefile target, but we deleted the Makefile some time ago so it was failing.

This PR updates the `release.yaml` GH workflow to use the SPM directly instead, and also removes some doc references to the makefile.