### PR TITLE
Better distinguish between connection drops and regular closes

### DIFF
--- a/Tests/GRPCHTTP2CoreTests/Client/Connection/Connection+Equatable.swift
+++ b/Tests/GRPCHTTP2CoreTests/Client/Connection/Connection+Equatable.swift
@@ -15,8 +15,7 @@
  */
 
 import GRPCCore
-
-@testable import GRPCHTTP2Core
+@_spi(Package) @testable import GRPCHTTP2Core
 
 @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 extension Connection.Event: Equatable {
@@ -48,13 +47,43 @@ extension Connection.CloseReason: Equatable {
       (.remote, .remote):
       return true
 
-    case (.error(let lhsError), .error(let rhsError)):
+    case (.error(let lhsError, let lhsStreams), .error(let rhsError, let rhsStreams)):
       if let lhs = lhsError as? RPCError, let rhs = rhsError as? RPCError {
-        return lhs == rhs
+        return lhs == rhs && lhsStreams == rhsStreams
       } else {
-        return true
+        return lhsStreams == rhsStreams
       }
 
+    default:
+      return false
+    }
+  }
+}
+
+extension ClientConnectionEvent: Equatable {
+  public static func == (lhs: ClientConnectionEvent, rhs: ClientConnectionEvent) -> Bool {
+    switch (lhs, rhs) {
+    case (.ready, .ready):
+      return true
+    case (.closing(let lhsReason), .closing(let rhsReason)):
+      return lhsReason == rhsReason
+    default:
+      return false
+    }
+  }
+}
+
+extension ClientConnectionEvent.CloseReason: Equatable {
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    switch (lhs, rhs) {
+    case (.goAway(let lhsCode, let lhsMessage), .goAway(let rhsCode, let rhsMessage)):
+      return lhsCode == rhsCode && lhsMessage == rhsMessage
+    case (.unexpected(_, let lhsIsIdle), .unexpected(_, let rhsIsIdle)):
+      return lhsIsIdle == rhsIsIdle
+    case (.keepaliveExpired, .keepaliveExpired),
+      (.idle, .idle),
+      (.initiatedLocally, .initiatedLocally):
+      return true
     default:
       return false
     }

--- a/Tests/GRPCHTTP2CoreTests/Client/Connection/Connection+Equatable.swift
+++ b/Tests/GRPCHTTP2CoreTests/Client/Connection/Connection+Equatable.swift
@@ -78,8 +78,12 @@ extension ClientConnectionEvent.CloseReason: Equatable {
     switch (lhs, rhs) {
     case (.goAway(let lhsCode, let lhsMessage), .goAway(let rhsCode, let rhsMessage)):
       return lhsCode == rhsCode && lhsMessage == rhsMessage
-    case (.unexpected(_, let lhsIsIdle), .unexpected(_, let rhsIsIdle)):
-      return lhsIsIdle == rhsIsIdle
+    case (.unexpected(let lhsError, let lhsIsIdle), .unexpected(let rhsError, let rhsIsIdle)):
+      if let lhs = lhsError as? RPCError, let rhs = rhsError as? RPCError {
+        return lhs == rhs && lhsIsIdle == rhsIsIdle
+      } else {
+        return lhsIsIdle == rhsIsIdle
+      }
     case (.keepaliveExpired, .keepaliveExpired),
       (.idle, .idle),
       (.initiatedLocally, .initiatedLocally):


### PR DESCRIPTION
Motivation:

If a connection is closed because the tcp connection is dropped then the `Connection` doesn't receive any indication as to why it was closed which ends up being classified as a locally initiated close. In turns the subchannel will be shutdown and can't be reused.

This isn't correct: we know the connection was dropped unexpectedly and we whether there were any active RPCs at the time. This means the subchannel can transition to idle if there were no active RPCs or transient failure if there were.

Modifications:

- Add a new 'unexpected' close reason to the connection handler which optionally includes an error. This can provide further diagnostic information as to why a connection has been dropped.
- Alter the semantics in subchannel such that go-aways and unexpected closes when there are no RPCs transition cause a transition to the idle state, and unexpected closes when there are RPCs lead to a transition to the transient failure state.

Result:

More sensible state updates when connections are closed