### PR TITLE
Update to a newer version of NIO HTTP/2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let packageDependencies: [Package.Dependency] = [
   ),
   .package(
     url: "https://github.com/apple/swift-nio-http2.git",
-    from: "1.31.0"
+    from: "1.32.0"
   ),
   .package(
     url: "https://github.com/apple/swift-nio-transport-services.git",

--- a/Sources/GRPCHTTP2Core/Client/Connection/ClientConnectionHandler.swift
+++ b/Sources/GRPCHTTP2Core/Client/Connection/ClientConnectionHandler.swift
@@ -247,8 +247,6 @@ final class ClientConnectionHandler: ChannelInboundHandler, ChannelOutboundHandl
         switch self.state.beginGracefulShutdown(promise: promise) {
         case .sendGoAway(let close):
           context.fireChannelRead(self.wrapInboundOut(.closing(.initiatedLocally)))
-          // Clients should send GOAWAYs when closing a connection.
-          self.writeAndFlushGoAway(context: context, errorCode: .noError)
           if close {
             context.close(promise: nil)
           }

--- a/Sources/GRPCHTTP2Core/Client/Connection/ClientConnectionHandler.swift
+++ b/Sources/GRPCHTTP2Core/Client/Connection/ClientConnectionHandler.swift
@@ -247,6 +247,8 @@ final class ClientConnectionHandler: ChannelInboundHandler, ChannelOutboundHandl
         switch self.state.beginGracefulShutdown(promise: promise) {
         case .sendGoAway(let close):
           context.fireChannelRead(self.wrapInboundOut(.closing(.initiatedLocally)))
+          // The client could send a GOAWAY at this point but it's not really necessary, the server
+          // can't open streams anyway, the client will just close the connection when it's done.
           if close {
             context.close(promise: nil)
           }

--- a/Tests/GRPCHTTP2CoreTests/Client/Connection/GRPCChannelTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Client/Connection/GRPCChannelTests.swift
@@ -329,8 +329,6 @@ final class GRPCChannelTests: XCTestCase {
   }
 
   func testCloseWhenRPCsAreInProgress() async throws {
-    try XCTSkipIf(true, "https://github.com/apple/swift-nio-http2/pull/439")
-
     // Verify that closing the channel while there are RPCs in progress allows the RPCs to finish
     // gracefully.
 

--- a/Tests/GRPCHTTP2CoreTests/Client/Connection/LoadBalancers/SubchannelTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Client/Connection/LoadBalancers/SubchannelTests.swift
@@ -386,8 +386,6 @@ final class SubchannelTests: XCTestCase {
   }
 
   func testConnectionDropWithOpenStreams() async throws {
-    try XCTSkipIf(true, "HTTP/2 stream delegate API isn't currently exposed")
-
     let server = TestServer(eventLoopGroup: .singletonMultiThreadedEventLoopGroup)
     let address = try await server.bind()
     let subchannel = self.makeSubchannel(address: address, connector: .posix())
@@ -439,6 +437,8 @@ final class SubchannelTests: XCTestCase {
         .connectivityStateChanged(.connecting),
         .connectivityStateChanged(.ready),
         .connectivityStateChanged(.transientFailure),
+        .requiresNameResolution,
+        .connectivityStateChanged(.connecting),
         .connectivityStateChanged(.shutdown),
       ]
 

--- a/Tests/GRPCHTTP2CoreTests/Client/Connection/Utilities/TestServer.swift
+++ b/Tests/GRPCHTTP2CoreTests/Client/Connection/Utilities/TestServer.swift
@@ -164,6 +164,7 @@ extension TestServer {
             try await outbound.write(.message(bytes))
           }
         }
+        try await outbound.write(.status(Status(code: .ok, message: ""), [:]))
       }
 
     case .never:


### PR DESCRIPTION
Motivation:

swift-nio-http2 1.32.0 contains new API we need for configuring an async http/2 pipeline with a stream delegate.

Modifications:

- Bump the minimum version
- Wire through the stream delegate
- Fix a test bug where the server didn't send the final status

Result:

Stream delegates are wired up