### PR TITLE
Use different test error

### DIFF
--- a/Tests/GRPCHTTP2CoreTests/Client/Connection/ClientConnectionHandlerTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Client/Connection/ClientConnectionHandlerTests.swift
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import GRPCCore
 @_spi(Package) @testable import GRPCHTTP2Core
 import NIOCore
 import NIOEmbedded
@@ -231,7 +232,7 @@ final class ClientConnectionHandlerTests: XCTestCase {
     XCTAssertEqual(try connection.readEvent(), .ready)
 
     // Write an error and close.
-    let error = CancellationError()
+    let error = RPCError(code: .aborted, message: "")
     connection.channel.pipeline.fireErrorCaught(error)
     connection.channel.close(mode: .all, promise: nil)
 
@@ -250,7 +251,7 @@ final class ClientConnectionHandlerTests: XCTestCase {
     connection.streamOpened(1)
 
     // Write an error and close.
-    let error = CancellationError()
+    let error = RPCError(code: .aborted, message: "")
     connection.channel.pipeline.fireErrorCaught(error)
     connection.channel.close(mode: .all, promise: nil)
 


### PR DESCRIPTION
Motivation:

Some tests arbitrarily used a CancellationError. This requires availability guards on the tests which were missing.

Modifications:

- Switch to a different error type which doesn't require availability

Result:

Tests build on more platforms