### PR TITLE
Add some slack to allocation tests

### DIFF
--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -94,6 +94,7 @@ if "$lint"; then
     "${REPO}/Sources" \
     "${REPO}/Tests" \
     "${REPO}/Plugins" \
+    "${REPO}/Performance/Benchmarks/Benchmarks/GRPCSwiftBenchmark" \
     && SWIFT_FORMAT_RC=$? || SWIFT_FORMAT_RC=$?
 
   if [[ "${SWIFT_FORMAT_RC}" -ne 0 ]]; then
@@ -113,6 +114,7 @@ elif "$format"; then
     "${REPO}/Sources" \
     "${REPO}/Tests" \
     "${REPO}/Plugins" \
+    "${REPO}/Performance/Benchmarks/Benchmarks/GRPCSwiftBenchmark" \
     && SWIFT_FORMAT_RC=$? || SWIFT_FORMAT_RC=$?
 
   if [[ "${SWIFT_FORMAT_RC}" -ne 0 ]]; then


### PR DESCRIPTION
Motivation:

Occasionally one or two allocations are added which we want to ignore in
benchmarks where we care about changes in the 1000s.

Modifications:

- Add some slack to benchmarks
- Pass in the config to each of the benchmarks, which was previously
  dropped on the floor
- Add the benchmarks to the formatter

Result:

Allocation limits allow some slack