### PR TITLE
Enable `Metadata` to be initializable from a `Sequence` of `Elements`

### DIFF
--- a/Sources/GRPCCore/Metadata.swift
+++ b/Sources/GRPCCore/Metadata.swift
@@ -130,7 +130,7 @@ public struct Metadata: Sendable, Hashable {
     self.elements = []
   }
 
-  /// Initialize Metadata from a Sequence of Elements
+  /// Initialize `Metadata` from a `Sequence` of `Element`s.
   public init(from elements: some Sequence<Element>) {
     self.elements = elements.map { key, value in
       KeyValuePair(key: key, value: value)

--- a/Sources/GRPCCore/Metadata.swift
+++ b/Sources/GRPCCore/Metadata.swift
@@ -131,7 +131,7 @@ public struct Metadata: Sendable, Hashable {
   }
 
   /// Initialize `Metadata` from a `Sequence` of `Element`s.
-  public init(from elements: some Sequence<Element>) {
+  public init(_ elements: some Sequence<Element>) {
     self.elements = elements.map { key, value in
       KeyValuePair(key: key, value: value)
     }

--- a/Sources/GRPCCore/Metadata.swift
+++ b/Sources/GRPCCore/Metadata.swift
@@ -130,6 +130,13 @@ public struct Metadata: Sendable, Hashable {
     self.elements = []
   }
 
+  /// Initialize Metadata from a Sequence of Elements
+  public init(from elements: some Sequence<Element>) {
+    self.elements = elements.map { key, value in
+      KeyValuePair(key: key, value: value)
+    }
+  }
+
   /// Reserve the specified minimum capacity in the collection.
   ///
   /// - Parameter minimumCapacity: The minimum capacity to reserve in the collection.

--- a/Tests/GRPCCoreTests/MetadataTests.swift
+++ b/Tests/GRPCCoreTests/MetadataTests.swift
@@ -17,7 +17,7 @@ import GRPCCore
 import XCTest
 
 final class MetadataTests: XCTestCase {
-  func testInitFrom() {
+  func testInitFromSequence() {
     let elements: [Metadata.Element] = [
       (key: "key1", value: "value1"),
       (key: "key2", value: "value2"),

--- a/Tests/GRPCCoreTests/MetadataTests.swift
+++ b/Tests/GRPCCoreTests/MetadataTests.swift
@@ -17,6 +17,19 @@ import GRPCCore
 import XCTest
 
 final class MetadataTests: XCTestCase {
+  func testInitFrom() {
+    let elements: [Metadata.Element] = [
+      (key: "key1", value: "value1"),
+      (key: "key2", value: "value2"),
+      (key: "key3", value: "value3"),
+    ]
+
+    let metadata = Metadata(from: elements)
+    let expected: Metadata = ["key1": "value1", "key2": "value2", "key3": "value3"]
+
+    XCTAssertEqual(metadata, expected)
+  }
+
   func testAddStringValue() {
     var metadata = Metadata()
     XCTAssertTrue(metadata.isEmpty)

--- a/Tests/GRPCCoreTests/MetadataTests.swift
+++ b/Tests/GRPCCoreTests/MetadataTests.swift
@@ -24,7 +24,7 @@ final class MetadataTests: XCTestCase {
       (key: "key3", value: "value3"),
     ]
 
-    let metadata = Metadata(from: elements)
+    let metadata = Metadata(elements)
     let expected: Metadata = ["key1": "value1", "key2": "value2", "key3": "value3"]
 
     XCTAssertEqual(metadata, expected)


### PR DESCRIPTION
Motivation:

This would be a convenient API to have.

Modifications:

Add a new `public init` to `Metadata` which takes `some Sequence<Element>` and initializes `Metadata` collection from the `Sequence` of `Elements`.

Result:

Users can now initialize `Metadata` from a `Sequence` of `Elements`.