### PR TITLE
Fix a few server state machine transitions

### DIFF
--- a/Sources/GRPCHTTP2Core/Client/GRPCClientStreamHandler.swift
+++ b/Sources/GRPCHTTP2Core/Client/GRPCClientStreamHandler.swift
@@ -87,6 +87,9 @@ extension GRPCClientStreamHandler {
                 break loop
               }
             }
+
+          case .doNothing:
+            ()
           }
         } catch {
           context.fireErrorCaught(error)

--- a/Sources/GRPCHTTP2Core/Client/GRPCClientStreamHandler.swift
+++ b/Sources/GRPCHTTP2Core/Client/GRPCClientStreamHandler.swift
@@ -116,6 +116,10 @@ extension GRPCClientStreamHandler {
           context.fireChannelRead(self.wrapInboundOut(.status(status, metadata)))
           context.fireUserInboundEventTriggered(ChannelEvent.inputClosed)
 
+        case .protocolViolation:
+          // Should only happen for servers
+          assertionFailure("Unexpected protocol violation")
+
         case .doNothing:
           ()
         }

--- a/Sources/GRPCHTTP2Core/GRPCStreamStateMachine.swift
+++ b/Sources/GRPCHTTP2Core/GRPCStreamStateMachine.swift
@@ -1422,24 +1422,26 @@ extension GRPCStreamStateMachine {
       let request = state.inboundMessageBuffer.pop()
       self.state = .clientOpenServerIdle(state)
       return request.map { .receiveMessage($0) } ?? .awaitMoreMessages
+
     case .clientOpenServerOpen(var state):
       let request = state.inboundMessageBuffer.pop()
       self.state = .clientOpenServerOpen(state)
       return request.map { .receiveMessage($0) } ?? .awaitMoreMessages
-    case .clientOpenServerClosed(var state):
+
+    case .clientClosedServerIdle(var state):
       let request = state.inboundMessageBuffer.pop()
-      self.state = .clientOpenServerClosed(state)
-      return request.map { .receiveMessage($0) } ?? .awaitMoreMessages
+      self.state = .clientClosedServerIdle(state)
+      return request.map { .receiveMessage($0) } ?? .noMoreMessages
+
     case .clientClosedServerOpen(var state):
       let request = state.inboundMessageBuffer.pop()
       self.state = .clientClosedServerOpen(state)
       return request.map { .receiveMessage($0) } ?? .noMoreMessages
-    case .clientClosedServerClosed(var state):
-      let request = state.inboundMessageBuffer.pop()
-      self.state = .clientClosedServerClosed(state)
-      return request.map { .receiveMessage($0) } ?? .noMoreMessages
-    case .clientClosedServerIdle:
+
+    case .clientOpenServerClosed, .clientClosedServerClosed:
+      // Server has closed, no need to read.
       return .noMoreMessages
+
     case .clientIdleServerIdle:
       return .awaitMoreMessages
     }

--- a/Sources/GRPCHTTP2Core/Server/GRPCServerStreamHandler.swift
+++ b/Sources/GRPCHTTP2Core/Server/GRPCServerStreamHandler.swift
@@ -85,6 +85,8 @@ extension GRPCServerStreamHandler {
                 break loop
               }
             }
+          case .doNothing:
+            ()
           }
         } catch {
           context.fireErrorCaught(error)

--- a/Sources/GRPCHTTP2Core/Server/GRPCServerStreamHandler.swift
+++ b/Sources/GRPCHTTP2Core/Server/GRPCServerStreamHandler.swift
@@ -126,6 +126,10 @@ extension GRPCServerStreamHandler {
             message: "Server cannot get receivedStatusAndMetadata."
           )
 
+        case .protocolViolation:
+          context.writeAndFlush(self.wrapOutboundOut(.rstStream(.protocolError)), promise: nil)
+          context.close(promise: nil)
+
         case .doNothing:
           throw RPCError(code: .internalError, message: "Server cannot receive doNothing.")
         }

--- a/Tests/GRPCHTTP2CoreTests/GRPCStreamStateMachineTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/GRPCStreamStateMachineTests.swift
@@ -2085,7 +2085,7 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
     var stateMachine = self.makeServerStateMachine(targetState: .clientOpenServerClosed)
 
     // Client is not done sending request, don't fail.
-    XCTAssertNoThrow(try stateMachine.receive(buffer: .init(), endStream: false))
+    XCTAssertEqual(try stateMachine.receive(buffer: ByteBuffer(), endStream: false), .doNothing)
   }
 
   func testReceiveMessageWhenClientClosedAndServerIdle() {

--- a/Tests/GRPCHTTP2CoreTests/Test Utilities/XCTest+Utilities.swift
+++ b/Tests/GRPCHTTP2CoreTests/Test Utilities/XCTest+Utilities.swift
@@ -18,12 +18,14 @@ import XCTest
 
 func XCTAssertThrowsError<T, E: Error>(
   ofType: E.Type,
+  file: StaticString = #filePath,
+  line: UInt = #line,
   _ expression: @autoclosure () throws -> T,
   _ errorHandler: (E) -> Void
 ) {
-  XCTAssertThrowsError(try expression()) { error in
+  XCTAssertThrowsError(try expression(), file: file, line: line) { error in
     guard let error = error as? E else {
-      return XCTFail("Error had unexpected type '\(type(of: error))'")
+      return XCTFail("Error had unexpected type '\(type(of: error))'", file: file, line: line)
     }
     errorHandler(error)
   }


### PR DESCRIPTION
Motivation:

The server stream state machine had a few incorrect or missing state
transitions.

Modification:

- Add missing transition when receiving headers
- Close the stream if the client misbehaves
- Don't read inbound when the server has closed
- Read inbound when the client is closed and the server isn't

Result:

Fewer bugs