### PR TITLE
Rename a few things

### DIFF
--- a/Sources/GRPCCore/Call/Client/CallOptions.swift
+++ b/Sources/GRPCCore/Call/Client/CallOptions.swift
@@ -148,7 +148,7 @@ extension CallOptions {
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension CallOptions {
-  mutating func formUnion(with methodConfig: MethodConfiguration?) {
+  mutating func formUnion(with methodConfig: MethodConfig?) {
     guard let methodConfig = methodConfig else { return }
 
     self.timeout.setIfNone(to: methodConfig.timeout)

--- a/Sources/GRPCCore/Configuration/MethodConfig.swift
+++ b/Sources/GRPCCore/Configuration/MethodConfig.swift
@@ -18,7 +18,7 @@
 ///
 /// See also: https://github.com/grpc/grpc-proto/blob/master/grpc/service_config/service_config.proto
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-public struct MethodConfiguration: Hashable, Sendable {
+public struct MethodConfig: Hashable, Sendable {
   public struct Name: Sendable, Hashable {
     /// The name of the service, including the namespace.
     ///
@@ -414,7 +414,7 @@ extension Duration {
 }
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-extension MethodConfiguration: Codable {
+extension MethodConfig: Codable {
   private enum CodingKeys: String, CodingKey {
     case name
     case waitForReady
@@ -472,7 +472,7 @@ extension MethodConfiguration: Codable {
 }
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-extension MethodConfiguration.Name: Codable {
+extension MethodConfig.Name: Codable {
   private enum CodingKeys: String, CodingKey {
     case service
     case method

--- a/Sources/GRPCCore/Configuration/ServiceConfig.swift
+++ b/Sources/GRPCCore/Configuration/ServiceConfig.swift
@@ -18,9 +18,9 @@
 ///
 /// See also: https://github.com/grpc/grpc-proto/blob/master/grpc/service_config/service_config.proto
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-public struct ServiceConfiguration: Hashable, Sendable {
+public struct ServiceConfig: Hashable, Sendable {
   /// Per-method configuration.
-  public var methodConfiguration: [MethodConfiguration]
+  public var methodConfig: [MethodConfig]
 
   /// Load balancing policies.
   ///
@@ -44,26 +44,26 @@ public struct ServiceConfiguration: Hashable, Sendable {
   /// and hedged RPCs will not be sent.
   public var retryThrottlingPolicy: RetryThrottlingPolicy?
 
-  /// Creates a new ``ServiceConfiguration``.
+  /// Creates a new ``ServiceConfig``.
   ///
   /// - Parameters:
-  ///   - methodConfiguration: Per-method configuration.
+  ///   - methodConfig: Per-method configuration.
   ///   - loadBalancingConfiguration: Load balancing policies. Clients use the the first supported
   ///       policy when iterating the list in order.
   ///   - retryThrottlingPolicy: Policy for throttling retries.
   public init(
-    methodConfiguration: [MethodConfiguration] = [],
+    methodConfig: [MethodConfig] = [],
     loadBalancingConfiguration: [LoadBalancingConfiguration] = [],
     retryThrottlingPolicy: RetryThrottlingPolicy? = nil
   ) {
-    self.methodConfiguration = methodConfiguration
+    self.methodConfig = methodConfig
     self.loadBalancingConfiguration = loadBalancingConfiguration
     self.retryThrottlingPolicy = retryThrottlingPolicy
   }
 }
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-extension ServiceConfiguration: Codable {
+extension ServiceConfig: Codable {
   private enum CodingKeys: String, CodingKey {
     case methodConfig
     case loadBalancingConfig
@@ -73,11 +73,11 @@ extension ServiceConfiguration: Codable {
   public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
 
-    let methodConfiguration = try container.decodeIfPresent(
-      [MethodConfiguration].self,
+    let methodConfig = try container.decodeIfPresent(
+      [MethodConfig].self,
       forKey: .methodConfig
     )
-    self.methodConfiguration = methodConfiguration ?? []
+    self.methodConfig = methodConfig ?? []
 
     let loadBalancingConfiguration = try container.decodeIfPresent(
       [LoadBalancingConfiguration].self,
@@ -93,14 +93,14 @@ extension ServiceConfiguration: Codable {
 
   public func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
-    try container.encode(self.methodConfiguration, forKey: .methodConfig)
+    try container.encode(self.methodConfig, forKey: .methodConfig)
     try container.encode(self.loadBalancingConfiguration, forKey: .loadBalancingConfig)
     try container.encodeIfPresent(self.retryThrottlingPolicy, forKey: .retryThrottling)
   }
 }
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-extension ServiceConfiguration {
+extension ServiceConfig {
   /// Configuration used by clients for load-balancing.
   public struct LoadBalancingConfiguration: Hashable, Sendable {
     private enum Value: Hashable, Sendable {
@@ -166,7 +166,7 @@ extension ServiceConfiguration {
 }
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-extension ServiceConfiguration.LoadBalancingConfiguration {
+extension ServiceConfig.LoadBalancingConfiguration {
   /// Configuration for the pick-first load balancing policy.
   public struct PickFirst: Hashable, Sendable, Codable {
     /// Whether the resolved addresses should be shuffled before attempting to connect to them.
@@ -194,7 +194,7 @@ extension ServiceConfiguration.LoadBalancingConfiguration {
 }
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-extension ServiceConfiguration.LoadBalancingConfiguration: Codable {
+extension ServiceConfig.LoadBalancingConfiguration: Codable {
   private enum CodingKeys: String, CodingKey {
     case roundRobin = "round_robin"
     case pickFirst = "pick_first"
@@ -225,7 +225,7 @@ extension ServiceConfiguration.LoadBalancingConfiguration: Codable {
 }
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-extension ServiceConfiguration {
+extension ServiceConfig {
   public struct RetryThrottlingPolicy: Hashable, Sendable, Codable {
     /// The initial, and maximum number of tokens.
     ///

--- a/Sources/GRPCCore/GRPCClient.swift
+++ b/Sources/GRPCCore/GRPCClient.swift
@@ -28,7 +28,7 @@ import Atomics
 ///
 /// However, in most cases you should prefer wrapping the ``GRPCClient`` with a generated stub.
 ///
-/// You can set ``ServiceConfiguration``s on this client to override whatever configurations have been
+/// You can set ``ServiceConfig``s on this client to override whatever configurations have been
 /// set on the given transport. You can also use ``ClientInterceptor``s to implement cross-cutting
 /// logic which apply to all RPCs. Example uses of interceptors include authentication and logging.
 ///
@@ -40,11 +40,11 @@ import Atomics
 /// // Create a configuration object for the client and override the timeout for the 'Get' method on
 /// // the 'echo.Echo' service. This configuration takes precedence over any set by the transport.
 /// var configuration = GRPCClient.Configuration()
-/// configuration.service.override = ServiceConfiguration(
-///   methodConfiguration: [
-///     MethodConfiguration(
+/// configuration.service.override = ServiceConfig(
+///   methodConfig: [
+///     MethodConfig(
 ///       names: [
-///         MethodConfiguration.Name(service: "echo.Echo", method: "Get")
+///         MethodConfig.Name(service: "echo.Echo", method: "Get")
 ///       ],
 ///       timeout: .seconds(5)
 ///     )
@@ -53,11 +53,11 @@ import Atomics
 ///
 /// // Configure a fallback timeout for all RPCs (indicated by an empty service and method name) if
 /// // no configuration is provided in the overrides or by the transport.
-/// configuration.service.defaults = ServiceConfiguration(
-///   methodConfiguration: [
-///     MethodConfiguration(
+/// configuration.service.defaults = ServiceConfig(
+///   methodConfig: [
+///     MethodConfig(
 ///       names: [
-///         MethodConfiguration.Name(service: "", method: "")
+///         MethodConfig.Name(service: "", method: "")
 ///       ],
 ///       timeout: .seconds(10)
 ///     )

--- a/Sources/GRPCCore/Internal/MethodConfigs.swift
+++ b/Sources/GRPCCore/Internal/MethodConfigs.swift
@@ -16,7 +16,7 @@
 
 // TODO: when swift(>=5.9), use 'package' access level
 
-/// A collection of ``MethodConfiguration``s, mapped to specific methods or services.
+/// A collection of ``MethodConfig``s, mapped to specific methods or services.
 ///
 /// When creating a new instance, no overrides and no default will be set for using when getting
 /// a configuration for a method that has not been given a specific override.
@@ -25,23 +25,23 @@
 ///
 /// Use the subscript to get and set configurations for specific methods.
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-public struct _MethodConfigurations: Sendable, Hashable {
-  private var elements: [MethodConfiguration.Name: MethodConfiguration]
+public struct _MethodConfigs: Sendable, Hashable {
+  private var elements: [MethodConfig.Name: MethodConfig]
 
-  /// Create a new ``_MethodConfigurations``.
+  /// Create a new ``_MethodConfigs``.
   ///
-  /// - Parameter serviceConfiguration: The configuration to read ``MethodConfiguration`` from.
-  public init(serviceConfiguration: ServiceConfiguration = ServiceConfiguration()) {
+  /// - Parameter serviceConfig: The configuration to read ``MethodConfig`` from.
+  public init(serviceConfig: ServiceConfig = ServiceConfig()) {
     self.elements = [:]
 
-    for configuration in serviceConfiguration.methodConfiguration {
+    for configuration in serviceConfig.methodConfig {
       for name in configuration.names {
         self.elements[name] = configuration
       }
     }
   }
 
-  /// Get or set the corresponding ``MethodConfiguration`` for the given ``MethodDescriptor``.
+  /// Get or set the corresponding ``MethodConfig`` for the given ``MethodDescriptor``.
   ///
   /// Configuration is hierarchical and can be set per-method, per-service
   /// (``setDefaultConfiguration(_:forService:)``) and globally (``setDefaultConfiguration(_:)``).
@@ -51,10 +51,10 @@ public struct _MethodConfigurations: Sendable, Hashable {
   /// global configuration is returned, if present.
   ///
   /// - Parameters:
-  ///  - descriptor: The ``MethodDescriptor`` for which to get or set a ``MethodConfiguration``.
-  public subscript(_ descriptor: MethodDescriptor) -> MethodConfiguration? {
+  ///  - descriptor: The ``MethodDescriptor`` for which to get or set a ``MethodConfig``.
+  public subscript(_ descriptor: MethodDescriptor) -> MethodConfig? {
     get {
-      var name = MethodConfiguration.Name(service: descriptor.service, method: descriptor.method)
+      var name = MethodConfig.Name(service: descriptor.service, method: descriptor.method)
 
       if let configuration = self.elements[name] {
         return configuration
@@ -73,7 +73,7 @@ public struct _MethodConfigurations: Sendable, Hashable {
     }
 
     set {
-      let name = MethodConfiguration.Name(service: descriptor.service, method: descriptor.method)
+      let name = MethodConfig.Name(service: descriptor.service, method: descriptor.method)
       self.elements[name] = newValue
     }
   }
@@ -81,8 +81,8 @@ public struct _MethodConfigurations: Sendable, Hashable {
   /// Set a default configuration for all methods that have no overrides.
   ///
   /// - Parameter configuration: The default configuration.
-  public mutating func setDefaultConfiguration(_ configuration: MethodConfiguration?) {
-    let name = MethodConfiguration.Name(service: "", method: "")
+  public mutating func setDefaultConfiguration(_ configuration: MethodConfig?) {
+    let name = MethodConfig.Name(service: "", method: "")
     self.elements[name] = configuration
   }
 
@@ -90,16 +90,16 @@ public struct _MethodConfigurations: Sendable, Hashable {
   ///
   /// If getting a configuration for a method that's part of a service, and the method itself doesn't have an
   /// override, then this configuration will be used instead of the default configuration passed when creating
-  /// this instance of ``MethodConfigurations``.
+  /// this instance of ``MethodConfigs``.
   ///
   /// - Parameters:
   ///   - configuration: The default configuration for the service.
   ///   - service: The name of the service for which this override applies.
   public mutating func setDefaultConfiguration(
-    _ configuration: MethodConfiguration?,
+    _ configuration: MethodConfig?,
     forService service: String
   ) {
-    let name = MethodConfiguration.Name(service: "", method: "")
+    let name = MethodConfig.Name(service: "", method: "")
     self.elements[name] = configuration
   }
 }

--- a/Sources/GRPCCore/Transport/ClientTransport.swift
+++ b/Sources/GRPCCore/Transport/ClientTransport.swift
@@ -77,5 +77,5 @@ public protocol ClientTransport: Sendable {
   ///
   /// - Parameter descriptor: The method to lookup configuration for.
   /// - Returns: Configuration for the method, if it exists.
-  func configuration(forMethod descriptor: MethodDescriptor) -> MethodConfiguration?
+  func configuration(forMethod descriptor: MethodDescriptor) -> MethodConfig?
 }

--- a/Sources/GRPCCore/Transport/RetryThrottle.swift
+++ b/Sources/GRPCCore/Transport/RetryThrottle.swift
@@ -107,7 +107,7 @@ public struct RetryThrottle: Sendable {
   ///
   /// - Parameter policy: The policy to use to configure the throttle.
   @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-  public init(policy: ServiceConfiguration.RetryThrottlingPolicy) {
+  public init(policy: ServiceConfig.RetryThrottlingPolicy) {
     self.init(maximumTokens: policy.maxTokens, tokenRatio: policy.tokenRatio)
   }
 

--- a/Sources/GRPCHTTP2Core/Client/Resolver/NameResolver+IPv4.swift
+++ b/Sources/GRPCHTTP2Core/Client/Resolver/NameResolver+IPv4.swift
@@ -68,7 +68,7 @@ extension NameResolvers {
 
     public func resolver(for target: Target) -> NameResolver {
       let endpoints = target.addresses.map { Endpoint(addresses: [.ipv4($0)]) }
-      let resolutionResult = NameResolutionResult(endpoints: endpoints, serviceConfiguration: nil)
+      let resolutionResult = NameResolutionResult(endpoints: endpoints, serviceConfig: nil)
       return NameResolver(names: .constant(resolutionResult), updateMode: .pull)
     }
   }

--- a/Sources/GRPCHTTP2Core/Client/Resolver/NameResolver+IPv6.swift
+++ b/Sources/GRPCHTTP2Core/Client/Resolver/NameResolver+IPv6.swift
@@ -68,7 +68,7 @@ extension NameResolvers {
 
     public func resolver(for target: Target) -> NameResolver {
       let endpoints = target.addresses.map { Endpoint(addresses: [.ipv6($0)]) }
-      let resolutionResult = NameResolutionResult(endpoints: endpoints, serviceConfiguration: nil)
+      let resolutionResult = NameResolutionResult(endpoints: endpoints, serviceConfig: nil)
       return NameResolver(names: .constant(resolutionResult), updateMode: .pull)
     }
   }

--- a/Sources/GRPCHTTP2Core/Client/Resolver/NameResolver+UDS.swift
+++ b/Sources/GRPCHTTP2Core/Client/Resolver/NameResolver+UDS.swift
@@ -53,7 +53,7 @@ extension NameResolvers {
 
     public func resolver(for target: Target) -> NameResolver {
       let endpoint = Endpoint(addresses: [.unixDomainSocket(target.address)])
-      let resolutionResult = NameResolutionResult(endpoints: [endpoint], serviceConfiguration: nil)
+      let resolutionResult = NameResolutionResult(endpoints: [endpoint], serviceConfig: nil)
       return NameResolver(names: .constant(resolutionResult), updateMode: .pull)
     }
   }

--- a/Sources/GRPCHTTP2Core/Client/Resolver/NameResolver+VSOCK.swift
+++ b/Sources/GRPCHTTP2Core/Client/Resolver/NameResolver+VSOCK.swift
@@ -57,7 +57,7 @@ extension NameResolvers {
 
     public func resolver(for target: Target) -> NameResolver {
       let endpoint = Endpoint(addresses: [.vsock(target.address)])
-      let resolutionResult = NameResolutionResult(endpoints: [endpoint], serviceConfiguration: nil)
+      let resolutionResult = NameResolutionResult(endpoints: [endpoint], serviceConfig: nil)
       return NameResolver(names: .constant(resolutionResult), updateMode: .pull)
     }
   }

--- a/Sources/GRPCHTTP2Core/Client/Resolver/NameResolver.swift
+++ b/Sources/GRPCHTTP2Core/Client/Resolver/NameResolver.swift
@@ -67,14 +67,14 @@ public struct NameResolutionResult: Hashable, Sendable {
 
   /// The service configuration reported by the resolver, or an error if it couldn't be parsed.
   /// This value may be `nil` if the resolver doesn't support fetching service configuration.
-  public var serviceConfiguration: Result<ServiceConfiguration, RPCError>?
+  public var serviceConfig: Result<ServiceConfig, RPCError>?
 
   public init(
     endpoints: [Endpoint],
-    serviceConfiguration: Result<ServiceConfiguration, RPCError>?
+    serviceConfig: Result<ServiceConfig, RPCError>?
   ) {
     self.endpoints = endpoints
-    self.serviceConfiguration = serviceConfiguration
+    self.serviceConfig = serviceConfig
   }
 }
 

--- a/Sources/GRPCHTTP2Core/Server/Connection/ServerConnectionManagementHandler+StateMachine.swift
+++ b/Sources/GRPCHTTP2Core/Server/Connection/ServerConnectionManagementHandler+StateMachine.swift
@@ -33,19 +33,19 @@ extension ServerConnectionManagementHandler {
     /// Create a new state machine.
     ///
     /// - Parameters:
-    ///   - allowKeepAliveWithoutCalls: Whether the client is permitted to send keep alive pings
+    ///   - allowKeepaliveWithoutCalls: Whether the client is permitted to send keep alive pings
     ///       when there are no active calls.
     ///   - minPingReceiveIntervalWithoutCalls: The minimum time interval required between keep
     ///       alive pings when there are no active calls.
     ///   - goAwayPingData: Opaque data sent to the client in a PING frame when the server
     ///       initiates graceful shutdown.
     init(
-      allowKeepAliveWithoutCalls: Bool,
+      allowKeepaliveWithoutCalls: Bool,
       minPingReceiveIntervalWithoutCalls: TimeAmount,
       goAwayPingData: HTTP2PingData = HTTP2PingData(withInteger: .random(in: .min ... .max))
     ) {
-      let keepalive = KeepAlive(
-        allowWithoutCalls: allowKeepAliveWithoutCalls,
+      let keepalive = Keepalive(
+        allowWithoutCalls: allowKeepaliveWithoutCalls,
         minPingReceiveIntervalWithoutCalls: minPingReceiveIntervalWithoutCalls
       )
 
@@ -226,7 +226,7 @@ extension ServerConnectionManagementHandler {
     }
 
     /// Reset the state of keep-alive policing.
-    mutating func resetKeepAliveState() {
+    mutating func resetKeepaliveState() {
       switch self.state {
       case .active(var state):
         state.keepalive.reset()
@@ -249,7 +249,7 @@ extension ServerConnectionManagementHandler {
 }
 
 extension ServerConnectionManagementHandler.StateMachine {
-  fileprivate struct KeepAlive {
+  fileprivate struct Keepalive {
     /// Allow the client to send keep alive pings when there are no active calls.
     private let allowWithoutCalls: Bool
 
@@ -328,9 +328,9 @@ extension ServerConnectionManagementHandler.StateMachine {
       /// The ID of the most recently opened stream (zero indicates no streams have been opened yet).
       var lastStreamID: HTTP2StreamID
       /// The state of keep alive.
-      var keepalive: KeepAlive
+      var keepalive: Keepalive
 
-      init(keepalive: KeepAlive) {
+      init(keepalive: Keepalive) {
         self.openStreams = []
         self.lastStreamID = .rootStream
         self.keepalive = keepalive
@@ -345,7 +345,7 @@ extension ServerConnectionManagementHandler.StateMachine {
       /// The ID of the most recently opened stream (zero indicates no streams have been opened yet).
       var lastStreamID: HTTP2StreamID
       /// The state of keep alive.
-      var keepalive: KeepAlive
+      var keepalive: Keepalive
       /// Whether the second GOAWAY frame has been sent with a lower stream ID.
       var sentSecondGoAway: Bool
 

--- a/Sources/GRPCHTTP2Core/Server/Connection/ServerConnectionManagementHandler+StateMachine.swift
+++ b/Sources/GRPCHTTP2Core/Server/Connection/ServerConnectionManagementHandler+StateMachine.swift
@@ -44,12 +44,12 @@ extension ServerConnectionManagementHandler {
       minPingReceiveIntervalWithoutCalls: TimeAmount,
       goAwayPingData: HTTP2PingData = HTTP2PingData(withInteger: .random(in: .min ... .max))
     ) {
-      let keepAlive = KeepAlive(
+      let keepalive = KeepAlive(
         allowWithoutCalls: allowKeepAliveWithoutCalls,
         minPingReceiveIntervalWithoutCalls: minPingReceiveIntervalWithoutCalls
       )
 
-      self.state = .active(State.Active(keepAlive: keepAlive))
+      self.state = .active(State.Active(keepalive: keepalive))
       self.goAwayPingData = goAwayPingData
     }
 
@@ -128,7 +128,7 @@ extension ServerConnectionManagementHandler {
 
       switch self.state {
       case .active(var state):
-        let tooManyPings = state.keepAlive.receivedPing(
+        let tooManyPings = state.keepalive.receivedPing(
           atTime: time,
           hasOpenStreams: !state.openStreams.isEmpty
         )
@@ -142,7 +142,7 @@ extension ServerConnectionManagementHandler {
         }
 
       case .closing(var state):
-        let tooManyPings = state.keepAlive.receivedPing(
+        let tooManyPings = state.keepalive.receivedPing(
           atTime: time,
           hasOpenStreams: !state.openStreams.isEmpty
         )
@@ -229,11 +229,11 @@ extension ServerConnectionManagementHandler {
     mutating func resetKeepAliveState() {
       switch self.state {
       case .active(var state):
-        state.keepAlive.reset()
+        state.keepalive.reset()
         self.state = .active(state)
 
       case .closing(var state):
-        state.keepAlive.reset()
+        state.keepalive.reset()
         self.state = .closing(state)
 
       case .closed:
@@ -328,12 +328,12 @@ extension ServerConnectionManagementHandler.StateMachine {
       /// The ID of the most recently opened stream (zero indicates no streams have been opened yet).
       var lastStreamID: HTTP2StreamID
       /// The state of keep alive.
-      var keepAlive: KeepAlive
+      var keepalive: KeepAlive
 
-      init(keepAlive: KeepAlive) {
+      init(keepalive: KeepAlive) {
         self.openStreams = []
         self.lastStreamID = .rootStream
-        self.keepAlive = keepAlive
+        self.keepalive = keepalive
       }
     }
 
@@ -345,14 +345,14 @@ extension ServerConnectionManagementHandler.StateMachine {
       /// The ID of the most recently opened stream (zero indicates no streams have been opened yet).
       var lastStreamID: HTTP2StreamID
       /// The state of keep alive.
-      var keepAlive: KeepAlive
+      var keepalive: KeepAlive
       /// Whether the second GOAWAY frame has been sent with a lower stream ID.
       var sentSecondGoAway: Bool
 
       init(from state: Active) {
         self.openStreams = state.openStreams
         self.lastStreamID = state.lastStreamID
-        self.keepAlive = state.keepAlive
+        self.keepalive = state.keepalive
         self.sentSecondGoAway = false
       }
     }

--- a/Sources/GRPCHTTP2Core/Server/Connection/ServerConnectionManagementHandler.swift
+++ b/Sources/GRPCHTTP2Core/Server/Connection/ServerConnectionManagementHandler.swift
@@ -60,14 +60,14 @@ final class ServerConnectionManagementHandler: ChannelDuplexHandler {
   private var maxGraceTimer: Timer?
 
   /// The amount of time to wait before sending a keep alive ping.
-  private var keepAliveTimer: Timer?
+  private var keepaliveTimer: Timer?
 
   /// The amount of time the client has to reply after sending a keep alive ping. Only used if
-  /// `keepAliveTimer` is set.
-  private var keepAliveTimeoutTimer: Timer
+  /// `keepaliveTimer` is set.
+  private var keepaliveTimeoutTimer: Timer
 
   /// Opaque data sent in keep alive pings.
-  private let keepAlivePingData: HTTP2PingData
+  private let keepalivePingData: HTTP2PingData
 
   /// Whether a flush is pending.
   private var flushPending: Bool
@@ -186,9 +186,9 @@ final class ServerConnectionManagementHandler: ChannelDuplexHandler {
   ///   - maxIdleTime: The maximum amount time a connection may be idle for before being closed.
   ///   - maxAge: The maximum amount of time a connection may exist before being gracefully closed.
   ///   - maxGraceTime: The maximum amount of time that the connection has to close gracefully.
-  ///   - keepAliveTime: The amount of time to wait after reading data before sending a keep-alive
+  ///   - keepaliveTime: The amount of time to wait after reading data before sending a keep-alive
   ///       ping.
-  ///   - keepAliveTimeout: The amount of time the client has to reply after the server sends a
+  ///   - keepaliveTimeout: The amount of time the client has to reply after the server sends a
   ///       keep-alive ping to keep the connection open. The connection is closed if no reply
   ///       is received.
   ///   - allowKeepAliveWithoutCalls: Whether the server allows the client to send keep-alive pings
@@ -202,8 +202,8 @@ final class ServerConnectionManagementHandler: ChannelDuplexHandler {
     maxIdleTime: TimeAmount?,
     maxAge: TimeAmount?,
     maxGraceTime: TimeAmount?,
-    keepAliveTime: TimeAmount?,
-    keepAliveTimeout: TimeAmount?,
+    keepaliveTime: TimeAmount?,
+    keepaliveTimeout: TimeAmount?,
     allowKeepAliveWithoutCalls: Bool,
     minPingIntervalWithoutCalls: TimeAmount,
     clock: Clock = .nio
@@ -214,13 +214,13 @@ final class ServerConnectionManagementHandler: ChannelDuplexHandler {
     self.maxAgeTimer = maxAge.map { Timer(delay: $0) }
     self.maxGraceTimer = maxGraceTime.map { Timer(delay: $0) }
 
-    self.keepAliveTimer = keepAliveTime.map { Timer(delay: $0) }
+    self.keepaliveTimer = keepaliveTime.map { Timer(delay: $0) }
     // Always create a keep alive timeout timer, it's only used if there is a keep alive timer.
-    self.keepAliveTimeoutTimer = Timer(delay: keepAliveTimeout ?? .seconds(20))
+    self.keepaliveTimeoutTimer = Timer(delay: keepaliveTimeout ?? .seconds(20))
 
     // Generate a random value to be used as keep alive ping data.
     let pingData = UInt64.random(in: .min ... .max)
-    self.keepAlivePingData = HTTP2PingData(withInteger: pingData)
+    self.keepalivePingData = HTTP2PingData(withInteger: pingData)
 
     self.state = StateMachine(
       allowKeepAliveWithoutCalls: allowKeepAliveWithoutCalls,
@@ -247,8 +247,8 @@ final class ServerConnectionManagementHandler: ChannelDuplexHandler {
       self.initiateGracefulShutdown(context: context)
     }
 
-    self.keepAliveTimer?.schedule(on: context.eventLoop) {
-      self.keepAliveTimerFired(context: context)
+    self.keepaliveTimer?.schedule(on: context.eventLoop) {
+      self.keepaliveTimerFired(context: context)
     }
 
     context.fireChannelActive()
@@ -258,8 +258,8 @@ final class ServerConnectionManagementHandler: ChannelDuplexHandler {
     self.maxIdleTimer?.cancel()
     self.maxAgeTimer?.cancel()
     self.maxGraceTimer?.cancel()
-    self.keepAliveTimer?.cancel()
-    self.keepAliveTimeoutTimer.cancel()
+    self.keepaliveTimer?.cancel()
+    self.keepaliveTimeoutTimer.cancel()
     context.fireChannelInactive()
   }
 
@@ -295,8 +295,8 @@ final class ServerConnectionManagementHandler: ChannelDuplexHandler {
     self.inReadLoop = true
 
     // Any read data indicates that the connection is alive so cancel the keep-alive timers.
-    self.keepAliveTimer?.cancel()
-    self.keepAliveTimeoutTimer.cancel()
+    self.keepaliveTimer?.cancel()
+    self.keepaliveTimeoutTimer.cancel()
 
     let frame = self.unwrapInboundIn(data)
     switch frame.payload {
@@ -323,8 +323,8 @@ final class ServerConnectionManagementHandler: ChannelDuplexHandler {
     self.inReadLoop = false
 
     // Done reading: schedule the keep-alive timer.
-    self.keepAliveTimer?.schedule(on: context.eventLoop) {
-      self.keepAliveTimerFired(context: context)
+    self.keepaliveTimer?.schedule(on: context.eventLoop) {
+      self.keepaliveTimerFired(context: context)
     }
 
     context.fireChannelReadComplete()
@@ -350,8 +350,8 @@ extension ServerConnectionManagementHandler {
     // Cancel any timers if initiating shutdown.
     self.maxIdleTimer?.cancel()
     self.maxAgeTimer?.cancel()
-    self.keepAliveTimer?.cancel()
-    self.keepAliveTimeoutTimer.cancel()
+    self.keepaliveTimer?.cancel()
+    self.keepaliveTimeoutTimer.cancel()
 
     switch self.state.startGracefulShutdown() {
     case .sendGoAwayAndPing(let pingData):
@@ -436,13 +436,13 @@ extension ServerConnectionManagementHandler {
     }
   }
 
-  private func keepAliveTimerFired(context: ChannelHandlerContext) {
-    let ping = HTTP2Frame(streamID: .rootStream, payload: .ping(self.keepAlivePingData, ack: false))
+  private func keepaliveTimerFired(context: ChannelHandlerContext) {
+    let ping = HTTP2Frame(streamID: .rootStream, payload: .ping(self.keepalivePingData, ack: false))
     context.write(self.wrapInboundOut(ping), promise: nil)
     self.maybeFlush(context: context)
 
     // Schedule a timeout on waiting for the response.
-    self.keepAliveTimeoutTimer.schedule(on: context.eventLoop) {
+    self.keepaliveTimeoutTimer.schedule(on: context.eventLoop) {
       self.initiateGracefulShutdown(context: context)
     }
   }

--- a/Sources/GRPCHTTP2Core/Server/Connection/ServerConnectionManagementHandler.swift
+++ b/Sources/GRPCHTTP2Core/Server/Connection/ServerConnectionManagementHandler.swift
@@ -162,7 +162,7 @@ final class ServerConnectionManagementHandler: ChannelDuplexHandler {
       self.handler.eventLoop.assertInEventLoop()
       if self.handler.frameStats.didWriteHeadersOrData {
         self.handler.frameStats.reset()
-        self.handler.state.resetKeepAliveState()
+        self.handler.state.resetKeepaliveState()
       }
     }
 
@@ -191,7 +191,7 @@ final class ServerConnectionManagementHandler: ChannelDuplexHandler {
   ///   - keepaliveTimeout: The amount of time the client has to reply after the server sends a
   ///       keep-alive ping to keep the connection open. The connection is closed if no reply
   ///       is received.
-  ///   - allowKeepAliveWithoutCalls: Whether the server allows the client to send keep-alive pings
+  ///   - allowKeepaliveWithoutCalls: Whether the server allows the client to send keep-alive pings
   ///       when there are no calls in progress.
   ///   - minPingIntervalWithoutCalls: The minimum allowed interval the client is allowed to send
   ///       keep-alive pings. Pings more frequent than this interval count as 'strikes' and the
@@ -204,7 +204,7 @@ final class ServerConnectionManagementHandler: ChannelDuplexHandler {
     maxGraceTime: TimeAmount?,
     keepaliveTime: TimeAmount?,
     keepaliveTimeout: TimeAmount?,
-    allowKeepAliveWithoutCalls: Bool,
+    allowKeepaliveWithoutCalls: Bool,
     minPingIntervalWithoutCalls: TimeAmount,
     clock: Clock = .nio
   ) {
@@ -223,7 +223,7 @@ final class ServerConnectionManagementHandler: ChannelDuplexHandler {
     self.keepalivePingData = HTTP2PingData(withInteger: pingData)
 
     self.state = StateMachine(
-      allowKeepAliveWithoutCalls: allowKeepAliveWithoutCalls,
+      allowKeepaliveWithoutCalls: allowKeepaliveWithoutCalls,
       minPingReceiveIntervalWithoutCalls: minPingIntervalWithoutCalls,
       goAwayPingData: HTTP2PingData(withInteger: ~pingData)
     )

--- a/Sources/GRPCInProcessTransport/InProcessClientTransport.swift
+++ b/Sources/GRPCInProcessTransport/InProcessClientTransport.swift
@@ -98,22 +98,22 @@ public struct InProcessClientTransport: ClientTransport {
 
   public let retryThrottle: RetryThrottle?
 
-  private let methodConfiguration: _MethodConfigurations
+  private let methodConfig: _MethodConfigs
   private let state: _LockedValueBox<State>
 
   /// Creates a new in-process client transport.
   ///
   /// - Parameters:
   ///   - server: The in-process server transport to connect to.
-  ///   - serviceConfiguration: Service configuration.
+  ///   - serviceConfig: Service configuration.
   public init(
     server: InProcessServerTransport,
-    serviceConfiguration: ServiceConfiguration = ServiceConfiguration()
+    serviceConfig: ServiceConfig = ServiceConfig()
   ) {
-    self.retryThrottle = serviceConfiguration.retryThrottlingPolicy.map {
+    self.retryThrottle = serviceConfig.retryThrottlingPolicy.map {
       RetryThrottle(policy: $0)
     }
-    self.methodConfiguration = _MethodConfigurations(serviceConfiguration: serviceConfiguration)
+    self.methodConfig = _MethodConfigs(serviceConfig: serviceConfig)
     self.state = _LockedValueBox(.unconnected(.init(serverTransport: server)))
   }
 
@@ -340,7 +340,7 @@ public struct InProcessClientTransport: ClientTransport {
   /// - Returns: Execution configuration for the method, if it exists.
   public func configuration(
     forMethod descriptor: MethodDescriptor
-  ) -> MethodConfiguration? {
-    self.methodConfiguration[descriptor]
+  ) -> MethodConfig? {
+    self.methodConfig[descriptor]
   }
 }

--- a/Sources/GRPCInProcessTransport/InProcessTransport.swift
+++ b/Sources/GRPCInProcessTransport/InProcessTransport.swift
@@ -22,16 +22,16 @@ public enum InProcessTransport {
   /// and a client using that server transport.
   ///
   /// - Parameters:
-  ///   - serviceConfiguration: Configuration describing how methods should be executed.
+  ///   - serviceConfig: Configuration describing how methods should be executed.
   /// - Returns: A tuple containing the connected server and client in-process transports.
   @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
   public static func makePair(
-    serviceConfiguration: ServiceConfiguration = ServiceConfiguration()
+    serviceConfig: ServiceConfig = ServiceConfig()
   ) -> (server: InProcessServerTransport, client: InProcessClientTransport) {
     let server = InProcessServerTransport()
     let client = InProcessClientTransport(
       server: server,
-      serviceConfiguration: serviceConfiguration
+      serviceConfig: serviceConfig
     )
     return (server, client)
   }

--- a/Tests/GRPCCoreTests/Configuration/MethodConfigCodingTests.swift
+++ b/Tests/GRPCCoreTests/Configuration/MethodConfigCodingTests.swift
@@ -21,7 +21,7 @@ import XCTest
 @testable import GRPCCore
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-internal final class MethodConfigurationCodingTests: XCTestCase {
+internal final class MethodConfigCodingTests: XCTestCase {
   private let encoder = JSONEncoder()
   private let decoder = JSONDecoder()
 
@@ -35,30 +35,30 @@ internal final class MethodConfigurationCodingTests: XCTestCase {
   }
 
   func testDecodeMethodConfigName() throws {
-    let inputs: [(String, MethodConfiguration.Name)] = [
+    let inputs: [(String, MethodConfig.Name)] = [
       (#"{"service": "foo.bar", "method": "baz"}"#, .init(service: "foo.bar", method: "baz")),
       (#"{"service": "foo.bar"}"#, .init(service: "foo.bar", method: "")),
       (#"{}"#, .init(service: "", method: "")),
     ]
 
     for (json, expected) in inputs {
-      let decoded = try self.decoder.decode(MethodConfiguration.Name.self, from: Data(json.utf8))
+      let decoded = try self.decoder.decode(MethodConfig.Name.self, from: Data(json.utf8))
       XCTAssertEqual(decoded, expected)
     }
   }
 
   func testEncodeDecodeMethodConfigName() throws {
-    let inputs: [MethodConfiguration.Name] = [
-      MethodConfiguration.Name(service: "foo.bar", method: "baz"),
-      MethodConfiguration.Name(service: "foo.bar", method: ""),
-      MethodConfiguration.Name(service: "", method: ""),
+    let inputs: [MethodConfig.Name] = [
+      MethodConfig.Name(service: "foo.bar", method: "baz"),
+      MethodConfig.Name(service: "foo.bar", method: ""),
+      MethodConfig.Name(service: "", method: ""),
     ]
 
     // We can't do encode-only tests as the output is non-deterministic (the ordering of
     // service/method in the JSON object)
     for name in inputs {
       let encoded = try self.encoder.encode(name)
-      let decoded = try self.decoder.decode(MethodConfiguration.Name.self, from: encoded)
+      let decoded = try self.decoder.decode(MethodConfig.Name.self, from: encoded)
       XCTAssertEqual(decoded, name)
     }
   }
@@ -364,8 +364,8 @@ internal final class MethodConfigurationCodingTests: XCTestCase {
     // Test the 'regular' config.
     do {
       let jsonConfig = try config.jsonUTF8Data()
-      let decoded = try self.decoder.decode(MethodConfiguration.self, from: jsonConfig)
-      XCTAssertEqual(decoded.names, [MethodConfiguration.Name(service: "echo.Echo", method: "Get")])
+      let decoded = try self.decoder.decode(MethodConfig.self, from: jsonConfig)
+      XCTAssertEqual(decoded.names, [MethodConfig.Name(service: "echo.Echo", method: "Get")])
       XCTAssertEqual(decoded.waitForReady, true)
       XCTAssertEqual(decoded.timeout, Duration(secondsComponent: 1, attosecondsComponent: 0))
       XCTAssertEqual(decoded.maxRequestMessageBytes, 1024)
@@ -386,7 +386,7 @@ internal final class MethodConfigurationCodingTests: XCTestCase {
       }
 
       let jsonConfig = try config.jsonUTF8Data()
-      let decoded = try self.decoder.decode(MethodConfiguration.self, from: jsonConfig)
+      let decoded = try self.decoder.decode(MethodConfig.self, from: jsonConfig)
 
       switch decoded.executionPolicy?.wrapped {
       case let .some(.hedge(policy)):
@@ -413,7 +413,7 @@ internal final class MethodConfigurationCodingTests: XCTestCase {
       }
 
       let jsonConfig = try config.jsonUTF8Data()
-      let decoded = try self.decoder.decode(MethodConfiguration.self, from: jsonConfig)
+      let decoded = try self.decoder.decode(MethodConfig.self, from: jsonConfig)
 
       switch decoded.executionPolicy?.wrapped {
       case let .some(.retry(policy)):

--- a/Tests/GRPCCoreTests/Configuration/MethodConfigTests.swift
+++ b/Tests/GRPCCoreTests/Configuration/MethodConfigTests.swift
@@ -17,7 +17,7 @@ import GRPCCore
 import XCTest
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-final class MethodConfigurationTests: XCTestCase {
+final class MethodConfigTests: XCTestCase {
   func testRetryPolicyClampsMaxAttempts() {
     var policy = RetryPolicy(
       maximumAttempts: 10,

--- a/Tests/GRPCCoreTests/Internal/MethodConfigsTests.swift
+++ b/Tests/GRPCCoreTests/Internal/MethodConfigsTests.swift
@@ -17,15 +17,15 @@ import GRPCCore
 import XCTest
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-final class MethodConfigurationsTests: XCTestCase {
+final class MethodConfigsTests: XCTestCase {
   func testGetConfigurationForKnownMethod() async throws {
     let policy = HedgingPolicy(
       maximumAttempts: 10,
       hedgingDelay: .seconds(1),
       nonFatalStatusCodes: []
     )
-    let defaultConfiguration = MethodConfiguration(names: [], executionPolicy: .hedge(policy))
-    var configurations = _MethodConfigurations()
+    let defaultConfiguration = MethodConfig(names: [], executionPolicy: .hedge(policy))
+    var configurations = _MethodConfigs()
     configurations.setDefaultConfiguration(defaultConfiguration)
     let descriptor = MethodDescriptor(service: "test", method: "first")
     let retryPolicy = RetryPolicy(
@@ -35,7 +35,7 @@ final class MethodConfigurationsTests: XCTestCase {
       backoffMultiplier: 1.0,
       retryableStatusCodes: [.unavailable]
     )
-    let overrideConfiguration = MethodConfiguration(names: [], executionPolicy: .retry(retryPolicy))
+    let overrideConfiguration = MethodConfig(names: [], executionPolicy: .retry(retryPolicy))
     configurations[descriptor] = overrideConfiguration
 
     XCTAssertEqual(configurations[descriptor], overrideConfiguration)
@@ -47,8 +47,8 @@ final class MethodConfigurationsTests: XCTestCase {
       hedgingDelay: .seconds(1),
       nonFatalStatusCodes: []
     )
-    let defaultConfiguration = MethodConfiguration(names: [], executionPolicy: .hedge(policy))
-    var configurations = _MethodConfigurations()
+    let defaultConfiguration = MethodConfig(names: [], executionPolicy: .hedge(policy))
+    var configurations = _MethodConfigs()
     configurations.setDefaultConfiguration(defaultConfiguration)
     let firstDescriptor = MethodDescriptor(service: "test", method: "")
     let retryPolicy = RetryPolicy(
@@ -58,7 +58,7 @@ final class MethodConfigurationsTests: XCTestCase {
       backoffMultiplier: 1.0,
       retryableStatusCodes: [.unavailable]
     )
-    let overrideConfiguration = MethodConfiguration(names: [], executionPolicy: .retry(retryPolicy))
+    let overrideConfiguration = MethodConfig(names: [], executionPolicy: .retry(retryPolicy))
     configurations[firstDescriptor] = overrideConfiguration
 
     let secondDescriptor = MethodDescriptor(service: "test", method: "second")
@@ -71,8 +71,8 @@ final class MethodConfigurationsTests: XCTestCase {
       hedgingDelay: .seconds(1),
       nonFatalStatusCodes: []
     )
-    let defaultConfiguration = MethodConfiguration(names: [], executionPolicy: .hedge(policy))
-    var configurations = _MethodConfigurations()
+    let defaultConfiguration = MethodConfig(names: [], executionPolicy: .hedge(policy))
+    var configurations = _MethodConfigs()
     configurations.setDefaultConfiguration(defaultConfiguration)
     let firstDescriptor = MethodDescriptor(service: "test1", method: "first")
     let retryPolicy = RetryPolicy(
@@ -82,7 +82,7 @@ final class MethodConfigurationsTests: XCTestCase {
       backoffMultiplier: 1.0,
       retryableStatusCodes: [.unavailable]
     )
-    let overrideConfiguration = MethodConfiguration(names: [], executionPolicy: .retry(retryPolicy))
+    let overrideConfiguration = MethodConfig(names: [], executionPolicy: .retry(retryPolicy))
     configurations[firstDescriptor] = overrideConfiguration
 
     let secondDescriptor = MethodDescriptor(service: "test2", method: "second")

--- a/Tests/GRPCCoreTests/Test Utilities/Transport/AnyTransport.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/Transport/AnyTransport.swift
@@ -29,7 +29,7 @@ struct AnyClientTransport: ClientTransport, Sendable {
     ) async throws -> Any
   private let _connect: @Sendable (Bool) async throws -> Void
   private let _close: @Sendable () -> Void
-  private let _configuration: @Sendable (MethodDescriptor) -> MethodConfiguration?
+  private let _configuration: @Sendable (MethodDescriptor) -> MethodConfig?
 
   init<Transport: ClientTransport>(wrapping transport: Transport)
   where Transport.Inbound == Inbound, Transport.Outbound == Outbound {
@@ -76,7 +76,7 @@ struct AnyClientTransport: ClientTransport, Sendable {
 
   func configuration(
     forMethod descriptor: MethodDescriptor
-  ) -> MethodConfiguration? {
+  ) -> MethodConfig? {
     self._configuration(descriptor)
   }
 }

--- a/Tests/GRPCCoreTests/Test Utilities/Transport/StreamCountingTransport.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/Transport/StreamCountingTransport.swift
@@ -72,7 +72,7 @@ struct StreamCountingClientTransport: ClientTransport, Sendable {
 
   func configuration(
     forMethod descriptor: MethodDescriptor
-  ) -> MethodConfiguration? {
+  ) -> MethodConfig? {
     self.transport.configuration(forMethod: descriptor)
   }
 }

--- a/Tests/GRPCCoreTests/Test Utilities/Transport/ThrowingTransport.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/Transport/ThrowingTransport.swift
@@ -38,7 +38,7 @@ struct ThrowOnStreamCreationTransport: ClientTransport {
 
   func configuration(
     forMethod descriptor: MethodDescriptor
-  ) -> MethodConfiguration? {
+  ) -> MethodConfig? {
     return nil
   }
 

--- a/Tests/GRPCHTTP2CoreTests/Client/Connection/ClientConnectionHandlerStateMachineTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Client/Connection/ClientConnectionHandlerStateMachineTests.swift
@@ -22,9 +22,9 @@ import XCTest
 
 final class ClientConnectionHandlerStateMachineTests: XCTestCase {
   private func makeStateMachine(
-    keepAliveWithoutCalls: Bool = false
+    keepaliveWithoutCalls: Bool = false
   ) -> ClientConnectionHandler.StateMachine {
-    return ClientConnectionHandler.StateMachine(allowKeepAliveWithoutCalls: keepAliveWithoutCalls)
+    return ClientConnectionHandler.StateMachine(allowKeepAliveWithoutCalls: keepaliveWithoutCalls)
   }
 
   func testCloseSomeStreamsWhenActive() {
@@ -52,7 +52,7 @@ final class ClientConnectionHandlerStateMachineTests: XCTestCase {
   }
 
   func testSendKeepAlivePing() {
-    var state = self.makeStateMachine(keepAliveWithoutCalls: false)
+    var state = self.makeStateMachine(keepaliveWithoutCalls: false)
     // No streams open so ping isn't allowed.
     XCTAssertFalse(state.sendKeepAlivePing())
 
@@ -66,7 +66,7 @@ final class ClientConnectionHandlerStateMachineTests: XCTestCase {
   }
 
   func testSendKeepAlivePingWhenAllowedWithoutCalls() {
-    var state = self.makeStateMachine(keepAliveWithoutCalls: true)
+    var state = self.makeStateMachine(keepaliveWithoutCalls: true)
     // Keep alive is allowed when no streams are open, so pings are allowed.
     XCTAssertTrue(state.sendKeepAlivePing())
 
@@ -78,7 +78,7 @@ final class ClientConnectionHandlerStateMachineTests: XCTestCase {
   }
 
   func testSendKeepAlivePingWhenClosing() {
-    var state = self.makeStateMachine(keepAliveWithoutCalls: false)
+    var state = self.makeStateMachine(keepaliveWithoutCalls: false)
     state.streamOpened(1)
     XCTAssertTrue(state.beginClosing())
 
@@ -87,7 +87,7 @@ final class ClientConnectionHandlerStateMachineTests: XCTestCase {
   }
 
   func testSendKeepAlivePingWhenClosed() {
-    var state = self.makeStateMachine(keepAliveWithoutCalls: true)
+    var state = self.makeStateMachine(keepaliveWithoutCalls: true)
     _ = state.closed()
     XCTAssertFalse(state.sendKeepAlivePing())
   }

--- a/Tests/GRPCHTTP2CoreTests/Client/Connection/ClientConnectionHandlerStateMachineTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Client/Connection/ClientConnectionHandlerStateMachineTests.swift
@@ -24,7 +24,7 @@ final class ClientConnectionHandlerStateMachineTests: XCTestCase {
   private func makeStateMachine(
     keepaliveWithoutCalls: Bool = false
   ) -> ClientConnectionHandler.StateMachine {
-    return ClientConnectionHandler.StateMachine(allowKeepAliveWithoutCalls: keepaliveWithoutCalls)
+    return ClientConnectionHandler.StateMachine(allowKeepaliveWithoutCalls: keepaliveWithoutCalls)
   }
 
   func testCloseSomeStreamsWhenActive() {
@@ -32,7 +32,7 @@ final class ClientConnectionHandlerStateMachineTests: XCTestCase {
     state.streamOpened(1)
     state.streamOpened(2)
     XCTAssertEqual(state.streamClosed(2), .none)
-    XCTAssertEqual(state.streamClosed(1), .startIdleTimer(cancelKeepAlive: true))
+    XCTAssertEqual(state.streamClosed(1), .startIdleTimer(cancelKeepalive: true))
   }
 
   func testCloseSomeStreamsWhenClosing() {
@@ -51,45 +51,45 @@ final class ClientConnectionHandlerStateMachineTests: XCTestCase {
     XCTAssertEqual(state.streamClosed(1), .none)
   }
 
-  func testSendKeepAlivePing() {
+  func testSendKeepalivePing() {
     var state = self.makeStateMachine(keepaliveWithoutCalls: false)
     // No streams open so ping isn't allowed.
-    XCTAssertFalse(state.sendKeepAlivePing())
+    XCTAssertFalse(state.sendKeepalivePing())
 
     // Stream open, ping allowed.
     state.streamOpened(1)
-    XCTAssertTrue(state.sendKeepAlivePing())
+    XCTAssertTrue(state.sendKeepalivePing())
 
     // No stream, no ping.
-    XCTAssertEqual(state.streamClosed(1), .startIdleTimer(cancelKeepAlive: true))
-    XCTAssertFalse(state.sendKeepAlivePing())
+    XCTAssertEqual(state.streamClosed(1), .startIdleTimer(cancelKeepalive: true))
+    XCTAssertFalse(state.sendKeepalivePing())
   }
 
-  func testSendKeepAlivePingWhenAllowedWithoutCalls() {
+  func testSendKeepalivePingWhenAllowedWithoutCalls() {
     var state = self.makeStateMachine(keepaliveWithoutCalls: true)
     // Keep alive is allowed when no streams are open, so pings are allowed.
-    XCTAssertTrue(state.sendKeepAlivePing())
+    XCTAssertTrue(state.sendKeepalivePing())
 
     state.streamOpened(1)
-    XCTAssertTrue(state.sendKeepAlivePing())
+    XCTAssertTrue(state.sendKeepalivePing())
 
-    XCTAssertEqual(state.streamClosed(1), .startIdleTimer(cancelKeepAlive: false))
-    XCTAssertTrue(state.sendKeepAlivePing())
+    XCTAssertEqual(state.streamClosed(1), .startIdleTimer(cancelKeepalive: false))
+    XCTAssertTrue(state.sendKeepalivePing())
   }
 
-  func testSendKeepAlivePingWhenClosing() {
+  func testSendKeepalivePingWhenClosing() {
     var state = self.makeStateMachine(keepaliveWithoutCalls: false)
     state.streamOpened(1)
     XCTAssertTrue(state.beginClosing())
 
     // Stream is opened and state is closing, ping is allowed.
-    XCTAssertTrue(state.sendKeepAlivePing())
+    XCTAssertTrue(state.sendKeepalivePing())
   }
 
-  func testSendKeepAlivePingWhenClosed() {
+  func testSendKeepalivePingWhenClosed() {
     var state = self.makeStateMachine(keepaliveWithoutCalls: true)
     _ = state.closed()
-    XCTAssertFalse(state.sendKeepAlivePing())
+    XCTAssertFalse(state.sendKeepalivePing())
   }
 
   func testBeginGracefulShutdownWhenStreamsAreOpen() {

--- a/Tests/GRPCHTTP2CoreTests/Client/Connection/ClientConnectionHandlerTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Client/Connection/ClientConnectionHandlerTests.swift
@@ -71,7 +71,7 @@ final class ClientConnectionHandlerTests: XCTestCase {
   }
 
   func testKeepAliveWithOpenStreams() throws {
-    let connection = try Connection(keepAliveTime: .minutes(1), keepAliveTimeout: .seconds(10))
+    let connection = try Connection(keepaliveTime: .minutes(1), keepaliveTimeout: .seconds(10))
     try connection.activate()
 
     // Open a stream so keep-alive starts.
@@ -97,7 +97,7 @@ final class ClientConnectionHandlerTests: XCTestCase {
   }
 
   func testKeepAliveWithNoOpenStreams() throws {
-    let connection = try Connection(keepAliveTime: .minutes(1), allowKeepAliveWithoutCalls: true)
+    let connection = try Connection(keepaliveTime: .minutes(1), allowKeepAliveWithoutCalls: true)
     try connection.activate()
 
     for _ in 0 ..< 10 {
@@ -115,7 +115,7 @@ final class ClientConnectionHandlerTests: XCTestCase {
   }
 
   func testKeepAliveWithOpenStreamsTimingOut() throws {
-    let connection = try Connection(keepAliveTime: .minutes(1), keepAliveTimeout: .seconds(10))
+    let connection = try Connection(keepaliveTime: .minutes(1), keepaliveTimeout: .seconds(10))
     try connection.activate()
 
     // Open a stream so keep-alive starts.
@@ -135,7 +135,7 @@ final class ClientConnectionHandlerTests: XCTestCase {
     // - be closed
     connection.loop.advanceTime(by: .seconds(10))
 
-    XCTAssertEqual(try connection.readEvent(), .closing(.keepAliveExpired))
+    XCTAssertEqual(try connection.readEvent(), .closing(.keepaliveExpired))
 
     let frame2 = try XCTUnwrap(connection.readFrame())
     XCTAssertEqual(frame2.streamID, .rootStream)
@@ -217,17 +217,17 @@ extension ClientConnectionHandlerTests {
 
     init(
       maxIdleTime: TimeAmount? = nil,
-      keepAliveTime: TimeAmount? = nil,
-      keepAliveTimeout: TimeAmount? = nil,
+      keepaliveTime: TimeAmount? = nil,
+      keepaliveTimeout: TimeAmount? = nil,
       allowKeepAliveWithoutCalls: Bool = false
     ) throws {
       let loop = EmbeddedEventLoop()
       let handler = ClientConnectionHandler(
         eventLoop: loop,
         maxIdleTime: maxIdleTime,
-        keepAliveTime: keepAliveTime,
-        keepAliveTimeout: keepAliveTimeout,
-        keepAliveWithoutCalls: allowKeepAliveWithoutCalls
+        keepaliveTime: keepaliveTime,
+        keepaliveTimeout: keepaliveTimeout,
+        keepaliveWithoutCalls: allowKeepAliveWithoutCalls
       )
 
       self.channel = EmbeddedChannel(handler: handler, loop: loop)

--- a/Tests/GRPCHTTP2CoreTests/Client/Connection/ClientConnectionHandlerTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Client/Connection/ClientConnectionHandlerTests.swift
@@ -70,7 +70,7 @@ final class ClientConnectionHandlerTests: XCTestCase {
     try connection.waitUntilClosed()
   }
 
-  func testKeepAliveWithOpenStreams() throws {
+  func testKeepaliveWithOpenStreams() throws {
     let connection = try Connection(keepaliveTime: .minutes(1), keepaliveTimeout: .seconds(10))
     try connection.activate()
 
@@ -96,8 +96,8 @@ final class ClientConnectionHandlerTests: XCTestCase {
     XCTAssertNil(try connection.readFrame())
   }
 
-  func testKeepAliveWithNoOpenStreams() throws {
-    let connection = try Connection(keepaliveTime: .minutes(1), allowKeepAliveWithoutCalls: true)
+  func testKeepaliveWithNoOpenStreams() throws {
+    let connection = try Connection(keepaliveTime: .minutes(1), allowKeepaliveWithoutCalls: true)
     try connection.activate()
 
     for _ in 0 ..< 10 {
@@ -114,7 +114,7 @@ final class ClientConnectionHandlerTests: XCTestCase {
     }
   }
 
-  func testKeepAliveWithOpenStreamsTimingOut() throws {
+  func testKeepaliveWithOpenStreamsTimingOut() throws {
     let connection = try Connection(keepaliveTime: .minutes(1), keepaliveTimeout: .seconds(10))
     try connection.activate()
 
@@ -219,7 +219,7 @@ extension ClientConnectionHandlerTests {
       maxIdleTime: TimeAmount? = nil,
       keepaliveTime: TimeAmount? = nil,
       keepaliveTimeout: TimeAmount? = nil,
-      allowKeepAliveWithoutCalls: Bool = false
+      allowKeepaliveWithoutCalls: Bool = false
     ) throws {
       let loop = EmbeddedEventLoop()
       let handler = ClientConnectionHandler(
@@ -227,7 +227,7 @@ extension ClientConnectionHandlerTests {
         maxIdleTime: maxIdleTime,
         keepaliveTime: keepaliveTime,
         keepaliveTimeout: keepaliveTimeout,
-        keepaliveWithoutCalls: allowKeepAliveWithoutCalls
+        keepaliveWithoutCalls: allowKeepaliveWithoutCalls
       )
 
       self.channel = EmbeddedChannel(handler: handler, loop: loop)

--- a/Tests/GRPCHTTP2CoreTests/Client/Resolver/NameResolverRegistryTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Client/Resolver/NameResolverRegistryTests.swift
@@ -178,7 +178,7 @@ final class NameResolverRegistryTests: XCTestCase {
     for _ in 0 ..< 1000 {
       let result = try await XCTUnwrapAsync { try await iterator.next() }
       XCTAssertEqual(result.endpoints, [Endpoint(addresses: [.ipv4(host: "foo", port: 1234)])])
-      XCTAssertNil(result.serviceConfiguration)
+      XCTAssertNil(result.serviceConfig)
     }
   }
 
@@ -199,7 +199,7 @@ final class NameResolverRegistryTests: XCTestCase {
           Endpoint(addresses: [.ipv4(host: "bar", port: 444)]),
         ]
       )
-      XCTAssertNil(result.serviceConfiguration)
+      XCTAssertNil(result.serviceConfig)
     }
   }
 
@@ -214,7 +214,7 @@ final class NameResolverRegistryTests: XCTestCase {
     for _ in 0 ..< 1000 {
       let result = try await XCTUnwrapAsync { try await iterator.next() }
       XCTAssertEqual(result.endpoints, [Endpoint(addresses: [.ipv6(host: "foo", port: 1234)])])
-      XCTAssertNil(result.serviceConfiguration)
+      XCTAssertNil(result.serviceConfig)
     }
   }
 
@@ -235,7 +235,7 @@ final class NameResolverRegistryTests: XCTestCase {
           Endpoint(addresses: [.ipv6(host: "bar", port: 444)]),
         ]
       )
-      XCTAssertNil(result.serviceConfiguration)
+      XCTAssertNil(result.serviceConfig)
     }
   }
 
@@ -250,7 +250,7 @@ final class NameResolverRegistryTests: XCTestCase {
     for _ in 0 ..< 1000 {
       let result = try await XCTUnwrapAsync { try await iterator.next() }
       XCTAssertEqual(result.endpoints, [Endpoint(addresses: [.unixDomainSocket(path: "/foo")])])
-      XCTAssertNil(result.serviceConfiguration)
+      XCTAssertNil(result.serviceConfig)
     }
   }
 
@@ -265,7 +265,7 @@ final class NameResolverRegistryTests: XCTestCase {
     for _ in 0 ..< 1000 {
       let result = try await XCTUnwrapAsync { try await iterator.next() }
       XCTAssertEqual(result.endpoints, [Endpoint(addresses: [.vsock(contextID: .any, port: .any)])])
-      XCTAssertNil(result.serviceConfiguration)
+      XCTAssertNil(result.serviceConfig)
     }
   }
 }

--- a/Tests/GRPCHTTP2CoreTests/Server/Connection/ServerConnectionManagementHandler+StateMachineTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Server/Connection/ServerConnectionManagementHandler+StateMachineTests.swift
@@ -22,12 +22,12 @@ import XCTest
 
 final class ServerConnectionManagementHandlerStateMachineTests: XCTestCase {
   private func makeStateMachine(
-    allowKeepAliveWithoutCalls: Bool = false,
+    allowKeepaliveWithoutCalls: Bool = false,
     minPingReceiveIntervalWithoutCalls: TimeAmount = .minutes(5),
     goAwayPingData: HTTP2PingData = HTTP2PingData(withInteger: 42)
   ) -> ServerConnectionManagementHandler.StateMachine {
     return .init(
-      allowKeepAliveWithoutCalls: allowKeepAliveWithoutCalls,
+      allowKeepaliveWithoutCalls: allowKeepaliveWithoutCalls,
       minPingReceiveIntervalWithoutCalls: minPingReceiveIntervalWithoutCalls,
       goAwayPingData: goAwayPingData
     )
@@ -193,9 +193,9 @@ final class ServerConnectionManagementHandlerStateMachineTests: XCTestCase {
     XCTAssertEqual(state.receivedPing(atTime: time, data: data), .enhanceYourCalmThenClose(id))
   }
 
-  func testPingStrikesWhenKeepAliveIsNotPermittedWithoutCalls() {
+  func testPingStrikesWhenKeepaliveIsNotPermittedWithoutCalls() {
     let initialState = self.makeStateMachine(
-      allowKeepAliveWithoutCalls: false,
+      allowKeepaliveWithoutCalls: false,
       minPingReceiveIntervalWithoutCalls: .minutes(5)
     )
 
@@ -207,9 +207,9 @@ final class ServerConnectionManagementHandlerStateMachineTests: XCTestCase {
     self.testPingStrikeUsingMinReceiveInterval(state: &state, interval: .hours(2), expectedID: 0)
   }
 
-  func testPingStrikesWhenKeepAliveIsPermittedWithoutCalls() {
+  func testPingStrikesWhenKeepaliveIsPermittedWithoutCalls() {
     var state = self.makeStateMachine(
-      allowKeepAliveWithoutCalls: true,
+      allowKeepaliveWithoutCalls: true,
       minPingReceiveIntervalWithoutCalls: .minutes(5)
     )
 
@@ -218,7 +218,7 @@ final class ServerConnectionManagementHandlerStateMachineTests: XCTestCase {
 
   func testResetPingStrikeState() {
     var state = self.makeStateMachine(
-      allowKeepAliveWithoutCalls: true,
+      allowKeepaliveWithoutCalls: true,
       minPingReceiveIntervalWithoutCalls: .minutes(5)
     )
 
@@ -234,7 +234,7 @@ final class ServerConnectionManagementHandlerStateMachineTests: XCTestCase {
     XCTAssertEqual(state.receivedPing(atTime: time, data: data), .sendAck)
 
     // Reset the ping strike state and test ping strikes as normal.
-    state.resetKeepAliveState()
+    state.resetKeepaliveState()
     self.testPingStrikeUsingMinReceiveInterval(state: &state, interval: .minutes(5), expectedID: 0)
   }
 }

--- a/Tests/GRPCHTTP2CoreTests/Server/Connection/ServerConnectionManagementHandlerTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Server/Connection/ServerConnectionManagementHandlerTests.swift
@@ -128,7 +128,7 @@ final class ServerConnectionManagementHandlerTests: XCTestCase {
     try connection.waitUntilClosed()
   }
 
-  func testKeepAliveOnNewConnection() throws {
+  func testKeepaliveOnNewConnection() throws {
     let connection = try Connection(
       keepaliveTime: .minutes(5),
       keepaliveTimeout: .seconds(5)
@@ -151,7 +151,7 @@ final class ServerConnectionManagementHandlerTests: XCTestCase {
     XCTAssertNil(try connection.readFrame())
   }
 
-  func testKeepAliveStartsAfterReadLoop() throws {
+  func testKeepaliveStartsAfterReadLoop() throws {
     let connection = try Connection(
       keepaliveTime: .minutes(5),
       keepaliveTimeout: .seconds(5)
@@ -179,7 +179,7 @@ final class ServerConnectionManagementHandlerTests: XCTestCase {
     }
   }
 
-  func testKeepAliveOnNewConnectionWithoutResponse() throws {
+  func testKeepaliveOnNewConnectionWithoutResponse() throws {
     let connection = try Connection(
       keepaliveTime: .minutes(5),
       keepaliveTimeout: .seconds(5)
@@ -203,9 +203,9 @@ final class ServerConnectionManagementHandlerTests: XCTestCase {
     try connection.waitUntilClosed()
   }
 
-  func testClientKeepAlivePolicing() throws {
+  func testClientKeepalivePolicing() throws {
     let connection = try Connection(
-      allowKeepAliveWithoutCalls: true,
+      allowKeepaliveWithoutCalls: true,
       minPingIntervalWithoutCalls: .minutes(1)
     )
     try connection.activate()
@@ -235,9 +235,9 @@ final class ServerConnectionManagementHandlerTests: XCTestCase {
     try connection.waitUntilClosed()
   }
 
-  func testClientKeepAliveWithPermissibleIntervals() throws {
+  func testClientKeepaliveWithPermissibleIntervals() throws {
     let connection = try Connection(
-      allowKeepAliveWithoutCalls: true,
+      allowKeepaliveWithoutCalls: true,
       minPingIntervalWithoutCalls: .minutes(1),
       manualClock: true
     )
@@ -257,14 +257,14 @@ final class ServerConnectionManagementHandlerTests: XCTestCase {
     }
   }
 
-  func testClientKeepAliveResetState() throws {
+  func testClientKeepaliveResetState() throws {
     let connection = try Connection(
-      allowKeepAliveWithoutCalls: true,
+      allowKeepaliveWithoutCalls: true,
       minPingIntervalWithoutCalls: .minutes(1)
     )
     try connection.activate()
 
-    func sendThreeKeepAlivePings() throws {
+    func sendThreeKeepalivePings() throws {
       // The first ping is valid, the second and third are strikes.
       for _ in 1 ... 3 {
         try connection.ping(data: HTTP2PingData(), ack: false)
@@ -277,14 +277,14 @@ final class ServerConnectionManagementHandlerTests: XCTestCase {
       }
     }
 
-    try sendThreeKeepAlivePings()
+    try sendThreeKeepalivePings()
 
     // "send" a HEADERS frame and flush to reset keep alive state.
     connection.syncView.wroteHeadersFrame()
     connection.syncView.connectionWillFlush()
 
     // As above, the first ping is valid, the next two are strikes.
-    try sendThreeKeepAlivePings()
+    try sendThreeKeepalivePings()
 
     // The next ping is the third strike and triggers a GOAWAY.
     try connection.ping(data: HTTP2PingData(), ack: false)
@@ -355,7 +355,7 @@ extension ServerConnectionManagementHandlerTests {
       maxGraceTime: TimeAmount? = nil,
       keepaliveTime: TimeAmount? = nil,
       keepaliveTimeout: TimeAmount? = nil,
-      allowKeepAliveWithoutCalls: Bool = false,
+      allowKeepaliveWithoutCalls: Bool = false,
       minPingIntervalWithoutCalls: TimeAmount = .minutes(5),
       manualClock: Bool = false
     ) throws {
@@ -373,7 +373,7 @@ extension ServerConnectionManagementHandlerTests {
         maxGraceTime: maxGraceTime,
         keepaliveTime: keepaliveTime,
         keepaliveTimeout: keepaliveTimeout,
-        allowKeepAliveWithoutCalls: allowKeepAliveWithoutCalls,
+        allowKeepaliveWithoutCalls: allowKeepaliveWithoutCalls,
         minPingIntervalWithoutCalls: minPingIntervalWithoutCalls,
         clock: self.clock
       )

--- a/Tests/GRPCHTTP2CoreTests/Server/Connection/ServerConnectionManagementHandlerTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Server/Connection/ServerConnectionManagementHandlerTests.swift
@@ -130,8 +130,8 @@ final class ServerConnectionManagementHandlerTests: XCTestCase {
 
   func testKeepAliveOnNewConnection() throws {
     let connection = try Connection(
-      keepAliveTime: .minutes(5),
-      keepAliveTimeout: .seconds(5)
+      keepaliveTime: .minutes(5),
+      keepaliveTimeout: .seconds(5)
     )
     try connection.activate()
 
@@ -153,8 +153,8 @@ final class ServerConnectionManagementHandlerTests: XCTestCase {
 
   func testKeepAliveStartsAfterReadLoop() throws {
     let connection = try Connection(
-      keepAliveTime: .minutes(5),
-      keepAliveTimeout: .seconds(5)
+      keepaliveTime: .minutes(5),
+      keepaliveTimeout: .seconds(5)
     )
     try connection.activate()
 
@@ -181,8 +181,8 @@ final class ServerConnectionManagementHandlerTests: XCTestCase {
 
   func testKeepAliveOnNewConnectionWithoutResponse() throws {
     let connection = try Connection(
-      keepAliveTime: .minutes(5),
-      keepAliveTimeout: .seconds(5)
+      keepaliveTime: .minutes(5),
+      keepaliveTimeout: .seconds(5)
     )
     try connection.activate()
 
@@ -353,8 +353,8 @@ extension ServerConnectionManagementHandlerTests {
       maxIdleTime: TimeAmount? = nil,
       maxAge: TimeAmount? = nil,
       maxGraceTime: TimeAmount? = nil,
-      keepAliveTime: TimeAmount? = nil,
-      keepAliveTimeout: TimeAmount? = nil,
+      keepaliveTime: TimeAmount? = nil,
+      keepaliveTimeout: TimeAmount? = nil,
       allowKeepAliveWithoutCalls: Bool = false,
       minPingIntervalWithoutCalls: TimeAmount = .minutes(5),
       manualClock: Bool = false
@@ -371,8 +371,8 @@ extension ServerConnectionManagementHandlerTests {
         maxIdleTime: maxIdleTime,
         maxAge: maxAge,
         maxGraceTime: maxGraceTime,
-        keepAliveTime: keepAliveTime,
-        keepAliveTimeout: keepAliveTimeout,
+        keepaliveTime: keepaliveTime,
+        keepaliveTimeout: keepaliveTimeout,
         allowKeepAliveWithoutCalls: allowKeepAliveWithoutCalls,
         minPingIntervalWithoutCalls: minPingIntervalWithoutCalls,
         clock: self.clock

--- a/Tests/GRPCInProcessTransportTests/InProcessClientTransportTests.swift
+++ b/Tests/GRPCInProcessTransportTests/InProcessClientTransportTests.swift
@@ -197,11 +197,11 @@ final class InProcessClientTransportTests: XCTestCase {
       nonFatalStatusCodes: []
     )
 
-    var serviceConfiguration = ServiceConfiguration(
-      methodConfiguration: [
-        MethodConfiguration(
+    var serviceConfig = ServiceConfig(
+      methodConfig: [
+        MethodConfig(
           names: [
-            MethodConfiguration.Name(service: "", method: "")
+            MethodConfig.Name(service: "", method: "")
           ],
           executionPolicy: .hedge(policy)
         )
@@ -210,13 +210,13 @@ final class InProcessClientTransportTests: XCTestCase {
 
     var client = InProcessClientTransport(
       server: InProcessServerTransport(),
-      serviceConfiguration: serviceConfiguration
+      serviceConfig: serviceConfig
     )
 
     let firstDescriptor = MethodDescriptor(service: "test", method: "first")
     XCTAssertEqual(
       client.configuration(forMethod: firstDescriptor),
-      serviceConfiguration.methodConfiguration.first
+      serviceConfig.methodConfig.first
     )
 
     let retryPolicy = RetryPolicy(
@@ -227,24 +227,24 @@ final class InProcessClientTransportTests: XCTestCase {
       retryableStatusCodes: [.unavailable]
     )
 
-    let overrideConfiguration = MethodConfiguration(
-      names: [MethodConfiguration.Name(service: "test", method: "second")],
+    let overrideConfiguration = MethodConfig(
+      names: [MethodConfig.Name(service: "test", method: "second")],
       executionPolicy: .retry(retryPolicy)
     )
-    serviceConfiguration.methodConfiguration.append(overrideConfiguration)
+    serviceConfig.methodConfig.append(overrideConfiguration)
     client = InProcessClientTransport(
       server: InProcessServerTransport(),
-      serviceConfiguration: serviceConfiguration
+      serviceConfig: serviceConfig
     )
 
     let secondDescriptor = MethodDescriptor(service: "test", method: "second")
     XCTAssertEqual(
       client.configuration(forMethod: firstDescriptor),
-      serviceConfiguration.methodConfiguration.first
+      serviceConfig.methodConfig.first
     )
     XCTAssertEqual(
       client.configuration(forMethod: secondDescriptor),
-      serviceConfiguration.methodConfiguration.last
+      serviceConfig.methodConfig.last
     )
   }
 
@@ -295,10 +295,10 @@ final class InProcessClientTransportTests: XCTestCase {
       retryableStatusCodes: [.unavailable]
     )
 
-    let serviceConfiguration = ServiceConfiguration(
-      methodConfiguration: [
-        MethodConfiguration(
-          names: [MethodConfiguration.Name(service: "", method: "")],
+    let serviceConfig = ServiceConfig(
+      methodConfig: [
+        MethodConfig(
+          names: [MethodConfig.Name(service: "", method: "")],
           executionPolicy: .retry(defaultPolicy)
         )
       ]
@@ -306,7 +306,7 @@ final class InProcessClientTransportTests: XCTestCase {
 
     return InProcessClientTransport(
       server: server,
-      serviceConfiguration: serviceConfiguration
+      serviceConfig: serviceConfig
     )
   }
 }


### PR DESCRIPTION
Motivation:

"Service config" is the name of a gRPC feature, yet we've named the corresponding type "ServiceConfiguration". We should follow the gRPC naming here.

In a similar vein, "keepAlive" should be "keepalive".

Modifications:

- Rename "ServiceConfiguration" to "ServiceConfig"
- Rename "MethodConfiguration" to "MethodConfig"
- Rename various "keepAlive"s to "keepalive"

Result:

Naming is more consistent with gRPC