### PR TITLE
Always store compression algorithm in stream state machine

### DIFF
--- a/Sources/GRPCHTTP2Core/GRPCStreamStateMachine.swift
+++ b/Sources/GRPCHTTP2Core/GRPCStreamStateMachine.swift
@@ -89,12 +89,14 @@ private enum GRPCStreamStateMachineState {
     init(
       previousState: ClientIdleServerIdleState,
       compressor: Zlib.Compressor?,
+      outboundCompression: CompressionAlgorithm?,
       framer: GRPCMessageFramer,
       decompressor: Zlib.Decompressor?,
       deframer: NIOSingleStepByteToMessageProcessor<GRPCMessageDeframer>?
     ) {
       self.maximumPayloadSize = previousState.maximumPayloadSize
       self.compressor = compressor
+      self.outboundCompression = outboundCompression
       self.framer = framer
       self.decompressor = decompressor
       self.deframer = deframer
@@ -105,6 +107,7 @@ private enum GRPCStreamStateMachineState {
   struct ClientOpenServerOpenState {
     var framer: GRPCMessageFramer
     var compressor: Zlib.Compressor?
+    var outboundCompression: CompressionAlgorithm?
 
     let deframer: NIOSingleStepByteToMessageProcessor<GRPCMessageDeframer>
     var decompressor: Zlib.Decompressor?
@@ -118,6 +121,7 @@ private enum GRPCStreamStateMachineState {
     ) {
       self.framer = previousState.framer
       self.compressor = previousState.compressor
+      self.outboundCompression = previousState.outboundCompression
 
       self.deframer = deframer
       self.decompressor = decompressor
@@ -129,6 +133,7 @@ private enum GRPCStreamStateMachineState {
   struct ClientOpenServerClosedState {
     var framer: GRPCMessageFramer?
     var compressor: Zlib.Compressor?
+    var outboundCompression: CompressionAlgorithm?
 
     let deframer: NIOSingleStepByteToMessageProcessor<GRPCMessageDeframer>?
     var decompressor: Zlib.Decompressor?
@@ -145,6 +150,7 @@ private enum GRPCStreamStateMachineState {
     init(previousState: ClientIdleServerIdleState) {
       self.framer = nil
       self.compressor = nil
+      self.outboundCompression = nil
       self.deframer = nil
       self.decompressor = nil
       self.inboundMessageBuffer = .init()
@@ -153,6 +159,7 @@ private enum GRPCStreamStateMachineState {
     init(previousState: ClientOpenServerOpenState) {
       self.framer = previousState.framer
       self.compressor = previousState.compressor
+      self.outboundCompression = previousState.outboundCompression
       self.deframer = previousState.deframer
       self.decompressor = previousState.decompressor
       self.inboundMessageBuffer = previousState.inboundMessageBuffer
@@ -161,6 +168,7 @@ private enum GRPCStreamStateMachineState {
     init(previousState: ClientOpenServerIdleState) {
       self.framer = previousState.framer
       self.compressor = previousState.compressor
+      self.outboundCompression = previousState.outboundCompression
       self.inboundMessageBuffer = previousState.inboundMessageBuffer
       // The server went directly from idle to closed - this means it sent a
       // trailers-only response:
@@ -195,9 +203,9 @@ private enum GRPCStreamStateMachineState {
 
       if let zlibMethod = Zlib.Method(encoding: compressionAlgorithm) {
         self.compressor = Zlib.Compressor(method: zlibMethod)
+        self.outboundCompression = compressionAlgorithm
       }
       self.framer = GRPCMessageFramer()
-      self.outboundCompression = compressionAlgorithm
       // We don't need a deframer since we won't receive any messages from the
       // client: it's closed.
       self.deframer = nil
@@ -218,6 +226,7 @@ private enum GRPCStreamStateMachineState {
   struct ClientClosedServerOpenState {
     var framer: GRPCMessageFramer
     var compressor: Zlib.Compressor?
+    var outboundCompression: CompressionAlgorithm?
 
     let deframer: NIOSingleStepByteToMessageProcessor<GRPCMessageDeframer>?
     var decompressor: Zlib.Decompressor?
@@ -227,6 +236,7 @@ private enum GRPCStreamStateMachineState {
     init(previousState: ClientOpenServerOpenState) {
       self.framer = previousState.framer
       self.compressor = previousState.compressor
+      self.outboundCompression = previousState.outboundCompression
       self.deframer = previousState.deframer
       self.decompressor = previousState.decompressor
       self.inboundMessageBuffer = previousState.inboundMessageBuffer
@@ -236,6 +246,7 @@ private enum GRPCStreamStateMachineState {
     init(previousState: ClientClosedServerIdleState) {
       self.framer = previousState.framer
       self.compressor = previousState.compressor
+      self.outboundCompression = previousState.outboundCompression
 
       // In the case of the server, we don't need to deframe/decompress any more
       // messages, since the client's closed.
@@ -252,6 +263,7 @@ private enum GRPCStreamStateMachineState {
     ) {
       self.framer = previousState.framer
       self.compressor = previousState.compressor
+      self.outboundCompression = previousState.outboundCompression
 
       // In the case of the client, it will only be able to set up the deframer
       // after it receives the chosen encoding from the server.
@@ -274,6 +286,7 @@ private enum GRPCStreamStateMachineState {
     // the client.
     var framer: GRPCMessageFramer?
     var compressor: Zlib.Compressor?
+    var outboundCompression: CompressionAlgorithm?
 
     // These are already deframed, so we don't need the deframer anymore.
     var inboundMessageBuffer: OneOrManyQueue<[UInt8]>
@@ -288,36 +301,42 @@ private enum GRPCStreamStateMachineState {
     init(previousState: ClientIdleServerIdleState) {
       self.framer = nil
       self.compressor = nil
+      self.outboundCompression = nil
       self.inboundMessageBuffer = .init()
     }
 
     init(previousState: ClientClosedServerOpenState) {
       self.framer = previousState.framer
       self.compressor = previousState.compressor
+      self.outboundCompression = previousState.outboundCompression
       self.inboundMessageBuffer = previousState.inboundMessageBuffer
     }
 
     init(previousState: ClientClosedServerIdleState) {
       self.framer = previousState.framer
       self.compressor = previousState.compressor
+      self.outboundCompression = previousState.outboundCompression
       self.inboundMessageBuffer = previousState.inboundMessageBuffer
     }
 
     init(previousState: ClientOpenServerIdleState) {
       self.framer = previousState.framer
       self.compressor = previousState.compressor
+      self.outboundCompression = previousState.outboundCompression
       self.inboundMessageBuffer = previousState.inboundMessageBuffer
     }
 
     init(previousState: ClientOpenServerOpenState) {
       self.framer = previousState.framer
       self.compressor = previousState.compressor
+      self.outboundCompression = previousState.outboundCompression
       self.inboundMessageBuffer = previousState.inboundMessageBuffer
     }
 
     init(previousState: ClientOpenServerClosedState) {
       self.framer = previousState.framer
       self.compressor = previousState.compressor
+      self.outboundCompression = previousState.outboundCompression
       self.inboundMessageBuffer = previousState.inboundMessageBuffer
     }
   }
@@ -555,6 +574,7 @@ extension GRPCStreamStateMachine {
         .init(
           previousState: state,
           compressor: compressor,
+          outboundCompression: outboundEncoding,
           framer: GRPCMessageFramer(),
           decompressor: nil,
           deframer: nil
@@ -1037,6 +1057,7 @@ extension GRPCStreamStateMachine {
     // Server sends initial metadata
     switch self.state {
     case .clientOpenServerIdle(let state):
+      let outboundEncoding = state.outboundCompression
       self.state = .clientOpenServerOpen(
         .init(
           previousState: state,
@@ -1048,14 +1069,15 @@ extension GRPCStreamStateMachine {
         )
       )
       return self.makeResponseHeaders(
-        outboundEncoding: state.outboundCompression,
+        outboundEncoding: outboundEncoding,
         configuration: configuration,
         customMetadata: metadata
       )
     case .clientClosedServerIdle(let state):
+      let outboundEncoding = state.outboundCompression
       self.state = .clientClosedServerOpen(.init(previousState: state))
       return self.makeResponseHeaders(
-        outboundEncoding: state.outboundCompression,
+        outboundEncoding: outboundEncoding,
         configuration: configuration,
         customMetadata: metadata
       )
@@ -1326,8 +1348,6 @@ extension GRPCStreamStateMachine {
         canonicalForm: true
       )
       // Find the preferred encoding and use it to compress responses.
-      // If it's identity, just skip it altogether, since we won't be
-      // compressing.
       for clientAdvertisedEncoding in clientAdvertisedEncodings {
         if let algorithm = CompressionAlgorithm(name: clientAdvertisedEncoding),
           configuration.acceptedEncodings.contains(algorithm)
@@ -1358,6 +1378,7 @@ extension GRPCStreamStateMachine {
           .init(
             previousState: state,
             compressor: compressor,
+            outboundCompression: outboundEncoding,
             framer: GRPCMessageFramer(),
             decompressor: decompressor,
             deframer: NIOSingleStepByteToMessageProcessor(deframer)

--- a/Sources/GRPCHTTP2Core/GRPCStreamStateMachine.swift
+++ b/Sources/GRPCHTTP2Core/GRPCStreamStateMachine.swift
@@ -1039,10 +1039,6 @@ extension GRPCStreamStateMachine {
       headers.add(outboundEncoding.name, forKey: .encoding)
     }
 
-    for acceptedEncoding in configuration.acceptedEncodings.elements.filter({ $0 != .none }) {
-      headers.add(acceptedEncoding.name, forKey: .acceptEncoding)
-    }
-
     for metadataPair in customMetadata {
       headers.add(name: metadataPair.key, value: metadataPair.value.encoded())
     }

--- a/Sources/GRPCHTTP2Core/GRPCStreamStateMachine.swift
+++ b/Sources/GRPCHTTP2Core/GRPCStreamStateMachine.swift
@@ -75,7 +75,7 @@ private enum GRPCStreamStateMachineState {
     let maximumPayloadSize: Int
     var framer: GRPCMessageFramer
     var compressor: Zlib.Compressor?
-    var outboundCompression: CompressionAlgorithm?
+    var outboundCompression: CompressionAlgorithm
 
     // The deframer must be optional because the client will not have one configured
     // until the server opens and sends a grpc-encoding header.
@@ -89,7 +89,7 @@ private enum GRPCStreamStateMachineState {
     init(
       previousState: ClientIdleServerIdleState,
       compressor: Zlib.Compressor?,
-      outboundCompression: CompressionAlgorithm?,
+      outboundCompression: CompressionAlgorithm,
       framer: GRPCMessageFramer,
       decompressor: Zlib.Decompressor?,
       deframer: NIOSingleStepByteToMessageProcessor<GRPCMessageDeframer>?
@@ -107,7 +107,7 @@ private enum GRPCStreamStateMachineState {
   struct ClientOpenServerOpenState {
     var framer: GRPCMessageFramer
     var compressor: Zlib.Compressor?
-    var outboundCompression: CompressionAlgorithm?
+    var outboundCompression: CompressionAlgorithm
 
     let deframer: NIOSingleStepByteToMessageProcessor<GRPCMessageDeframer>
     var decompressor: Zlib.Decompressor?
@@ -133,7 +133,7 @@ private enum GRPCStreamStateMachineState {
   struct ClientOpenServerClosedState {
     var framer: GRPCMessageFramer?
     var compressor: Zlib.Compressor?
-    var outboundCompression: CompressionAlgorithm?
+    var outboundCompression: CompressionAlgorithm
 
     let deframer: NIOSingleStepByteToMessageProcessor<GRPCMessageDeframer>?
     var decompressor: Zlib.Decompressor?
@@ -150,7 +150,7 @@ private enum GRPCStreamStateMachineState {
     init(previousState: ClientIdleServerIdleState) {
       self.framer = nil
       self.compressor = nil
-      self.outboundCompression = nil
+      self.outboundCompression = .none
       self.deframer = nil
       self.decompressor = nil
       self.inboundMessageBuffer = .init()
@@ -185,7 +185,7 @@ private enum GRPCStreamStateMachineState {
     let maximumPayloadSize: Int
     var framer: GRPCMessageFramer
     var compressor: Zlib.Compressor?
-    var outboundCompression: CompressionAlgorithm?
+    var outboundCompression: CompressionAlgorithm
 
     let deframer: NIOSingleStepByteToMessageProcessor<GRPCMessageDeframer>?
     var decompressor: Zlib.Decompressor?
@@ -204,6 +204,9 @@ private enum GRPCStreamStateMachineState {
       if let zlibMethod = Zlib.Method(encoding: compressionAlgorithm) {
         self.compressor = Zlib.Compressor(method: zlibMethod)
         self.outboundCompression = compressionAlgorithm
+      } else {
+        self.compressor = nil
+        self.outboundCompression = .none
       }
       self.framer = GRPCMessageFramer()
       // We don't need a deframer since we won't receive any messages from the
@@ -226,7 +229,7 @@ private enum GRPCStreamStateMachineState {
   struct ClientClosedServerOpenState {
     var framer: GRPCMessageFramer
     var compressor: Zlib.Compressor?
-    var outboundCompression: CompressionAlgorithm?
+    var outboundCompression: CompressionAlgorithm
 
     let deframer: NIOSingleStepByteToMessageProcessor<GRPCMessageDeframer>?
     var decompressor: Zlib.Decompressor?
@@ -286,7 +289,7 @@ private enum GRPCStreamStateMachineState {
     // the client.
     var framer: GRPCMessageFramer?
     var compressor: Zlib.Compressor?
-    var outboundCompression: CompressionAlgorithm?
+    var outboundCompression: CompressionAlgorithm
 
     // These are already deframed, so we don't need the deframer anymore.
     var inboundMessageBuffer: OneOrManyQueue<[UInt8]>
@@ -301,7 +304,7 @@ private enum GRPCStreamStateMachineState {
     init(previousState: ClientIdleServerIdleState) {
       self.framer = nil
       self.compressor = nil
-      self.outboundCompression = nil
+      self.outboundCompression = .none
       self.inboundMessageBuffer = .init()
     }
 

--- a/Tests/GRPCHTTP2CoreTests/GRPCStreamStateMachineTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/GRPCStreamStateMachineTests.swift
@@ -1352,7 +1352,6 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
       [
         ":status": "200",
         "content-type": "application/grpc",
-        "grpc-accept-encoding": "deflate",
       ]
     )
   }
@@ -1370,7 +1369,6 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
         ":status": "200",
         "content-type": "application/grpc",
         "grpc-encoding": "deflate",
-        "grpc-accept-encoding": "deflate",
       ]
     )
   }
@@ -2458,7 +2456,6 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
       [
         ":status": "200",
         "content-type": "application/grpc",
-        "grpc-accept-encoding": "deflate",
         "custom": "value",
       ]
     )
@@ -2580,7 +2577,6 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
         "custom": "value",
         ":status": "200",
         "content-type": "application/grpc",
-        "grpc-accept-encoding": "deflate",
       ]
     )
 
@@ -2654,7 +2650,6 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
         "custom": "value",
         ":status": "200",
         "content-type": "application/grpc",
-        "grpc-accept-encoding": "deflate",
       ]
     )
 

--- a/Tests/GRPCHTTP2CoreTests/GRPCStreamStateMachineTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/GRPCStreamStateMachineTests.swift
@@ -116,8 +116,7 @@ extension HPACKHeaders {
   // Server
   fileprivate static let serverInitialMetadata: Self = [
     GRPCHTTP2Keys.status.rawValue: "200",
-    GRPCHTTP2Keys.contentType.rawValue: ContentType.grpc.canonicalValue,
-    GRPCHTTP2Keys.acceptEncoding.rawValue: "deflate",
+    GRPCHTTP2Keys.contentType.rawValue: ContentType.grpc.canonicalValue
   ]
   fileprivate static let serverInitialMetadataWithDeflateCompression: Self = [
     GRPCHTTP2Keys.status.rawValue: "200",
@@ -129,7 +128,7 @@ extension HPACKHeaders {
     GRPCHTTP2Keys.status.rawValue: "200",
     GRPCHTTP2Keys.contentType.rawValue: ContentType.grpc.canonicalValue,
     GRPCHTTP2Keys.encoding.rawValue: "gzip",
-    GRPCHTTP2Keys.acceptEncoding.rawValue: "deflate",
+    GRPCHTTP2Keys.acceptEncoding.rawValue: "gzip",
   ]
   fileprivate static let serverTrailers: Self = [
     GRPCHTTP2Keys.status.rawValue: "200",
@@ -366,7 +365,7 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
           ":status": "200",
           "content-type": "application/grpc",
           "grpc-encoding": "gzip",
-          "grpc-accept-encoding": "deflate",
+          "grpc-accept-encoding": "gzip",
         ]
       )
     )
@@ -1009,8 +1008,7 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
       .receivedMetadata(
         [
           ":status": "200",
-          "content-type": "application/grpc",
-          "grpc-accept-encoding": "deflate",
+          "content-type": "application/grpc"
         ],
         nil
       )
@@ -1112,8 +1110,7 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
       .receivedMetadata(
         [
           ":status": "200",
-          "content-type": "application/grpc",
-          "grpc-accept-encoding": "deflate",
+          "content-type": "application/grpc"
         ],
         nil
       )
@@ -1199,8 +1196,7 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
       .receivedMetadata(
         [
           ":status": "200",
-          "content-type": "application/grpc",
-          "grpc-accept-encoding": "deflate",
+          "content-type": "application/grpc"
         ],
         nil
       )

--- a/Tests/GRPCHTTP2CoreTests/GRPCStreamStateMachineTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/GRPCStreamStateMachineTests.swift
@@ -1343,8 +1343,36 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
   }
 
   func testSendMetadataWhenClientOpenAndServerIdle() throws {
-    var stateMachine = self.makeServerStateMachine(targetState: .clientOpenServerIdle)
-    XCTAssertNoThrow(try stateMachine.send(metadata: .init()))
+    var stateMachine = self.makeServerStateMachine(
+      targetState: .clientOpenServerIdle,
+      compressionEnabled: false
+    )
+    XCTAssertEqual(
+      try stateMachine.send(metadata: .init()),
+      [
+        ":status": "200",
+        "content-type": "application/grpc",
+        "grpc-accept-encoding": "deflate",
+      ]
+    )
+  }
+
+  func testSendMetadataWhenClientOpenAndServerIdle_AndCompressionEnabled() {
+    // Enable deflate compression on server
+    var stateMachine = self.makeServerStateMachine(
+      targetState: .clientOpenServerIdle,
+      compressionEnabled: true
+    )
+
+    XCTAssertEqual(
+      try stateMachine.send(metadata: .init()),
+      [
+        ":status": "200",
+        "content-type": "application/grpc",
+        "grpc-encoding": "deflate",
+        "grpc-accept-encoding": "deflate",
+      ]
+    )
   }
 
   func testSendMetadataWhenClientOpenAndServerOpen() throws {


### PR DESCRIPTION
## Motivation
The `grpc-encoding` header is currently missing when the server sends a compressed response.

## Modifications
This PR makes sure that the compression algorithm is always available to the state machine so the server can send the `grpc-encoding` header when necessary.

## Result
The `grpc-encoding` header is present when the server sends a compressed response.