### PR TITLE
Round robin load balancer

### DIFF
--- a/Sources/GRPCHTTP2Core/Client/Connection/LoadBalancers/LoadBalancerEvent.swift
+++ b/Sources/GRPCHTTP2Core/Client/Connection/LoadBalancers/LoadBalancerEvent.swift
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// Events emitted by load-balancers.
+enum LoadBalancerEvent: Sendable, Hashable {
+  /// The connectivity state of the subchannel changed.
+  case connectivityStateChanged(ConnectivityState)
+  /// The subchannel requests that the load balancer re-resolves names.
+  case requiresNameResolution
+}

--- a/Sources/GRPCHTTP2Core/Client/Connection/LoadBalancers/RoundRobinLoadBalancer.swift
+++ b/Sources/GRPCHTTP2Core/Client/Connection/LoadBalancers/RoundRobinLoadBalancer.swift
@@ -544,8 +544,8 @@ extension RoundRobinLoadBalancer {
           return (run: [], close: [], newState: nil)
         }
 
-        // The load balancer should keep subchannels to remove in service until they a new subchannel
-        // can replace it so that requests can continue to be served.
+        // The load balancer should keep subchannels to remove in service until new subchannels
+        // can replace each of them so that requests can continue to be served.
         //
         // If there are more keys to remove than to add, remove some now.
         let numberToRemoveNow = max(keysToRemove.count - keysToAdd.count, 0)

--- a/Sources/GRPCHTTP2Core/Client/Connection/LoadBalancers/RoundRobinLoadBalancer.swift
+++ b/Sources/GRPCHTTP2Core/Client/Connection/LoadBalancers/RoundRobinLoadBalancer.swift
@@ -1,0 +1,766 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import GRPCCore
+import NIOConcurrencyHelpers
+
+/// A load-balancer which maintains to a set of subchannels and uses round-robin to pick a
+/// subchannel when picking a subchannel to use.
+///
+/// This load-balancer starts in an 'idle' state and begins connecting when a set of addresses is
+/// provided to it with ``updateAddresses(_:)``. Repeated calls to ``updateAddresses(_:)`` will
+/// update the subchannels gracefully: new subchannels will be added for new addresses and existing
+/// subchannels will be removed if their addresses are no longer present.
+///
+/// The state of the load-balancer is aggregated across the state of its subchannels, changes in
+/// the aggregate state are reported up via ``events``.
+///
+/// You must call ``close()`` on the load-balancer when it's no longer required. This will move
+/// it to the ``ConnectivityState/shutdown`` state: existing RPCs may continue but all subsequent
+/// calls to ``makeStream(descriptor:options:)`` will fail.
+///
+/// To use this load-balancer you must run it in a task:
+///
+/// ```swift
+/// await withTaskGroup(of: Void.self) { group in
+///   // Run the load-balancer
+///   group.addTask { await roundRobin.run() }
+///
+///   // Update its address list
+///   let endpoints: [Endpoint] = [
+///     Endpoint(addresses: [.ipv4(host: "127.0.0.1", port: 1001)]),
+///     Endpoint(addresses: [.ipv4(host: "127.0.0.1", port: 1002)]),
+///     Endpoint(addresses: [.ipv4(host: "127.0.0.1", port: 1003)])
+///   ]
+///   roundRobin.updateAddresses(endpoints)
+///
+///   // Consume state update events
+///   for await event in roundRobin.events {
+///     switch event {
+///     case .connectivityStateChanged(.ready):
+///       // ...
+///     default:
+///       // ...
+///     }
+///   }
+/// }
+/// ```
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+struct RoundRobinLoadBalancer {
+  enum Input: Sendable, Hashable {
+    /// Update the addresses used by the load balancer to the following endpoints.
+    case updateAddresses([Endpoint])
+    /// Close the load balancer.
+    case close
+  }
+
+  /// A key for an endpoint which identifies it uniquely, regardless of the ordering of addresses.
+  private struct EndpointKey: Hashable, Sendable, CustomStringConvertible {
+    /// Opaque data.
+    private let opaque: [String]
+
+    /// The endpoint this key is for.
+    let endpoint: Endpoint
+
+    init(_ endpoint: Endpoint) {
+      self.endpoint = endpoint
+      self.opaque = endpoint.addresses.map { String(describing: $0) }.sorted()
+    }
+
+    var description: String {
+      String(describing: self.endpoint.addresses)
+    }
+
+    func hash(into hasher: inout Hasher) {
+      hasher.combine(self.opaque)
+    }
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+      lhs.opaque == rhs.opaque
+    }
+  }
+
+  /// Events which can happen to the load balancer.
+  private let event:
+    (
+      stream: AsyncStream<LoadBalancerEvent>,
+      continuation: AsyncStream<LoadBalancerEvent>.Continuation
+    )
+
+  /// Inputs which this load balancer should react to.
+  private let input: (stream: AsyncStream<Input>, continuation: AsyncStream<Input>.Continuation)
+
+  /// The state of the load balancer.
+  private let state: NIOLockedValueBox<State>
+
+  /// A connector, capable of creating connections.
+  private let connector: any HTTP2Connector
+
+  /// Connection backoff configuration.
+  private let backoff: ConnectionBackoff
+
+  /// The default compression algorithm to use. Can be overridden on a per-call basis.
+  private let defaultCompression: CompressionAlgorithm
+
+  /// The set of enabled compression algorithms.
+  private let enabledCompression: CompressionAlgorithmSet
+
+  init(
+    connector: any HTTP2Connector,
+    backoff: ConnectionBackoff,
+    defaultCompression: CompressionAlgorithm,
+    enabledCompression: CompressionAlgorithmSet
+  ) {
+    self.connector = connector
+    self.backoff = backoff
+    self.defaultCompression = defaultCompression
+    self.enabledCompression = enabledCompression
+
+    self.event = AsyncStream.makeStream(of: LoadBalancerEvent.self)
+    self.input = AsyncStream.makeStream(of: Input.self)
+    self.state = NIOLockedValueBox(.active(State.Active()))
+
+    // The load balancer starts in the idle state.
+    self.event.continuation.yield(.connectivityStateChanged(.idle))
+  }
+
+  /// A stream of events which can happen to the load balancer.
+  var events: AsyncStream<LoadBalancerEvent> {
+    self.event.stream
+  }
+
+  /// Runs the load balancer, returning when it has closed.
+  ///
+  /// You can monitor events which happen on the load balancer with ``events``.
+  func run() async {
+    await withDiscardingTaskGroup { group in
+      for await input in self.input.stream {
+        switch input {
+        case .updateAddresses(let addresses):
+          self.handleUpdateAddresses(addresses, in: &group)
+        case .close:
+          self.handleCloseInput()
+        }
+      }
+    }
+
+    if Task.isCancelled {
+      // Finish the event stream as it's unlikely to have been finished by a regular code path.
+      self.event.continuation.finish()
+    }
+  }
+
+  /// Update the addresses used by the load balancer.
+  ///
+  /// This may result in new subchannels being created and some subchannels being removed.
+  func updateAddresses(_ endpoints: [Endpoint]) {
+    self.input.continuation.yield(.updateAddresses(endpoints))
+  }
+
+  /// Close the load balancer, and all subchannels it manages.
+  func close() {
+    self.input.continuation.yield(.close)
+  }
+
+  /// Pick a ready subchannel from the load balancer.
+  ///
+  /// - Returns: A subchannel, or `nil` if there aren't any ready subchannels.
+  func pickSubchannel() -> Subchannel? {
+    switch self.state.withLockedValue({ $0.pickSubchannel() }) {
+    case .picked(let subchannel):
+      return subchannel
+
+    case .notAvailable(let subchannels):
+      // Tell the subchannels to start connecting.
+      for subchannel in subchannels {
+        subchannel.connect()
+      }
+      return nil
+    }
+  }
+}
+
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+extension RoundRobinLoadBalancer {
+  /// Handles an update in endpoints.
+  ///
+  /// The load-balancer will diff the set of endpoints with the existing set of endpoints:
+  /// - endpoints which are new will have subchannels created for them,
+  /// - endpoints which existed previously but are not present in `endpoints` are closed,
+  /// - endpoints which existed previously and are still present in `endpoints` are untouched.
+  ///
+  /// This process is gradual: the load-balancer won't remove an old endpoint until a subchannel
+  /// for a corresponding new subchannel becomes ready.
+  ///
+  /// - Parameters:
+  ///   - endpoints: Endpoints which should have subchannels. Must not be empty.
+  ///   - group: The group which should manage and run new subchannels.
+  private func handleUpdateAddresses(_ endpoints: [Endpoint], in group: inout DiscardingTaskGroup) {
+    if endpoints.isEmpty { return }
+
+    // Compute the keys for each endpoint.
+    let newEndpoints = Set(endpoints.map { EndpointKey($0) })
+
+    let (added, removed, newState) = self.state.withLockedValue { state in
+      state.updateSubchannels(newEndpoints: newEndpoints) { endpoint, id in
+        Subchannel(
+          endpoint: endpoint,
+          id: id,
+          connector: self.connector,
+          backoff: self.backoff,
+          defaultCompression: self.defaultCompression,
+          enabledCompression: self.enabledCompression
+        )
+      }
+    }
+
+    // Publish the new connectivity state.
+    if let newState = newState {
+      self.event.continuation.yield(.connectivityStateChanged(newState))
+    }
+
+    // Run each of the new subchannels.
+    for subchannel in added {
+      let key = EndpointKey(subchannel.endpoint)
+      self.runSubchannel(subchannel, forKey: key, in: &group)
+    }
+
+    // Old subchannels are removed when new subchannels become ready. Excess subchannels are only
+    // present if there are more to remove than to add. These are the excess subchannels which
+    // are closed now.
+    for subchannel in removed {
+      subchannel.close()
+    }
+  }
+
+  private func runSubchannel(
+    _ subchannel: Subchannel,
+    forKey key: EndpointKey,
+    in group: inout DiscardingTaskGroup
+  ) {
+    // Start running it and tell it to connect.
+    subchannel.connect()
+    group.addTask {
+      await subchannel.run()
+    }
+
+    group.addTask {
+      for await event in subchannel.events {
+        switch event {
+        case .connectivityStateChanged(let state):
+          self.handleSubchannelConnectivityStateChange(state, key: key)
+        case .goingAway:
+          self.handleSubchannelGoingAway(key: key)
+        case .requiresNameResolution:
+          self.event.continuation.yield(.requiresNameResolution)
+        }
+      }
+    }
+  }
+
+  private func handleSubchannelConnectivityStateChange(
+    _ connectivityState: ConnectivityState,
+    key: EndpointKey
+  ) {
+    let onChange = self.state.withLockedValue { state in
+      state.updateSubchannelConnectivityState(connectivityState, key: key)
+    }
+
+    switch onChange {
+    case .publishStateChange(let aggregateState):
+      self.event.continuation.yield(.connectivityStateChanged(aggregateState))
+
+    case .closeAndPublishStateChange(let subchannel, let aggregateState):
+      self.event.continuation.yield(.connectivityStateChanged(aggregateState))
+      subchannel.close()
+
+    case .close(let subchannel):
+      subchannel.close()
+
+    case .closed:
+      // All subchannels are closed; finish the streams so the run loop exits.
+      self.event.continuation.finish()
+      self.input.continuation.finish()
+
+    case .none:
+      ()
+    }
+  }
+
+  private func handleSubchannelGoingAway(key: EndpointKey) {
+    switch self.state.withLockedValue({ $0.parkSubchannel(withKey: key) }) {
+    case .closeAndUpdateState(_, let connectivityState):
+      // No need to close the subchannel, it's already going away and will close itself.
+      if let connectivityState = connectivityState {
+        self.event.continuation.yield(.connectivityStateChanged(connectivityState))
+      }
+    case .none:
+      ()
+    }
+  }
+
+  private func handleCloseInput() {
+    switch self.state.withLockedValue({ $0.close() }) {
+    case .closeSubchannels(let subchannels):
+      // Publish a new shutdown state, this LB is no longer usable for new RPCs.
+      self.event.continuation.yield(.connectivityStateChanged(.shutdown))
+
+      // Close the subchannels.
+      for subchannel in subchannels {
+        subchannel.close()
+      }
+
+    case .closed:
+      // No subchannels to close.
+      self.event.continuation.yield(.connectivityStateChanged(.shutdown))
+      self.event.continuation.finish()
+      self.input.continuation.finish()
+
+    case .none:
+      ()
+    }
+  }
+}
+
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+extension RoundRobinLoadBalancer {
+  private enum State {
+    case active(Active)
+    case closing(Closing)
+    case closed
+
+    struct Active {
+      private(set) var aggregateConnectivityState: ConnectivityState
+      private var picker: Picker?
+
+      var endpoints: [Endpoint]
+      var subchannels: [EndpointKey: SubchannelState]
+      var parkedSubchannels: [EndpointKey: Subchannel]
+
+      init() {
+        self.endpoints = []
+        self.subchannels = [:]
+        self.parkedSubchannels = [:]
+        self.aggregateConnectivityState = .idle
+        self.picker = nil
+      }
+
+      mutating func updateConnectivityState(
+        _ state: ConnectivityState,
+        key: EndpointKey
+      ) -> OnSubchannelConnectivityStateUpdate {
+        if let changed = self.subchannels[key]?.updateState(state) {
+          guard changed else { return .none }
+
+          let subchannelToClose: Subchannel?
+
+          switch state {
+          case .ready:
+            if let index = self.subchannels.firstIndex(where: { $0.value.markedForRemoval }) {
+              let (key, subchannelState) = self.subchannels.remove(at: index)
+              self.parkedSubchannels[key] = subchannelState.subchannel
+              subchannelToClose = subchannelState.subchannel
+            } else {
+              subchannelToClose = nil
+            }
+
+          case .idle, .connecting, .transientFailure, .shutdown:
+            subchannelToClose = nil
+          }
+
+          self.refreshPicker()
+          let aggregateState = self.recomputeAggregateState()
+
+          switch (subchannelToClose, aggregateState) {
+          case (.some(let subchannel), .some(let state)):
+            return .closeAndPublishStateChange(subchannel, state)
+          case (.some(let subchannel), .none):
+            return .close(subchannel)
+          case (.none, .some(let state)):
+            return .publishStateChange(state)
+          case (.none, .none):
+            return .none
+          }
+        } else {
+          switch state {
+          case .idle, .connecting, .ready, .transientFailure:
+            ()
+          case .shutdown:
+            self.parkedSubchannels.removeValue(forKey: key)
+          }
+
+          return .none
+        }
+      }
+
+      mutating func refreshPicker() {
+        let readySubchannels = self.subchannels.values.compactMap {
+          $0.state == .ready ? $0.subchannel : nil
+        }
+
+        self.picker = Picker(subchannels: readySubchannels)
+      }
+
+      mutating func recomputeAggregateState() -> ConnectivityState? {
+        let aggregate = ConnectivityState.aggregate(self.subchannels.values.map { $0.state })
+        if aggregate == self.aggregateConnectivityState {
+          return nil
+        }
+
+        // Update the current state.
+        self.aggregateConnectivityState = aggregate
+        return aggregate
+      }
+
+      mutating func pick() -> Subchannel? {
+        self.picker?.pick()
+      }
+
+      mutating func markForRemoval(
+        _ keys: some Sequence<EndpointKey>,
+        numberToRemoveNow: Int
+      ) -> [Subchannel] {
+        var numberToRemoveNow = numberToRemoveNow
+        var keyIterator = keys.makeIterator()
+        var subchannelsToClose = [Subchannel]()
+
+        while numberToRemoveNow > 0, let key = keyIterator.next() {
+          if let subchannelState = self.subchannels.removeValue(forKey: key) {
+            numberToRemoveNow -= 1
+            self.parkedSubchannels[key] = subchannelState.subchannel
+            subchannelsToClose.append(subchannelState.subchannel)
+          }
+        }
+
+        while let key = keyIterator.next() {
+          self.subchannels[key]?.markForRemoval()
+        }
+
+        return subchannelsToClose
+      }
+
+      mutating func registerSubchannels(
+        withKeys keys: some Sequence<EndpointKey>,
+        _ makeSubchannel: (_ endpoint: Endpoint, _ id: SubchannelID) -> Subchannel
+      ) -> [Subchannel] {
+        var subchannels = [Subchannel]()
+
+        for key in keys {
+          let subchannel = makeSubchannel(key.endpoint, SubchannelID())
+          subchannels.append(subchannel)
+          self.subchannels[key] = SubchannelState(subchannel: subchannel)
+        }
+
+        return subchannels
+      }
+    }
+
+    struct Closing {
+      enum Reason: Sendable, Hashable {
+        case goAway
+        case user
+      }
+
+      var reason: Reason
+      var parkedSubchannels: [EndpointKey: Subchannel]
+
+      mutating func updateConnectivityState(_ state: ConnectivityState, key: EndpointKey) -> Bool {
+        switch state {
+        case .idle, .connecting, .ready, .transientFailure:
+          ()
+        case .shutdown:
+          self.parkedSubchannels.removeValue(forKey: key)
+        }
+
+        return self.parkedSubchannels.isEmpty
+      }
+    }
+
+    struct SubchannelState {
+      var subchannel: Subchannel
+      var state: ConnectivityState
+      var markedForRemoval: Bool
+
+      init(subchannel: Subchannel) {
+        self.subchannel = subchannel
+        self.state = .idle
+        self.markedForRemoval = false
+      }
+
+      mutating func updateState(_ newState: ConnectivityState) -> Bool {
+        // The transition from transient failure to connecting is ignored.
+        //
+        // See: https://github.com/grpc/grpc/blob/master/doc/load-balancing.md
+        if self.state == .transientFailure, newState == .connecting {
+          return false
+        }
+
+        let oldState = self.state
+        self.state = newState
+        return oldState != newState
+      }
+
+      mutating func markForRemoval() {
+        self.markedForRemoval = true
+      }
+    }
+
+    struct Picker {
+      private var subchannels: [Subchannel]
+      private var index: Int
+
+      init?(subchannels: [Subchannel]) {
+        if subchannels.isEmpty { return nil }
+
+        self.subchannels = subchannels
+        self.index = (0 ..< subchannels.count).randomElement()!
+      }
+
+      mutating func pick() -> Subchannel {
+        defer {
+          self.index = (self.index + 1) % self.subchannels.count
+        }
+        return self.subchannels[self.index]
+      }
+    }
+
+    mutating func updateSubchannels(
+      newEndpoints: Set<EndpointKey>,
+      makeSubchannel: (_ endpoint: Endpoint, _ id: SubchannelID) -> Subchannel
+    ) -> (run: [Subchannel], close: [Subchannel], newState: ConnectivityState?) {
+      switch self {
+      case .active(var state):
+        let existingEndpoints = Set(state.subchannels.keys)
+        let keysToAdd = newEndpoints.subtracting(existingEndpoints)
+        let keysToRemove = existingEndpoints.subtracting(newEndpoints)
+
+        if keysToRemove.isEmpty && keysToAdd.isEmpty {
+          // Nothing to do.
+          return (run: [], close: [], newState: nil)
+        }
+
+        // The load balancer should keep subchannels to remove in service until they a new subchannel
+        // can replace it so that requests can continue to be served.
+        //
+        // If there are more keys to remove than to add, remove some now.
+        let numberToRemoveNow = max(keysToRemove.count - keysToAdd.count, 0)
+
+        let removed = state.markForRemoval(keysToRemove, numberToRemoveNow: numberToRemoveNow)
+        let added = state.registerSubchannels(withKeys: keysToAdd, makeSubchannel)
+
+        state.refreshPicker()
+        let newState = state.recomputeAggregateState()
+        self = .active(state)
+        return (run: added, close: removed, newState: newState)
+
+      case .closing, .closed:
+        // Nothing to do.
+        return (run: [], close: [], newState: nil)
+      }
+
+    }
+
+    enum OnParkChannel {
+      case closeAndUpdateState(Subchannel, ConnectivityState?)
+      case none
+    }
+
+    mutating func parkSubchannel(withKey key: EndpointKey) -> OnParkChannel {
+      switch self {
+      case .active(var state):
+        guard let subchannelState = state.subchannels.removeValue(forKey: key) else {
+          return .none
+        }
+
+        // Parking the subchannel may invalidate the picker and the aggregate state, refresh both.
+        state.parkedSubchannels[key] = subchannelState.subchannel
+        state.refreshPicker()
+        let newState = state.recomputeAggregateState()
+        self = .active(state)
+        return .closeAndUpdateState(subchannelState.subchannel, newState)
+
+      case .closing, .closed:
+        return .none
+      }
+    }
+
+    mutating func registerSubchannels(
+      withKeys keys: some Sequence<EndpointKey>,
+      _ makeSubchannel: (Endpoint) -> Subchannel
+    ) -> [Subchannel] {
+      switch self {
+      case .active(var state):
+        var subchannels = [Subchannel]()
+
+        for key in keys {
+          let subchannel = makeSubchannel(key.endpoint)
+          subchannels.append(subchannel)
+          state.subchannels[key] = SubchannelState(subchannel: subchannel)
+        }
+
+        self = .active(state)
+        return subchannels
+
+      case .closing, .closed:
+        return []
+      }
+    }
+
+    mutating func refreshPickerAndAggregateState() -> ConnectivityState? {
+      switch self {
+      case .active(var state):
+        state.refreshPicker()
+        let aggregate = state.recomputeAggregateState()
+        self = .active(state)
+        return aggregate
+
+      case .closing, .closed:
+        return nil
+      }
+    }
+
+    mutating func parkSoon(_ keys: [EndpointKey]) {
+      switch self {
+      case .active(var state):
+        for key in keys {
+          state.subchannels[key]?.markForRemoval()
+        }
+        self = .active(state)
+      case .closing, .closed:
+        ()
+      }
+    }
+
+    enum OnSubchannelConnectivityStateUpdate {
+      case closeAndPublishStateChange(Subchannel, ConnectivityState)
+      case publishStateChange(ConnectivityState)
+      case close(Subchannel)
+      case closed
+      case none
+    }
+
+    mutating func updateSubchannelConnectivityState(
+      _ connectivityState: ConnectivityState,
+      key: EndpointKey
+    ) -> OnSubchannelConnectivityStateUpdate {
+      switch self {
+      case .active(var state):
+        let result = state.updateConnectivityState(connectivityState, key: key)
+        self = .active(state)
+        return result
+
+      case .closing(var state):
+        if state.updateConnectivityState(connectivityState, key: key) {
+          self = .closed
+          return .closed
+        } else {
+          self = .closing(state)
+          return .none
+        }
+
+      case .closed:
+        return .none
+      }
+    }
+
+    enum OnClose {
+      case closeSubchannels([Subchannel])
+      case closed
+      case none
+    }
+
+    mutating func close() -> OnClose {
+      switch self {
+      case .active(var active):
+        var subchannelsToClose = [Subchannel]()
+
+        for (id, subchannelState) in active.subchannels {
+          subchannelsToClose.append(subchannelState.subchannel)
+          active.parkedSubchannels[id] = subchannelState.subchannel
+        }
+
+        if subchannelsToClose.isEmpty {
+          self = .closed
+          return .closed
+        } else {
+          self = .closing(Closing(reason: .user, parkedSubchannels: active.parkedSubchannels))
+          return .closeSubchannels(subchannelsToClose)
+        }
+
+      case .closing, .closed:
+        return .none
+      }
+    }
+
+    enum OnPickSubchannel {
+      case picked(Subchannel)
+      case notAvailable([Subchannel])
+    }
+
+    mutating func pickSubchannel() -> OnPickSubchannel {
+      let onMakeStream: OnPickSubchannel
+
+      switch self {
+      case .active(var active):
+        if let subchannel = active.pick() {
+          onMakeStream = .picked(subchannel)
+        } else {
+          switch active.aggregateConnectivityState {
+          case .idle:
+            onMakeStream = .notAvailable(active.subchannels.values.map { $0.subchannel })
+          case .connecting, .ready, .transientFailure, .shutdown:
+            onMakeStream = .notAvailable([])
+          }
+        }
+        self = .active(active)
+
+      case .closing, .closed:
+        onMakeStream = .notAvailable([])
+      }
+
+      return onMakeStream
+    }
+  }
+}
+
+extension ConnectivityState {
+  static func aggregate(_ states: some Collection<ConnectivityState>) -> ConnectivityState {
+    // See https://github.com/grpc/grpc/blob/master/doc/load-balancing.md
+
+    // If any one subchannel is in READY state, the channel's state is READY.
+    if states.contains(where: { $0 == .ready }) {
+      return .ready
+    }
+
+    // Otherwise, if there is any subchannel in state CONNECTING, the channel's state is CONNECTING.
+    if states.contains(where: { $0 == .connecting }) {
+      return .connecting
+    }
+
+    // Otherwise, if there is any subchannel in state IDLE, the channel's state is IDLE.
+    if states.contains(where: { $0 == .idle }) {
+      return .idle
+    }
+
+    // Otherwise, if all subchannels are in state TRANSIENT_FAILURE, the channel's state
+    //   is TRANSIENT_FAILURE.
+    if states.allSatisfy({ $0 == .transientFailure }) {
+      return .transientFailure
+    }
+
+    return .shutdown
+  }
+}

--- a/Sources/GRPCHTTP2Core/Client/Connection/LoadBalancers/RoundRobinLoadBalancer.swift
+++ b/Sources/GRPCHTTP2Core/Client/Connection/LoadBalancers/RoundRobinLoadBalancer.swift
@@ -15,7 +15,6 @@
  */
 
 import GRPCCore
-import NIOConcurrencyHelpers
 
 /// A load-balancer which maintains to a set of subchannels and uses round-robin to pick a
 /// subchannel when picking a subchannel to use.
@@ -104,7 +103,7 @@ struct RoundRobinLoadBalancer {
   private let input: (stream: AsyncStream<Input>, continuation: AsyncStream<Input>.Continuation)
 
   /// The state of the load balancer.
-  private let state: NIOLockedValueBox<State>
+  private let state: _LockedValueBox<State>
 
   /// A connector, capable of creating connections.
   private let connector: any HTTP2Connector
@@ -131,7 +130,7 @@ struct RoundRobinLoadBalancer {
 
     self.event = AsyncStream.makeStream(of: LoadBalancerEvent.self)
     self.input = AsyncStream.makeStream(of: Input.self)
-    self.state = NIOLockedValueBox(.active(State.Active()))
+    self.state = _LockedValueBox(.active(State.Active()))
 
     // The load balancer starts in the idle state.
     self.event.continuation.yield(.connectivityStateChanged(.idle))

--- a/Sources/GRPCHTTP2Core/Client/Connection/LoadBalancers/RoundRobinLoadBalancer.swift
+++ b/Sources/GRPCHTTP2Core/Client/Connection/LoadBalancers/RoundRobinLoadBalancer.swift
@@ -35,7 +35,7 @@ import NIOConcurrencyHelpers
 /// To use this load-balancer you must run it in a task:
 ///
 /// ```swift
-/// await withTaskGroup(of: Void.self) { group in
+/// await withDiscardingTaskGroup { group in
 ///   // Run the load-balancer
 ///   group.addTask { await roundRobin.run() }
 ///

--- a/Sources/GRPCHTTP2Core/Internal/ProcessUniqueID.swift
+++ b/Sources/GRPCHTTP2Core/Internal/ProcessUniqueID.swift
@@ -37,3 +37,11 @@ struct SubchannelID: Hashable, Sendable, CustomStringConvertible {
     "subchan_\(self.id)"
   }
 }
+
+/// A process-unique ID for a load-balancer.
+struct LoadBalancerID: Hashable, Sendable, CustomStringConvertible {
+  private let id = ProcessUniqueID()
+  var description: String {
+    "lb_\(self.id)"
+  }
+}

--- a/Tests/GRPCHTTP2CoreTests/Client/Connection/LoadBalancers/RoundRobinLoadBalancerTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Client/Connection/LoadBalancers/RoundRobinLoadBalancerTests.swift
@@ -1,0 +1,440 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Atomics
+import GRPCCore
+@_spi(Package) @testable import GRPCHTTP2Core
+import NIOHTTP2
+import NIOPosix
+import XCTest
+
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+final class RoundRobinLoadBalancerTests: XCTestCase {
+  func testMultipleConnectionsAreEstablished() async throws {
+    try await RoundRobinLoadBalancerTest.run(servers: 3, connector: .posix()) { context, event in
+      switch event {
+      case .connectivityStateChanged(.idle):
+        // Update the addresses for the load balancer, this will trigger subchannels to be created
+        // for each.
+        let endpoints = context.servers.map { Endpoint(addresses: [$0.address]) }
+        context.loadBalancer.updateAddresses(endpoints)
+
+      case .connectivityStateChanged(.ready):
+        // Poll until each server has one connected client.
+        try await XCTPoll(every: .milliseconds(10)) {
+          context.servers.allSatisfy { server, _ in server.clients.count == 1 }
+        }
+
+        // Close to end the test.
+        context.loadBalancer.close()
+
+      default:
+        ()
+      }
+    } verifyEvents: { events in
+      let expected: [LoadBalancerEvent] = [
+        .connectivityStateChanged(.idle),
+        .connectivityStateChanged(.connecting),
+        .connectivityStateChanged(.ready),
+        .connectivityStateChanged(.shutdown),
+      ]
+      XCTAssertEqual(events, expected)
+    }
+  }
+
+  func testSubchannelsArePickedEvenly() async throws {
+    try await RoundRobinLoadBalancerTest.run(servers: 3, connector: .posix()) { context, event in
+      switch event {
+      case .connectivityStateChanged(.idle):
+        // Update the addresses for the load balancer, this will trigger subchannels to be created
+        // for each.
+        let endpoints = context.servers.map { Endpoint(addresses: [$0.address]) }
+        context.loadBalancer.updateAddresses(endpoints)
+
+      case .connectivityStateChanged(.ready):
+        // Subchannel is ready. This happens when any subchannel becomes ready. Loop until
+        // we can pick three distinct subchannels.
+        try await XCTPoll(every: .milliseconds(10)) {
+          var subchannelIDs = Set<SubchannelID>()
+          for _ in 0 ..< 3 {
+            let subchannel = try XCTUnwrap(context.loadBalancer.pickSubchannel())
+            subchannelIDs.insert(subchannel.id)
+          }
+          return subchannelIDs.count == 3
+        }
+
+        // Now that all are ready, load should be distributed evenly among them.
+        var counts = [SubchannelID: Int]()
+
+        for round in 1 ... 10 {
+          for _ in 1 ... 3 {
+            if let subchannel = context.loadBalancer.pickSubchannel() {
+              counts[subchannel.id, default: 0] += 1
+            } else {
+              XCTFail("Didn't pick subchannel from ready load balancer")
+            }
+          }
+
+          XCTAssertEqual(counts.count, 3, "\(counts)")
+          XCTAssert(counts.values.allSatisfy({ $0 == round }), "\(counts)")
+        }
+
+        // Close to finish the test.
+        context.loadBalancer.close()
+
+      default:
+        ()
+      }
+    } verifyEvents: { events in
+      let expected: [LoadBalancerEvent] = [
+        .connectivityStateChanged(.idle),
+        .connectivityStateChanged(.connecting),
+        .connectivityStateChanged(.ready),
+        .connectivityStateChanged(.shutdown),
+      ]
+      XCTAssertEqual(events, expected)
+    }
+  }
+
+  func testAddressUpdatesAreHandledGracefully() async throws {
+    try await RoundRobinLoadBalancerTest.run(servers: 3, connector: .posix()) { context, event in
+      switch event {
+      case .connectivityStateChanged(.idle):
+        // Do the first connect.
+        let endpoints = [Endpoint(addresses: [context.servers[0].address])]
+        context.loadBalancer.updateAddresses(endpoints)
+
+      case .connectivityStateChanged(.ready):
+        // Now the first connection should be established.
+        do {
+          try await XCTPoll(every: .milliseconds(10)) {
+            context.servers[0].server.clients.count == 1
+          }
+        }
+
+        // First connection is okay, add a second.
+        do {
+          let endpoints = [
+            Endpoint(addresses: [context.servers[0].address]),
+            Endpoint(addresses: [context.servers[1].address]),
+          ]
+          context.loadBalancer.updateAddresses(endpoints)
+
+          try await XCTPoll(every: .milliseconds(10)) {
+            context.servers.prefix(2).allSatisfy { $0.server.clients.count == 1 }
+          }
+        }
+
+        // Remove those two endpoints and add a third.
+        do {
+          let endpoints = [Endpoint(addresses: [context.servers[2].address])]
+          context.loadBalancer.updateAddresses(endpoints)
+
+          try await XCTPoll(every: .milliseconds(10)) {
+            let disconnected = context.servers.prefix(2).allSatisfy { $0.server.clients.isEmpty }
+            let connected = context.servers.last!.server.clients.count == 1
+            return disconnected && connected
+          }
+        }
+
+        context.loadBalancer.close()
+
+      default:
+        ()
+      }
+    } verifyEvents: { events in
+      // Transitioning to new addresses should be graceful, i.e. a complete change shouldn't
+      // result in dropping away from the ready state.
+      let expected: [LoadBalancerEvent] = [
+        .connectivityStateChanged(.idle),
+        .connectivityStateChanged(.connecting),
+        .connectivityStateChanged(.ready),
+        .connectivityStateChanged(.shutdown),
+      ]
+      XCTAssertEqual(events, expected)
+    }
+  }
+
+  func testEmptyAddressUpdatesAreIgnored() async throws {
+    try await RoundRobinLoadBalancerTest.run(servers: 3, connector: .posix()) { context, event in
+      switch event {
+      case .connectivityStateChanged(.idle):
+        let endpoints = context.servers.map { _, address in Endpoint(addresses: [address]) }
+        context.loadBalancer.updateAddresses(endpoints)
+
+      case .connectivityStateChanged(.ready):
+        // Update with no-addresses, should be ignored so a subchannel can still be picked.
+        context.loadBalancer.updateAddresses([])
+
+        // We should still have three connections.
+        try await XCTPoll(every: .milliseconds(10)) {
+          context.servers.allSatisfy { $0.server.clients.count == 1 }
+        }
+
+        context.loadBalancer.close()
+
+      default:
+        ()
+      }
+    } verifyEvents: { events in
+      let expected: [LoadBalancerEvent] = [
+        .connectivityStateChanged(.idle),
+        .connectivityStateChanged(.connecting),
+        .connectivityStateChanged(.ready),
+        .connectivityStateChanged(.shutdown),
+      ]
+      XCTAssertEqual(events, expected)
+    }
+  }
+
+  func testSubchannelReceivesGoAway() async throws {
+    try await RoundRobinLoadBalancerTest.run(servers: 3, connector: .posix()) {
+      context,
+      event in
+      switch event {
+      case .connectivityStateChanged(.idle):
+        // Trigger the connect.
+        let endpoints = context.servers.map { Endpoint(addresses: [$0.address]) }
+        context.loadBalancer.updateAddresses(endpoints)
+
+      case .connectivityStateChanged(.ready):
+        // Wait for all servers to become ready.
+        try await XCTPoll(every: .milliseconds(10)) {
+          context.servers.allSatisfy { $0.server.clients.count == 1 }
+        }
+
+        // Pick the first server and send a GOAWAY to the client.
+        let client = context.servers[0].server.clients[0]
+        let goAway = HTTP2Frame(
+          streamID: .rootStream,
+          payload: .goAway(lastStreamID: 0, errorCode: .cancel, opaqueData: nil)
+        )
+
+        // Send a GOAWAY, this should eventually close the subchannel and trigger a name
+        // resolution.
+        client.writeAndFlush(goAway, promise: nil)
+
+      case .requiresNameResolution:
+        // One subchannel should've been taken out, meaning we can only pick from the remaining two:
+        let id1 = try XCTUnwrap(context.loadBalancer.pickSubchannel()?.id)
+        let id2 = try XCTUnwrap(context.loadBalancer.pickSubchannel()?.id)
+        let id3 = try XCTUnwrap(context.loadBalancer.pickSubchannel()?.id)
+        XCTAssertNotEqual(id1, id2)
+        XCTAssertEqual(id1, id3)
+
+        // End the test.
+        context.loadBalancer.close()
+
+      default:
+        ()
+      }
+
+    } verifyEvents: { events in
+      let expected: [LoadBalancerEvent] = [
+        .connectivityStateChanged(.idle),
+        .connectivityStateChanged(.connecting),
+        .connectivityStateChanged(.ready),
+        .requiresNameResolution,
+        .connectivityStateChanged(.shutdown),
+      ]
+      XCTAssertEqual(events, expected)
+    }
+  }
+
+  func testPickSubchannelWhenNotReady() {
+    let loadBalancer = RoundRobinLoadBalancer(
+      connector: .never,
+      backoff: .defaults,
+      defaultCompression: .none,
+      enabledCompression: .none
+    )
+
+    XCTAssertNil(loadBalancer.pickSubchannel())
+  }
+
+  func testPickSubchannelWhenNotClosed() async {
+    let loadBalancer = RoundRobinLoadBalancer(
+      connector: .never,
+      backoff: .defaults,
+      defaultCompression: .none,
+      enabledCompression: .none
+    )
+
+    loadBalancer.close()
+    await loadBalancer.run()
+
+    XCTAssertNil(loadBalancer.pickSubchannel())
+  }
+
+  func testPickOnIdleLoadBalancerTriggersConnect() async throws {
+    let idle = ManagedAtomic(0)
+    let ready = ManagedAtomic(0)
+
+    try await RoundRobinLoadBalancerTest.run(
+      servers: 1,
+      connector: .posix(maxIdleTime: .milliseconds(25))  // Aggressively idle the connection
+    ) { context, event in
+      switch event {
+      case .connectivityStateChanged(.idle):
+        let idleCount = idle.wrappingIncrementThenLoad(ordering: .sequentiallyConsistent)
+
+        switch idleCount {
+        case 1:
+          // The first idle happens when the load balancer in started, give it a set of addresses
+          // which it will connect to. Wait for it to be ready and then idle again.
+          let address = context.servers[0].address
+          let endpoints = [Endpoint(addresses: [address])]
+          context.loadBalancer.updateAddresses(endpoints)
+
+        case 2:
+          // Load-balancer has the endpoints but all are idle. Picking will trigger a connect.
+          XCTAssertNil(context.loadBalancer.pickSubchannel())
+
+        case 3:
+          // Connection idled again. Shut it down.
+          context.loadBalancer.close()
+
+        default:
+          XCTFail("Became idle too many times")
+        }
+
+      case .connectivityStateChanged(.ready):
+        let readyCount = ready.wrappingIncrementThenLoad(ordering: .sequentiallyConsistent)
+
+        if readyCount == 2 {
+          XCTAssertNotNil(context.loadBalancer.pickSubchannel())
+        }
+
+      default:
+        ()
+      }
+    } verifyEvents: { events in
+      let expected: [LoadBalancerEvent] = [
+        .connectivityStateChanged(.idle),
+        .connectivityStateChanged(.connecting),
+        .connectivityStateChanged(.ready),
+        .connectivityStateChanged(.idle),
+        .connectivityStateChanged(.connecting),
+        .connectivityStateChanged(.ready),
+        .connectivityStateChanged(.idle),
+        .connectivityStateChanged(.shutdown),
+      ]
+      XCTAssertEqual(events, expected)
+    }
+  }
+}
+
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+enum RoundRobinLoadBalancerTest {
+  struct Context {
+    let servers: [(server: TestServer, address: GRPCHTTP2Core.SocketAddress)]
+    let loadBalancer: RoundRobinLoadBalancer
+  }
+
+  static func run(
+    servers serverCount: Int,
+    connector: any HTTP2Connector,
+    backoff: ConnectionBackoff = .defaults,
+    timeout: Duration = .seconds(10),
+    function: String = #function,
+    handleEvent: @escaping @Sendable (Context, LoadBalancerEvent) async throws -> Void,
+    verifyEvents: @escaping @Sendable ([LoadBalancerEvent]) -> Void = { _ in }
+  ) async throws {
+    enum TestEvent {
+      case timedOut
+      case completed(Result<Void, Error>)
+    }
+
+    try await withThrowingTaskGroup(of: TestEvent.self) { group in
+      group.addTask {
+        try? await Task.sleep(for: timeout)
+        return .timedOut
+      }
+
+      group.addTask {
+        do {
+          try await Self._run(
+            servers: serverCount,
+            connector: connector,
+            backoff: backoff,
+            handleEvent: handleEvent,
+            verifyEvents: verifyEvents
+          )
+          return .completed(.success(()))
+        } catch {
+          return .completed(.failure(error))
+        }
+      }
+
+      let result = try await group.next()!
+      group.cancelAll()
+
+      switch result {
+      case .timedOut:
+        XCTFail("'\(function)' timed out after \(timeout)")
+      case .completed(let result):
+        try result.get()
+      }
+    }
+  }
+
+  private static func _run(
+    servers serverCount: Int,
+    connector: some HTTP2Connector,
+    backoff: ConnectionBackoff,
+    handleEvent: @escaping @Sendable (Context, LoadBalancerEvent) async throws -> Void,
+    verifyEvents: @escaping @Sendable ([LoadBalancerEvent]) -> Void
+  ) async throws {
+    try await withThrowingTaskGroup(of: Void.self) { group in
+      // Create the test servers.
+      var servers = [(server: TestServer, address: GRPCHTTP2Core.SocketAddress)]()
+      for _ in 1 ... serverCount {
+        let server = TestServer(eventLoopGroup: .singletonMultiThreadedEventLoopGroup)
+        let address = try await server.bind()
+        servers.append((server, address))
+
+        group.addTask {
+          try await server.run { _, _ in
+            XCTFail("Unexpected stream")
+          }
+        }
+      }
+
+      // Create the load balancer.
+      let loadBalancer = RoundRobinLoadBalancer(
+        connector: connector,
+        backoff: backoff,
+        defaultCompression: .none,
+        enabledCompression: .none
+      )
+
+      group.addTask {
+        await loadBalancer.run()
+      }
+
+      let context = Context(servers: servers, loadBalancer: loadBalancer)
+
+      var events = [LoadBalancerEvent]()
+      for await event in loadBalancer.events {
+        events.append(event)
+        try await handleEvent(context, event)
+      }
+
+      verifyEvents(events)
+      group.cancelAll()
+    }
+  }
+}

--- a/Tests/GRPCHTTP2CoreTests/Client/Connection/LoadBalancers/RoundRobinLoadBalancerTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Client/Connection/LoadBalancers/RoundRobinLoadBalancerTests.swift
@@ -201,9 +201,7 @@ final class RoundRobinLoadBalancerTests: XCTestCase {
   }
 
   func testSubchannelReceivesGoAway() async throws {
-    try await RoundRobinLoadBalancerTest.run(servers: 3, connector: .posix()) {
-      context,
-      event in
+    try await RoundRobinLoadBalancerTest.run(servers: 3, connector: .posix()) { context, event in
       switch event {
       case .connectivityStateChanged(.idle):
         // Trigger the connect.

--- a/Tests/GRPCHTTP2CoreTests/Client/Connection/LoadBalancers/RoundRobinLoadBalancerTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Client/Connection/LoadBalancers/RoundRobinLoadBalancerTests.swift
@@ -263,7 +263,7 @@ final class RoundRobinLoadBalancerTests: XCTestCase {
     XCTAssertNil(loadBalancer.pickSubchannel())
   }
 
-  func testPickSubchannelWhenNotClosed() async {
+  func testPickSubchannelWhenClosed() async {
     let loadBalancer = RoundRobinLoadBalancer(
       connector: .never,
       backoff: .defaults,

--- a/Tests/GRPCHTTP2CoreTests/Client/Connection/LoadBalancers/RoundRobinLoadBalancerTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Client/Connection/LoadBalancers/RoundRobinLoadBalancerTests.swift
@@ -251,7 +251,7 @@ final class RoundRobinLoadBalancerTests: XCTestCase {
         // subchannels being ready, poll until we get three distinct IDs.
         var ids = Set<SubchannelID>()
         try await XCTPoll(every: .milliseconds(10)) {
-          for _ in 1...3 {
+          for _ in 1 ... 3 {
             if let subchannel = context.loadBalancer.pickSubchannel() {
               ids.insert(subchannel.id)
             }

--- a/Tests/GRPCHTTP2CoreTests/Internal/ProcessUniqueIDTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Internal/ProcessUniqueIDTests.swift
@@ -42,4 +42,10 @@ final class ProcessUniqueIDTests: XCTestCase {
     let description = String(describing: id)
     XCTAssert(description.hasPrefix("subchan_"))
   }
+
+  func testLoadBalancerIDDescription() {
+    let id = LoadBalancerID()
+    let description = String(describing: id)
+    XCTAssert(description.hasPrefix("lb_"))
+  }
 }

--- a/Tests/GRPCHTTP2CoreTests/Test Utilities/Task+Poll.swift
+++ b/Tests/GRPCHTTP2CoreTests/Test Utilities/Task+Poll.swift
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+extension Task where Success == Never, Failure == Never {
+  static func poll(
+    every interval: Duration,
+    timeLimit: Duration = .seconds(5),
+    until predicate: () async throws -> Bool
+  ) async throws -> Bool {
+    var start = ContinuousClock.now
+    let end = start.advanced(by: timeLimit)
+
+    while end > .now {
+      let canReturn = try await predicate()
+      if canReturn { return true }
+
+      start = start.advanced(by: interval)
+      try await Task.sleep(until: start)
+    }
+
+    return false
+  }
+}

--- a/Tests/GRPCHTTP2CoreTests/Test Utilities/XCTest+Utilities.swift
+++ b/Tests/GRPCHTTP2CoreTests/Test Utilities/XCTest+Utilities.swift
@@ -67,3 +67,13 @@ func XCTAssert<T>(_ value: Any, as type: T.Type, _ verify: (T) throws -> Void) r
     XCTFail("\(value) couldn't be cast to \(T.self)")
   }
 }
+
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+func XCTPoll(
+  every interval: Duration,
+  timeLimit: Duration = .seconds(5),
+  until predicate: () async throws -> Bool
+) async throws {
+  let becameTrue = try await Task.poll(every: interval, timeLimit: timeLimit, until: predicate)
+  XCTAssertTrue(becameTrue, "Predicate didn't return true within \(timeLimit)")
+}


### PR DESCRIPTION
Motivation:

To build a grpc channel we need to support different load-balancers. One of these is the round-robin load balancer which is added by this patch.

Modifications:

Add a `RoundRobinLoadBalancer` which maintains a set of subchannels and picks between ready subchannels for RPCs using the round-robin algorithm.

Result:

Can maintain a set of connections to a service using and pick between them using round-robin