### PR TITLE
Fix unusual fatal error when closing outbound client stream

### DIFF
--- a/Sources/GRPCHTTP2Core/GRPCStreamStateMachine.swift
+++ b/Sources/GRPCHTTP2Core/GRPCStreamStateMachine.swift
@@ -609,7 +609,8 @@ extension GRPCStreamStateMachine {
     case .clientOpenServerClosed(let state):
       self.state = .clientClosedServerClosed(.init(previousState: state))
     case .clientClosedServerIdle, .clientClosedServerOpen, .clientClosedServerClosed:
-      try self.invalidState("Client is already closed.")
+      // Client is already closed - nothing to do.
+      ()
     }
   }
 

--- a/Tests/InProcessInteroperabilityTests/InProcessInteroperabilityTests.swift
+++ b/Tests/InProcessInteroperabilityTests/InProcessInteroperabilityTests.swift
@@ -53,7 +53,7 @@ final class InProcessInteroperabilityTests: XCTestCase {
     }
   }
 
-  func testEmtyUnary() async throws {
+  func testEmptyUnary() async throws {
     try await self.runInProcessTransport(interopTestCase: .emptyUnary)
   }
 


### PR DESCRIPTION
## Motivation
`ConnectionTests.testMakeStreamOnActiveConnection` was found to be flaky because we'd sometimes get a fatal error "Client is already closed". 
In CI, `SubchannelTests.testMakeStreamOnReadySubchannel` was failing for the same reason.

## Modifications
This PR avoids failing if the client has already been closed, and instead does nothing if we reach this state.

## Result
Tests aren't flaky anymore.