### PR TITLE
Improve naming

### DIFF
--- a/Sources/GRPCCore/Configuration/ServiceConfig.swift
+++ b/Sources/GRPCCore/Configuration/ServiceConfig.swift
@@ -26,11 +26,11 @@ public struct ServiceConfig: Hashable, Sendable {
   ///
   /// The client iterates through the list in order and picks the first configuration it supports.
   /// If no policies are supported then the configuration is considered to be invalid.
-  public var loadBalancingConfiguration: [LoadBalancingConfiguration]
+  public var loadBalancingConfig: [LoadBalancingConfig]
 
   /// The policy for throttling retries.
   ///
-  /// If a ``RetryThrottlingPolicy`` is provided, gRPC will automatically throttle retry attempts
+  /// If ``RetryThrottling`` is provided, gRPC will automatically throttle retry attempts
   /// and hedged RPCs when the client's ratio of failures to successes exceeds a threshold.
   ///
   /// For each server name, the gRPC client will maintain a `token_count` which is initially set
@@ -42,23 +42,23 @@ public struct ServiceConfig: Hashable, Sendable {
   ///
   /// If `token_count` is less than or equal to `max_tokens / 2`, then RPCs will not be retried
   /// and hedged RPCs will not be sent.
-  public var retryThrottlingPolicy: RetryThrottlingPolicy?
+  public var retryThrottling: RetryThrottling?
 
   /// Creates a new ``ServiceConfig``.
   ///
   /// - Parameters:
   ///   - methodConfig: Per-method configuration.
-  ///   - loadBalancingConfiguration: Load balancing policies. Clients use the the first supported
+  ///   - loadBalancingConfig: Load balancing policies. Clients use the the first supported
   ///       policy when iterating the list in order.
-  ///   - retryThrottlingPolicy: Policy for throttling retries.
+  ///   - retryThrottling: Policy for throttling retries.
   public init(
     methodConfig: [MethodConfig] = [],
-    loadBalancingConfiguration: [LoadBalancingConfiguration] = [],
-    retryThrottlingPolicy: RetryThrottlingPolicy? = nil
+    loadBalancingConfig: [LoadBalancingConfig] = [],
+    retryThrottling: RetryThrottling? = nil
   ) {
     self.methodConfig = methodConfig
-    self.loadBalancingConfiguration = loadBalancingConfiguration
-    self.retryThrottlingPolicy = retryThrottlingPolicy
+    self.loadBalancingConfig = loadBalancingConfig
+    self.retryThrottling = retryThrottling
   }
 }
 
@@ -80,13 +80,13 @@ extension ServiceConfig: Codable {
     self.methodConfig = methodConfig ?? []
 
     let loadBalancingConfiguration = try container.decodeIfPresent(
-      [LoadBalancingConfiguration].self,
+      [LoadBalancingConfig].self,
       forKey: .loadBalancingConfig
     )
-    self.loadBalancingConfiguration = loadBalancingConfiguration ?? []
+    self.loadBalancingConfig = loadBalancingConfiguration ?? []
 
-    self.retryThrottlingPolicy = try container.decodeIfPresent(
-      RetryThrottlingPolicy.self,
+    self.retryThrottling = try container.decodeIfPresent(
+      RetryThrottling.self,
       forKey: .retryThrottling
     )
   }
@@ -94,15 +94,15 @@ extension ServiceConfig: Codable {
   public func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(self.methodConfig, forKey: .methodConfig)
-    try container.encode(self.loadBalancingConfiguration, forKey: .loadBalancingConfig)
-    try container.encodeIfPresent(self.retryThrottlingPolicy, forKey: .retryThrottling)
+    try container.encode(self.loadBalancingConfig, forKey: .loadBalancingConfig)
+    try container.encodeIfPresent(self.retryThrottling, forKey: .retryThrottling)
   }
 }
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension ServiceConfig {
   /// Configuration used by clients for load-balancing.
-  public struct LoadBalancingConfiguration: Hashable, Sendable {
+  public struct LoadBalancingConfig: Hashable, Sendable {
     private enum Value: Hashable, Sendable {
       case pickFirst(PickFirst)
       case roundRobin(RoundRobin)
@@ -166,7 +166,7 @@ extension ServiceConfig {
 }
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-extension ServiceConfig.LoadBalancingConfiguration {
+extension ServiceConfig.LoadBalancingConfig {
   /// Configuration for the pick-first load balancing policy.
   public struct PickFirst: Hashable, Sendable, Codable {
     /// Whether the resolved addresses should be shuffled before attempting to connect to them.
@@ -194,7 +194,7 @@ extension ServiceConfig.LoadBalancingConfiguration {
 }
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-extension ServiceConfig.LoadBalancingConfiguration: Codable {
+extension ServiceConfig.LoadBalancingConfig: Codable {
   private enum CodingKeys: String, CodingKey {
     case roundRobin = "round_robin"
     case pickFirst = "pick_first"
@@ -226,7 +226,7 @@ extension ServiceConfig.LoadBalancingConfiguration: Codable {
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension ServiceConfig {
-  public struct RetryThrottlingPolicy: Hashable, Sendable, Codable {
+  public struct RetryThrottling: Hashable, Sendable, Codable {
     /// The initial, and maximum number of tokens.
     ///
     /// - Precondition: Must be greater than zero.

--- a/Sources/GRPCCore/Transport/RetryThrottle.swift
+++ b/Sources/GRPCCore/Transport/RetryThrottle.swift
@@ -107,7 +107,7 @@ public struct RetryThrottle: Sendable {
   ///
   /// - Parameter policy: The policy to use to configure the throttle.
   @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-  public init(policy: ServiceConfig.RetryThrottlingPolicy) {
+  public init(policy: ServiceConfig.RetryThrottling) {
     self.init(maximumTokens: policy.maxTokens, tokenRatio: policy.tokenRatio)
   }
 

--- a/Sources/GRPCInProcessTransport/InProcessClientTransport.swift
+++ b/Sources/GRPCInProcessTransport/InProcessClientTransport.swift
@@ -110,9 +110,7 @@ public struct InProcessClientTransport: ClientTransport {
     server: InProcessServerTransport,
     serviceConfig: ServiceConfig = ServiceConfig()
   ) {
-    self.retryThrottle = serviceConfig.retryThrottlingPolicy.map {
-      RetryThrottle(policy: $0)
-    }
+    self.retryThrottle = serviceConfig.retryThrottling.map { RetryThrottle(policy: $0) }
     self.methodConfig = _MethodConfigs(serviceConfig: serviceConfig)
     self.state = _LockedValueBox(.unconnected(.init(serverTransport: server)))
   }

--- a/Tests/GRPCCoreTests/Configuration/ServiceConfigCodingTests.swift
+++ b/Tests/GRPCCoreTests/Configuration/ServiceConfigCodingTests.swift
@@ -46,9 +46,9 @@ final class ServiceConfigCodingTests: XCTestCase {
       }
       """
 
-    let expected = try ServiceConfig.RetryThrottlingPolicy(maxTokens: 10, tokenRatio: 0.5)
+    let expected = try ServiceConfig.RetryThrottling(maxTokens: 10, tokenRatio: 0.5)
     let policy = try self.decoder.decode(
-      ServiceConfig.RetryThrottlingPolicy.self,
+      ServiceConfig.RetryThrottling.self,
       from: Data(json.utf8)
     )
 
@@ -56,7 +56,7 @@ final class ServiceConfigCodingTests: XCTestCase {
   }
 
   func testEncodeDecodeRetryThrottlingPolicy() throws {
-    let policy = try ServiceConfig.RetryThrottlingPolicy(maxTokens: 10, tokenRatio: 0.5)
+    let policy = try ServiceConfig.RetryThrottling(maxTokens: 10, tokenRatio: 0.5)
     try self.testRoundTripEncodeDecode(policy)
   }
 
@@ -72,7 +72,7 @@ final class ServiceConfigCodingTests: XCTestCase {
 
       try self.testDecodeThrowsRuntimeError(
         json: json,
-        as: ServiceConfig.RetryThrottlingPolicy.self
+        as: ServiceConfig.RetryThrottling.self
       )
     }
   }
@@ -89,13 +89,13 @@ final class ServiceConfigCodingTests: XCTestCase {
 
       try self.testDecodeThrowsRuntimeError(
         json: json,
-        as: ServiceConfig.RetryThrottlingPolicy.self
+        as: ServiceConfig.RetryThrottling.self
       )
     }
   }
 
   func testDecodePickFirstPolicy() throws {
-    let inputs: [(String, ServiceConfig.LoadBalancingConfiguration.PickFirst)] = [
+    let inputs: [(String, ServiceConfig.LoadBalancingConfig.PickFirst)] = [
       (#"{"shuffleAddressList": true}"#, .init(shuffleAddressList: true)),
       (#"{"shuffleAddressList": false}"#, .init(shuffleAddressList: false)),
       (#"{}"#, .init(shuffleAddressList: false)),
@@ -103,7 +103,7 @@ final class ServiceConfigCodingTests: XCTestCase {
 
     for (input, expected) in inputs {
       let pickFirst = try self.decoder.decode(
-        ServiceConfig.LoadBalancingConfiguration.PickFirst.self,
+        ServiceConfig.LoadBalancingConfig.PickFirst.self,
         from: Data(input.utf8)
       )
 
@@ -112,7 +112,7 @@ final class ServiceConfigCodingTests: XCTestCase {
   }
 
   func testEncodePickFirstPolicy() throws {
-    let inputs: [(ServiceConfig.LoadBalancingConfiguration.PickFirst, String)] = [
+    let inputs: [(ServiceConfig.LoadBalancingConfig.PickFirst, String)] = [
       (.init(shuffleAddressList: true), #"{"shuffleAddressList":true}"#),
       (.init(shuffleAddressList: false), #"{"shuffleAddressList":false}"#),
     ]
@@ -126,20 +126,20 @@ final class ServiceConfigCodingTests: XCTestCase {
   func testDecodeRoundRobinPolicy() throws {
     let json = "{}"
     let policy = try self.decoder.decode(
-      ServiceConfig.LoadBalancingConfiguration.RoundRobin.self,
+      ServiceConfig.LoadBalancingConfig.RoundRobin.self,
       from: Data(json.utf8)
     )
-    XCTAssertEqual(policy, ServiceConfig.LoadBalancingConfiguration.RoundRobin())
+    XCTAssertEqual(policy, ServiceConfig.LoadBalancingConfig.RoundRobin())
   }
 
   func testEncodeRoundRobinPolicy() throws {
-    let policy = ServiceConfig.LoadBalancingConfiguration.RoundRobin()
+    let policy = ServiceConfig.LoadBalancingConfig.RoundRobin()
     let encoded = try self.encoder.encode(policy)
     XCTAssertEqual(String(decoding: encoded, as: UTF8.self), "{}")
   }
 
   func testDecodeLoadBalancingConfiguration() throws {
-    let inputs: [(String, ServiceConfig.LoadBalancingConfiguration)] = [
+    let inputs: [(String, ServiceConfig.LoadBalancingConfig)] = [
       (#"{"round_robin": {}}"#, .roundRobin),
       (#"{"pick_first": {}}"#, .pickFirst(shuffleAddressList: false)),
       (#"{"pick_first": {"shuffleAddressList": false}}"#, .pickFirst(shuffleAddressList: false)),
@@ -147,7 +147,7 @@ final class ServiceConfigCodingTests: XCTestCase {
 
     for (input, expected) in inputs {
       let decoded = try self.decoder.decode(
-        ServiceConfig.LoadBalancingConfiguration.self,
+        ServiceConfig.LoadBalancingConfig.self,
         from: Data(input.utf8)
       )
       XCTAssertEqual(decoded, expected)
@@ -155,7 +155,7 @@ final class ServiceConfigCodingTests: XCTestCase {
   }
 
   func testEncodeLoadBalancingConfiguration() throws {
-    let inputs: [(ServiceConfig.LoadBalancingConfiguration, String)] = [
+    let inputs: [(ServiceConfig.LoadBalancingConfig, String)] = [
       (.roundRobin, #"{"round_robin":{}}"#),
       (.pickFirst(shuffleAddressList: false), #"{"pick_first":{"shuffleAddressList":false}}"#),
     ]
@@ -206,14 +206,11 @@ final class ServiceConfigCodingTests: XCTestCase {
           maxResponseMessageBytes: 456
         )
       ],
-      loadBalancingConfiguration: [
+      loadBalancingConfig: [
         .roundRobin,
         .pickFirst(shuffleAddressList: true),
       ],
-      retryThrottlingPolicy: try ServiceConfig.RetryThrottlingPolicy(
-        maxTokens: 10,
-        tokenRatio: 0.1
-      )
+      retryThrottling: try ServiceConfig.RetryThrottling(maxTokens: 10, tokenRatio: 0.1)
     )
 
     XCTAssertEqual(decoded, expected)
@@ -246,14 +243,11 @@ final class ServiceConfigCodingTests: XCTestCase {
           maxRequestMessageBytes: 10_000
         ),
       ],
-      loadBalancingConfiguration: [
+      loadBalancingConfig: [
         .pickFirst(shuffleAddressList: true),
         .roundRobin,
       ],
-      retryThrottlingPolicy: try ServiceConfig.RetryThrottlingPolicy(
-        maxTokens: 10,
-        tokenRatio: 3.141
-      )
+      retryThrottling: try ServiceConfig.RetryThrottling(maxTokens: 10, tokenRatio: 3.141)
     )
 
     try self.testRoundTripEncodeDecode(serviceConfig)


### PR DESCRIPTION
Motivation:

We recently standardised on 'config' over 'configuration' for service and method config. However, load balancing config was missed. We should also standardise other service config names; retry throttling policy should become retry throttling.

Modifications:

- replace configuration with config
- drop 'policy' from retry throttling policy

Result:

Better naming