### PR TITLE
BenchmarkClient RPCs implementation

### DIFF
--- a/Sources/performance-worker/BenchmarkClient.swift
+++ b/Sources/performance-worker/BenchmarkClient.swift
@@ -22,7 +22,7 @@ import NIOConcurrencyHelpers
 struct BenchmarkClient {
   private var client: GRPCClient
   private var rpcNumber: Int32
-  private var rpcType: RpcType
+  private var rpcType: RPCType
   private var messagesPerStream: Int32
   private var protoParams: Grpc_Testing_SimpleProtoParams
   private let rpcStats: NIOLockedValueBox<RPCStats>
@@ -30,11 +30,11 @@ struct BenchmarkClient {
   init(
     client: GRPCClient,
     rpcNumber: Int32,
-    rpcType: RpcType,
+    rpcType: RPCType,
     messagesPerStream: Int32,
     protoParams: Grpc_Testing_SimpleProtoParams,
     histogramParams: Grpc_Testing_HistogramParams?
-  ) throws {
+  ) {
     self.client = client
     self.rpcNumber = rpcNumber
     self.messagesPerStream = messagesPerStream
@@ -54,7 +54,7 @@ struct BenchmarkClient {
     self.rpcStats = NIOLockedValueBox(RPCStats(latencyHistogram: histogram))
   }
 
-  enum RpcType {
+  enum RPCType {
     case unary
     case streaming
     case streamingFromClient
@@ -122,8 +122,7 @@ struct BenchmarkClient {
         do {
           try await benchmarkClient.unaryCall(
             request: ClientRequest.Single(message: message)
-          ) {
-            response in
+          ) { response in
             _ = try response.message
           }
           return nil
@@ -178,7 +177,7 @@ struct BenchmarkClient {
             }
           }
 
-          _ = try await benchmarkClient.streamingFromClient(
+          try await benchmarkClient.streamingFromClient(
             request: streamingRequest
           ) { response in
             _ = try response.message

--- a/Sources/performance-worker/BenchmarkClient.swift
+++ b/Sources/performance-worker/BenchmarkClient.swift
@@ -23,17 +23,20 @@ struct BenchmarkClient {
   private var client: GRPCClient
   private var rpcNumber: Int32
   private var rpcType: Grpc_Testing_RpcType
+  private var messagesPerStream: Int32
   private let rpcStats: NIOLockedValueBox<RPCStats>
 
   init(
     client: GRPCClient,
     rpcNumber: Int32,
     rpcType: Grpc_Testing_RpcType,
+    messagesPerStream: Int32,
     histogramParams: Grpc_Testing_HistogramParams?
   ) {
     self.client = client
     self.rpcNumber = rpcNumber
     self.rpcType = rpcType
+    self.messagesPerStream = messagesPerStream
 
     let histogram: RPCStats.LatencyHistogram
     if let histogramParams = histogramParams {
@@ -64,7 +67,13 @@ struct BenchmarkClient {
       try await withThrowingTaskGroup(of: Void.self) { rpcsGroup in
         for _ in 0 ..< self.rpcNumber {
           rpcsGroup.addTask {
-            let (latency, errorCode) = self.makeRPC(client: benchmarkClient, rpcType: self.rpcType)
+            let (latency, errorCode) = try await self.makeRPC(
+              benchmarkClient: benchmarkClient,
+              rpcType: self.rpcType
+            )
+            guard errorCode != RPCError.Code.unknown else {
+              throw RPCError(code: .unknown, message: "The RPC type is UNRECOGNIZED.")
+            }
             self.rpcStats.withLockedValue {
               $0.latencyHistogram.record(latency)
               if let errorCode = errorCode {
@@ -80,18 +89,123 @@ struct BenchmarkClient {
     }
   }
 
+  private func computeTimeAndErrorCode<Contents>(
+    _ body: (Grpc_Testing_SimpleRequest) async throws -> Result<Contents, RPCError>
+  ) async throws -> (latency: Double, errorCode: RPCError.Code?) {
+    let request = Grpc_Testing_SimpleRequest.with {
+      $0.responseSize = 10
+    }
+    let startTime = DispatchTime.now().uptimeNanoseconds
+    let result = try await body(request)
+    let endTime = DispatchTime.now().uptimeNanoseconds
+
+    var errorCode: RPCError.Code?
+    switch result {
+    case .success:
+      errorCode = nil
+    case let .failure(error):
+      errorCode = error.code
+    }
+    return (
+      latency: Double(endTime - startTime), errorCode: errorCode
+    )
+  }
+
   // The result is the number of nanoseconds for processing the RPC.
   private func makeRPC(
-    client: Grpc_Testing_BenchmarkServiceClient,
+    benchmarkClient: Grpc_Testing_BenchmarkServiceClient,
     rpcType: Grpc_Testing_RpcType
-  ) -> (latency: Double, errorCode: RPCError.Code?) {
+  ) async throws -> (latency: Double, errorCode: RPCError.Code?) {
     switch rpcType {
-    case .unary, .streaming, .streamingFromClient, .streamingFromServer, .streamingBothWays,
-      .UNRECOGNIZED:
-      let startTime = DispatchTime.now().uptimeNanoseconds
-      let endTime = DispatchTime.now().uptimeNanoseconds
+    case .unary:
+      return try await self.computeTimeAndErrorCode { request in
+        let responseStatus = try await benchmarkClient.unaryCall(
+          request: ClientRequest.Single(message: request)
+        ) {
+          response in
+          return response.accepted
+        }
+
+        return responseStatus
+      }
+
+    // Repeated sequence of one request followed by one response.
+    // It is a ping-pong of messages between the client and the server.
+    case .streaming:
+      return try await self.computeTimeAndErrorCode { request in
+        let ids = AsyncStream.makeStream(of: Int.self)
+        let streamingRequest = ClientRequest.Stream { writer in
+          for try await id in ids.stream {
+            if id <= self.messagesPerStream {
+              try await writer.write(request)
+            } else {
+              return
+            }
+          }
+        }
+
+        ids.continuation.yield(1)
+
+        let responseStatus = try await benchmarkClient.streamingCall(request: streamingRequest) {
+          response in
+          var id = 1
+          for try await _ in response.messages {
+            id += 1
+            ids.continuation.yield(id)
+          }
+          return response.accepted
+        }
+
+        return responseStatus
+      }
+
+    case .streamingFromClient:
+      return try await self.computeTimeAndErrorCode { request in
+        let streamingRequest = ClientRequest.Stream { writer in
+          for _ in 1 ... self.messagesPerStream {
+            try await writer.write(request)
+          }
+        }
+
+        let responseStatus = try await benchmarkClient.streamingFromClient(
+          request: streamingRequest
+        ) { response in
+          return response.accepted
+        }
+
+        return responseStatus
+      }
+
+    case .streamingFromServer:
+      return try await self.computeTimeAndErrorCode { request in
+        let responseStatus = try await benchmarkClient.streamingFromServer(
+          request: ClientRequest.Single(message: request)
+        ) { response in
+          return response.accepted
+        }
+
+        return responseStatus
+      }
+
+    case .streamingBothWays:
+      return try await self.computeTimeAndErrorCode { request in
+        let streamingRequest = ClientRequest.Stream { writer in
+          for _ in 1 ... self.messagesPerStream {
+            try await writer.write(request)
+          }
+        }
+
+        let responseStatus = try await benchmarkClient.streamingBothWays(request: streamingRequest)
+        { response in
+          return response.accepted
+        }
+
+        return responseStatus
+      }
+
+    case .UNRECOGNIZED:
       return (
-        latency: Double(endTime - startTime), errorCode: RPCError.Code(.unimplemented)
+        latency: -1, errorCode: RPCError.Code(.unknown)
       )
     }
   }

--- a/Sources/performance-worker/Internal/AsyncStream+MakeStream.swift
+++ b/Sources/performance-worker/Internal/AsyncStream+MakeStream.swift
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if swift(<5.9)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension AsyncStream {
+  @inlinable
+  static func makeStream(
+    of elementType: Element.Type = Element.self,
+    bufferingPolicy limit: AsyncStream<Element>.Continuation.BufferingPolicy = .unbounded
+  ) -> (stream: AsyncStream<Element>, continuation: AsyncStream<Element>.Continuation) {
+    var continuation: AsyncStream<Element>.Continuation!
+    let stream = AsyncStream(Element.self, bufferingPolicy: limit) {
+      continuation = $0
+    }
+    return (stream, continuation)
+  }
+}
+#endif

--- a/Sources/performance-worker/WorkerService.swift
+++ b/Sources/performance-worker/WorkerService.swift
@@ -325,6 +325,22 @@ extension WorkerService {
   }
 
   private func setupClients(_ config: Grpc_Testing_ClientConfig) async throws -> [BenchmarkClient] {
+    let rpcType: BenchmarkClient.RpcType
+    switch config.rpcType {
+    case .unary:
+      rpcType = .unary
+    case .streaming:
+      rpcType = .streaming
+    case .streamingFromClient:
+      rpcType = .streamingFromClient
+    case .streamingFromServer:
+      rpcType = .streamingFromServer
+    case .streamingBothWays:
+      rpcType = .streamingBothWays
+    case .UNRECOGNIZED:
+      throw RPCError(code: .unknown, message: "The RPC type is UNRECOGNIZED.")
+    }
+
     var clients = [BenchmarkClient]()
     for _ in 0 ..< config.clientChannels {
       let grpcClient = self.makeGRPCClient()
@@ -332,7 +348,7 @@ extension WorkerService {
         BenchmarkClient(
           client: grpcClient,
           rpcNumber: config.outstandingRpcsPerChannel,
-          rpcType: config.rpcType,
+          rpcType: rpcType,
           messagesPerStream: config.messagesPerStream,
           protoParams: config.payloadConfig.simpleParams,
           histogramParams: config.histogramParams

--- a/Sources/performance-worker/WorkerService.swift
+++ b/Sources/performance-worker/WorkerService.swift
@@ -333,6 +333,7 @@ extension WorkerService {
           client: grpcClient,
           rpcNumber: config.outstandingRpcsPerChannel,
           rpcType: config.rpcType,
+          messagesPerStream: config.messagesPerStream,
           histogramParams: config.histogramParams
         )
       )

--- a/Sources/performance-worker/WorkerService.swift
+++ b/Sources/performance-worker/WorkerService.swift
@@ -325,7 +325,7 @@ extension WorkerService {
   }
 
   private func setupClients(_ config: Grpc_Testing_ClientConfig) async throws -> [BenchmarkClient] {
-    let rpcType: BenchmarkClient.RpcType
+    let rpcType: BenchmarkClient.RPCType
     switch config.rpcType {
     case .unary:
       rpcType = .unary
@@ -344,7 +344,7 @@ extension WorkerService {
     var clients = [BenchmarkClient]()
     for _ in 0 ..< config.clientChannels {
       let grpcClient = self.makeGRPCClient()
-      try clients.append(
+      clients.append(
         BenchmarkClient(
           client: grpcClient,
           rpcNumber: config.outstandingRpcsPerChannel,

--- a/Sources/performance-worker/WorkerService.swift
+++ b/Sources/performance-worker/WorkerService.swift
@@ -328,12 +328,13 @@ extension WorkerService {
     var clients = [BenchmarkClient]()
     for _ in 0 ..< config.clientChannels {
       let grpcClient = self.makeGRPCClient()
-      clients.append(
+      try clients.append(
         BenchmarkClient(
           client: grpcClient,
           rpcNumber: config.outstandingRpcsPerChannel,
           rpcType: config.rpcType,
           messagesPerStream: config.messagesPerStream,
+          protoParams: config.payloadConfig.simpleParams,
           histogramParams: config.histogramParams
         )
       )


### PR DESCRIPTION
Motivation:

When the WorkerService holds and monitors BenchmarkClients, they need to make the requests to the server, as configured in the config input the WorkerService receives from the Test Driver.

Modifications:

- implemented a helper function that computes the latency and extracts the error code for a RPC
- implemented the body of the makeRPC function that makes one of the 5 possible RPCs (implemented the RPCs)

Result:

The BenchmarkClient implementation for performance testing will be completed.