### PR TITLE
Add missing dependency to package manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -216,7 +216,8 @@ extension Target {
   static let grpcHTTP2TransportNIOPosix: Target = .target(
     name: "GRPCHTTP2TransportNIOPosix",
     dependencies: [
-      .grpcHTTP2Core
+      .grpcHTTP2Core,
+      .nioExtras
     ]
   )
 


### PR DESCRIPTION
Motivation:

3272c32b uses NIOExtras but didn't add the dependency to the package manifest. This can cause compilation issues.

Modifications:

- Add the missing dependency

Result:

Fewer issues