### PR TITLE
Better handle errors on client connections

### DIFF
--- a/Sources/GRPCHTTP2Core/Client/Connection/ClientConnectionHandler.swift
+++ b/Sources/GRPCHTTP2Core/Client/Connection/ClientConnectionHandler.swift
@@ -173,8 +173,11 @@ final class ClientConnectionHandler: ChannelInboundHandler, ChannelOutboundHandl
   }
 
   func errorCaught(context: ChannelHandlerContext, error: any Error) {
+    // Store the error and close, this will result in the final close event being fired down
+    // the pipeline with an appropriate close reason and appropriate error. (This avoids
+    // the async channel just throwing the error.)
     self.state.receivedError(error)
-    context.fireErrorCaught(error)
+    context.close(mode: .all, promise: nil)
   }
 
   func channelRead(context: ChannelHandlerContext, data: NIOAny) {


### PR DESCRIPTION
Motivation:

At the moment if an error is encountered on an active client connection an error is thrown from the async channel. This results in the `Connection` being closed and, without further information, the subchannel is returned to the idle state. This can lead to some tests being flaky.

Rather than throwing the error down the pipeline, we should store it and close the connection so that the client connection handler can fire an approriate close reason (with the error) down the pipeline before becoming inactive. This allows the `Connection` to inform the `Subchannel` whether it should attempt to reconnect or remain idle.

Modifications:

- Call close when receiving an error in `ClientConnectionHandler` rather than forwarding it
- Make `testConnectionDropWithOpenStreams` more reliable

Result:

More consistent behavior