### PR TITLE
Fix a few invalid state transitions

### DIFF
--- a/Sources/GRPCHTTP2Core/Client/GRPCClientStreamHandler.swift
+++ b/Sources/GRPCHTTP2Core/Client/GRPCClientStreamHandler.swift
@@ -85,8 +85,12 @@ extension GRPCClientStreamHandler {
                 // If this happens, we should have forwarded an error status above
                 // so we should never reach this point. Do nothing.
                 break loop
+              case .doNothing:
+                break loop
               }
             }
+          case .doNothing:
+            ()
           }
         } catch {
           context.fireErrorCaught(error)

--- a/Sources/GRPCHTTP2Core/Server/GRPCServerStreamHandler.swift
+++ b/Sources/GRPCHTTP2Core/Server/GRPCServerStreamHandler.swift
@@ -83,8 +83,12 @@ extension GRPCServerStreamHandler {
               case .noMoreMessages:
                 context.fireUserInboundEventTriggered(ChannelEvent.inputClosed)
                 break loop
+              case .doNothing:
+                break loop
               }
             }
+          case .doNothing:
+            ()
           }
         } catch {
           context.fireErrorCaught(error)


### PR DESCRIPTION
Motivation:

The server stream state machine has a couple of rough edges. Broadly
speaking there are three categories of issue:

1. Mixing protocol errors with invalid state.
2. Remaining open when the server closes.
3. Not making a state transition.

In (1) an incorrectly implemented client could hit an assertion failure
because the state was believed to be unreachable. This isn't right, we
should close the stream instead.

For (2) the RPC is considered done when the server sends the final
status. In such situations any input from the client should be dropped
on the floor, it isn't necessarily invalid, but the server has no use
for it as the processing of the RPC has been completed.

For (3) this was missed a number of times when the server receives the
initial headers. To work around this the processing of headers was moved
to be a member function of the substate which also returns the next
state the state machine should transition to. This forces the
implementer to think about state transitions as well as side effects.

Modifications:

- Avoid invalid state in a few places
- Move to client and server closed when the server sends a status

Results:

Fewer bugs