### PR TITLE
Cache swift-format

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,9 +12,17 @@ jobs:
       image: swift
     steps:
     - uses: actions/checkout@v4
+    - uses: actions/cache/restore@v4
+      with:
+        path: scripts/.swift-format-source
+        key: ${{ runner.os }}-swift-format
     - name: "Formatting and License Headers check"
       run: |
         ./scripts/sanity.sh
+    - uses: actions/cache/save@v4
+      with:
+        path: scripts/.swift-format-source
+        key: ${{ runner.os }}-swift-format
   unit-tests:
     strategy:
       fail-fast: false

--- a/scripts/license-check.sh
+++ b/scripts/license-check.sh
@@ -102,6 +102,10 @@ check_copyright_headers() {
     ! -name '*.grpc.swift' \
     ! -name 'LinuxMain.swift' \
     ! -name 'XCTestManifests.swift' \
+    ! -path './FuzzTesting/.build/*' \
+    ! -path './Performance/QPSBenchmark/.build/*' \
+    ! -path './Performance/Benchmarks/.build/*' \
+    ! -path './.scripts/.swift-format-source/*' \
     ! -path './.build/*')
 }
 

--- a/scripts/license-check.sh
+++ b/scripts/license-check.sh
@@ -105,7 +105,7 @@ check_copyright_headers() {
     ! -path './FuzzTesting/.build/*' \
     ! -path './Performance/QPSBenchmark/.build/*' \
     ! -path './Performance/Benchmarks/.build/*' \
-    ! -path './.scripts/.swift-format-source/*' \
+    ! -path './scripts/.swift-format-source/*' \
     ! -path './.build/*')
 }
 


### PR DESCRIPTION
Motivation:

The CI takes ~7 minutes to run, the longest job is the formatting check which spends most of its time compiling swift-format.

Modifications:

- Cache the swift-format build directory

Result:

Faster CI