### PR TITLE
Add client to v2 interop tests

### DIFF
--- a/Sources/InteroperabilityTests/InteroperabilityTestCase.swift
+++ b/Sources/InteroperabilityTests/InteroperabilityTestCase.swift
@@ -66,6 +66,27 @@ public enum InteroperabilityTestCase: String, CaseIterable {
   }
 }
 
+public struct InteroperabilityTestError: Error {
+  private enum _Error {
+    case testNotFound(name: String)
+    case testFailed(cause: any Error)
+  }
+
+  private let _error: _Error
+
+  private init(_error: _Error) {
+    self._error = _error
+  }
+
+  public static func testNotFound(name: String) -> Self {
+    Self(_error: .testNotFound(name: name))
+  }
+
+  public static func testFailed(cause error: any Error) -> Self {
+    Self(_error: .testFailed(cause: error))
+  }
+}
+
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension InteroperabilityTestCase {
   /// Return a new instance of the test case.

--- a/Sources/InteroperabilityTests/InteroperabilityTestCase.swift
+++ b/Sources/InteroperabilityTests/InteroperabilityTestCase.swift
@@ -66,27 +66,6 @@ public enum InteroperabilityTestCase: String, CaseIterable {
   }
 }
 
-public struct InteroperabilityTestError: Error {
-  private enum _Error {
-    case testNotFound(name: String)
-    case testFailed(cause: any Error)
-  }
-
-  private let _error: _Error
-
-  private init(_error: _Error) {
-    self._error = _error
-  }
-
-  public static func testNotFound(name: String) -> Self {
-    Self(_error: .testNotFound(name: name))
-  }
-
-  public static func testFailed(cause error: any Error) -> Self {
-    Self(_error: .testFailed(cause: error))
-  }
-}
-
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension InteroperabilityTestCase {
   /// Return a new instance of the test case.


### PR DESCRIPTION
## Motivation
The counterpart to https://github.com/grpc/grpc-swift/pull/1897

## Modifications
We now have the GRPCClient integrated with the v2 interop tests. 

## Result
We can now run v2 client against v2 server interop tests.