### PR TITLE
Add `Hashable` conformance to `GRPC.ConnectionTarget`

### DIFF
--- a/Sources/GRPC/ClientConnection.swift
+++ b/Sources/GRPC/ClientConnection.swift
@@ -270,8 +270,8 @@ extension ClientConnection: GRPCChannel {
 // MARK: - Configuration structures
 
 /// A target to connect to.
-public struct ConnectionTarget: Sendable {
-  internal enum Wrapped {
+public struct ConnectionTarget: Sendable, Hashable {
+  internal enum Wrapped: Hashable {
     case hostAndPort(String, Int)
     case unixDomainSocket(String)
     case socketAddress(SocketAddress)


### PR DESCRIPTION
Motivation:

`GRPC.ConnectionTarget` is not `Hashable` and, for example, cannot be stored in a set.

Modifications:

Add `Hashable` conformance to `GRPC.ConnectionTarget`.

Result:

`GRPC.ConnectionTarget` is now `Hashable`.