### PR TITLE
Add missing availability guards in tests

### DIFF
--- a/Tests/GRPCCoreTests/Call/Client/RetryDelaySequenceTests.swift
+++ b/Tests/GRPCCoreTests/Call/Client/RetryDelaySequenceTests.swift
@@ -66,7 +66,7 @@ final class RetryDelaySequenceTests: XCTestCase {
       (.seconds(1), 1.0),
       (.milliseconds(1500), 1.5),
       (.nanoseconds(1_000_000_000), 1.0),
-      (.nanoseconds(3_141_592_653), 3.141592653),
+      (.nanoseconds(3_141_592_653 as Int64), 3.141592653),
     ]
 
     for (duration, expected) in testData {
@@ -80,7 +80,7 @@ final class RetryDelaySequenceTests: XCTestCase {
       (1.0, .seconds(1)),
       (1.5, .milliseconds(1500)),
       (1.0, .nanoseconds(1_000_000_000)),
-      (3.141592653, .nanoseconds(3_141_592_653)),
+      (3.141592653, .nanoseconds(3_141_592_653 as Int64)),
     ]
 
     for (seconds, expected) in testData {

--- a/Tests/GRPCCoreTests/TimeoutTests.swift
+++ b/Tests/GRPCCoreTests/TimeoutTests.swift
@@ -127,7 +127,7 @@ final class TimeoutTests: XCTestCase {
   }
 
   func testEncodeValidTimeout_Seconds_TooLong_Hours() {
-    let duration = Duration.seconds(9_999_999_999)
+    let duration = Duration.seconds(9_999_999_999 as Int64)
     let timeout = Timeout(duration: duration)
     // The conversion from seconds to hours results in a loss of precision.
     // 9,999,999,999 seconds / 60 = 166,666,666.65 minutes -rounding up->
@@ -142,7 +142,7 @@ final class TimeoutTests: XCTestCase {
   }
 
   func testEncodeValidTimeout_Seconds_TooLong_MaxAmount() {
-    let duration = Duration.seconds(999_999_999_999)
+    let duration = Duration.seconds(999_999_999_999 as Int64)
     let timeout = Timeout(duration: duration)
     // The conversion from seconds to hours results in a number that still has
     // more than the maximum allowed 8 digits, so we must clamp it.

--- a/Tests/GRPCHTTP2CoreTests/Client/Connection/ConnectionTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Client/Connection/ConnectionTests.swift
@@ -167,6 +167,7 @@ final class ConnectionTests: XCTestCase {
 }
 
 extension ClientBootstrap {
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   func connect<T>(
     to address: GRPCHTTP2Core.SocketAddress,
     _ configure: @Sendable @escaping (Channel) -> EventLoopFuture<T>

--- a/Tests/GRPCHTTP2CoreTests/Client/Connection/Utilities/HTTP2Connectors.swift
+++ b/Tests/GRPCHTTP2CoreTests/Client/Connection/Utilities/HTTP2Connectors.swift
@@ -21,6 +21,7 @@ import NIOHTTP2
 import NIOPosix
 
 @_spi(Package)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension HTTP2Connector where Self == ThrowingConnector {
   /// A connector which throws the given error on a connect attempt.
   static func throwing(_ error: RPCError) -> Self {
@@ -29,6 +30,7 @@ extension HTTP2Connector where Self == ThrowingConnector {
 }
 
 @_spi(Package)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension HTTP2Connector where Self == NeverConnector {
   /// A connector which fatal errors if a connect attempt is made.
   static var never: Self {
@@ -37,6 +39,7 @@ extension HTTP2Connector where Self == NeverConnector {
 }
 
 @_spi(Package)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension HTTP2Connector where Self == NIOPosixConnector {
   /// A connector which uses NIOPosix to establish a connection.
   static func posix(
@@ -56,6 +59,7 @@ extension HTTP2Connector where Self == NIOPosixConnector {
   }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 struct ThrowingConnector: HTTP2Connector {
   private let error: RPCError
 
@@ -70,6 +74,7 @@ struct ThrowingConnector: HTTP2Connector {
   }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 struct NeverConnector: HTTP2Connector {
   func establishConnection(
     to address: GRPCHTTP2Core.SocketAddress
@@ -78,6 +83,7 @@ struct NeverConnector: HTTP2Connector {
   }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 struct NIOPosixConnector: HTTP2Connector {
   private let eventLoopGroup: any EventLoopGroup
   private let maxIdleTime: TimeAmount?


### PR DESCRIPTION
Motivation:

Some test helpers were missing availbility guards. Also, some tests used integer literal which would overlflow an `Int` when it's only 32-bits.

Modifications:

- Add missing availbility guards
- Use Int64 explicitly to avoid overlflow

Result:

Tests build on other platforms