### PR TITLE
Remove a few retroactive conformance warnings

### DIFF
--- a/Sources/GRPCHTTP2Core/Server/GRPCServerStreamHandler.swift
+++ b/Sources/GRPCHTTP2Core/Server/GRPCServerStreamHandler.swift
@@ -19,7 +19,7 @@ import NIOCore
 import NIOHTTP2
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-final class GRPCServerStreamHandler: ChannelDuplexHandler {
+final class GRPCServerStreamHandler: ChannelDuplexHandler, RemovableChannelHandler {
   typealias InboundIn = HTTP2Frame.FramePayload
   typealias InboundOut = RPCRequestPart
 

--- a/Tests/GRPCHTTP2CoreTests/Client/Connection/Connection+Equatable.swift
+++ b/Tests/GRPCHTTP2CoreTests/Client/Connection/Connection+Equatable.swift
@@ -17,8 +17,30 @@
 import GRPCCore
 @_spi(Package) @testable import GRPCHTTP2Core
 
+// Equatable conformance for these types is 'best effort', this is sufficient for testing but not
+// for general use. As such the conformance is added in the test module and must be declared
+// as a `@retroactive` conformance.
+#if compiler(>=6.0)
 @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
-extension Connection.Event: Equatable {
+extension Connection.Event: @retroactive Equatable {}
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+extension Connection.CloseReason: @retroactive Equatable {}
+
+extension ClientConnectionEvent: @retroactive Equatable {}
+extension ClientConnectionEvent.CloseReason: @retroactive Equatable {}
+
+#else
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+extension Connection.Event: Equatable {}
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+extension Connection.CloseReason: Equatable {}
+
+extension ClientConnectionEvent: Equatable {}
+extension ClientConnectionEvent.CloseReason: Equatable {}
+#endif
+
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+extension Connection.Event {
   public static func == (lhs: Connection.Event, rhs: Connection.Event) -> Bool {
     switch (lhs, rhs) {
     case (.connectSucceeded, .connectSucceeded),
@@ -38,7 +60,7 @@ extension Connection.Event: Equatable {
 }
 
 @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
-extension Connection.CloseReason: Equatable {
+extension Connection.CloseReason {
   public static func == (lhs: Connection.CloseReason, rhs: Connection.CloseReason) -> Bool {
     switch (lhs, rhs) {
     case (.idleTimeout, .idleTimeout),
@@ -60,7 +82,7 @@ extension Connection.CloseReason: Equatable {
   }
 }
 
-extension ClientConnectionEvent: Equatable {
+extension ClientConnectionEvent {
   public static func == (lhs: ClientConnectionEvent, rhs: ClientConnectionEvent) -> Bool {
     switch (lhs, rhs) {
     case (.ready, .ready):
@@ -73,7 +95,7 @@ extension ClientConnectionEvent: Equatable {
   }
 }
 
-extension ClientConnectionEvent.CloseReason: Equatable {
+extension ClientConnectionEvent.CloseReason {
   public static func == (lhs: Self, rhs: Self) -> Bool {
     switch (lhs, rhs) {
     case (.goAway(let lhsCode, let lhsMessage), .goAway(let rhsCode, let rhsMessage)):

--- a/Tests/GRPCHTTP2CoreTests/Server/GRPCServerStreamHandlerTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Server/GRPCServerStreamHandlerTests.swift
@@ -909,6 +909,3 @@ extension EmbeddedChannel {
 private enum TestError: Error {
   case assertionFailure(String)
 }
-
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-extension GRPCServerStreamHandler: RemovableChannelHandler {}


### PR DESCRIPTION
Motivation:

Swift 6 warns when types retroactively conform to a protocol. There are a few places where we do this, for example in testing where we add 'best effort' equatable conformance. These warnings can be suppressed by marking the conformance as `@retroactive`.

Modifications:

- Add `@retroactive` to a conformances in tests
- Move conformance to `RemovableChannelHandler` to the core module the server stream handler

Result:

Fewer warnings