### PR TITLE
Update links in documents

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,3 +1,3 @@
 ## Community Code of Conduct
 
-gRPC follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+gRPC follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # How to contribute
 
 We definitely welcome patches and contributions to grpc-swift! Please read the gRPC
-organization's [governance rules](https://github.com/grpc/grpc-community/blob/master/governance.md)
-and [contribution guidelines](https://github.com/grpc/grpc-community/blob/master/CONTRIBUTING.md) before proceeding.
+organization's [governance rules](https://github.com/grpc/grpc-community/blob/main/governance.md)
+and [contribution guidelines](https://github.com/grpc/grpc-community/blob/main/CONTRIBUTING.md) before proceeding.
 
 Here are some guidelines and information about how to participate.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,1 +1,1 @@
-This repository is governed by the gRPC organization's [governance rules](https://github.com/grpc/grpc-community/blob/master/governance.md).
+This repository is governed by the gRPC organization's [governance rules](https://github.com/grpc/grpc-community/blob/main/governance.md).

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,9 +2,9 @@ This page lists all active maintainers of this repository. If you were a
 maintainer and would like to add your name to the Emeritus list, please send us a
 PR.
 
-See [GOVERNANCE.md](https://github.com/grpc/grpc-community/blob/master/governance.md)
+See [GOVERNANCE.md](https://github.com/grpc/grpc-community/blob/main/governance.md)
 for governance guidelines and how to become a maintainer.
-See [CONTRIBUTING.md](https://github.com/grpc/grpc-community/blob/master/CONTRIBUTING.md)
+See [CONTRIBUTING.md](https://github.com/grpc/grpc-community/blob/main/CONTRIBUTING.md)
 for general contribution guidelines.
 
 ## Maintainers (in alphabetical order)

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -119,6 +119,6 @@ protoc <your proto> --grpc-swift_opt=Client=true,Server=false --grpc-swift_out=.
 ```
 
 [protocol-buffers]: https://developers.google.com/protocol-buffers/docs/overview
-[swift-protobuf-filenaming]: https://github.com/apple/swift-protobuf/blob/master/Documentation/PLUGIN.md#generation-option-filenaming---naming-of-generated-sources
-[swift-protobuf-module-mappings]: https://github.com/apple/swift-protobuf/blob/master/Documentation/PLUGIN.md#generation-option-protopathmodulemappings---swift-module-names-for-proto-paths
+[swift-protobuf-filenaming]: https://github.com/apple/swift-protobuf/blob/main/Documentation/PLUGIN.md#generation-option-filenaming---naming-of-generated-sources
+[swift-protobuf-module-mappings]: https://github.com/apple/swift-protobuf/blob/main/Documentation/PLUGIN.md#generation-option-protopathmodulemappings---swift-module-names-for-proto-paths
 [swift-protobuf-module-name]: https://github.com/apple/swift-protobuf/commit/9df381f72ff22062080d434e9c2f68e71ee44298#diff-1b08f0a80bd568509049d851b8d8af90d1f2db3cd8711eaba974b5380cd59bf3


### PR DESCRIPTION
This PR updates some links in the documents because branch 'master' was renamed to 'main' in some repositories.