### PR TITLE
Add a sendable view to ClientConnectionHandler/ServerConnectionManage…

### DIFF
--- a/Tests/GRPCHTTP2CoreTests/Client/Connection/ClientConnectionHandlerTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Client/Connection/ClientConnectionHandlerTests.swift
@@ -246,7 +246,7 @@ extension ClientConnectionHandlerTests {
         keepaliveWithoutCalls: allowKeepaliveWithoutCalls
       )
 
-      self.streamDelegate = handler
+      self.streamDelegate = handler.http2StreamDelegate
       self.channel = EmbeddedChannel(handler: handler, loop: loop)
     }
 

--- a/Tests/GRPCHTTP2CoreTests/Server/Connection/ServerConnectionManagementHandlerTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Server/Connection/ServerConnectionManagementHandlerTests.swift
@@ -379,7 +379,7 @@ extension ServerConnectionManagementHandlerTests {
         clock: self.clock
       )
 
-      self.streamDelegate = handler
+      self.streamDelegate = handler.http2StreamDelegate
       self.syncView = handler.syncView
       self.channel = EmbeddedChannel(handler: handler, loop: loop)
     }


### PR DESCRIPTION
…mentHandler

Motivation:

In #1875 the `ClientConnectionHandler` and
`ServerConnectionManagementHandler` had conformance added to `NIOHTTP2StreamDelegate`. This, in turn, requires that they are `Sendable`. However, they aren't really `Sendable` as most of their API relies on being on the correct event-loop.

Modifications:

- Add stream-delegate views over each where the conformance ensures that the methods are called on the appropriate event loop

Result:

Fewer warnings