### PR TITLE
Allow single response to contain initial metadata and error

### DIFF
--- a/Sources/GRPCCore/Call/Client/Internal/ClientResponse+Convenience.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientResponse+Convenience.swift
@@ -70,7 +70,7 @@ extension ClientResponse.Single {
         }
       } catch let error as RPCError {
         // Known error type.
-        self.accepted = .failure(error)
+        self.accepted = .success(Contents(metadata: contents.metadata, error: error))
       } catch {
         // Unexpected, but should be handled nonetheless.
         self.accepted = .failure(RPCError(code: .unknown, message: String(describing: error)))

--- a/Tests/GRPCCoreTests/Call/Client/ClientResponseTests.swift
+++ b/Tests/GRPCCoreTests/Call/Client/ClientResponseTests.swift
@@ -43,6 +43,17 @@ final class ClientResponseTests: XCTestCase {
     XCTAssertEqual(response.trailingMetadata, ["bar": "baz"])
   }
 
+  func testAcceptedButFailedSingleResponseConvenienceMethods() {
+    let error = RPCError(code: .aborted, message: "error message", metadata: ["bar": "baz"])
+    let response = ClientResponse.Single(of: String.self, metadata: ["foo": "bar"], error: error)
+
+    XCTAssertEqual(response.metadata, ["foo": "bar"])
+    XCTAssertThrowsRPCError(try response.message) {
+      XCTAssertEqual($0, error)
+    }
+    XCTAssertEqual(response.trailingMetadata, ["bar": "baz"])
+  }
+
   func testAcceptedStreamResponseConvenienceMethods() async throws {
     let response = ClientResponse.Stream(
       of: String.self,


### PR DESCRIPTION
Motivation:

Currently the client API doesn't allow for users to distinguish between receiving metadata and a failed status and just a failed status. The distinction being that the server "accepted" the former request but it resulted in failure and the rejected the latter.

Modifications:

- Allow this to be represented by turning the message in the contents to be a result

Result:

More flexible API