### PR TITLE
Add 'cause' to error description if present

### DIFF
--- a/Sources/GRPCCore/RPCError.swift
+++ b/Sources/GRPCCore/RPCError.swift
@@ -74,7 +74,11 @@ public struct RPCError: Sendable, Hashable, Error {
 
 extension RPCError: CustomStringConvertible {
   public var description: String {
-    "\(self.code): \"\(self.message)\""
+    if let cause = self.cause {
+      return "\(self.code): \"\(self.message)\" (cause: \"\(cause)\")"
+    } else {
+      return "\(self.code): \"\(self.message)\""
+    }
   }
 }
 

--- a/Tests/GRPCCoreTests/RPCErrorTests.swift
+++ b/Tests/GRPCCoreTests/RPCErrorTests.swift
@@ -40,6 +40,10 @@ final class RPCErrorTests: XCTestCase {
     XCTAssertDescription(RPCError(code: .dataLoss, message: ""), #"dataLoss: """#)
     XCTAssertDescription(RPCError(code: .unknown, message: "message"), #"unknown: "message""#)
     XCTAssertDescription(RPCError(code: .aborted, message: "message"), #"aborted: "message""#)
+    XCTAssertDescription(
+      RPCError(code: .aborted, message: "message", cause: CancellationError()),
+      #"aborted: "message" (cause: "CancellationError()")"#
+    )
   }
 
   func testErrorFromStatus() throws {


### PR DESCRIPTION
Motivation:

A description of an `RPCError`'s `cause` isn't included in its description if present, it should be to provide more context.

Modifications:

- Add cause to the description if present

Result:

More context in errors