### PR TITLE
Add grpc channel

### DIFF
--- a/Sources/GRPCCore/Call/Client/CallOptions.swift
+++ b/Sources/GRPCCore/Call/Client/CallOptions.swift
@@ -127,7 +127,8 @@ extension CallOptions {
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension CallOptions {
-  mutating func formUnion(with methodConfig: MethodConfig?) {
+  @_spi(Package)
+  public mutating func formUnion(with methodConfig: MethodConfig?) {
     guard let methodConfig = methodConfig else { return }
 
     self.timeout.setIfNone(to: methodConfig.timeout)

--- a/Sources/GRPCCore/Streaming/RPCWriter+Closable.swift
+++ b/Sources/GRPCCore/Streaming/RPCWriter+Closable.swift
@@ -24,7 +24,7 @@ extension RPCWriter {
     ///
     /// - Parameter other: The writer to wrap.
     @inlinable
-    init(wrapping other: some ClosableRPCWriterProtocol<Element>) {
+    public init(wrapping other: some ClosableRPCWriterProtocol<Element>) {
       self.writer = other
     }
 

--- a/Sources/GRPCHTTP2Core/Client/Connection/GRPCChannel.swift
+++ b/Sources/GRPCHTTP2Core/Client/Connection/GRPCChannel.swift
@@ -1,0 +1,912 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Atomics
+import DequeModule
+@_spi(Package) import GRPCCore
+
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+@_spi(Package)
+public struct GRPCChannel: ClientTransport {
+  private enum Input: Sendable {
+    /// Close the channel, if possible.
+    case close
+    /// Handle the result of a name resolution.
+    case handleResolutionResult(NameResolutionResult)
+    /// Handle the event from the underlying connection object.
+    case handleLoadBalancerEvent(LoadBalancerEvent, LoadBalancerID)
+  }
+
+  /// Events which can happen to the channel.
+  private let _connectivityState:
+    (
+      stream: AsyncStream<ConnectivityState>,
+      continuation: AsyncStream<ConnectivityState>.Continuation
+    )
+
+  /// Inputs which this channel should react to.
+  private let input: (stream: AsyncStream<Input>, continuation: AsyncStream<Input>.Continuation)
+
+  /// A resolver providing resolved names to the channel.
+  private let resolver: NameResolver
+
+  /// The state of the channel.
+  private let state: _LockedValueBox<StateMachine>
+
+  /// The maximum number of times to attempt to create a stream per RPC.
+  private static let maxStreamCreationAttempts = 5
+
+  /// A factory for connections.
+  private let connector: any HTTP2Connector
+
+  /// The connection backoff configuration used by the subchannel when establishing a connection.
+  private let backoff: ConnectionBackoff
+
+  /// The default compression algorithm used for requests.
+  private let defaultCompression: CompressionAlgorithm
+
+  /// The set of enabled compression algorithms.
+  private let enabledCompression: CompressionAlgorithmSet
+
+  /// The default service config to use.
+  ///
+  /// Used when the resolve doesn't provide one.
+  private let defaultServiceConfig: ServiceConfig
+
+  // These are both read frequently and updated infrequently so may be a bottleneck.
+  private let _methodConfig: _LockedValueBox<_MethodConfigs>
+  private let _retryThrottle: _LockedValueBox<RetryThrottle?>
+
+  @_spi(Package)
+  public init(
+    resolver: NameResolver,
+    connector: any HTTP2Connector,
+    config: Config,
+    defaultServiceConfig: ServiceConfig
+  ) {
+    self.resolver = resolver
+    self.state = _LockedValueBox(StateMachine())
+    self._connectivityState = AsyncStream.makeStream()
+    self.input = AsyncStream.makeStream()
+    self.connector = connector
+
+    self.backoff = ConnectionBackoff(
+      initial: config.backoff.initial,
+      max: config.backoff.max,
+      multiplier: config.backoff.multiplier,
+      jitter: config.backoff.jitter
+    )
+    self.defaultCompression = config.compression.algorithm
+    self.enabledCompression = config.compression.enabledAlgorithms
+    self.defaultServiceConfig = defaultServiceConfig
+
+    let throttle = defaultServiceConfig.retryThrottling.map { RetryThrottle(policy: $0) }
+    self._retryThrottle = _LockedValueBox(throttle)
+
+    let methodConfig = _MethodConfigs(serviceConfig: defaultServiceConfig)
+    self._methodConfig = _LockedValueBox(methodConfig)
+  }
+
+  /// The connectivity state of the channel.
+  var connectivityState: AsyncStream<ConnectivityState> {
+    self._connectivityState.stream
+  }
+
+  /// Returns a throttle which gRPC uses to determine whether retries can be executed.
+  public var retryThrottle: RetryThrottle? {
+    self._retryThrottle.withLockedValue { $0 }
+  }
+
+  /// Returns the configuration for a given method.
+  ///
+  /// - Parameter descriptor: The method to lookup configuration for.
+  /// - Returns: Configuration for the method, if it exists.
+  public func configuration(forMethod descriptor: MethodDescriptor) -> MethodConfig? {
+    self._methodConfig.withLockedValue { $0[descriptor] }
+  }
+
+  /// Establishes and maintains a connection to the remote destination.
+  public func connect() async {
+    self.state.withLockedValue { $0.start() }
+    self._connectivityState.continuation.yield(.idle)
+
+    await withDiscardingTaskGroup { group in
+      var iterator: Optional<RPCAsyncSequence<NameResolutionResult>.AsyncIterator>
+
+      // The resolve can either push or pull values. If it pushes values the channel should
+      // listen for new results. Otherwise the channel will pull values as and when necessary.
+      switch self.resolver.updateMode.value {
+      case .push:
+        iterator = nil
+
+        let handle = group.addCancellableTask {
+          do {
+            for try await result in self.resolver.names {
+              self.input.continuation.yield(.handleResolutionResult(result))
+            }
+            self.close()
+          } catch {
+            self.close()
+          }
+        }
+
+        // When the channel is closed gracefully, the task group running the load balancer mustn't
+        // be cancelled (otherwise in-flight RPCs would fail), but the push based resolver will
+        // continue indefinitely. Store its handle and cancel it on close when closing the channel.
+        self.state.withLockedValue { state in
+          state.setNameResolverTaskHandle(handle)
+        }
+
+      case .pull:
+        iterator = self.resolver.names.makeAsyncIterator()
+        await self.resolve(iterator: &iterator, in: &group)
+      }
+
+      // Resolver is setup, start handling events.
+      for await input in self.input.stream {
+        switch input {
+        case .close:
+          self.handleClose(in: &group)
+
+        case .handleResolutionResult(let result):
+          self.handleNameResolutionResult(result, in: &group)
+
+        case .handleLoadBalancerEvent(let event, let id):
+          await self.handleLoadBalancerEvent(
+            event,
+            loadBalancerID: id,
+            in: &group,
+            iterator: &iterator
+          )
+        }
+      }
+    }
+
+    if Task.isCancelled {
+      self._connectivityState.continuation.finish()
+    }
+  }
+
+  /// Signal to the transport that no new streams may be created and that connections should be
+  /// closed when all streams are closed.
+  public func close() {
+    self.input.continuation.yield(.close)
+  }
+
+  /// Opens a stream using the transport, and uses it as input into a user-provided closure.
+  public func withStream<T>(
+    descriptor: MethodDescriptor,
+    options: CallOptions,
+    _ closure: (_ stream: RPCStream<Inbound, Outbound>) async throws -> T
+  ) async throws -> T {
+    // Merge options from the call with those from the service config.
+    let methodConfig = self.configuration(forMethod: descriptor)
+    var options = options
+    options.formUnion(with: methodConfig)
+
+    loop: for attempt in 1 ... Self.maxStreamCreationAttempts {
+      switch await self.makeStream(descriptor: descriptor, options: options) {
+      case .created(let stream):
+        return try await stream.execute { inbound, outbound in
+          let rpcStream = RPCStream(
+            descriptor: stream.descriptor,
+            inbound: RPCAsyncSequence(wrapping: inbound),
+            outbound: RPCWriter.Closable(wrapping: outbound)
+          )
+          return try await closure(rpcStream)
+        }
+
+      case .tryAgain(let error):
+        if error is CancellationError || attempt == Self.maxStreamCreationAttempts {
+          throw error
+        } else {
+          continue
+        }
+
+      case .stopTrying(let error):
+        throw error
+      }
+    }
+
+    fatalError("Internal inconsistency")
+  }
+}
+
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+extension GRPCChannel {
+  @_spi(Package)
+  public struct Config: Sendable {
+    /// Configuration for HTTP/2 connections.
+    var http2: HTTP2ClientTransport.Config.HTTP2
+
+    /// Configuration for backoff used when establishing a connection.
+    var backoff: HTTP2ClientTransport.Config.Backoff
+
+    /// Configuration for dealing with idle connections.
+    var idle: HTTP2ClientTransport.Config.Idle?
+
+    /// Configuration for keepalive.
+    var keepalive: HTTP2ClientTransport.Config.Keepalive?
+
+    /// Compression configuration.
+    var compression: HTTP2ClientTransport.Config.Compression
+
+    @_spi(Package)
+    public init(
+      http2: HTTP2ClientTransport.Config.HTTP2,
+      backoff: HTTP2ClientTransport.Config.Backoff,
+      idle: HTTP2ClientTransport.Config.Idle?,
+      keepalive: HTTP2ClientTransport.Config.Keepalive?,
+      compression: HTTP2ClientTransport.Config.Compression
+    ) {
+      self.http2 = http2
+      self.backoff = backoff
+      self.idle = idle
+      self.keepalive = keepalive
+      self.compression = compression
+    }
+  }
+}
+
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+extension GRPCChannel {
+  enum MakeStreamResult {
+    /// A stream was created, use it.
+    case created(Connection.Stream)
+    /// An error occurred while trying to create a stream, try again if possible.
+    case tryAgain(Error)
+    /// An unrecoverable error occurred (e.g. the channel is closed), fail the RPC and don't retry.
+    case stopTrying(Error)
+  }
+
+  private func makeStream(
+    descriptor: MethodDescriptor,
+    options: CallOptions
+  ) async -> MakeStreamResult {
+    let waitForReady = options.waitForReady ?? true
+    switch self.state.withLockedValue({ $0.makeStream(waitForReady: waitForReady) }) {
+    case .useLoadBalancer(let loadBalancer):
+      return await self.makeStream(
+        descriptor: descriptor,
+        options: options,
+        loadBalancer: loadBalancer
+      )
+
+    case .joinQueue:
+      do {
+        let loadBalancer = try await self.enqueue(waitForReady: waitForReady)
+        return await self.makeStream(
+          descriptor: descriptor,
+          options: options,
+          loadBalancer: loadBalancer
+        )
+      } catch {
+        // All errors from enqueue are non-recoverable: either the channel is shutting down or
+        // the request has been cancelled.
+        return .stopTrying(error)
+      }
+
+    case .failRPC:
+      return .stopTrying(RPCError(code: .unavailable, message: "channel isn't ready"))
+    }
+  }
+
+  private func makeStream(
+    descriptor: MethodDescriptor,
+    options: CallOptions,
+    loadBalancer: LoadBalancer
+  ) async -> MakeStreamResult {
+    guard let subchannel = loadBalancer.pickSubchannel() else {
+      return .tryAgain(RPCError(code: .unavailable, message: "channel isn't ready"))
+    }
+
+    let methodConfig = self.configuration(forMethod: descriptor)
+    var options = options
+    options.formUnion(with: methodConfig)
+
+    do {
+      let stream = try await subchannel.makeStream(descriptor: descriptor, options: options)
+      return .created(stream)
+    } catch {
+      return .tryAgain(error)
+    }
+  }
+
+  private func enqueue(waitForReady: Bool) async throws -> LoadBalancer {
+    let id = QueueEntryID()
+    return try await withTaskCancellationHandler {
+      try await withCheckedThrowingContinuation { continuation in
+        if Task.isCancelled {
+          continuation.resume(throwing: CancellationError())
+          return
+        }
+
+        let enqueued = self.state.withLockedValue { state in
+          state.enqueue(continuation: continuation, waitForReady: waitForReady, id: id)
+        }
+
+        // Not enqueued because the channel is shutdown or shutting down.
+        if !enqueued {
+          let error = RPCError(code: .unavailable, message: "channel is shutdown")
+          continuation.resume(throwing: error)
+        }
+      }
+    } onCancel: {
+      let continuation = self.state.withLockedValue { state in
+        state.dequeueContinuation(id: id)
+      }
+
+      continuation?.resume(throwing: CancellationError())
+    }
+  }
+}
+
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+extension GRPCChannel {
+  private func handleClose(in group: inout DiscardingTaskGroup) {
+    switch self.state.withLockedValue({ $0.close() }) {
+    case .close(let current, let next, let resolver):
+      resolver?.cancel()
+      current.close()
+      next?.close()
+      self._connectivityState.continuation.yield(.shutdown)
+
+    case .cancelAll(let continuations):
+      for continuation in continuations {
+        continuation.resume(throwing: RPCError(code: .unavailable, message: "channel is closed"))
+      }
+      self._connectivityState.continuation.yield(.shutdown)
+      group.cancelAll()
+
+    case .none:
+      ()
+    }
+  }
+
+  private func handleNameResolutionResult(
+    _ result: NameResolutionResult,
+    in group: inout DiscardingTaskGroup
+  ) {
+    // Ignore empty endpoint lists.
+    if result.endpoints.isEmpty { return }
+
+    switch result.serviceConfig ?? .success(self.defaultServiceConfig) {
+    case .success(let config):
+      // Update per RPC configuration.
+      let methodConfig = _MethodConfigs(serviceConfig: config)
+      self._methodConfig.withLockedValue { $0 = methodConfig }
+
+      let retryThrottle = config.retryThrottling.map { RetryThrottle(policy: $0) }
+      self._retryThrottle.withLockedValue { $0 = retryThrottle }
+
+      // Update the load balancer.
+      self.updateLoadBalancer(serviceConfig: config, endpoints: result.endpoints, in: &group)
+
+    case .failure:
+      self.close()
+    }
+  }
+
+  private func updateLoadBalancer(
+    serviceConfig: ServiceConfig,
+    endpoints: [Endpoint],
+    in group: inout DiscardingTaskGroup
+  ) {
+    // Pick the first applicable policy, else fallback to pick-first.
+    for policy in serviceConfig.loadBalancingConfig {
+      let onUpdatePolicy: GRPCChannel.StateMachine.OnChangeLoadBalancer
+
+      if policy.roundRobin != nil {
+        onUpdatePolicy = self.state.withLockedValue { state in
+          state.changeLoadBalancerKind(to: .roundRobin) {
+            let loadBalancer = RoundRobinLoadBalancer(
+              connector: self.connector,
+              backoff: self.backoff,
+              defaultCompression: self.defaultCompression,
+              enabledCompression: self.enabledCompression
+            )
+            return .roundRobin(loadBalancer)
+          }
+        }
+      } else if policy.pickFirst != nil {
+        fatalError("TODO: use pick-first when supported")
+      } else {
+        // Policy isn't known, ignore it.
+        continue
+      }
+
+      self.handleLoadBalancerChange(onUpdatePolicy, endpoints: endpoints, in: &group)
+      return
+    }
+
+    // No suitable config was found, fallback to pick-first.
+    fatalError("TODO: use pick-first when supported")
+  }
+
+  private func handleLoadBalancerChange(
+    _ update: StateMachine.OnChangeLoadBalancer,
+    endpoints: [Endpoint],
+    in group: inout DiscardingTaskGroup
+  ) {
+    switch update {
+    case .runLoadBalancer(let new, let old):
+      old?.close()
+      new.updateAddresses(endpoints)
+
+      group.addTask {
+        await new.run()
+      }
+
+      group.addTask {
+        for await event in new.events {
+          self.input.continuation.yield(.handleLoadBalancerEvent(event, new.id))
+        }
+      }
+
+    case .updateLoadBalancer(let existing):
+      existing.updateAddresses(endpoints)
+
+    case .none:
+      ()
+    }
+  }
+
+  private func handleLoadBalancerEvent(
+    _ event: LoadBalancerEvent,
+    loadBalancerID: LoadBalancerID,
+    in group: inout DiscardingTaskGroup,
+    iterator: inout RPCAsyncSequence<NameResolutionResult>.AsyncIterator?
+  ) async {
+    switch event {
+    case .connectivityStateChanged(let connectivityState):
+      let actions = self.state.withLockedValue { state in
+        state.loadBalancerStateChanged(to: connectivityState, id: loadBalancerID)
+      }
+
+      if let newState = actions.publishState {
+        self._connectivityState.continuation.yield(newState)
+      }
+
+      if let subchannel = actions.close {
+        subchannel.close()
+      }
+
+      if let resumable = actions.resumeContinuations {
+        for continuation in resumable.continuations {
+          continuation.resume(with: resumable.result)
+        }
+      }
+
+      if actions.finish {
+        // Fully closed.
+        self._connectivityState.continuation.finish()
+        self.input.continuation.finish()
+      }
+
+    case .requiresNameResolution:
+      await self.resolve(iterator: &iterator, in: &group)
+    }
+  }
+
+  private func resolve(
+    iterator: inout RPCAsyncSequence<NameResolutionResult>.AsyncIterator?,
+    in group: inout DiscardingTaskGroup
+  ) async {
+    guard var iterator = iterator else { return }
+
+    do {
+      if let result = try await iterator.next() {
+        self.handleNameResolutionResult(result, in: &group)
+      } else {
+        self.close()
+      }
+    } catch {
+      self.close()
+    }
+  }
+}
+
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+extension GRPCChannel {
+  struct StateMachine {
+    enum State {
+      case notRunning(NotRunning)
+      case running(Running)
+      case stopping(Stopping)
+      case stopped
+      case _modifying
+
+      struct NotRunning {
+        /// Queue of requests waiting for a load-balancer.
+        var queue: RequestQueue
+        /// A handle to the name resolver task.
+        var nameResolverHandle: CancellableTaskHandle?
+
+        init() {
+          self.queue = RequestQueue()
+        }
+      }
+
+      struct Running {
+        /// The connectivity state of the channel.
+        var connectivityState: ConnectivityState
+        /// The load-balancer currently in use.
+        var current: LoadBalancer
+        /// The next load-balancer to use. This will be promoted to `current` when it enters the
+        /// ready state.
+        var next: LoadBalancer?
+        /// Previously created load-balancers which are in the process of shutting down.
+        var past: [LoadBalancerID: LoadBalancer]
+        /// Queue of requests wait for a load-balancer.
+        var queue: RequestQueue
+        /// A handle to the name resolver task.
+        var nameResolverHandle: CancellableTaskHandle?
+
+        init(
+          from state: NotRunning,
+          loadBalancer: LoadBalancer
+        ) {
+          self.connectivityState = .idle
+          self.current = loadBalancer
+          self.next = nil
+          self.past = [:]
+          self.queue = state.queue
+          self.nameResolverHandle = state.nameResolverHandle
+        }
+      }
+
+      struct Stopping {
+        /// Previously created load-balancers which are in the process of shutting down.
+        var past: [LoadBalancerID: LoadBalancer]
+
+        init(from state: Running) {
+          self.past = state.past
+        }
+
+        init(loadBalancers: [LoadBalancerID: LoadBalancer]) {
+          self.past = loadBalancers
+        }
+      }
+    }
+
+    /// The current state.
+    private var state: State
+    /// Whether the channel is running.
+    private var running: Bool
+
+    init() {
+      self.state = .notRunning(State.NotRunning())
+      self.running = false
+    }
+  }
+}
+
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+extension GRPCChannel.StateMachine {
+  mutating func start() {
+    precondition(!self.running, "channel must only be started once")
+    self.running = true
+  }
+
+  mutating func setNameResolverTaskHandle(_ handle: CancellableTaskHandle) {
+    switch self.state {
+    case .notRunning(var state):
+      state.nameResolverHandle = handle
+      self.state = .notRunning(state)
+    case .running, .stopping, .stopped, ._modifying:
+      fatalError("Invalid state")
+    }
+  }
+
+  enum LoadBalancerKind {
+    case roundRobin
+
+    func matches(loadBalancer: LoadBalancer) -> Bool {
+      switch (self, loadBalancer) {
+      case (.roundRobin, .roundRobin):
+        return true
+      }
+    }
+  }
+
+  enum OnChangeLoadBalancer {
+    case runLoadBalancer(LoadBalancer, stop: LoadBalancer?)
+    case updateLoadBalancer(LoadBalancer)
+    case none
+  }
+
+  mutating func changeLoadBalancerKind(
+    to newLoadBalancerKind: LoadBalancerKind,
+    _ makeLoadBalancer: () -> LoadBalancer
+  ) -> OnChangeLoadBalancer {
+    let onChangeLoadBalancer: OnChangeLoadBalancer
+
+    switch self.state {
+    case .notRunning(let state):
+      let loadBalancer = makeLoadBalancer()
+      let state = State.Running(from: state, loadBalancer: loadBalancer)
+      self.state = .running(state)
+      onChangeLoadBalancer = .runLoadBalancer(state.current, stop: nil)
+
+    case .running(var state):
+      self.state = ._modifying
+
+      if let next = state.next {
+        if newLoadBalancerKind.matches(loadBalancer: next) {
+          onChangeLoadBalancer = .updateLoadBalancer(next)
+        } else {
+          // The 'next' didn't become ready in time. Close it and replace it with a load-balancer
+          // of the next kind.
+          let nextNext = makeLoadBalancer()
+          let previous = state.next
+          state.next = nextNext
+          state.past[next.id] = next
+          onChangeLoadBalancer = .runLoadBalancer(nextNext, stop: previous)
+        }
+      } else {
+        if newLoadBalancerKind.matches(loadBalancer: state.current) {
+          onChangeLoadBalancer = .updateLoadBalancer(state.current)
+        } else {
+          // Create the 'next' load-balancer, it'll replace 'current' when it becomes ready.
+          let next = makeLoadBalancer()
+          state.next = next
+          onChangeLoadBalancer = .runLoadBalancer(next, stop: nil)
+        }
+      }
+
+      self.state = .running(state)
+
+    case .stopping, .stopped:
+      onChangeLoadBalancer = .none
+
+    case ._modifying:
+      fatalError("Invalid state")
+    }
+
+    return onChangeLoadBalancer
+  }
+
+  struct ConnectivityStateChangeActions {
+    var close: LoadBalancer? = nil
+    var publishState: ConnectivityState? = nil
+    var resumeContinuations: ResumableContinuations? = nil
+    var finish: Bool = false
+
+    struct ResumableContinuations {
+      var continuations: [CheckedContinuation<LoadBalancer, Error>]
+      var result: Result<LoadBalancer, Error>
+    }
+  }
+
+  mutating func loadBalancerStateChanged(
+    to connectivityState: ConnectivityState,
+    id: LoadBalancerID
+  ) -> ConnectivityStateChangeActions {
+    var actions = ConnectivityStateChangeActions()
+
+    switch self.state {
+    case .running(var state):
+      self.state = ._modifying
+
+      if id == state.current.id {
+        // No change in state, ignore.
+        if state.connectivityState == connectivityState {
+          self.state = .running(state)
+          break
+        }
+
+        state.connectivityState = connectivityState
+        actions.publishState = connectivityState
+
+        switch connectivityState {
+        case .ready:
+          // Current load-balancer became ready; resume all continuations in the queue.
+          let continuations = state.queue.removeAll()
+          actions.resumeContinuations = ConnectivityStateChangeActions.ResumableContinuations(
+            continuations: continuations,
+            result: .success(state.current)
+          )
+
+        case .transientFailure, .shutdown:  // shutdown includes shutting down
+          // Current load-balancer failed. Remove all the 'fast-failing' continuations in the
+          // queue, these are RPCs which set the 'wait for ready' option to false. The rest of
+          // the entries in the queue will wait for a load-balancer to become ready.
+          let continuations = state.queue.removeFastFailingEntries()
+          actions.resumeContinuations = ConnectivityStateChangeActions.ResumableContinuations(
+            continuations: continuations,
+            result: .failure(RPCError(code: .unavailable, message: "channel isn't ready"))
+          )
+
+        case .idle, .connecting:
+          ()  // Ignore.
+        }
+      } else if let next = state.next, next.id == id {
+        // State change came from the next LB, if it's now ready promote it to be the current.
+        switch connectivityState {
+        case .ready:
+          // Next load-balancer is ready, promote it to current.
+          let previous = state.current
+          state.past[previous.id] = previous
+          state.current = next
+          state.next = nil
+
+          actions.close = previous
+
+          if state.connectivityState != connectivityState {
+            actions.publishState = connectivityState
+          }
+
+          actions.resumeContinuations = ConnectivityStateChangeActions.ResumableContinuations(
+            continuations: state.queue.removeAll(),
+            result: .success(next)
+          )
+
+        case .idle, .connecting, .transientFailure, .shutdown:
+          ()
+        }
+      }
+
+      self.state = .running(state)
+
+    case .stopping(var state):
+      self.state = ._modifying
+
+      // Remove the load balancer if it's now shutdown.
+      switch connectivityState {
+      case .shutdown:
+        state.past.removeValue(forKey: id)
+      case .idle, .connecting, .ready, .transientFailure:
+        ()
+      }
+
+      // If that was the last load-balancer then finish the input streams so that the channel
+      // eventually finishes.
+      if state.past.isEmpty {
+        actions.finish = true
+        self.state = .stopped
+      } else {
+        self.state = .stopping(state)
+      }
+
+    case .notRunning, .stopped:
+      ()
+
+    case ._modifying:
+      fatalError("Invalid state")
+    }
+
+    return actions
+  }
+
+  enum OnMakeStream {
+    /// Use the given load-balancer to make a stream.
+    case useLoadBalancer(LoadBalancer)
+    /// Join the queue and wait until a load-balancer becomes ready.
+    case joinQueue
+    /// Fail the stream request, the channel isn't in a suitable state.
+    case failRPC
+  }
+
+  func makeStream(waitForReady: Bool) -> OnMakeStream {
+    let onMakeStream: OnMakeStream
+
+    switch self.state {
+    case .notRunning:
+      onMakeStream = .joinQueue
+
+    case .running(let state):
+      switch state.connectivityState {
+      case .idle, .connecting:
+        onMakeStream = .joinQueue
+      case .ready:
+        onMakeStream = .useLoadBalancer(state.current)
+      case .transientFailure:
+        onMakeStream = waitForReady ? .joinQueue : .failRPC
+      case .shutdown:
+        onMakeStream = .failRPC
+      }
+
+    case .stopping, .stopped:
+      onMakeStream = .failRPC
+
+    case ._modifying:
+      fatalError("Invalid state")
+    }
+
+    return onMakeStream
+  }
+
+  mutating func enqueue(
+    continuation: CheckedContinuation<LoadBalancer, Error>,
+    waitForReady: Bool,
+    id: QueueEntryID
+  ) -> Bool {
+    switch self.state {
+    case .notRunning(var state):
+      self.state = ._modifying
+      state.queue.append(continuation: continuation, waitForReady: waitForReady, id: id)
+      self.state = .notRunning(state)
+      return true
+    case .running(var state):
+      self.state = ._modifying
+      state.queue.append(continuation: continuation, waitForReady: waitForReady, id: id)
+      self.state = .running(state)
+      return true
+    case .stopping, .stopped:
+      return false
+    case ._modifying:
+      fatalError("Invalid state")
+    }
+  }
+
+  mutating func dequeueContinuation(
+    id: QueueEntryID
+  ) -> CheckedContinuation<LoadBalancer, Error>? {
+    switch self.state {
+    case .notRunning(var state):
+      self.state = ._modifying
+      let continuation = state.queue.removeEntry(withID: id)
+      self.state = .notRunning(state)
+      return continuation
+
+    case .running(var state):
+      self.state = ._modifying
+      let continuation = state.queue.removeEntry(withID: id)
+      self.state = .running(state)
+      return continuation
+
+    case .stopping, .stopped:
+      return nil
+
+    case ._modifying:
+      fatalError("Invalid state")
+    }
+  }
+
+  enum OnClose {
+    case none
+    case cancelAll([RequestQueue.Continuation])
+    case close(LoadBalancer, LoadBalancer?, CancellableTaskHandle?)
+  }
+
+  mutating func close() -> OnClose {
+    let onClose: OnClose
+
+    switch self.state {
+    case .notRunning(var state):
+      self.state = .stopped
+      onClose = .cancelAll(state.queue.removeAll())
+
+    case .running(var state):
+      onClose = .close(state.current, state.next, state.nameResolverHandle)
+
+      state.past[state.current.id] = state.current
+      if let next = state.next {
+        state.past[next.id] = next
+      }
+
+      self.state = .stopping(State.Stopping(loadBalancers: state.past))
+
+    case .stopping, .stopped:
+      onClose = .none
+
+    case ._modifying:
+      fatalError("Invalid state")
+    }
+
+    return onClose
+  }
+}

--- a/Sources/GRPCHTTP2Core/Internal/DiscardingTaskGroup+CancellableHandle.swift
+++ b/Sources/GRPCHTTP2Core/Internal/DiscardingTaskGroup+CancellableHandle.swift
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+extension DiscardingTaskGroup {
+  /// Adds a child task to the group which is individually cancellable.
+  ///
+  /// - Parameter operation: The task to add to the group.
+  /// - Returns: A handle which can be used to cancel the task without cancelling the rest of
+  ///     the group.
+  @inlinable
+  mutating func addCancellableTask(
+    _ operation: @Sendable @escaping () async -> Void
+  ) -> CancellableTaskHandle {
+    let signal = AsyncStream.makeStream(of: Void.self)
+    self.addTask {
+      return await withTaskGroup(of: FinishedOrCancelled.self) { group in
+        group.addTask {
+          await operation()
+          return .finished
+        }
+
+        group.addTask {
+          for await _ in signal.stream {}
+          return .cancelled
+        }
+
+        let first = await group.next()!
+        group.cancelAll()
+        let second = await group.next()!
+
+        switch (first, second) {
+        case (.finished, .cancelled), (.cancelled, .finished):
+          return
+        default:
+          fatalError("Internal inconsistency")
+        }
+      }
+    }
+
+    return CancellableTaskHandle(continuation: signal.continuation)
+  }
+
+  @usableFromInline
+  enum FinishedOrCancelled {
+    case finished
+    case cancelled
+  }
+}
+
+@usableFromInline
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+struct CancellableTaskHandle: Sendable {
+  @usableFromInline
+  private(set) var continuation: AsyncStream<Void>.Continuation
+
+  @inlinable
+  init(continuation: AsyncStream<Void>.Continuation) {
+    self.continuation = continuation
+  }
+
+  @inlinable
+  func cancel() {
+    self.continuation.finish()
+  }
+}

--- a/Sources/GRPCHTTP2Core/Internal/NIOChannelPipeline+GRPC.swift
+++ b/Sources/GRPCHTTP2Core/Internal/NIOChannelPipeline+GRPC.swift
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import GRPCCore
+import NIOCore
+import NIOHPACK
+import NIOHTTP2
+
+extension ChannelPipeline.SynchronousOperations {
+  @_spi(Package)
+  @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+  public func configureGRPCClientPipeline(
+    channel: Channel,
+    config: GRPCChannel.Config
+  ) throws -> (
+    NIOAsyncChannel<ClientConnectionEvent, Void>,
+    NIOHTTP2Handler.AsyncStreamMultiplexer<Void>
+  ) {
+    // Window size which mustn't exceed 2^32 - 1 (RFC 9113 § 6.1.3).
+    let clampedTargetWindowSize = min(config.http2.targetWindowSize, (1 << 31) - 1)
+
+    // Max frame size must be in the range 2^14 ..< 2^24 (RFC 9113 § 6.1.3).
+    let clampedMaxFrameSize: Int
+    if config.http2.maxFrameSize >= (1 << 24) {
+      clampedMaxFrameSize = (1 << 24) - 1
+    } else if config.http2.maxFrameSize < (1 << 14) {
+      clampedMaxFrameSize = (1 << 14)
+    } else {
+      clampedMaxFrameSize = config.http2.maxFrameSize
+    }
+
+    // Use NIOs defaults as a starting point.
+    var http2 = NIOHTTP2Handler.Configuration()
+    http2.stream.targetWindowSize = clampedTargetWindowSize
+    http2.connection.initialSettings = [
+      // Disallow servers from creating push streams.
+      HTTP2Setting(parameter: .enablePush, value: 0),
+      // Set the initial window size and max frame size to the clamped configured values.
+      HTTP2Setting(parameter: .initialWindowSize, value: clampedTargetWindowSize),
+      HTTP2Setting(parameter: .maxFrameSize, value: clampedMaxFrameSize),
+      // Use NIOs default max header list size (16kB)
+      HTTP2Setting(parameter: .maxHeaderListSize, value: HPACKDecoder.defaultMaxHeaderListSize),
+    ]
+
+    let multiplexer = try self.configureAsyncHTTP2Pipeline(
+      mode: .client,
+      configuration: http2
+    ) { stream in
+      // Shouldn't happen, push-promises are disabled so the server shouldn't be able to
+      // open streams.
+      stream.close()
+    }
+
+    let connectionHandler = ClientConnectionHandler(
+      eventLoop: self.eventLoop,
+      maxIdleTime: config.idle.map { TimeAmount($0.maxTime) },
+      keepaliveTime: config.keepalive.map { TimeAmount($0.time) },
+      keepaliveTimeout: config.keepalive.map { TimeAmount($0.timeout) },
+      keepaliveWithoutCalls: config.keepalive?.permitWithoutCalls ?? false
+    )
+
+    try self.addHandler(connectionHandler)
+
+    let connection = try NIOAsyncChannel(
+      wrappingChannelSynchronously: channel,
+      configuration: NIOAsyncChannel.Configuration(
+        inboundType: ClientConnectionEvent.self,
+        outboundType: Void.self
+      )
+    )
+
+    return (connection, multiplexer)
+  }
+}

--- a/Tests/GRPCHTTP2CoreTests/Client/Connection/GRPCChannelTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Client/Connection/GRPCChannelTests.swift
@@ -1,0 +1,595 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import GRPCCore
+@_spi(Package) @testable import GRPCHTTP2Core
+import NIOHTTP2
+import NIOPosix
+import XCTest
+
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+final class GRPCChannelTests: XCTestCase {
+  func testDefaultServiceConfig() throws {
+    var serviceConfig = ServiceConfig()
+    serviceConfig.loadBalancingConfig = [.roundRobin]
+    serviceConfig.methodConfig = [MethodConfig(names: [MethodConfig.Name(.echoGet)])]
+    serviceConfig.retryThrottling = try ServiceConfig.RetryThrottling(
+      maxTokens: 100,
+      tokenRatio: 0.1
+    )
+
+    let channel = GRPCChannel(
+      resolver: .static(endpoints: []),
+      connector: .never,
+      config: .defaults,
+      defaultServiceConfig: serviceConfig
+    )
+
+    XCTAssertNotNil(channel.configuration(forMethod: .echoGet))
+    XCTAssertNil(channel.configuration(forMethod: .echoUpdate))
+
+    let throttle = try XCTUnwrap(channel.retryThrottle)
+    XCTAssertEqual(throttle.maximumTokens, 100)
+    XCTAssertEqual(throttle.tokenRatio, 0.1)
+  }
+
+  func testServiceConfigFromResolver() async throws {
+    // Verify that service config from the resolver takes precedence over the default service
+    // config. This is done indirectly by checking method config and retry throttle config.
+
+    // Create a service config to provide via the resolver.
+    var serviceConfig = ServiceConfig()
+    serviceConfig.loadBalancingConfig = [.roundRobin]
+    serviceConfig.methodConfig = [MethodConfig(names: [MethodConfig.Name(.echoGet)])]
+    serviceConfig.retryThrottling = try ServiceConfig.RetryThrottling(
+      maxTokens: 100,
+      tokenRatio: 0.1
+    )
+
+    // Need a server to connect to, no RPCs will be created though.
+    let server = TestServer(eventLoopGroup: .singletonMultiThreadedEventLoopGroup)
+    let address = try await server.bind()
+
+    let channel = GRPCChannel(
+      resolver: .static(endpoints: [Endpoint(addresses: [address])], serviceConfig: serviceConfig),
+      connector: .posix(),
+      config: .defaults,
+      defaultServiceConfig: ServiceConfig()
+    )
+
+    // Not resolved yet so the default (empty) service config is used.
+    XCTAssertNil(channel.configuration(forMethod: .echoGet))
+    XCTAssertNil(channel.configuration(forMethod: .echoUpdate))
+    XCTAssertNil(channel.retryThrottle)
+
+    try await withThrowingDiscardingTaskGroup { group in
+      group.addTask {
+        try await server.run(.never)
+      }
+
+      group.addTask {
+        await channel.connect()
+      }
+
+      for await event in channel.connectivityState {
+        switch event {
+        case .ready:
+          // When the channel is ready it must have the service config from the resolver.
+          XCTAssertNotNil(channel.configuration(forMethod: .echoGet))
+          XCTAssertNil(channel.configuration(forMethod: .echoUpdate))
+
+          let throttle = try XCTUnwrap(channel.retryThrottle)
+          XCTAssertEqual(throttle.maximumTokens, 100)
+          XCTAssertEqual(throttle.tokenRatio, 0.1)
+
+          // Now close.
+          channel.close()
+
+        default:
+          ()
+        }
+      }
+
+      group.cancelAll()
+    }
+  }
+
+  func testServiceConfigFromResolverAfterUpdate() async throws {
+    // Verify that the channel uses service config from the resolver and that it uses the latest
+    // version provided by the resolver. This is done indirectly by checking method config and retry
+    // throttle config.
+
+    let server = TestServer(eventLoopGroup: .singletonMultiThreadedEventLoopGroup)
+    let address = try await server.bind()
+
+    let (resolver, continuation) = NameResolver.dynamic(updateMode: .push)
+    let channel = GRPCChannel(
+      resolver: resolver,
+      connector: .posix(),
+      config: .defaults,
+      defaultServiceConfig: ServiceConfig()
+    )
+
+    // Not resolved yet so the default (empty) service config is used.
+    XCTAssertNil(channel.configuration(forMethod: .echoGet))
+    XCTAssertNil(channel.configuration(forMethod: .echoUpdate))
+    XCTAssertNil(channel.retryThrottle)
+
+    // Yield the first address list and service config.
+    var serviceConfig = ServiceConfig()
+    serviceConfig.loadBalancingConfig = [.roundRobin]
+    serviceConfig.methodConfig = [MethodConfig(names: [MethodConfig.Name(.echoGet)])]
+    serviceConfig.retryThrottling = try ServiceConfig.RetryThrottling(
+      maxTokens: 100,
+      tokenRatio: 0.1
+    )
+    let resolutionResult = NameResolutionResult(
+      endpoints: [Endpoint(address)],
+      serviceConfig: .success(serviceConfig)
+    )
+    continuation.yield(resolutionResult)
+
+    try await withThrowingDiscardingTaskGroup { group in
+      group.addTask {
+        try await server.run(.never)
+      }
+
+      group.addTask {
+        await channel.connect()
+      }
+
+      for await event in channel.connectivityState {
+        switch event {
+        case .ready:
+          // When the channel it must have the service config from the resolver.
+          XCTAssertNotNil(channel.configuration(forMethod: .echoGet))
+          XCTAssertNil(channel.configuration(forMethod: .echoUpdate))
+          let throttle = try XCTUnwrap(channel.retryThrottle)
+          XCTAssertEqual(throttle.maximumTokens, 100)
+          XCTAssertEqual(throttle.tokenRatio, 0.1)
+
+          // Now yield a new service config with the same addresses.
+          var resolutionResult = resolutionResult
+          serviceConfig.methodConfig = [MethodConfig(names: [MethodConfig.Name(.echoUpdate)])]
+          serviceConfig.retryThrottling = nil
+          resolutionResult.serviceConfig = .success(serviceConfig)
+          continuation.yield(resolutionResult)
+
+          // This should be propagated quickly.
+          try await XCTPoll(every: .milliseconds(10)) {
+            let noConfigForGet = channel.configuration(forMethod: .echoGet) == nil
+            let configForUpdate = channel.configuration(forMethod: .echoUpdate) != nil
+            let noThrottle = channel.retryThrottle == nil
+            return noConfigForGet && configForUpdate && noThrottle
+          }
+
+          channel.close()
+
+        default:
+          ()
+        }
+      }
+
+      group.cancelAll()
+    }
+  }
+
+  func testPushBasedResolutionUpdates() async throws {
+    // Verify that the channel responds to name resolution changes which are pushed into
+    // the resolver. Do this by starting two servers and only making the address of one available
+    // via the resolver at a time. Server identity is provided via metadata in the RPC.
+
+    // Start a few servers.
+    let server1 = TestServer(eventLoopGroup: .singletonMultiThreadedEventLoopGroup)
+    let address1 = try await server1.bind()
+
+    let server2 = TestServer(eventLoopGroup: .singletonMultiThreadedEventLoopGroup)
+    let address2 = try await server2.bind()
+
+    // Setup a resolver and push some changes into it.
+    let (resolver, continuation) = NameResolver.dynamic(updateMode: .push)
+    let resolution1 = NameResolutionResult(endpoints: [Endpoint(address1)], serviceConfig: nil)
+    continuation.yield(resolution1)
+
+    var serviceConfig = ServiceConfig()
+    serviceConfig.loadBalancingConfig = [.roundRobin]
+    let channel = GRPCChannel(
+      resolver: resolver,
+      connector: .posix(),
+      config: .defaults,
+      defaultServiceConfig: serviceConfig
+    )
+
+    try await withThrowingDiscardingTaskGroup { group in
+      // Servers respond with their own address in the trailing metadata.
+      for (server, address) in [(server1, address1), (server2, address2)] {
+        group.addTask {
+          try await server.run { inbound, outbound in
+            let status = Status(code: .ok, message: "")
+            let metadata: Metadata = ["server-addr": "\(address)"]
+            try await outbound.write(.status(status, metadata))
+            outbound.finish()
+          }
+        }
+      }
+
+      group.addTask {
+        await channel.connect()
+      }
+
+      // The stream will be queued until the channel is ready.
+      let serverAddress1 = try await channel.serverAddress()
+      XCTAssertEqual(serverAddress1, "\(address1)")
+      XCTAssertEqual(server1.clients.count, 1)
+      XCTAssertEqual(server2.clients.count, 0)
+
+      // Yield the second address. Because this happens asynchronously there's no guarantee that
+      // the next stream will be made against the same server, so poll until the servers have the
+      // appropriate connections.
+      let resolution2 = NameResolutionResult(endpoints: [Endpoint(address2)], serviceConfig: nil)
+      continuation.yield(resolution2)
+
+      try await XCTPoll(every: .milliseconds(10)) {
+        server1.clients.count == 0 && server2.clients.count == 1
+      }
+
+      let serverAddress2 = try await channel.serverAddress()
+      XCTAssertEqual(serverAddress2, "\(address2)")
+
+      group.cancelAll()
+    }
+  }
+
+  func testPullBasedResolutionUpdates() async throws {
+    // Verify that the channel responds to name resolution changes which are pulled because a
+    // subchannel asked the channel to re-resolve. Do this by starting two servers and changing
+    // which is available via resolution updates. Server identity is provided via metadata in
+    // the RPC.
+
+    // Start a few servers.
+    let server1 = TestServer(eventLoopGroup: .singletonMultiThreadedEventLoopGroup)
+    let address1 = try await server1.bind()
+
+    let server2 = TestServer(eventLoopGroup: .singletonMultiThreadedEventLoopGroup)
+    let address2 = try await server2.bind()
+
+    // Setup a resolve which we push changes into.
+    let (resolver, continuation) = NameResolver.dynamic(updateMode: .pull)
+
+    // Yield the addresses.
+    for address in [address1, address2] {
+      let resolution = NameResolutionResult(endpoints: [Endpoint(address)], serviceConfig: nil)
+      continuation.yield(resolution)
+    }
+
+    var serviceConfig = ServiceConfig()
+    serviceConfig.loadBalancingConfig = [.roundRobin]
+    let channel = GRPCChannel(
+      resolver: resolver,
+      connector: .posix(),
+      config: .defaults,
+      defaultServiceConfig: serviceConfig
+    )
+
+    try await withThrowingDiscardingTaskGroup { group in
+      // Servers respond with their own address in the trailing metadata.
+      for (server, address) in [(server1, address1), (server2, address2)] {
+        group.addTask {
+          try await server.run { inbound, outbound in
+            let status = Status(code: .ok, message: "")
+            let metadata: Metadata = ["server-addr": "\(address)"]
+            try await outbound.write(.status(status, metadata))
+            outbound.finish()
+          }
+        }
+      }
+
+      group.addTask {
+        await channel.connect()
+      }
+
+      // The stream will be queued until the channel is ready.
+      let serverAddress1 = try await channel.serverAddress()
+      XCTAssertEqual(serverAddress1, "\(address1)")
+      XCTAssertEqual(server1.clients.count, 1)
+      XCTAssertEqual(server2.clients.count, 0)
+
+      // Tell the first server to GOAWAY. This will cause the subchannel to re-resolve.
+      let server1Client = try XCTUnwrap(server1.clients.first)
+      let goAway = HTTP2Frame(
+        streamID: .rootStream,
+        payload: .goAway(lastStreamID: 1, errorCode: .noError, opaqueData: nil)
+      )
+      try await server1Client.writeAndFlush(goAway)
+
+      // Poll until the first client drops, addresses are re-resolved, and a connection is
+      // established to server2.
+      try await XCTPoll(every: .milliseconds(10)) {
+        server1.clients.count == 0 && server2.clients.count == 1
+      }
+
+      let serverAddress2 = try await channel.serverAddress()
+      XCTAssertEqual(serverAddress2, "\(address2)")
+
+      group.cancelAll()
+    }
+  }
+
+  func testCloseWhenRPCsAreInProgress() async throws {
+    // Verify that closing the channel while there are RPCs in progress allows the RPCs to finish
+    // gracefully.
+
+    let server = TestServer(eventLoopGroup: .singletonMultiThreadedEventLoopGroup)
+    let address = try await server.bind()
+
+    try await withThrowingDiscardingTaskGroup { group in
+      group.addTask {
+        try await server.run(.echo)
+      }
+
+      var serviceConfig = ServiceConfig()
+      serviceConfig.loadBalancingConfig = [.roundRobin]
+
+      let channel = GRPCChannel(
+        resolver: .static(endpoints: [Endpoint(address)]),
+        connector: .posix(),
+        config: .defaults,
+        defaultServiceConfig: serviceConfig
+      )
+
+      group.addTask {
+        await channel.connect()
+      }
+
+      try await channel.withStream(descriptor: .echoGet, options: .defaults) { stream in
+        try await stream.outbound.write(.metadata([:]))
+
+        var iterator = stream.inbound.makeAsyncIterator()
+        let part1 = try await iterator.next()
+        switch part1 {
+        case .metadata:
+          // Got metadata, close the channel.
+          channel.close()
+        case .message, .status, .none:
+          XCTFail("Expected metadata, got \(String(describing: part1))")
+        }
+
+        for await state in channel.connectivityState {
+          switch state {
+          case .shutdown:
+            // Happens when shutting-down has been initiated, so finish the RPC.
+            stream.outbound.finish()
+
+            let part2 = try await iterator.next()
+            XCTExpectFailure("https://github.com/apple/swift-nio-http2/pull/439")
+            switch part2 {
+            case .status(let status, _):
+              XCTAssertEqual(status.code, .ok)
+            case .metadata, .message, .none:
+              XCTFail("Expected status, got \(String(describing: part2))")
+            }
+
+          default:
+            ()
+          }
+        }
+      }
+
+      group.cancelAll()
+    }
+  }
+
+  func testQueueRequestsWhileNotReady() async throws {
+    // Verify that requests are queued until the channel becomes ready. As creating streams
+    // will race with the channel becoming ready, we add numerous tasks to the task group which
+    // each create a stream before making the server address known to the channel via the resolver.
+    // This isn't perfect as the resolution _could_ happen before attempting to create all streams
+    // although this is unlikely.
+
+    let server = TestServer(eventLoopGroup: .singletonMultiThreadedEventLoopGroup)
+    let address = try await server.bind()
+
+    let (resolver, continuation) = NameResolver.dynamic(updateMode: .push)
+    var serviceConfig = ServiceConfig()
+    serviceConfig.loadBalancingConfig = [.roundRobin]
+    let channel = GRPCChannel(
+      resolver: resolver,
+      connector: .posix(),
+      config: .defaults,
+      defaultServiceConfig: serviceConfig
+    )
+
+    enum Subtask { case rpc, other }
+    try await withThrowingTaskGroup(of: Subtask.self) { group in
+      // Run the server.
+      group.addTask {
+        try await server.run { inbound, outbound in
+          for try await part in inbound {
+            switch part {
+            case .metadata:
+              try await outbound.write(.metadata([:]))
+            case .message(let bytes):
+              try await outbound.write(.message(bytes))
+            }
+          }
+
+          let status = Status(code: .ok, message: "")
+          try await outbound.write(.status(status, [:]))
+          outbound.finish()
+        }
+
+        return .other
+      }
+
+      group.addTask {
+        await channel.connect()
+        return .other
+      }
+
+      // Start a bunch of requests. These won't start until an address is yielded, they should
+      // be queued though.
+      for _ in 1 ... 100 {
+        group.addTask {
+          try await channel.withStream(descriptor: .echoGet, options: .defaults) { stream in
+            try await stream.outbound.write(.metadata([:]))
+            stream.outbound.finish()
+
+            for try await part in stream.inbound {
+              switch part {
+              case .metadata, .message:
+                ()
+              case .status(let status, _):
+                XCTAssertEqual(status.code, .ok)
+              }
+            }
+          }
+
+          return .rpc
+        }
+      }
+
+      // At least some of the RPCs should have been queued by now.
+      let resolution = NameResolutionResult(endpoints: [Endpoint(address)], serviceConfig: nil)
+      continuation.yield(resolution)
+
+      var outstandingRPCs = 100
+      for try await subtask in group {
+        switch subtask {
+        case .rpc:
+          outstandingRPCs -= 1
+
+          // All RPCs done, close the channel and cancel the group to stop the server.
+          if outstandingRPCs == 0 {
+            channel.close()
+            group.cancelAll()
+          }
+
+        case .other:
+          ()
+        }
+      }
+    }
+  }
+
+  func testQueueRequestsFailFast() async throws {
+    // Verifies that if 'waitsForReady' is 'false', that queued requests are failed when there is
+    // a transient failure. The transient failure is triggered by attempting to connect to a
+    // non-existent server.
+
+    let (resolver, continuation) = NameResolver.dynamic(updateMode: .push)
+    var serviceConfig = ServiceConfig()
+    serviceConfig.loadBalancingConfig = [.roundRobin]
+    let channel = GRPCChannel(
+      resolver: resolver,
+      connector: .posix(),
+      config: .defaults,
+      defaultServiceConfig: serviceConfig
+    )
+
+    enum Subtask { case rpc, other }
+    try await withThrowingTaskGroup(of: Subtask.self) { group in
+      group.addTask {
+        await channel.connect()
+        return .other
+      }
+
+      for _ in 1 ... 100 {
+        group.addTask {
+          var options = CallOptions.defaults
+          options.waitForReady = false
+
+          await XCTAssertThrowsErrorAsync(ofType: RPCError.self) {
+            try await channel.withStream(descriptor: .echoGet, options: options) { _ in
+              XCTFail("Unexpected stream")
+            }
+          } errorHandler: { error in
+            XCTAssertEqual(error.code, .unavailable)
+          }
+
+          return .rpc
+        }
+      }
+
+      // At least some of the RPCs should have been queued by now.
+      let resolution = NameResolutionResult(
+        endpoints: [Endpoint(.unixDomainSocket(path: "/test-queue-requests-fail-fast"))],
+        serviceConfig: nil
+      )
+      continuation.yield(resolution)
+
+      var outstandingRPCs = 100
+      for try await subtask in group {
+        switch subtask {
+        case .rpc:
+          outstandingRPCs -= 1
+
+          // All RPCs done, close the channel and cancel the group to stop the server.
+          if outstandingRPCs == 0 {
+            channel.close()
+            group.cancelAll()
+          }
+
+        case .other:
+          ()
+        }
+      }
+    }
+  }
+}
+
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+extension GRPCChannel.Config {
+  static var defaults: Self {
+    Self(
+      http2: .defaults,
+      backoff: .defaults,
+      idle: .defaults,
+      keepalive: nil,
+      compression: .defaults
+    )
+  }
+}
+
+extension Endpoint {
+  init(_ addresses: SocketAddress...) {
+    self.init(addresses: addresses)
+  }
+}
+
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+extension GRPCChannel {
+  fileprivate func serverAddress() async throws -> String? {
+    let values: Metadata.StringValues? = try await self.withStream(
+      descriptor: .echoGet,
+      options: .defaults
+    ) { stream in
+      try await stream.outbound.write(.metadata([:]))
+      stream.outbound.finish()
+
+      for try await part in stream.inbound {
+        switch part {
+        case .metadata, .message:
+          XCTFail("Unexpected part: \(part)")
+        case .status(_, let metadata):
+          return metadata[stringValues: "server-addr"]
+        }
+      }
+      return nil
+    }
+
+    return values?.first(where: { _ in true })
+  }
+}

--- a/Tests/GRPCHTTP2CoreTests/Client/Connection/Utilities/NameResolvers.swift
+++ b/Tests/GRPCHTTP2CoreTests/Client/Connection/Utilities/NameResolvers.swift
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import GRPCCore
+import GRPCHTTP2Core
+
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+extension NameResolver {
+  static func `static`(
+    endpoints: [Endpoint],
+    serviceConfig: ServiceConfig? = nil
+  ) -> Self {
+    let result = NameResolutionResult(
+      endpoints: endpoints,
+      serviceConfig: serviceConfig.map { .success($0) }
+    )
+
+    return NameResolver(
+      names: RPCAsyncSequence(wrapping: ConstantAsyncSequence(element: result)),
+      updateMode: .pull
+    )
+  }
+
+  static func `dynamic`(
+    updateMode: UpdateMode
+  ) -> (Self, AsyncStream<NameResolutionResult>.Continuation) {
+    let (stream, continuation) = AsyncStream.makeStream(of: NameResolutionResult.self)
+    let resolver = NameResolver(names: RPCAsyncSequence(wrapping: stream), updateMode: updateMode)
+    return (resolver, continuation)
+  }
+}
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+struct ConstantAsyncSequence<Element>: AsyncSequence {
+  private let result: Result<Element, Error>
+
+  init(element: Element) {
+    self.result = .success(element)
+  }
+
+  init(error: any Error) {
+    self.result = .failure(error)
+  }
+
+  func makeAsyncIterator() -> AsyncIterator {
+    AsyncIterator(result: self.result)
+  }
+
+  struct AsyncIterator: AsyncIteratorProtocol {
+    private let result: Result<Element, Error>
+
+    fileprivate init(result: Result<Element, Error>) {
+      self.result = result
+    }
+
+    func next() async throws -> Element? {
+      try self.result.get()
+    }
+  }
+
+}

--- a/Tests/GRPCHTTP2CoreTests/Test Utilities/MethodDescriptor+Common.swift
+++ b/Tests/GRPCHTTP2CoreTests/Test Utilities/MethodDescriptor+Common.swift
@@ -20,4 +20,15 @@ extension MethodDescriptor {
   static var echoGet: Self {
     MethodDescriptor(service: "echo.Echo", method: "Get")
   }
+
+  static var echoUpdate: Self {
+    MethodDescriptor(service: "echo.Echo", method: "Update")
+  }
+}
+
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+extension MethodConfig.Name {
+  init(_ descriptor: MethodDescriptor) {
+    self = MethodConfig.Name(service: descriptor.service, method: descriptor.method)
+  }
 }


### PR DESCRIPTION
Motivation:

The grpc channel provides a long-lived connection to some remote backend(s). This allows us to build up a client transport.

Modifications:

- Add the `GRPCChannel`, a long-lives way of providing connections to a remote backend

Result:

Can make RPCs to a remote backend