### PR TITLE
Remove input/output typealiases for RPC methods

### DIFF
--- a/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
@@ -214,18 +214,12 @@ extension ClientCodeTranslator {
         FunctionArgumentDescription(label: "request", expression: .identifierPattern("request")),
         FunctionArgumentDescription(
           label: "serializer",
-          expression: .identifierPattern(
-            codeGenerationRequest.lookupSerializer(
-              self.methodInputOutputTypealias(for: method, service: service, type: .input)
-            )
-          )
+          expression: .identifierPattern(codeGenerationRequest.lookupSerializer(method.inputType))
         ),
         FunctionArgumentDescription(
           label: "deserializer",
           expression: .identifierPattern(
-            codeGenerationRequest.lookupDeserializer(
-              self.methodInputOutputTypealias(for: method, service: service, type: .output)
-            )
+            codeGenerationRequest.lookupDeserializer(method.outputType)
           )
         ),
         FunctionArgumentDescription(label: "options", expression: .identifierPattern("options")),
@@ -273,9 +267,7 @@ extension ClientCodeTranslator {
       label: "request",
       type: .generic(
         wrapper: clientRequestType,
-        wrapped: .member(
-          self.methodInputOutputTypealias(for: method, service: service, type: .input)
-        )
+        wrapped: .member(method.inputType)
       )
     )
   }
@@ -289,9 +281,7 @@ extension ClientCodeTranslator {
       type: ExistingTypeDescription.some(
         .generic(
           wrapper: .member("MessageSerializer"),
-          wrapped: .member(
-            self.methodInputOutputTypealias(for: method, service: service, type: .input)
-          )
+          wrapped: .member(method.inputType)
         )
       )
     )
@@ -306,9 +296,7 @@ extension ClientCodeTranslator {
       type: ExistingTypeDescription.some(
         .generic(
           wrapper: .member("MessageDeserializer"),
-          wrapped: .member(
-            self.methodInputOutputTypealias(for: method, service: service, type: .output)
-          )
+          wrapped: .member(method.outputType)
         )
       )
     )
@@ -321,9 +309,7 @@ extension ClientCodeTranslator {
     let clientStreaming = method.isOutputStreaming ? "Stream" : "Single"
     let closureParameterType = ExistingTypeDescription.generic(
       wrapper: .member(["ClientResponse", clientStreaming]),
-      wrapped: .member(
-        self.methodInputOutputTypealias(for: method, service: service, type: .output)
-      )
+      wrapped: .member(method.outputType)
     )
 
     let bodyClosure = ClosureSignatureDescription(
@@ -457,24 +443,5 @@ extension ClientCodeTranslator {
   fileprivate enum InputOutputType {
     case input
     case output
-  }
-
-  /// Generates the fully qualified name of the typealias for the input or output type of a method.
-  private func methodInputOutputTypealias(
-    for method: CodeGenerationRequest.ServiceDescriptor.MethodDescriptor,
-    service: CodeGenerationRequest.ServiceDescriptor,
-    type: InputOutputType
-  ) -> String {
-    var components: String =
-      "\(service.namespacedGeneratedName).Method.\(method.name.generatedUpperCase)"
-
-    switch type {
-    case .input:
-      components.append(".Input")
-    case .output:
-      components.append(".Output")
-    }
-
-    return components
   }
 }

--- a/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
@@ -18,51 +18,56 @@
 /// specifications, using types from ``StructuredSwiftRepresentation``.
 ///
 /// For example, in the case of a service called "Bar", in the "foo" namespace which has
-/// one method "baz", the ``ClientCodeTranslator`` will create
+/// one method "baz" with input type "Input" and output type "Output", the ``ClientCodeTranslator`` will create
 /// a representation for the following generated code:
 ///
 /// ```swift
 /// @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 /// public protocol Foo_BarClientProtocol: Sendable {
-///   func baz<R: Sendable>(
-///     request: ClientRequest.Single<foo.Bar.Method.baz.Input>,
-///     serializer: some MessageSerializer<foo.Bar.Method.baz.Input>,
-///     deserializer: some MessageDeserializer<foo.Bar.Method.baz.Output>,
-///     _ body: @Sendable @escaping (ClientResponse.Single<foo.Bar.Method.Baz.Output>) async throws -> R
-///   ) async throws -> ServerResponse.Stream<foo.Bar.Method.Baz.Output>
+///   func baz<R>(
+///     request: ClientRequest.Single<Foo_Bar_Input>,
+///     serializer: some MessageSerializer<Foo_Bar_Input>,
+///     deserializer: some MessageDeserializer<Foo_Bar_Output>,
+///     options: CallOptions = .defaults,
+///     _ body: @Sendable @escaping (ClientResponse.Single<Foo_Bar_Output>) async throws -> R
+///   ) async throws -> R where R: Sendable
 /// }
 /// @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-/// extension Foo.Bar.ClientProtocol {
-///   public func get<R: Sendable>(
-///     request: ClientRequest.Single<Foo.Bar.Method.Baz.Input>,
-///     _ body: @Sendable @escaping (ClientResponse.Single<Foo.Bar.Method.Baz.Output>) async throws -> R
-///   ) async rethrows -> R {
+/// extension Foo_Bar.ClientProtocol {
+///   public func baz<R>(
+///     request: ClientRequest.Single<Foo_Bar_Input>,
+///     options: CallOptions = .defaults,
+///     _ body: @Sendable @escaping (ClientResponse.Single<Foo_Bar_Output>) async throws -> R
+///   ) async throws -> R where R: Sendable {
 ///     try await self.baz(
 ///       request: request,
-///       serializer: ProtobufSerializer<Foo.Bar.Method.Baz.Input>(),
-///       deserializer: ProtobufDeserializer<Foo.Bar.Method.Baz.Output>(),
+///       serializer: ProtobufSerializer<Foo_Bar_Input>(),
+///       deserializer: ProtobufDeserializer<Foo_Bar_Output>(),
+///       options: options,
 ///       body
 ///     )
 /// }
 /// @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-/// public struct foo_BarClient: foo.Bar.ClientProtocol {
+/// public struct Foo_BarClient: Foo_Bar.ClientProtocol {
 ///   private let client: GRPCCore.GRPCClient
 ///   public init(client: GRPCCore.GRPCClient) {
 ///     self.client = client
 ///   }
-///   public func methodA<R: Sendable>(
-///     request: ClientRequest.Stream<namespaceA.ServiceA.Method.methodA.Input>,
-///     serializer: some MessageSerializer<namespaceA.ServiceA.Method.methodA.Input>,
-///     deserializer: some MessageDeserializer<namespaceA.ServiceA.Method.methodA.Output>,
-///     _ body: @Sendable @escaping (ClientResponse.Single<namespaceA.ServiceA.Method.methodA.Output>) async throws -> R
-///   ) async rethrows -> R {
-///    try await self.client.clientStreaming(
-///      request: request,
-///      descriptor: NamespaceA.ServiceA.Method.MethodA.descriptor,
-///      serializer: serializer,
-///      deserializer: deserializer,
-///      handler: body
-///      )
+///   public func methodA<R>(
+///     request: ClientRequest.Stream<Foo_Bar_Input>,
+///     serializer: some MessageSerializer<Foo_Bar_Input>,
+///     deserializer: some MessageDeserializer<Foo_Bar_Output>,
+///     options: CallOptions = .defaults,
+///     _ body: @Sendable @escaping (ClientResponse.Single<Foo_Bar_Output>) async throws -> R
+///   ) async throws -> R where R: Sendable {
+///     try await self.client.unary(
+///       request: request,
+///       descriptor: NamespaceA.ServiceA.Method.MethodA.descriptor,
+///       serializer: serializer,
+///       deserializer: deserializer,
+///       options: options,
+///       handler: body
+///     )
 ///   }
 /// }
 ///```

--- a/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
@@ -148,9 +148,7 @@ extension ServerCodeTranslator {
           label: "request",
           type: .generic(
             wrapper: .member(["ServerRequest", "Stream"]),
-            wrapped: .member(
-              self.methodInputOutputTypealias(for: method, service: service, type: .input)
-            )
+            wrapped: .member(method.inputType)
           )
         )
       ],
@@ -158,9 +156,7 @@ extension ServerCodeTranslator {
       returnType: .identifierType(
         .generic(
           wrapper: .member(["ServerResponse", "Stream"]),
-          wrapped: .member(
-            self.methodInputOutputTypealias(for: method, service: service, type: .output)
-          )
+          wrapped: .member(method.outputType)
         )
       )
     )
@@ -244,11 +240,7 @@ extension ServerCodeTranslator {
     arguments.append(
       .init(
         label: "deserializer",
-        expression: .identifierPattern(
-          codeGenerationRequest.lookupDeserializer(
-            self.methodInputOutputTypealias(for: method, service: service, type: .input)
-          )
-        )
+        expression: .identifierPattern(codeGenerationRequest.lookupDeserializer(method.inputType))
       )
     )
 
@@ -256,11 +248,7 @@ extension ServerCodeTranslator {
       .init(
         label: "serializer",
         expression:
-          .identifierPattern(
-            codeGenerationRequest.lookupSerializer(
-              self.methodInputOutputTypealias(for: method, service: service, type: .output)
-            )
-          )
+          .identifierPattern(codeGenerationRequest.lookupSerializer(method.outputType))
       )
     )
 
@@ -326,17 +314,6 @@ extension ServerCodeTranslator {
     let inputStreaming = method.isInputStreaming ? "Stream" : "Single"
     let outputStreaming = method.isOutputStreaming ? "Stream" : "Single"
 
-    let inputTypealiasComponents = self.methodInputOutputTypealias(
-      for: method,
-      service: service,
-      type: .input
-    )
-    let outputTypealiasComponents = self.methodInputOutputTypealias(
-      for: method,
-      service: service,
-      type: .output
-    )
-
     let functionSignature = FunctionSignatureDescription(
       accessModifier: accessModifier,
       kind: .function(name: method.name.generatedLowerCase),
@@ -346,7 +323,7 @@ extension ServerCodeTranslator {
           type:
             .generic(
               wrapper: .member(["ServerRequest", inputStreaming]),
-              wrapped: .member(inputTypealiasComponents)
+              wrapped: .member(method.inputType)
             )
         )
       ],
@@ -354,7 +331,7 @@ extension ServerCodeTranslator {
       returnType: .identifierType(
         .generic(
           wrapper: .member(["ServerResponse", outputStreaming]),
-          wrapped: .member(outputTypealiasComponents)
+          wrapped: .member(method.outputType)
         )
       )
     )
@@ -470,25 +447,6 @@ extension ServerCodeTranslator {
   fileprivate enum InputOutputType {
     case input
     case output
-  }
-
-  /// Generates the fully qualified name of the typealias for the input or output type of a method.
-  private func methodInputOutputTypealias(
-    for method: CodeGenerationRequest.ServiceDescriptor.MethodDescriptor,
-    service: CodeGenerationRequest.ServiceDescriptor,
-    type: InputOutputType
-  ) -> String {
-    var components: String =
-      "\(service.namespacedGeneratedName).Method.\(method.name.generatedUpperCase)"
-
-    switch type {
-    case .input:
-      components.append(".Input")
-    case .output:
-      components.append(".Output")
-    }
-
-    return components
   }
 
   /// Generates the fully qualified name of a method descriptor.

--- a/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
@@ -18,41 +18,41 @@
 /// specifications, using types from ``StructuredSwiftRepresentation``.
 ///
 /// For example, in the case of a service called "Bar", in the "foo" namespace which has
-/// one method "baz", the ``ServerCodeTranslator`` will create
+/// one method "baz" with input type "Input" and output type "Output", the ``ServerCodeTranslator`` will create
 /// a representation for the following generated code:
 ///
 /// ```swift
 /// @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-/// public protocol foo_BarServiceStreamingProtocol: GRPCCore.RegistrableRPCService {
+/// public protocol Foo_BarStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
 ///   func baz(
-///     request: ServerRequest.Stream<foo.Method.baz.Input>
-///   ) async throws -> ServerResponse.Stream<foo.Method.baz.Output>
+///     request: ServerRequest.Stream<Foo_Bar_Input>
+///   ) async throws -> ServerResponse.Stream<Foo_Bar_Output>
 /// }
-/// // Generated conformance to `RegistrableRPCService`.
+/// // Conformance to `GRPCCore.RegistrableRPCService`.
 /// @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-/// extension foo.Bar.StreamingServiceProtocol {
-///   public func registerRPCs(with router: inout RPCRouter) {
+/// extension Foo_Bar.StreamingServiceProtocol {
+///   public func registerMethods(with router: inout GRPCCore.RPCRouter) {
 ///     router.registerHandler(
-///       forMethod: foo.Method.baz.descriptor,
-///       deserializer: ProtobufDeserializer<foo.Method.baz.Input>(),
-///       serializer: ProtobufSerializer<foo.Method.baz.Output>(),
+///       forMethod: Foo_Bar.Method.baz.descriptor,
+///       deserializer: ProtobufDeserializer<Foo_Bar_Input>(),
+///       serializer: ProtobufSerializer<Foo_Bar_Output>(),
 ///       handler: { request in try await self.baz(request: request) }
 ///     )
 ///   }
 /// }
 /// @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-/// public protocol foo_BarServiceProtocol: foo.Bar.StreamingServiceProtocol {
+/// public protocol Foo_BarServiceProtocol: Foo_Bar.StreamingServiceProtocol {
 ///   func baz(
-///     request: ServerRequest.Single<foo.Bar.Method.baz.Input>
-///   ) async throws -> ServerResponse.Single<foo.Bar.Method.baz.Output>
+///     request: ServerRequest.Single<Foo_Bar_Input>
+///   ) async throws -> ServerResponse.Single<Foo_Bar_Output>
 /// }
-/// // Generated partial conformance to `foo_BarStreamingServiceProtocol`.
+/// // Partial conformance to `Foo_BarStreamingServiceProtocol`.
 /// @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-/// extension foo.Bar.ServiceProtocol {
+/// extension Foo_Bar.ServiceProtocol {
 ///   public func baz(
-///     request: ServerRequest.Stream<foo.Bar.Method.baz.Input>
-///   ) async throws -> ServerResponse.Stream<foo.Bar.Method.baz.Output> {
-///     let response = try await self.baz(request: ServerRequest.Single(stream: request)
+///     request: ServerRequest.Stream<Foo_Bar_Input>
+///   ) async throws -> ServerResponse.Stream<Foo_Bar_Output> {
+///     let response = try await self.baz(request: ServerRequest.Single(stream: request))
 ///     return ServerResponse.Stream(single: response)
 ///   }
 /// }

--- a/Sources/InteroperabilityTests/Generated/test.grpc.swift
+++ b/Sources/InteroperabilityTests/Generated/test.grpc.swift
@@ -176,38 +176,38 @@ public enum Grpc_Testing_UnimplementedService {
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 public protocol Grpc_Testing_TestServiceStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
     /// One empty request followed by one empty response.
-    func emptyCall(request: ServerRequest.Stream<Grpc_Testing_TestService.Method.EmptyCall.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_TestService.Method.EmptyCall.Output>
+    func emptyCall(request: ServerRequest.Stream<Grpc_Testing_Empty>) async throws -> ServerResponse.Stream<Grpc_Testing_Empty>
 
     /// One request followed by one response.
-    func unaryCall(request: ServerRequest.Stream<Grpc_Testing_TestService.Method.UnaryCall.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_TestService.Method.UnaryCall.Output>
+    func unaryCall(request: ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_SimpleResponse>
 
     /// One request followed by one response. Response has cache control
     /// headers set such that a caching HTTP proxy (such as GFE) can
     /// satisfy subsequent requests.
-    func cacheableUnaryCall(request: ServerRequest.Stream<Grpc_Testing_TestService.Method.CacheableUnaryCall.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_TestService.Method.CacheableUnaryCall.Output>
+    func cacheableUnaryCall(request: ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_SimpleResponse>
 
     /// One request followed by a sequence of responses (streamed download).
     /// The server returns the payload with client desired type and sizes.
-    func streamingOutputCall(request: ServerRequest.Stream<Grpc_Testing_TestService.Method.StreamingOutputCall.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_TestService.Method.StreamingOutputCall.Output>
+    func streamingOutputCall(request: ServerRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>
 
     /// A sequence of requests followed by one response (streamed upload).
     /// The server returns the aggregated size of client payload as the result.
-    func streamingInputCall(request: ServerRequest.Stream<Grpc_Testing_TestService.Method.StreamingInputCall.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_TestService.Method.StreamingInputCall.Output>
+    func streamingInputCall(request: ServerRequest.Stream<Grpc_Testing_StreamingInputCallRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_StreamingInputCallResponse>
 
     /// A sequence of requests with each request served by the server immediately.
     /// As one request could lead to multiple responses, this interface
     /// demonstrates the idea of full duplexing.
-    func fullDuplexCall(request: ServerRequest.Stream<Grpc_Testing_TestService.Method.FullDuplexCall.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_TestService.Method.FullDuplexCall.Output>
+    func fullDuplexCall(request: ServerRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>
 
     /// A sequence of requests followed by a sequence of responses.
     /// The server buffers all the client requests and then serves them in order. A
     /// stream of responses are returned to the client when the server starts with
     /// first request.
-    func halfDuplexCall(request: ServerRequest.Stream<Grpc_Testing_TestService.Method.HalfDuplexCall.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_TestService.Method.HalfDuplexCall.Output>
+    func halfDuplexCall(request: ServerRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>
 
     /// The test server will not implement this method. It will be used
     /// to test the behavior when clients call unimplemented methods.
-    func unimplementedCall(request: ServerRequest.Stream<Grpc_Testing_TestService.Method.UnimplementedCall.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_TestService.Method.UnimplementedCall.Output>
+    func unimplementedCall(request: ServerRequest.Stream<Grpc_Testing_Empty>) async throws -> ServerResponse.Stream<Grpc_Testing_Empty>
 }
 
 /// Conformance to `GRPCCore.RegistrableRPCService`.
@@ -217,64 +217,64 @@ extension Grpc_Testing_TestService.StreamingServiceProtocol {
     public func registerMethods(with router: inout GRPCCore.RPCRouter) {
         router.registerHandler(
             forMethod: Grpc_Testing_TestService.Method.EmptyCall.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_TestService.Method.EmptyCall.Input>(),
-            serializer: ProtobufSerializer<Grpc_Testing_TestService.Method.EmptyCall.Output>(),
+            deserializer: ProtobufDeserializer<Grpc_Testing_Empty>(),
+            serializer: ProtobufSerializer<Grpc_Testing_Empty>(),
             handler: { request in
                 try await self.emptyCall(request: request)
             }
         )
         router.registerHandler(
             forMethod: Grpc_Testing_TestService.Method.UnaryCall.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_TestService.Method.UnaryCall.Input>(),
-            serializer: ProtobufSerializer<Grpc_Testing_TestService.Method.UnaryCall.Output>(),
+            deserializer: ProtobufDeserializer<Grpc_Testing_SimpleRequest>(),
+            serializer: ProtobufSerializer<Grpc_Testing_SimpleResponse>(),
             handler: { request in
                 try await self.unaryCall(request: request)
             }
         )
         router.registerHandler(
             forMethod: Grpc_Testing_TestService.Method.CacheableUnaryCall.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_TestService.Method.CacheableUnaryCall.Input>(),
-            serializer: ProtobufSerializer<Grpc_Testing_TestService.Method.CacheableUnaryCall.Output>(),
+            deserializer: ProtobufDeserializer<Grpc_Testing_SimpleRequest>(),
+            serializer: ProtobufSerializer<Grpc_Testing_SimpleResponse>(),
             handler: { request in
                 try await self.cacheableUnaryCall(request: request)
             }
         )
         router.registerHandler(
             forMethod: Grpc_Testing_TestService.Method.StreamingOutputCall.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_TestService.Method.StreamingOutputCall.Input>(),
-            serializer: ProtobufSerializer<Grpc_Testing_TestService.Method.StreamingOutputCall.Output>(),
+            deserializer: ProtobufDeserializer<Grpc_Testing_StreamingOutputCallRequest>(),
+            serializer: ProtobufSerializer<Grpc_Testing_StreamingOutputCallResponse>(),
             handler: { request in
                 try await self.streamingOutputCall(request: request)
             }
         )
         router.registerHandler(
             forMethod: Grpc_Testing_TestService.Method.StreamingInputCall.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_TestService.Method.StreamingInputCall.Input>(),
-            serializer: ProtobufSerializer<Grpc_Testing_TestService.Method.StreamingInputCall.Output>(),
+            deserializer: ProtobufDeserializer<Grpc_Testing_StreamingInputCallRequest>(),
+            serializer: ProtobufSerializer<Grpc_Testing_StreamingInputCallResponse>(),
             handler: { request in
                 try await self.streamingInputCall(request: request)
             }
         )
         router.registerHandler(
             forMethod: Grpc_Testing_TestService.Method.FullDuplexCall.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_TestService.Method.FullDuplexCall.Input>(),
-            serializer: ProtobufSerializer<Grpc_Testing_TestService.Method.FullDuplexCall.Output>(),
+            deserializer: ProtobufDeserializer<Grpc_Testing_StreamingOutputCallRequest>(),
+            serializer: ProtobufSerializer<Grpc_Testing_StreamingOutputCallResponse>(),
             handler: { request in
                 try await self.fullDuplexCall(request: request)
             }
         )
         router.registerHandler(
             forMethod: Grpc_Testing_TestService.Method.HalfDuplexCall.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_TestService.Method.HalfDuplexCall.Input>(),
-            serializer: ProtobufSerializer<Grpc_Testing_TestService.Method.HalfDuplexCall.Output>(),
+            deserializer: ProtobufDeserializer<Grpc_Testing_StreamingOutputCallRequest>(),
+            serializer: ProtobufSerializer<Grpc_Testing_StreamingOutputCallResponse>(),
             handler: { request in
                 try await self.halfDuplexCall(request: request)
             }
         )
         router.registerHandler(
             forMethod: Grpc_Testing_TestService.Method.UnimplementedCall.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_TestService.Method.UnimplementedCall.Input>(),
-            serializer: ProtobufSerializer<Grpc_Testing_TestService.Method.UnimplementedCall.Output>(),
+            deserializer: ProtobufDeserializer<Grpc_Testing_Empty>(),
+            serializer: ProtobufSerializer<Grpc_Testing_Empty>(),
             handler: { request in
                 try await self.unimplementedCall(request: request)
             }
@@ -287,69 +287,69 @@ extension Grpc_Testing_TestService.StreamingServiceProtocol {
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 public protocol Grpc_Testing_TestServiceServiceProtocol: Grpc_Testing_TestService.StreamingServiceProtocol {
     /// One empty request followed by one empty response.
-    func emptyCall(request: ServerRequest.Single<Grpc_Testing_TestService.Method.EmptyCall.Input>) async throws -> ServerResponse.Single<Grpc_Testing_TestService.Method.EmptyCall.Output>
+    func emptyCall(request: ServerRequest.Single<Grpc_Testing_Empty>) async throws -> ServerResponse.Single<Grpc_Testing_Empty>
 
     /// One request followed by one response.
-    func unaryCall(request: ServerRequest.Single<Grpc_Testing_TestService.Method.UnaryCall.Input>) async throws -> ServerResponse.Single<Grpc_Testing_TestService.Method.UnaryCall.Output>
+    func unaryCall(request: ServerRequest.Single<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Single<Grpc_Testing_SimpleResponse>
 
     /// One request followed by one response. Response has cache control
     /// headers set such that a caching HTTP proxy (such as GFE) can
     /// satisfy subsequent requests.
-    func cacheableUnaryCall(request: ServerRequest.Single<Grpc_Testing_TestService.Method.CacheableUnaryCall.Input>) async throws -> ServerResponse.Single<Grpc_Testing_TestService.Method.CacheableUnaryCall.Output>
+    func cacheableUnaryCall(request: ServerRequest.Single<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Single<Grpc_Testing_SimpleResponse>
 
     /// One request followed by a sequence of responses (streamed download).
     /// The server returns the payload with client desired type and sizes.
-    func streamingOutputCall(request: ServerRequest.Single<Grpc_Testing_TestService.Method.StreamingOutputCall.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_TestService.Method.StreamingOutputCall.Output>
+    func streamingOutputCall(request: ServerRequest.Single<Grpc_Testing_StreamingOutputCallRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>
 
     /// A sequence of requests followed by one response (streamed upload).
     /// The server returns the aggregated size of client payload as the result.
-    func streamingInputCall(request: ServerRequest.Stream<Grpc_Testing_TestService.Method.StreamingInputCall.Input>) async throws -> ServerResponse.Single<Grpc_Testing_TestService.Method.StreamingInputCall.Output>
+    func streamingInputCall(request: ServerRequest.Stream<Grpc_Testing_StreamingInputCallRequest>) async throws -> ServerResponse.Single<Grpc_Testing_StreamingInputCallResponse>
 
     /// A sequence of requests with each request served by the server immediately.
     /// As one request could lead to multiple responses, this interface
     /// demonstrates the idea of full duplexing.
-    func fullDuplexCall(request: ServerRequest.Stream<Grpc_Testing_TestService.Method.FullDuplexCall.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_TestService.Method.FullDuplexCall.Output>
+    func fullDuplexCall(request: ServerRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>
 
     /// A sequence of requests followed by a sequence of responses.
     /// The server buffers all the client requests and then serves them in order. A
     /// stream of responses are returned to the client when the server starts with
     /// first request.
-    func halfDuplexCall(request: ServerRequest.Stream<Grpc_Testing_TestService.Method.HalfDuplexCall.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_TestService.Method.HalfDuplexCall.Output>
+    func halfDuplexCall(request: ServerRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>
 
     /// The test server will not implement this method. It will be used
     /// to test the behavior when clients call unimplemented methods.
-    func unimplementedCall(request: ServerRequest.Single<Grpc_Testing_TestService.Method.UnimplementedCall.Input>) async throws -> ServerResponse.Single<Grpc_Testing_TestService.Method.UnimplementedCall.Output>
+    func unimplementedCall(request: ServerRequest.Single<Grpc_Testing_Empty>) async throws -> ServerResponse.Single<Grpc_Testing_Empty>
 }
 
 /// Partial conformance to `Grpc_Testing_TestServiceStreamingServiceProtocol`.
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension Grpc_Testing_TestService.ServiceProtocol {
-    public func emptyCall(request: ServerRequest.Stream<Grpc_Testing_TestService.Method.EmptyCall.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_TestService.Method.EmptyCall.Output> {
+    public func emptyCall(request: ServerRequest.Stream<Grpc_Testing_Empty>) async throws -> ServerResponse.Stream<Grpc_Testing_Empty> {
         let response = try await self.emptyCall(request: ServerRequest.Single(stream: request))
         return ServerResponse.Stream(single: response)
     }
 
-    public func unaryCall(request: ServerRequest.Stream<Grpc_Testing_TestService.Method.UnaryCall.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_TestService.Method.UnaryCall.Output> {
+    public func unaryCall(request: ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_SimpleResponse> {
         let response = try await self.unaryCall(request: ServerRequest.Single(stream: request))
         return ServerResponse.Stream(single: response)
     }
 
-    public func cacheableUnaryCall(request: ServerRequest.Stream<Grpc_Testing_TestService.Method.CacheableUnaryCall.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_TestService.Method.CacheableUnaryCall.Output> {
+    public func cacheableUnaryCall(request: ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_SimpleResponse> {
         let response = try await self.cacheableUnaryCall(request: ServerRequest.Single(stream: request))
         return ServerResponse.Stream(single: response)
     }
 
-    public func streamingOutputCall(request: ServerRequest.Stream<Grpc_Testing_TestService.Method.StreamingOutputCall.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_TestService.Method.StreamingOutputCall.Output> {
+    public func streamingOutputCall(request: ServerRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_StreamingOutputCallResponse> {
         let response = try await self.streamingOutputCall(request: ServerRequest.Single(stream: request))
         return response
     }
 
-    public func streamingInputCall(request: ServerRequest.Stream<Grpc_Testing_TestService.Method.StreamingInputCall.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_TestService.Method.StreamingInputCall.Output> {
+    public func streamingInputCall(request: ServerRequest.Stream<Grpc_Testing_StreamingInputCallRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_StreamingInputCallResponse> {
         let response = try await self.streamingInputCall(request: request)
         return ServerResponse.Stream(single: response)
     }
 
-    public func unimplementedCall(request: ServerRequest.Stream<Grpc_Testing_TestService.Method.UnimplementedCall.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_TestService.Method.UnimplementedCall.Output> {
+    public func unimplementedCall(request: ServerRequest.Stream<Grpc_Testing_Empty>) async throws -> ServerResponse.Stream<Grpc_Testing_Empty> {
         let response = try await self.unimplementedCall(request: ServerRequest.Single(stream: request))
         return ServerResponse.Stream(single: response)
     }
@@ -360,7 +360,7 @@ extension Grpc_Testing_TestService.ServiceProtocol {
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 public protocol Grpc_Testing_UnimplementedServiceStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
     /// A call that no server should implement
-    func unimplementedCall(request: ServerRequest.Stream<Grpc_Testing_UnimplementedService.Method.UnimplementedCall.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_UnimplementedService.Method.UnimplementedCall.Output>
+    func unimplementedCall(request: ServerRequest.Stream<Grpc_Testing_Empty>) async throws -> ServerResponse.Stream<Grpc_Testing_Empty>
 }
 
 /// Conformance to `GRPCCore.RegistrableRPCService`.
@@ -370,8 +370,8 @@ extension Grpc_Testing_UnimplementedService.StreamingServiceProtocol {
     public func registerMethods(with router: inout GRPCCore.RPCRouter) {
         router.registerHandler(
             forMethod: Grpc_Testing_UnimplementedService.Method.UnimplementedCall.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_UnimplementedService.Method.UnimplementedCall.Input>(),
-            serializer: ProtobufSerializer<Grpc_Testing_UnimplementedService.Method.UnimplementedCall.Output>(),
+            deserializer: ProtobufDeserializer<Grpc_Testing_Empty>(),
+            serializer: ProtobufSerializer<Grpc_Testing_Empty>(),
             handler: { request in
                 try await self.unimplementedCall(request: request)
             }
@@ -384,13 +384,13 @@ extension Grpc_Testing_UnimplementedService.StreamingServiceProtocol {
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 public protocol Grpc_Testing_UnimplementedServiceServiceProtocol: Grpc_Testing_UnimplementedService.StreamingServiceProtocol {
     /// A call that no server should implement
-    func unimplementedCall(request: ServerRequest.Single<Grpc_Testing_UnimplementedService.Method.UnimplementedCall.Input>) async throws -> ServerResponse.Single<Grpc_Testing_UnimplementedService.Method.UnimplementedCall.Output>
+    func unimplementedCall(request: ServerRequest.Single<Grpc_Testing_Empty>) async throws -> ServerResponse.Single<Grpc_Testing_Empty>
 }
 
 /// Partial conformance to `Grpc_Testing_UnimplementedServiceStreamingServiceProtocol`.
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension Grpc_Testing_UnimplementedService.ServiceProtocol {
-    public func unimplementedCall(request: ServerRequest.Stream<Grpc_Testing_UnimplementedService.Method.UnimplementedCall.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_UnimplementedService.Method.UnimplementedCall.Output> {
+    public func unimplementedCall(request: ServerRequest.Stream<Grpc_Testing_Empty>) async throws -> ServerResponse.Stream<Grpc_Testing_Empty> {
         let response = try await self.unimplementedCall(request: ServerRequest.Single(stream: request))
         return ServerResponse.Stream(single: response)
     }
@@ -399,9 +399,9 @@ extension Grpc_Testing_UnimplementedService.ServiceProtocol {
 /// A service used to control reconnect server.
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 public protocol Grpc_Testing_ReconnectServiceStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
-    func start(request: ServerRequest.Stream<Grpc_Testing_ReconnectService.Method.Start.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_ReconnectService.Method.Start.Output>
+    func start(request: ServerRequest.Stream<Grpc_Testing_ReconnectParams>) async throws -> ServerResponse.Stream<Grpc_Testing_Empty>
 
-    func stop(request: ServerRequest.Stream<Grpc_Testing_ReconnectService.Method.Stop.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_ReconnectService.Method.Stop.Output>
+    func stop(request: ServerRequest.Stream<Grpc_Testing_Empty>) async throws -> ServerResponse.Stream<Grpc_Testing_ReconnectInfo>
 }
 
 /// Conformance to `GRPCCore.RegistrableRPCService`.
@@ -411,16 +411,16 @@ extension Grpc_Testing_ReconnectService.StreamingServiceProtocol {
     public func registerMethods(with router: inout GRPCCore.RPCRouter) {
         router.registerHandler(
             forMethod: Grpc_Testing_ReconnectService.Method.Start.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_ReconnectService.Method.Start.Input>(),
-            serializer: ProtobufSerializer<Grpc_Testing_ReconnectService.Method.Start.Output>(),
+            deserializer: ProtobufDeserializer<Grpc_Testing_ReconnectParams>(),
+            serializer: ProtobufSerializer<Grpc_Testing_Empty>(),
             handler: { request in
                 try await self.start(request: request)
             }
         )
         router.registerHandler(
             forMethod: Grpc_Testing_ReconnectService.Method.Stop.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_ReconnectService.Method.Stop.Input>(),
-            serializer: ProtobufSerializer<Grpc_Testing_ReconnectService.Method.Stop.Output>(),
+            deserializer: ProtobufDeserializer<Grpc_Testing_Empty>(),
+            serializer: ProtobufSerializer<Grpc_Testing_ReconnectInfo>(),
             handler: { request in
                 try await self.stop(request: request)
             }
@@ -431,20 +431,20 @@ extension Grpc_Testing_ReconnectService.StreamingServiceProtocol {
 /// A service used to control reconnect server.
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 public protocol Grpc_Testing_ReconnectServiceServiceProtocol: Grpc_Testing_ReconnectService.StreamingServiceProtocol {
-    func start(request: ServerRequest.Single<Grpc_Testing_ReconnectService.Method.Start.Input>) async throws -> ServerResponse.Single<Grpc_Testing_ReconnectService.Method.Start.Output>
+    func start(request: ServerRequest.Single<Grpc_Testing_ReconnectParams>) async throws -> ServerResponse.Single<Grpc_Testing_Empty>
 
-    func stop(request: ServerRequest.Single<Grpc_Testing_ReconnectService.Method.Stop.Input>) async throws -> ServerResponse.Single<Grpc_Testing_ReconnectService.Method.Stop.Output>
+    func stop(request: ServerRequest.Single<Grpc_Testing_Empty>) async throws -> ServerResponse.Single<Grpc_Testing_ReconnectInfo>
 }
 
 /// Partial conformance to `Grpc_Testing_ReconnectServiceStreamingServiceProtocol`.
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension Grpc_Testing_ReconnectService.ServiceProtocol {
-    public func start(request: ServerRequest.Stream<Grpc_Testing_ReconnectService.Method.Start.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_ReconnectService.Method.Start.Output> {
+    public func start(request: ServerRequest.Stream<Grpc_Testing_ReconnectParams>) async throws -> ServerResponse.Stream<Grpc_Testing_Empty> {
         let response = try await self.start(request: ServerRequest.Single(stream: request))
         return ServerResponse.Stream(single: response)
     }
 
-    public func stop(request: ServerRequest.Stream<Grpc_Testing_ReconnectService.Method.Stop.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_ReconnectService.Method.Stop.Output> {
+    public func stop(request: ServerRequest.Stream<Grpc_Testing_Empty>) async throws -> ServerResponse.Stream<Grpc_Testing_ReconnectInfo> {
         let response = try await self.stop(request: ServerRequest.Single(stream: request))
         return ServerResponse.Stream(single: response)
     }
@@ -456,62 +456,62 @@ extension Grpc_Testing_ReconnectService.ServiceProtocol {
 public protocol Grpc_Testing_TestServiceClientProtocol: Sendable {
     /// One empty request followed by one empty response.
     func emptyCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_TestService.Method.EmptyCall.Input>,
-        serializer: some MessageSerializer<Grpc_Testing_TestService.Method.EmptyCall.Input>,
-        deserializer: some MessageDeserializer<Grpc_Testing_TestService.Method.EmptyCall.Output>,
+        request: ClientRequest.Single<Grpc_Testing_Empty>,
+        serializer: some MessageSerializer<Grpc_Testing_Empty>,
+        deserializer: some MessageDeserializer<Grpc_Testing_Empty>,
         options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_TestService.Method.EmptyCall.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
     ) async throws -> R where R: Sendable
 
     /// One request followed by one response.
     func unaryCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_TestService.Method.UnaryCall.Input>,
-        serializer: some MessageSerializer<Grpc_Testing_TestService.Method.UnaryCall.Input>,
-        deserializer: some MessageDeserializer<Grpc_Testing_TestService.Method.UnaryCall.Output>,
+        request: ClientRequest.Single<Grpc_Testing_SimpleRequest>,
+        serializer: some MessageSerializer<Grpc_Testing_SimpleRequest>,
+        deserializer: some MessageDeserializer<Grpc_Testing_SimpleResponse>,
         options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_TestService.Method.UnaryCall.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable
 
     /// One request followed by one response. Response has cache control
     /// headers set such that a caching HTTP proxy (such as GFE) can
     /// satisfy subsequent requests.
     func cacheableUnaryCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_TestService.Method.CacheableUnaryCall.Input>,
-        serializer: some MessageSerializer<Grpc_Testing_TestService.Method.CacheableUnaryCall.Input>,
-        deserializer: some MessageDeserializer<Grpc_Testing_TestService.Method.CacheableUnaryCall.Output>,
+        request: ClientRequest.Single<Grpc_Testing_SimpleRequest>,
+        serializer: some MessageSerializer<Grpc_Testing_SimpleRequest>,
+        deserializer: some MessageDeserializer<Grpc_Testing_SimpleResponse>,
         options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_TestService.Method.CacheableUnaryCall.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable
 
     /// One request followed by a sequence of responses (streamed download).
     /// The server returns the payload with client desired type and sizes.
     func streamingOutputCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_TestService.Method.StreamingOutputCall.Input>,
-        serializer: some MessageSerializer<Grpc_Testing_TestService.Method.StreamingOutputCall.Input>,
-        deserializer: some MessageDeserializer<Grpc_Testing_TestService.Method.StreamingOutputCall.Output>,
+        request: ClientRequest.Single<Grpc_Testing_StreamingOutputCallRequest>,
+        serializer: some MessageSerializer<Grpc_Testing_StreamingOutputCallRequest>,
+        deserializer: some MessageDeserializer<Grpc_Testing_StreamingOutputCallResponse>,
         options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_TestService.Method.StreamingOutputCall.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
     ) async throws -> R where R: Sendable
 
     /// A sequence of requests followed by one response (streamed upload).
     /// The server returns the aggregated size of client payload as the result.
     func streamingInputCall<R>(
-        request: ClientRequest.Stream<Grpc_Testing_TestService.Method.StreamingInputCall.Input>,
-        serializer: some MessageSerializer<Grpc_Testing_TestService.Method.StreamingInputCall.Input>,
-        deserializer: some MessageDeserializer<Grpc_Testing_TestService.Method.StreamingInputCall.Output>,
+        request: ClientRequest.Stream<Grpc_Testing_StreamingInputCallRequest>,
+        serializer: some MessageSerializer<Grpc_Testing_StreamingInputCallRequest>,
+        deserializer: some MessageDeserializer<Grpc_Testing_StreamingInputCallResponse>,
         options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_TestService.Method.StreamingInputCall.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_StreamingInputCallResponse>) async throws -> R
     ) async throws -> R where R: Sendable
 
     /// A sequence of requests with each request served by the server immediately.
     /// As one request could lead to multiple responses, this interface
     /// demonstrates the idea of full duplexing.
     func fullDuplexCall<R>(
-        request: ClientRequest.Stream<Grpc_Testing_TestService.Method.FullDuplexCall.Input>,
-        serializer: some MessageSerializer<Grpc_Testing_TestService.Method.FullDuplexCall.Input>,
-        deserializer: some MessageDeserializer<Grpc_Testing_TestService.Method.FullDuplexCall.Output>,
+        request: ClientRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>,
+        serializer: some MessageSerializer<Grpc_Testing_StreamingOutputCallRequest>,
+        deserializer: some MessageDeserializer<Grpc_Testing_StreamingOutputCallResponse>,
         options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_TestService.Method.FullDuplexCall.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
     ) async throws -> R where R: Sendable
 
     /// A sequence of requests followed by a sequence of responses.
@@ -519,133 +519,133 @@ public protocol Grpc_Testing_TestServiceClientProtocol: Sendable {
     /// stream of responses are returned to the client when the server starts with
     /// first request.
     func halfDuplexCall<R>(
-        request: ClientRequest.Stream<Grpc_Testing_TestService.Method.HalfDuplexCall.Input>,
-        serializer: some MessageSerializer<Grpc_Testing_TestService.Method.HalfDuplexCall.Input>,
-        deserializer: some MessageDeserializer<Grpc_Testing_TestService.Method.HalfDuplexCall.Output>,
+        request: ClientRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>,
+        serializer: some MessageSerializer<Grpc_Testing_StreamingOutputCallRequest>,
+        deserializer: some MessageDeserializer<Grpc_Testing_StreamingOutputCallResponse>,
         options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_TestService.Method.HalfDuplexCall.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
     ) async throws -> R where R: Sendable
 
     /// The test server will not implement this method. It will be used
     /// to test the behavior when clients call unimplemented methods.
     func unimplementedCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_TestService.Method.UnimplementedCall.Input>,
-        serializer: some MessageSerializer<Grpc_Testing_TestService.Method.UnimplementedCall.Input>,
-        deserializer: some MessageDeserializer<Grpc_Testing_TestService.Method.UnimplementedCall.Output>,
+        request: ClientRequest.Single<Grpc_Testing_Empty>,
+        serializer: some MessageSerializer<Grpc_Testing_Empty>,
+        deserializer: some MessageDeserializer<Grpc_Testing_Empty>,
         options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_TestService.Method.UnimplementedCall.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
     ) async throws -> R where R: Sendable
 }
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension Grpc_Testing_TestService.ClientProtocol {
     public func emptyCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_TestService.Method.EmptyCall.Input>,
+        request: ClientRequest.Single<Grpc_Testing_Empty>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_TestService.Method.EmptyCall.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.emptyCall(
             request: request,
-            serializer: ProtobufSerializer<Grpc_Testing_TestService.Method.EmptyCall.Input>(),
-            deserializer: ProtobufDeserializer<Grpc_Testing_TestService.Method.EmptyCall.Output>(),
+            serializer: ProtobufSerializer<Grpc_Testing_Empty>(),
+            deserializer: ProtobufDeserializer<Grpc_Testing_Empty>(),
             options: options,
             body
         )
     }
 
     public func unaryCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_TestService.Method.UnaryCall.Input>,
+        request: ClientRequest.Single<Grpc_Testing_SimpleRequest>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_TestService.Method.UnaryCall.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.unaryCall(
             request: request,
-            serializer: ProtobufSerializer<Grpc_Testing_TestService.Method.UnaryCall.Input>(),
-            deserializer: ProtobufDeserializer<Grpc_Testing_TestService.Method.UnaryCall.Output>(),
+            serializer: ProtobufSerializer<Grpc_Testing_SimpleRequest>(),
+            deserializer: ProtobufDeserializer<Grpc_Testing_SimpleResponse>(),
             options: options,
             body
         )
     }
 
     public func cacheableUnaryCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_TestService.Method.CacheableUnaryCall.Input>,
+        request: ClientRequest.Single<Grpc_Testing_SimpleRequest>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_TestService.Method.CacheableUnaryCall.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.cacheableUnaryCall(
             request: request,
-            serializer: ProtobufSerializer<Grpc_Testing_TestService.Method.CacheableUnaryCall.Input>(),
-            deserializer: ProtobufDeserializer<Grpc_Testing_TestService.Method.CacheableUnaryCall.Output>(),
+            serializer: ProtobufSerializer<Grpc_Testing_SimpleRequest>(),
+            deserializer: ProtobufDeserializer<Grpc_Testing_SimpleResponse>(),
             options: options,
             body
         )
     }
 
     public func streamingOutputCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_TestService.Method.StreamingOutputCall.Input>,
+        request: ClientRequest.Single<Grpc_Testing_StreamingOutputCallRequest>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_TestService.Method.StreamingOutputCall.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.streamingOutputCall(
             request: request,
-            serializer: ProtobufSerializer<Grpc_Testing_TestService.Method.StreamingOutputCall.Input>(),
-            deserializer: ProtobufDeserializer<Grpc_Testing_TestService.Method.StreamingOutputCall.Output>(),
+            serializer: ProtobufSerializer<Grpc_Testing_StreamingOutputCallRequest>(),
+            deserializer: ProtobufDeserializer<Grpc_Testing_StreamingOutputCallResponse>(),
             options: options,
             body
         )
     }
 
     public func streamingInputCall<R>(
-        request: ClientRequest.Stream<Grpc_Testing_TestService.Method.StreamingInputCall.Input>,
+        request: ClientRequest.Stream<Grpc_Testing_StreamingInputCallRequest>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_TestService.Method.StreamingInputCall.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_StreamingInputCallResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.streamingInputCall(
             request: request,
-            serializer: ProtobufSerializer<Grpc_Testing_TestService.Method.StreamingInputCall.Input>(),
-            deserializer: ProtobufDeserializer<Grpc_Testing_TestService.Method.StreamingInputCall.Output>(),
+            serializer: ProtobufSerializer<Grpc_Testing_StreamingInputCallRequest>(),
+            deserializer: ProtobufDeserializer<Grpc_Testing_StreamingInputCallResponse>(),
             options: options,
             body
         )
     }
 
     public func fullDuplexCall<R>(
-        request: ClientRequest.Stream<Grpc_Testing_TestService.Method.FullDuplexCall.Input>,
+        request: ClientRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_TestService.Method.FullDuplexCall.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.fullDuplexCall(
             request: request,
-            serializer: ProtobufSerializer<Grpc_Testing_TestService.Method.FullDuplexCall.Input>(),
-            deserializer: ProtobufDeserializer<Grpc_Testing_TestService.Method.FullDuplexCall.Output>(),
+            serializer: ProtobufSerializer<Grpc_Testing_StreamingOutputCallRequest>(),
+            deserializer: ProtobufDeserializer<Grpc_Testing_StreamingOutputCallResponse>(),
             options: options,
             body
         )
     }
 
     public func halfDuplexCall<R>(
-        request: ClientRequest.Stream<Grpc_Testing_TestService.Method.HalfDuplexCall.Input>,
+        request: ClientRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_TestService.Method.HalfDuplexCall.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.halfDuplexCall(
             request: request,
-            serializer: ProtobufSerializer<Grpc_Testing_TestService.Method.HalfDuplexCall.Input>(),
-            deserializer: ProtobufDeserializer<Grpc_Testing_TestService.Method.HalfDuplexCall.Output>(),
+            serializer: ProtobufSerializer<Grpc_Testing_StreamingOutputCallRequest>(),
+            deserializer: ProtobufDeserializer<Grpc_Testing_StreamingOutputCallResponse>(),
             options: options,
             body
         )
     }
 
     public func unimplementedCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_TestService.Method.UnimplementedCall.Input>,
+        request: ClientRequest.Single<Grpc_Testing_Empty>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_TestService.Method.UnimplementedCall.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.unimplementedCall(
             request: request,
-            serializer: ProtobufSerializer<Grpc_Testing_TestService.Method.UnimplementedCall.Input>(),
-            deserializer: ProtobufDeserializer<Grpc_Testing_TestService.Method.UnimplementedCall.Output>(),
+            serializer: ProtobufSerializer<Grpc_Testing_Empty>(),
+            deserializer: ProtobufDeserializer<Grpc_Testing_Empty>(),
             options: options,
             body
         )
@@ -664,11 +664,11 @@ public struct Grpc_Testing_TestServiceClient: Grpc_Testing_TestService.ClientPro
 
     /// One empty request followed by one empty response.
     public func emptyCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_TestService.Method.EmptyCall.Input>,
-        serializer: some MessageSerializer<Grpc_Testing_TestService.Method.EmptyCall.Input>,
-        deserializer: some MessageDeserializer<Grpc_Testing_TestService.Method.EmptyCall.Output>,
+        request: ClientRequest.Single<Grpc_Testing_Empty>,
+        serializer: some MessageSerializer<Grpc_Testing_Empty>,
+        deserializer: some MessageDeserializer<Grpc_Testing_Empty>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_TestService.Method.EmptyCall.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.unary(
             request: request,
@@ -682,11 +682,11 @@ public struct Grpc_Testing_TestServiceClient: Grpc_Testing_TestService.ClientPro
 
     /// One request followed by one response.
     public func unaryCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_TestService.Method.UnaryCall.Input>,
-        serializer: some MessageSerializer<Grpc_Testing_TestService.Method.UnaryCall.Input>,
-        deserializer: some MessageDeserializer<Grpc_Testing_TestService.Method.UnaryCall.Output>,
+        request: ClientRequest.Single<Grpc_Testing_SimpleRequest>,
+        serializer: some MessageSerializer<Grpc_Testing_SimpleRequest>,
+        deserializer: some MessageDeserializer<Grpc_Testing_SimpleResponse>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_TestService.Method.UnaryCall.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.unary(
             request: request,
@@ -702,11 +702,11 @@ public struct Grpc_Testing_TestServiceClient: Grpc_Testing_TestService.ClientPro
     /// headers set such that a caching HTTP proxy (such as GFE) can
     /// satisfy subsequent requests.
     public func cacheableUnaryCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_TestService.Method.CacheableUnaryCall.Input>,
-        serializer: some MessageSerializer<Grpc_Testing_TestService.Method.CacheableUnaryCall.Input>,
-        deserializer: some MessageDeserializer<Grpc_Testing_TestService.Method.CacheableUnaryCall.Output>,
+        request: ClientRequest.Single<Grpc_Testing_SimpleRequest>,
+        serializer: some MessageSerializer<Grpc_Testing_SimpleRequest>,
+        deserializer: some MessageDeserializer<Grpc_Testing_SimpleResponse>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_TestService.Method.CacheableUnaryCall.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.unary(
             request: request,
@@ -721,11 +721,11 @@ public struct Grpc_Testing_TestServiceClient: Grpc_Testing_TestService.ClientPro
     /// One request followed by a sequence of responses (streamed download).
     /// The server returns the payload with client desired type and sizes.
     public func streamingOutputCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_TestService.Method.StreamingOutputCall.Input>,
-        serializer: some MessageSerializer<Grpc_Testing_TestService.Method.StreamingOutputCall.Input>,
-        deserializer: some MessageDeserializer<Grpc_Testing_TestService.Method.StreamingOutputCall.Output>,
+        request: ClientRequest.Single<Grpc_Testing_StreamingOutputCallRequest>,
+        serializer: some MessageSerializer<Grpc_Testing_StreamingOutputCallRequest>,
+        deserializer: some MessageDeserializer<Grpc_Testing_StreamingOutputCallResponse>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_TestService.Method.StreamingOutputCall.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.serverStreaming(
             request: request,
@@ -740,11 +740,11 @@ public struct Grpc_Testing_TestServiceClient: Grpc_Testing_TestService.ClientPro
     /// A sequence of requests followed by one response (streamed upload).
     /// The server returns the aggregated size of client payload as the result.
     public func streamingInputCall<R>(
-        request: ClientRequest.Stream<Grpc_Testing_TestService.Method.StreamingInputCall.Input>,
-        serializer: some MessageSerializer<Grpc_Testing_TestService.Method.StreamingInputCall.Input>,
-        deserializer: some MessageDeserializer<Grpc_Testing_TestService.Method.StreamingInputCall.Output>,
+        request: ClientRequest.Stream<Grpc_Testing_StreamingInputCallRequest>,
+        serializer: some MessageSerializer<Grpc_Testing_StreamingInputCallRequest>,
+        deserializer: some MessageDeserializer<Grpc_Testing_StreamingInputCallResponse>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_TestService.Method.StreamingInputCall.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_StreamingInputCallResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.clientStreaming(
             request: request,
@@ -760,11 +760,11 @@ public struct Grpc_Testing_TestServiceClient: Grpc_Testing_TestService.ClientPro
     /// As one request could lead to multiple responses, this interface
     /// demonstrates the idea of full duplexing.
     public func fullDuplexCall<R>(
-        request: ClientRequest.Stream<Grpc_Testing_TestService.Method.FullDuplexCall.Input>,
-        serializer: some MessageSerializer<Grpc_Testing_TestService.Method.FullDuplexCall.Input>,
-        deserializer: some MessageDeserializer<Grpc_Testing_TestService.Method.FullDuplexCall.Output>,
+        request: ClientRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>,
+        serializer: some MessageSerializer<Grpc_Testing_StreamingOutputCallRequest>,
+        deserializer: some MessageDeserializer<Grpc_Testing_StreamingOutputCallResponse>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_TestService.Method.FullDuplexCall.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.bidirectionalStreaming(
             request: request,
@@ -781,11 +781,11 @@ public struct Grpc_Testing_TestServiceClient: Grpc_Testing_TestService.ClientPro
     /// stream of responses are returned to the client when the server starts with
     /// first request.
     public func halfDuplexCall<R>(
-        request: ClientRequest.Stream<Grpc_Testing_TestService.Method.HalfDuplexCall.Input>,
-        serializer: some MessageSerializer<Grpc_Testing_TestService.Method.HalfDuplexCall.Input>,
-        deserializer: some MessageDeserializer<Grpc_Testing_TestService.Method.HalfDuplexCall.Output>,
+        request: ClientRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>,
+        serializer: some MessageSerializer<Grpc_Testing_StreamingOutputCallRequest>,
+        deserializer: some MessageDeserializer<Grpc_Testing_StreamingOutputCallResponse>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_TestService.Method.HalfDuplexCall.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.bidirectionalStreaming(
             request: request,
@@ -800,11 +800,11 @@ public struct Grpc_Testing_TestServiceClient: Grpc_Testing_TestService.ClientPro
     /// The test server will not implement this method. It will be used
     /// to test the behavior when clients call unimplemented methods.
     public func unimplementedCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_TestService.Method.UnimplementedCall.Input>,
-        serializer: some MessageSerializer<Grpc_Testing_TestService.Method.UnimplementedCall.Input>,
-        deserializer: some MessageDeserializer<Grpc_Testing_TestService.Method.UnimplementedCall.Output>,
+        request: ClientRequest.Single<Grpc_Testing_Empty>,
+        serializer: some MessageSerializer<Grpc_Testing_Empty>,
+        deserializer: some MessageDeserializer<Grpc_Testing_Empty>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_TestService.Method.UnimplementedCall.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.unary(
             request: request,
@@ -823,25 +823,25 @@ public struct Grpc_Testing_TestServiceClient: Grpc_Testing_TestService.ClientPro
 public protocol Grpc_Testing_UnimplementedServiceClientProtocol: Sendable {
     /// A call that no server should implement
     func unimplementedCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_UnimplementedService.Method.UnimplementedCall.Input>,
-        serializer: some MessageSerializer<Grpc_Testing_UnimplementedService.Method.UnimplementedCall.Input>,
-        deserializer: some MessageDeserializer<Grpc_Testing_UnimplementedService.Method.UnimplementedCall.Output>,
+        request: ClientRequest.Single<Grpc_Testing_Empty>,
+        serializer: some MessageSerializer<Grpc_Testing_Empty>,
+        deserializer: some MessageDeserializer<Grpc_Testing_Empty>,
         options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_UnimplementedService.Method.UnimplementedCall.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
     ) async throws -> R where R: Sendable
 }
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension Grpc_Testing_UnimplementedService.ClientProtocol {
     public func unimplementedCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_UnimplementedService.Method.UnimplementedCall.Input>,
+        request: ClientRequest.Single<Grpc_Testing_Empty>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_UnimplementedService.Method.UnimplementedCall.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.unimplementedCall(
             request: request,
-            serializer: ProtobufSerializer<Grpc_Testing_UnimplementedService.Method.UnimplementedCall.Input>(),
-            deserializer: ProtobufDeserializer<Grpc_Testing_UnimplementedService.Method.UnimplementedCall.Output>(),
+            serializer: ProtobufSerializer<Grpc_Testing_Empty>(),
+            deserializer: ProtobufDeserializer<Grpc_Testing_Empty>(),
             options: options,
             body
         )
@@ -860,11 +860,11 @@ public struct Grpc_Testing_UnimplementedServiceClient: Grpc_Testing_Unimplemente
 
     /// A call that no server should implement
     public func unimplementedCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_UnimplementedService.Method.UnimplementedCall.Input>,
-        serializer: some MessageSerializer<Grpc_Testing_UnimplementedService.Method.UnimplementedCall.Input>,
-        deserializer: some MessageDeserializer<Grpc_Testing_UnimplementedService.Method.UnimplementedCall.Output>,
+        request: ClientRequest.Single<Grpc_Testing_Empty>,
+        serializer: some MessageSerializer<Grpc_Testing_Empty>,
+        deserializer: some MessageDeserializer<Grpc_Testing_Empty>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_UnimplementedService.Method.UnimplementedCall.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.unary(
             request: request,
@@ -881,47 +881,47 @@ public struct Grpc_Testing_UnimplementedServiceClient: Grpc_Testing_Unimplemente
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 public protocol Grpc_Testing_ReconnectServiceClientProtocol: Sendable {
     func start<R>(
-        request: ClientRequest.Single<Grpc_Testing_ReconnectService.Method.Start.Input>,
-        serializer: some MessageSerializer<Grpc_Testing_ReconnectService.Method.Start.Input>,
-        deserializer: some MessageDeserializer<Grpc_Testing_ReconnectService.Method.Start.Output>,
+        request: ClientRequest.Single<Grpc_Testing_ReconnectParams>,
+        serializer: some MessageSerializer<Grpc_Testing_ReconnectParams>,
+        deserializer: some MessageDeserializer<Grpc_Testing_Empty>,
         options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_ReconnectService.Method.Start.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
     ) async throws -> R where R: Sendable
 
     func stop<R>(
-        request: ClientRequest.Single<Grpc_Testing_ReconnectService.Method.Stop.Input>,
-        serializer: some MessageSerializer<Grpc_Testing_ReconnectService.Method.Stop.Input>,
-        deserializer: some MessageDeserializer<Grpc_Testing_ReconnectService.Method.Stop.Output>,
+        request: ClientRequest.Single<Grpc_Testing_Empty>,
+        serializer: some MessageSerializer<Grpc_Testing_Empty>,
+        deserializer: some MessageDeserializer<Grpc_Testing_ReconnectInfo>,
         options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_ReconnectService.Method.Stop.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_ReconnectInfo>) async throws -> R
     ) async throws -> R where R: Sendable
 }
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension Grpc_Testing_ReconnectService.ClientProtocol {
     public func start<R>(
-        request: ClientRequest.Single<Grpc_Testing_ReconnectService.Method.Start.Input>,
+        request: ClientRequest.Single<Grpc_Testing_ReconnectParams>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_ReconnectService.Method.Start.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.start(
             request: request,
-            serializer: ProtobufSerializer<Grpc_Testing_ReconnectService.Method.Start.Input>(),
-            deserializer: ProtobufDeserializer<Grpc_Testing_ReconnectService.Method.Start.Output>(),
+            serializer: ProtobufSerializer<Grpc_Testing_ReconnectParams>(),
+            deserializer: ProtobufDeserializer<Grpc_Testing_Empty>(),
             options: options,
             body
         )
     }
 
     public func stop<R>(
-        request: ClientRequest.Single<Grpc_Testing_ReconnectService.Method.Stop.Input>,
+        request: ClientRequest.Single<Grpc_Testing_Empty>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_ReconnectService.Method.Stop.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_ReconnectInfo>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.stop(
             request: request,
-            serializer: ProtobufSerializer<Grpc_Testing_ReconnectService.Method.Stop.Input>(),
-            deserializer: ProtobufDeserializer<Grpc_Testing_ReconnectService.Method.Stop.Output>(),
+            serializer: ProtobufSerializer<Grpc_Testing_Empty>(),
+            deserializer: ProtobufDeserializer<Grpc_Testing_ReconnectInfo>(),
             options: options,
             body
         )
@@ -938,11 +938,11 @@ public struct Grpc_Testing_ReconnectServiceClient: Grpc_Testing_ReconnectService
     }
 
     public func start<R>(
-        request: ClientRequest.Single<Grpc_Testing_ReconnectService.Method.Start.Input>,
-        serializer: some MessageSerializer<Grpc_Testing_ReconnectService.Method.Start.Input>,
-        deserializer: some MessageDeserializer<Grpc_Testing_ReconnectService.Method.Start.Output>,
+        request: ClientRequest.Single<Grpc_Testing_ReconnectParams>,
+        serializer: some MessageSerializer<Grpc_Testing_ReconnectParams>,
+        deserializer: some MessageDeserializer<Grpc_Testing_Empty>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_ReconnectService.Method.Start.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.unary(
             request: request,
@@ -955,11 +955,11 @@ public struct Grpc_Testing_ReconnectServiceClient: Grpc_Testing_ReconnectService
     }
 
     public func stop<R>(
-        request: ClientRequest.Single<Grpc_Testing_ReconnectService.Method.Stop.Input>,
-        serializer: some MessageSerializer<Grpc_Testing_ReconnectService.Method.Stop.Input>,
-        deserializer: some MessageDeserializer<Grpc_Testing_ReconnectService.Method.Stop.Output>,
+        request: ClientRequest.Single<Grpc_Testing_Empty>,
+        serializer: some MessageSerializer<Grpc_Testing_Empty>,
+        deserializer: some MessageDeserializer<Grpc_Testing_ReconnectInfo>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_ReconnectService.Method.Stop.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_ReconnectInfo>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.unary(
             request: request,

--- a/Sources/InteroperabilityTests/TestService.swift
+++ b/Sources/InteroperabilityTests/TestService.swift
@@ -22,18 +22,18 @@ public struct TestService: Grpc_Testing_TestService.ServiceProtocol {
   public init() {}
 
   public func unimplementedCall(
-    request: ServerRequest.Single<Grpc_Testing_TestService.Method.UnimplementedCall.Input>
+    request: ServerRequest.Single<Grpc_Testing_Empty>
   ) async throws
-    -> ServerResponse.Single<Grpc_Testing_TestService.Method.UnimplementedCall.Output>
+    -> ServerResponse.Single<Grpc_Testing_Empty>
   {
     throw RPCError(code: .unimplemented, message: "The RPC is not implemented.")
   }
 
   /// Server implements `emptyCall` which immediately returns the empty message.
   public func emptyCall(
-    request: ServerRequest.Single<Grpc_Testing_TestService.Method.EmptyCall.Input>
-  ) async throws -> ServerResponse.Single<Grpc_Testing_TestService.Method.EmptyCall.Output> {
-    let message = Grpc_Testing_TestService.Method.EmptyCall.Output()
+    request: ServerRequest.Single<Grpc_Testing_Empty>
+  ) async throws -> ServerResponse.Single<Grpc_Testing_Empty> {
+    let message = Grpc_Testing_Empty()
     let (initialMetadata, trailingMetadata) = request.metadata.makeInitialAndTrailingMetadata()
     return ServerResponse.Single(
       message: message,
@@ -49,8 +49,8 @@ public struct TestService: Grpc_Testing_TestService.ServiceProtocol {
   /// If the server does not support the `responseType`, then it should fail the RPC with
   /// `INVALID_ARGUMENT`.
   public func unaryCall(
-    request: ServerRequest.Single<Grpc_Testing_TestService.Method.UnaryCall.Input>
-  ) async throws -> ServerResponse.Single<Grpc_Testing_TestService.Method.UnaryCall.Output> {
+    request: ServerRequest.Single<Grpc_Testing_SimpleRequest>
+  ) async throws -> ServerResponse.Single<Grpc_Testing_SimpleResponse> {
     // We can't validate messages at the wire-encoding layer (i.e. where the compression byte is
     // set), so we have to check via the encoding header. Note that it is possible for the header
     // to be set and for the message to not be compressed.
@@ -84,7 +84,7 @@ public struct TestService: Grpc_Testing_TestService.ServiceProtocol {
       throw RPCError(code: .invalidArgument, message: "The response type is not recognized.")
     }
 
-    let responseMessage = Grpc_Testing_TestService.Method.UnaryCall.Output.with { response in
+    let responseMessage = Grpc_Testing_SimpleResponse.with { response in
       response.payload = Grpc_Testing_Payload.with { payload in
         payload.body = Data(repeating: 0, count: Int(request.message.responseSize))
         payload.type = request.message.responseType
@@ -108,9 +108,9 @@ public struct TestService: Grpc_Testing_TestService.ServiceProtocol {
   /// headers such that the response can be cached by proxies in the response path. Server should
   /// be behind a caching proxy for this test to pass. Currently we set the max-age to 60 seconds.
   public func cacheableUnaryCall(
-    request: ServerRequest.Single<Grpc_Testing_TestService.Method.CacheableUnaryCall.Input>
+    request: ServerRequest.Single<Grpc_Testing_SimpleRequest>
   ) async throws
-    -> ServerResponse.Single<Grpc_Testing_TestService.Method.CacheableUnaryCall.Output>
+    -> ServerResponse.Single<Grpc_Testing_SimpleResponse>
   {
     throw RPCError(code: .unimplemented, message: "The RPC is not implemented.")
   }
@@ -122,10 +122,10 @@ public struct TestService: Grpc_Testing_TestService.ServiceProtocol {
   /// closes with OK.
   public func streamingOutputCall(
     request: ServerRequest.Single<
-      Grpc_Testing_TestService.Method.StreamingOutputCall.Input
+      Grpc_Testing_StreamingOutputCallRequest
     >
   ) async throws
-    -> ServerResponse.Stream<Grpc_Testing_TestService.Method.StreamingOutputCall.Output>
+    -> ServerResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>
   {
     let (initialMetadata, trailingMetadata) = request.metadata.makeInitialAndTrailingMetadata()
     return ServerResponse.Stream(metadata: initialMetadata) { writer in
@@ -147,9 +147,9 @@ public struct TestService: Grpc_Testing_TestService.ServiceProtocol {
   /// `StreamingInputCallResponse` where `aggregatedPayloadSize` is the sum of all request payload
   /// bodies received.
   public func streamingInputCall(
-    request: ServerRequest.Stream<Grpc_Testing_TestService.Method.StreamingInputCall.Input>
+    request: ServerRequest.Stream<Grpc_Testing_StreamingInputCallRequest>
   ) async throws
-    -> ServerResponse.Single<Grpc_Testing_TestService.Method.StreamingInputCall.Output>
+    -> ServerResponse.Single<Grpc_Testing_StreamingInputCallResponse>
   {
     let isRequestCompressed =
       request.metadata["grpc-encoding"].filter({ $0 != "identity" }).count > 0
@@ -169,7 +169,7 @@ public struct TestService: Grpc_Testing_TestService.ServiceProtocol {
       aggregatedPayloadSize += message.payload.body.count
     }
 
-    let responseMessage = Grpc_Testing_TestService.Method.StreamingInputCall.Output.with {
+    let responseMessage = Grpc_Testing_StreamingInputCallResponse.with {
       $0.aggregatedPayloadSize = Int32(aggregatedPayloadSize)
     }
 
@@ -187,9 +187,9 @@ public struct TestService: Grpc_Testing_TestService.ServiceProtocol {
   /// of size `ResponseParameter.size` bytes, as specified by its respective `ResponseParameter`s.
   /// After receiving half close and sending all responses, it closes with OK.
   public func fullDuplexCall(
-    request: ServerRequest.Stream<Grpc_Testing_TestService.Method.FullDuplexCall.Input>
+    request: ServerRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>
   ) async throws
-    -> ServerResponse.Stream<Grpc_Testing_TestService.Method.FullDuplexCall.Output>
+    -> ServerResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>
   {
     let (initialMetadata, trailingMetadata) = request.metadata.makeInitialAndTrailingMetadata()
     return ServerResponse.Stream(metadata: initialMetadata) { writer in
@@ -226,9 +226,9 @@ public struct TestService: Grpc_Testing_TestService.ServiceProtocol {
   ///
   /// See: https://github.com/grpc/grpc/blob/master/doc/interop-test-descriptions.md
   public func halfDuplexCall(
-    request: ServerRequest.Stream<Grpc_Testing_TestService.Method.HalfDuplexCall.Input>
+    request: ServerRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>
   ) async throws
-    -> ServerResponse.Stream<Grpc_Testing_TestService.Method.HalfDuplexCall.Output>
+    -> ServerResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>
   {
     throw RPCError(code: .unimplemented, message: "The RPC is not implemented.")
   }

--- a/Sources/performance-worker/Generated/grpc_testing_benchmark_service.grpc.swift
+++ b/Sources/performance-worker/Generated/grpc_testing_benchmark_service.grpc.swift
@@ -91,24 +91,24 @@ internal enum Grpc_Testing_BenchmarkService {
 internal protocol Grpc_Testing_BenchmarkServiceStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
     /// One request followed by one response.
     /// The server returns the client payload as-is.
-    func unaryCall(request: ServerRequest.Stream<Grpc_Testing_BenchmarkService.Method.UnaryCall.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_BenchmarkService.Method.UnaryCall.Output>
+    func unaryCall(request: ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_SimpleResponse>
 
     /// Repeated sequence of one request followed by one response.
     /// Should be called streaming ping-pong
     /// The server returns the client payload as-is on each response
-    func streamingCall(request: ServerRequest.Stream<Grpc_Testing_BenchmarkService.Method.StreamingCall.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_BenchmarkService.Method.StreamingCall.Output>
+    func streamingCall(request: ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_SimpleResponse>
 
     /// Single-sided unbounded streaming from client to server
     /// The server returns the client payload as-is once the client does WritesDone
-    func streamingFromClient(request: ServerRequest.Stream<Grpc_Testing_BenchmarkService.Method.StreamingFromClient.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_BenchmarkService.Method.StreamingFromClient.Output>
+    func streamingFromClient(request: ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_SimpleResponse>
 
     /// Single-sided unbounded streaming from server to client
     /// The server repeatedly returns the client payload as-is
-    func streamingFromServer(request: ServerRequest.Stream<Grpc_Testing_BenchmarkService.Method.StreamingFromServer.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_BenchmarkService.Method.StreamingFromServer.Output>
+    func streamingFromServer(request: ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_SimpleResponse>
 
     /// Two-sided unbounded streaming between server to client
     /// Both sides send the content of their own choice to the other
-    func streamingBothWays(request: ServerRequest.Stream<Grpc_Testing_BenchmarkService.Method.StreamingBothWays.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_BenchmarkService.Method.StreamingBothWays.Output>
+    func streamingBothWays(request: ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_SimpleResponse>
 }
 
 /// Conformance to `GRPCCore.RegistrableRPCService`.
@@ -118,40 +118,40 @@ extension Grpc_Testing_BenchmarkService.StreamingServiceProtocol {
     internal func registerMethods(with router: inout GRPCCore.RPCRouter) {
         router.registerHandler(
             forMethod: Grpc_Testing_BenchmarkService.Method.UnaryCall.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_BenchmarkService.Method.UnaryCall.Input>(),
-            serializer: ProtobufSerializer<Grpc_Testing_BenchmarkService.Method.UnaryCall.Output>(),
+            deserializer: ProtobufDeserializer<Grpc_Testing_SimpleRequest>(),
+            serializer: ProtobufSerializer<Grpc_Testing_SimpleResponse>(),
             handler: { request in
                 try await self.unaryCall(request: request)
             }
         )
         router.registerHandler(
             forMethod: Grpc_Testing_BenchmarkService.Method.StreamingCall.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_BenchmarkService.Method.StreamingCall.Input>(),
-            serializer: ProtobufSerializer<Grpc_Testing_BenchmarkService.Method.StreamingCall.Output>(),
+            deserializer: ProtobufDeserializer<Grpc_Testing_SimpleRequest>(),
+            serializer: ProtobufSerializer<Grpc_Testing_SimpleResponse>(),
             handler: { request in
                 try await self.streamingCall(request: request)
             }
         )
         router.registerHandler(
             forMethod: Grpc_Testing_BenchmarkService.Method.StreamingFromClient.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_BenchmarkService.Method.StreamingFromClient.Input>(),
-            serializer: ProtobufSerializer<Grpc_Testing_BenchmarkService.Method.StreamingFromClient.Output>(),
+            deserializer: ProtobufDeserializer<Grpc_Testing_SimpleRequest>(),
+            serializer: ProtobufSerializer<Grpc_Testing_SimpleResponse>(),
             handler: { request in
                 try await self.streamingFromClient(request: request)
             }
         )
         router.registerHandler(
             forMethod: Grpc_Testing_BenchmarkService.Method.StreamingFromServer.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_BenchmarkService.Method.StreamingFromServer.Input>(),
-            serializer: ProtobufSerializer<Grpc_Testing_BenchmarkService.Method.StreamingFromServer.Output>(),
+            deserializer: ProtobufDeserializer<Grpc_Testing_SimpleRequest>(),
+            serializer: ProtobufSerializer<Grpc_Testing_SimpleResponse>(),
             handler: { request in
                 try await self.streamingFromServer(request: request)
             }
         )
         router.registerHandler(
             forMethod: Grpc_Testing_BenchmarkService.Method.StreamingBothWays.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_BenchmarkService.Method.StreamingBothWays.Input>(),
-            serializer: ProtobufSerializer<Grpc_Testing_BenchmarkService.Method.StreamingBothWays.Output>(),
+            deserializer: ProtobufDeserializer<Grpc_Testing_SimpleRequest>(),
+            serializer: ProtobufSerializer<Grpc_Testing_SimpleResponse>(),
             handler: { request in
                 try await self.streamingBothWays(request: request)
             }
@@ -163,40 +163,40 @@ extension Grpc_Testing_BenchmarkService.StreamingServiceProtocol {
 internal protocol Grpc_Testing_BenchmarkServiceServiceProtocol: Grpc_Testing_BenchmarkService.StreamingServiceProtocol {
     /// One request followed by one response.
     /// The server returns the client payload as-is.
-    func unaryCall(request: ServerRequest.Single<Grpc_Testing_BenchmarkService.Method.UnaryCall.Input>) async throws -> ServerResponse.Single<Grpc_Testing_BenchmarkService.Method.UnaryCall.Output>
+    func unaryCall(request: ServerRequest.Single<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Single<Grpc_Testing_SimpleResponse>
 
     /// Repeated sequence of one request followed by one response.
     /// Should be called streaming ping-pong
     /// The server returns the client payload as-is on each response
-    func streamingCall(request: ServerRequest.Stream<Grpc_Testing_BenchmarkService.Method.StreamingCall.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_BenchmarkService.Method.StreamingCall.Output>
+    func streamingCall(request: ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_SimpleResponse>
 
     /// Single-sided unbounded streaming from client to server
     /// The server returns the client payload as-is once the client does WritesDone
-    func streamingFromClient(request: ServerRequest.Stream<Grpc_Testing_BenchmarkService.Method.StreamingFromClient.Input>) async throws -> ServerResponse.Single<Grpc_Testing_BenchmarkService.Method.StreamingFromClient.Output>
+    func streamingFromClient(request: ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Single<Grpc_Testing_SimpleResponse>
 
     /// Single-sided unbounded streaming from server to client
     /// The server repeatedly returns the client payload as-is
-    func streamingFromServer(request: ServerRequest.Single<Grpc_Testing_BenchmarkService.Method.StreamingFromServer.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_BenchmarkService.Method.StreamingFromServer.Output>
+    func streamingFromServer(request: ServerRequest.Single<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_SimpleResponse>
 
     /// Two-sided unbounded streaming between server to client
     /// Both sides send the content of their own choice to the other
-    func streamingBothWays(request: ServerRequest.Stream<Grpc_Testing_BenchmarkService.Method.StreamingBothWays.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_BenchmarkService.Method.StreamingBothWays.Output>
+    func streamingBothWays(request: ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_SimpleResponse>
 }
 
 /// Partial conformance to `Grpc_Testing_BenchmarkServiceStreamingServiceProtocol`.
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension Grpc_Testing_BenchmarkService.ServiceProtocol {
-    internal func unaryCall(request: ServerRequest.Stream<Grpc_Testing_BenchmarkService.Method.UnaryCall.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_BenchmarkService.Method.UnaryCall.Output> {
+    internal func unaryCall(request: ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_SimpleResponse> {
         let response = try await self.unaryCall(request: ServerRequest.Single(stream: request))
         return ServerResponse.Stream(single: response)
     }
 
-    internal func streamingFromClient(request: ServerRequest.Stream<Grpc_Testing_BenchmarkService.Method.StreamingFromClient.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_BenchmarkService.Method.StreamingFromClient.Output> {
+    internal func streamingFromClient(request: ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_SimpleResponse> {
         let response = try await self.streamingFromClient(request: request)
         return ServerResponse.Stream(single: response)
     }
 
-    internal func streamingFromServer(request: ServerRequest.Stream<Grpc_Testing_BenchmarkService.Method.StreamingFromServer.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_BenchmarkService.Method.StreamingFromServer.Output> {
+    internal func streamingFromServer(request: ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_SimpleResponse> {
         let response = try await self.streamingFromServer(request: ServerRequest.Single(stream: request))
         return response
     }
@@ -207,122 +207,122 @@ internal protocol Grpc_Testing_BenchmarkServiceClientProtocol: Sendable {
     /// One request followed by one response.
     /// The server returns the client payload as-is.
     func unaryCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_BenchmarkService.Method.UnaryCall.Input>,
-        serializer: some MessageSerializer<Grpc_Testing_BenchmarkService.Method.UnaryCall.Input>,
-        deserializer: some MessageDeserializer<Grpc_Testing_BenchmarkService.Method.UnaryCall.Output>,
+        request: ClientRequest.Single<Grpc_Testing_SimpleRequest>,
+        serializer: some MessageSerializer<Grpc_Testing_SimpleRequest>,
+        deserializer: some MessageDeserializer<Grpc_Testing_SimpleResponse>,
         options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_BenchmarkService.Method.UnaryCall.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable
 
     /// Repeated sequence of one request followed by one response.
     /// Should be called streaming ping-pong
     /// The server returns the client payload as-is on each response
     func streamingCall<R>(
-        request: ClientRequest.Stream<Grpc_Testing_BenchmarkService.Method.StreamingCall.Input>,
-        serializer: some MessageSerializer<Grpc_Testing_BenchmarkService.Method.StreamingCall.Input>,
-        deserializer: some MessageDeserializer<Grpc_Testing_BenchmarkService.Method.StreamingCall.Output>,
+        request: ClientRequest.Stream<Grpc_Testing_SimpleRequest>,
+        serializer: some MessageSerializer<Grpc_Testing_SimpleRequest>,
+        deserializer: some MessageDeserializer<Grpc_Testing_SimpleResponse>,
         options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_BenchmarkService.Method.StreamingCall.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable
 
     /// Single-sided unbounded streaming from client to server
     /// The server returns the client payload as-is once the client does WritesDone
     func streamingFromClient<R>(
-        request: ClientRequest.Stream<Grpc_Testing_BenchmarkService.Method.StreamingFromClient.Input>,
-        serializer: some MessageSerializer<Grpc_Testing_BenchmarkService.Method.StreamingFromClient.Input>,
-        deserializer: some MessageDeserializer<Grpc_Testing_BenchmarkService.Method.StreamingFromClient.Output>,
+        request: ClientRequest.Stream<Grpc_Testing_SimpleRequest>,
+        serializer: some MessageSerializer<Grpc_Testing_SimpleRequest>,
+        deserializer: some MessageDeserializer<Grpc_Testing_SimpleResponse>,
         options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_BenchmarkService.Method.StreamingFromClient.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable
 
     /// Single-sided unbounded streaming from server to client
     /// The server repeatedly returns the client payload as-is
     func streamingFromServer<R>(
-        request: ClientRequest.Single<Grpc_Testing_BenchmarkService.Method.StreamingFromServer.Input>,
-        serializer: some MessageSerializer<Grpc_Testing_BenchmarkService.Method.StreamingFromServer.Input>,
-        deserializer: some MessageDeserializer<Grpc_Testing_BenchmarkService.Method.StreamingFromServer.Output>,
+        request: ClientRequest.Single<Grpc_Testing_SimpleRequest>,
+        serializer: some MessageSerializer<Grpc_Testing_SimpleRequest>,
+        deserializer: some MessageDeserializer<Grpc_Testing_SimpleResponse>,
         options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_BenchmarkService.Method.StreamingFromServer.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable
 
     /// Two-sided unbounded streaming between server to client
     /// Both sides send the content of their own choice to the other
     func streamingBothWays<R>(
-        request: ClientRequest.Stream<Grpc_Testing_BenchmarkService.Method.StreamingBothWays.Input>,
-        serializer: some MessageSerializer<Grpc_Testing_BenchmarkService.Method.StreamingBothWays.Input>,
-        deserializer: some MessageDeserializer<Grpc_Testing_BenchmarkService.Method.StreamingBothWays.Output>,
+        request: ClientRequest.Stream<Grpc_Testing_SimpleRequest>,
+        serializer: some MessageSerializer<Grpc_Testing_SimpleRequest>,
+        deserializer: some MessageDeserializer<Grpc_Testing_SimpleResponse>,
         options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_BenchmarkService.Method.StreamingBothWays.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable
 }
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension Grpc_Testing_BenchmarkService.ClientProtocol {
     internal func unaryCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_BenchmarkService.Method.UnaryCall.Input>,
+        request: ClientRequest.Single<Grpc_Testing_SimpleRequest>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_BenchmarkService.Method.UnaryCall.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.unaryCall(
             request: request,
-            serializer: ProtobufSerializer<Grpc_Testing_BenchmarkService.Method.UnaryCall.Input>(),
-            deserializer: ProtobufDeserializer<Grpc_Testing_BenchmarkService.Method.UnaryCall.Output>(),
+            serializer: ProtobufSerializer<Grpc_Testing_SimpleRequest>(),
+            deserializer: ProtobufDeserializer<Grpc_Testing_SimpleResponse>(),
             options: options,
             body
         )
     }
 
     internal func streamingCall<R>(
-        request: ClientRequest.Stream<Grpc_Testing_BenchmarkService.Method.StreamingCall.Input>,
+        request: ClientRequest.Stream<Grpc_Testing_SimpleRequest>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_BenchmarkService.Method.StreamingCall.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.streamingCall(
             request: request,
-            serializer: ProtobufSerializer<Grpc_Testing_BenchmarkService.Method.StreamingCall.Input>(),
-            deserializer: ProtobufDeserializer<Grpc_Testing_BenchmarkService.Method.StreamingCall.Output>(),
+            serializer: ProtobufSerializer<Grpc_Testing_SimpleRequest>(),
+            deserializer: ProtobufDeserializer<Grpc_Testing_SimpleResponse>(),
             options: options,
             body
         )
     }
 
     internal func streamingFromClient<R>(
-        request: ClientRequest.Stream<Grpc_Testing_BenchmarkService.Method.StreamingFromClient.Input>,
+        request: ClientRequest.Stream<Grpc_Testing_SimpleRequest>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_BenchmarkService.Method.StreamingFromClient.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.streamingFromClient(
             request: request,
-            serializer: ProtobufSerializer<Grpc_Testing_BenchmarkService.Method.StreamingFromClient.Input>(),
-            deserializer: ProtobufDeserializer<Grpc_Testing_BenchmarkService.Method.StreamingFromClient.Output>(),
+            serializer: ProtobufSerializer<Grpc_Testing_SimpleRequest>(),
+            deserializer: ProtobufDeserializer<Grpc_Testing_SimpleResponse>(),
             options: options,
             body
         )
     }
 
     internal func streamingFromServer<R>(
-        request: ClientRequest.Single<Grpc_Testing_BenchmarkService.Method.StreamingFromServer.Input>,
+        request: ClientRequest.Single<Grpc_Testing_SimpleRequest>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_BenchmarkService.Method.StreamingFromServer.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.streamingFromServer(
             request: request,
-            serializer: ProtobufSerializer<Grpc_Testing_BenchmarkService.Method.StreamingFromServer.Input>(),
-            deserializer: ProtobufDeserializer<Grpc_Testing_BenchmarkService.Method.StreamingFromServer.Output>(),
+            serializer: ProtobufSerializer<Grpc_Testing_SimpleRequest>(),
+            deserializer: ProtobufDeserializer<Grpc_Testing_SimpleResponse>(),
             options: options,
             body
         )
     }
 
     internal func streamingBothWays<R>(
-        request: ClientRequest.Stream<Grpc_Testing_BenchmarkService.Method.StreamingBothWays.Input>,
+        request: ClientRequest.Stream<Grpc_Testing_SimpleRequest>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_BenchmarkService.Method.StreamingBothWays.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.streamingBothWays(
             request: request,
-            serializer: ProtobufSerializer<Grpc_Testing_BenchmarkService.Method.StreamingBothWays.Input>(),
-            deserializer: ProtobufDeserializer<Grpc_Testing_BenchmarkService.Method.StreamingBothWays.Output>(),
+            serializer: ProtobufSerializer<Grpc_Testing_SimpleRequest>(),
+            deserializer: ProtobufDeserializer<Grpc_Testing_SimpleResponse>(),
             options: options,
             body
         )
@@ -340,11 +340,11 @@ internal struct Grpc_Testing_BenchmarkServiceClient: Grpc_Testing_BenchmarkServi
     /// One request followed by one response.
     /// The server returns the client payload as-is.
     internal func unaryCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_BenchmarkService.Method.UnaryCall.Input>,
-        serializer: some MessageSerializer<Grpc_Testing_BenchmarkService.Method.UnaryCall.Input>,
-        deserializer: some MessageDeserializer<Grpc_Testing_BenchmarkService.Method.UnaryCall.Output>,
+        request: ClientRequest.Single<Grpc_Testing_SimpleRequest>,
+        serializer: some MessageSerializer<Grpc_Testing_SimpleRequest>,
+        deserializer: some MessageDeserializer<Grpc_Testing_SimpleResponse>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_BenchmarkService.Method.UnaryCall.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.unary(
             request: request,
@@ -360,11 +360,11 @@ internal struct Grpc_Testing_BenchmarkServiceClient: Grpc_Testing_BenchmarkServi
     /// Should be called streaming ping-pong
     /// The server returns the client payload as-is on each response
     internal func streamingCall<R>(
-        request: ClientRequest.Stream<Grpc_Testing_BenchmarkService.Method.StreamingCall.Input>,
-        serializer: some MessageSerializer<Grpc_Testing_BenchmarkService.Method.StreamingCall.Input>,
-        deserializer: some MessageDeserializer<Grpc_Testing_BenchmarkService.Method.StreamingCall.Output>,
+        request: ClientRequest.Stream<Grpc_Testing_SimpleRequest>,
+        serializer: some MessageSerializer<Grpc_Testing_SimpleRequest>,
+        deserializer: some MessageDeserializer<Grpc_Testing_SimpleResponse>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_BenchmarkService.Method.StreamingCall.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.bidirectionalStreaming(
             request: request,
@@ -379,11 +379,11 @@ internal struct Grpc_Testing_BenchmarkServiceClient: Grpc_Testing_BenchmarkServi
     /// Single-sided unbounded streaming from client to server
     /// The server returns the client payload as-is once the client does WritesDone
     internal func streamingFromClient<R>(
-        request: ClientRequest.Stream<Grpc_Testing_BenchmarkService.Method.StreamingFromClient.Input>,
-        serializer: some MessageSerializer<Grpc_Testing_BenchmarkService.Method.StreamingFromClient.Input>,
-        deserializer: some MessageDeserializer<Grpc_Testing_BenchmarkService.Method.StreamingFromClient.Output>,
+        request: ClientRequest.Stream<Grpc_Testing_SimpleRequest>,
+        serializer: some MessageSerializer<Grpc_Testing_SimpleRequest>,
+        deserializer: some MessageDeserializer<Grpc_Testing_SimpleResponse>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_BenchmarkService.Method.StreamingFromClient.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.clientStreaming(
             request: request,
@@ -398,11 +398,11 @@ internal struct Grpc_Testing_BenchmarkServiceClient: Grpc_Testing_BenchmarkServi
     /// Single-sided unbounded streaming from server to client
     /// The server repeatedly returns the client payload as-is
     internal func streamingFromServer<R>(
-        request: ClientRequest.Single<Grpc_Testing_BenchmarkService.Method.StreamingFromServer.Input>,
-        serializer: some MessageSerializer<Grpc_Testing_BenchmarkService.Method.StreamingFromServer.Input>,
-        deserializer: some MessageDeserializer<Grpc_Testing_BenchmarkService.Method.StreamingFromServer.Output>,
+        request: ClientRequest.Single<Grpc_Testing_SimpleRequest>,
+        serializer: some MessageSerializer<Grpc_Testing_SimpleRequest>,
+        deserializer: some MessageDeserializer<Grpc_Testing_SimpleResponse>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_BenchmarkService.Method.StreamingFromServer.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.serverStreaming(
             request: request,
@@ -417,11 +417,11 @@ internal struct Grpc_Testing_BenchmarkServiceClient: Grpc_Testing_BenchmarkServi
     /// Two-sided unbounded streaming between server to client
     /// Both sides send the content of their own choice to the other
     internal func streamingBothWays<R>(
-        request: ClientRequest.Stream<Grpc_Testing_BenchmarkService.Method.StreamingBothWays.Input>,
-        serializer: some MessageSerializer<Grpc_Testing_BenchmarkService.Method.StreamingBothWays.Input>,
-        deserializer: some MessageDeserializer<Grpc_Testing_BenchmarkService.Method.StreamingBothWays.Output>,
+        request: ClientRequest.Stream<Grpc_Testing_SimpleRequest>,
+        serializer: some MessageSerializer<Grpc_Testing_SimpleRequest>,
+        deserializer: some MessageDeserializer<Grpc_Testing_SimpleResponse>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_BenchmarkService.Method.StreamingBothWays.Output>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.bidirectionalStreaming(
             request: request,

--- a/Sources/performance-worker/Generated/grpc_testing_worker_service.grpc.swift
+++ b/Sources/performance-worker/Generated/grpc_testing_worker_service.grpc.swift
@@ -82,7 +82,7 @@ internal protocol Grpc_Testing_WorkerServiceStreamingServiceProtocol: GRPCCore.R
     /// stats. Closing the stream will initiate shutdown of the test server
     /// and once the shutdown has finished, the OK status is sent to terminate
     /// this RPC.
-    func runServer(request: ServerRequest.Stream<Grpc_Testing_WorkerService.Method.RunServer.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_WorkerService.Method.RunServer.Output>
+    func runServer(request: ServerRequest.Stream<Grpc_Testing_ServerArgs>) async throws -> ServerResponse.Stream<Grpc_Testing_ServerStatus>
 
     /// Start client with specified workload.
     /// First request sent specifies the ClientConfig followed by ClientStatus
@@ -90,13 +90,13 @@ internal protocol Grpc_Testing_WorkerServiceStreamingServiceProtocol: GRPCCore.R
     /// stats. Closing the stream will initiate shutdown of the test client
     /// and once the shutdown has finished, the OK status is sent to terminate
     /// this RPC.
-    func runClient(request: ServerRequest.Stream<Grpc_Testing_WorkerService.Method.RunClient.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_WorkerService.Method.RunClient.Output>
+    func runClient(request: ServerRequest.Stream<Grpc_Testing_ClientArgs>) async throws -> ServerResponse.Stream<Grpc_Testing_ClientStatus>
 
     /// Just return the core count - unary call
-    func coreCount(request: ServerRequest.Stream<Grpc_Testing_WorkerService.Method.CoreCount.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_WorkerService.Method.CoreCount.Output>
+    func coreCount(request: ServerRequest.Stream<Grpc_Testing_CoreRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_CoreResponse>
 
     /// Quit this worker
-    func quitWorker(request: ServerRequest.Stream<Grpc_Testing_WorkerService.Method.QuitWorker.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_WorkerService.Method.QuitWorker.Output>
+    func quitWorker(request: ServerRequest.Stream<Grpc_Testing_Void>) async throws -> ServerResponse.Stream<Grpc_Testing_Void>
 }
 
 /// Conformance to `GRPCCore.RegistrableRPCService`.
@@ -106,32 +106,32 @@ extension Grpc_Testing_WorkerService.StreamingServiceProtocol {
     internal func registerMethods(with router: inout GRPCCore.RPCRouter) {
         router.registerHandler(
             forMethod: Grpc_Testing_WorkerService.Method.RunServer.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_WorkerService.Method.RunServer.Input>(),
-            serializer: ProtobufSerializer<Grpc_Testing_WorkerService.Method.RunServer.Output>(),
+            deserializer: ProtobufDeserializer<Grpc_Testing_ServerArgs>(),
+            serializer: ProtobufSerializer<Grpc_Testing_ServerStatus>(),
             handler: { request in
                 try await self.runServer(request: request)
             }
         )
         router.registerHandler(
             forMethod: Grpc_Testing_WorkerService.Method.RunClient.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_WorkerService.Method.RunClient.Input>(),
-            serializer: ProtobufSerializer<Grpc_Testing_WorkerService.Method.RunClient.Output>(),
+            deserializer: ProtobufDeserializer<Grpc_Testing_ClientArgs>(),
+            serializer: ProtobufSerializer<Grpc_Testing_ClientStatus>(),
             handler: { request in
                 try await self.runClient(request: request)
             }
         )
         router.registerHandler(
             forMethod: Grpc_Testing_WorkerService.Method.CoreCount.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_WorkerService.Method.CoreCount.Input>(),
-            serializer: ProtobufSerializer<Grpc_Testing_WorkerService.Method.CoreCount.Output>(),
+            deserializer: ProtobufDeserializer<Grpc_Testing_CoreRequest>(),
+            serializer: ProtobufSerializer<Grpc_Testing_CoreResponse>(),
             handler: { request in
                 try await self.coreCount(request: request)
             }
         )
         router.registerHandler(
             forMethod: Grpc_Testing_WorkerService.Method.QuitWorker.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_WorkerService.Method.QuitWorker.Input>(),
-            serializer: ProtobufSerializer<Grpc_Testing_WorkerService.Method.QuitWorker.Output>(),
+            deserializer: ProtobufDeserializer<Grpc_Testing_Void>(),
+            serializer: ProtobufSerializer<Grpc_Testing_Void>(),
             handler: { request in
                 try await self.quitWorker(request: request)
             }
@@ -147,7 +147,7 @@ internal protocol Grpc_Testing_WorkerServiceServiceProtocol: Grpc_Testing_Worker
     /// stats. Closing the stream will initiate shutdown of the test server
     /// and once the shutdown has finished, the OK status is sent to terminate
     /// this RPC.
-    func runServer(request: ServerRequest.Stream<Grpc_Testing_WorkerService.Method.RunServer.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_WorkerService.Method.RunServer.Output>
+    func runServer(request: ServerRequest.Stream<Grpc_Testing_ServerArgs>) async throws -> ServerResponse.Stream<Grpc_Testing_ServerStatus>
 
     /// Start client with specified workload.
     /// First request sent specifies the ClientConfig followed by ClientStatus
@@ -155,24 +155,24 @@ internal protocol Grpc_Testing_WorkerServiceServiceProtocol: Grpc_Testing_Worker
     /// stats. Closing the stream will initiate shutdown of the test client
     /// and once the shutdown has finished, the OK status is sent to terminate
     /// this RPC.
-    func runClient(request: ServerRequest.Stream<Grpc_Testing_WorkerService.Method.RunClient.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_WorkerService.Method.RunClient.Output>
+    func runClient(request: ServerRequest.Stream<Grpc_Testing_ClientArgs>) async throws -> ServerResponse.Stream<Grpc_Testing_ClientStatus>
 
     /// Just return the core count - unary call
-    func coreCount(request: ServerRequest.Single<Grpc_Testing_WorkerService.Method.CoreCount.Input>) async throws -> ServerResponse.Single<Grpc_Testing_WorkerService.Method.CoreCount.Output>
+    func coreCount(request: ServerRequest.Single<Grpc_Testing_CoreRequest>) async throws -> ServerResponse.Single<Grpc_Testing_CoreResponse>
 
     /// Quit this worker
-    func quitWorker(request: ServerRequest.Single<Grpc_Testing_WorkerService.Method.QuitWorker.Input>) async throws -> ServerResponse.Single<Grpc_Testing_WorkerService.Method.QuitWorker.Output>
+    func quitWorker(request: ServerRequest.Single<Grpc_Testing_Void>) async throws -> ServerResponse.Single<Grpc_Testing_Void>
 }
 
 /// Partial conformance to `Grpc_Testing_WorkerServiceStreamingServiceProtocol`.
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension Grpc_Testing_WorkerService.ServiceProtocol {
-    internal func coreCount(request: ServerRequest.Stream<Grpc_Testing_WorkerService.Method.CoreCount.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_WorkerService.Method.CoreCount.Output> {
+    internal func coreCount(request: ServerRequest.Stream<Grpc_Testing_CoreRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_CoreResponse> {
         let response = try await self.coreCount(request: ServerRequest.Single(stream: request))
         return ServerResponse.Stream(single: response)
     }
 
-    internal func quitWorker(request: ServerRequest.Stream<Grpc_Testing_WorkerService.Method.QuitWorker.Input>) async throws -> ServerResponse.Stream<Grpc_Testing_WorkerService.Method.QuitWorker.Output> {
+    internal func quitWorker(request: ServerRequest.Stream<Grpc_Testing_Void>) async throws -> ServerResponse.Stream<Grpc_Testing_Void> {
         let response = try await self.quitWorker(request: ServerRequest.Single(stream: request))
         return ServerResponse.Stream(single: response)
     }

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
@@ -47,24 +47,24 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       public protocol NamespaceA_ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
-              request: ClientRequest.Single<NamespaceA_ServiceA.Method.MethodA.Input>,
-              serializer: some MessageSerializer<NamespaceA_ServiceA.Method.MethodA.Input>,
-              deserializer: some MessageDeserializer<NamespaceA_ServiceA.Method.MethodA.Output>,
+              request: ClientRequest.Single<NamespaceA_ServiceARequest>,
+              serializer: some MessageSerializer<NamespaceA_ServiceARequest>,
+              deserializer: some MessageDeserializer<NamespaceA_ServiceAResponse>,
               options: CallOptions,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceA.Method.MethodA.Output>) async throws -> R
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable
       }
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
           public func methodA<R>(
-              request: ClientRequest.Single<NamespaceA_ServiceA.Method.MethodA.Input>,
+              request: ClientRequest.Single<NamespaceA_ServiceARequest>,
               options: CallOptions = .defaults,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceA.Method.MethodA.Output>) async throws -> R
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.methodA(
                   request: request,
-                  serializer: ProtobufSerializer<NamespaceA_ServiceA.Method.MethodA.Input>(),
-                  deserializer: ProtobufDeserializer<NamespaceA_ServiceA.Method.MethodA.Output>(),
+                  serializer: ProtobufSerializer<NamespaceA_ServiceARequest>(),
+                  deserializer: ProtobufDeserializer<NamespaceA_ServiceAResponse>(),
                   options: options,
                   body
               )
@@ -81,11 +81,11 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           
           /// Documentation for MethodA
           public func methodA<R>(
-              request: ClientRequest.Single<NamespaceA_ServiceA.Method.MethodA.Input>,
-              serializer: some MessageSerializer<NamespaceA_ServiceA.Method.MethodA.Input>,
-              deserializer: some MessageDeserializer<NamespaceA_ServiceA.Method.MethodA.Output>,
+              request: ClientRequest.Single<NamespaceA_ServiceARequest>,
+              serializer: some MessageSerializer<NamespaceA_ServiceARequest>,
+              deserializer: some MessageDeserializer<NamespaceA_ServiceAResponse>,
               options: CallOptions = .defaults,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceA.Method.MethodA.Output>) async throws -> R
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.client.unary(
                   request: request,
@@ -128,24 +128,24 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       public protocol NamespaceA_ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
-              request: ClientRequest.Stream<NamespaceA_ServiceA.Method.MethodA.Input>,
-              serializer: some MessageSerializer<NamespaceA_ServiceA.Method.MethodA.Input>,
-              deserializer: some MessageDeserializer<NamespaceA_ServiceA.Method.MethodA.Output>,
+              request: ClientRequest.Stream<NamespaceA_ServiceARequest>,
+              serializer: some MessageSerializer<NamespaceA_ServiceARequest>,
+              deserializer: some MessageDeserializer<NamespaceA_ServiceAResponse>,
               options: CallOptions,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceA.Method.MethodA.Output>) async throws -> R
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable
       }
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
           public func methodA<R>(
-              request: ClientRequest.Stream<NamespaceA_ServiceA.Method.MethodA.Input>,
+              request: ClientRequest.Stream<NamespaceA_ServiceARequest>,
               options: CallOptions = .defaults,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceA.Method.MethodA.Output>) async throws -> R
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.methodA(
                   request: request,
-                  serializer: ProtobufSerializer<NamespaceA_ServiceA.Method.MethodA.Input>(),
-                  deserializer: ProtobufDeserializer<NamespaceA_ServiceA.Method.MethodA.Output>(),
+                  serializer: ProtobufSerializer<NamespaceA_ServiceARequest>(),
+                  deserializer: ProtobufDeserializer<NamespaceA_ServiceAResponse>(),
                   options: options,
                   body
               )
@@ -162,11 +162,11 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           
           /// Documentation for MethodA
           public func methodA<R>(
-              request: ClientRequest.Stream<NamespaceA_ServiceA.Method.MethodA.Input>,
-              serializer: some MessageSerializer<NamespaceA_ServiceA.Method.MethodA.Input>,
-              deserializer: some MessageDeserializer<NamespaceA_ServiceA.Method.MethodA.Output>,
+              request: ClientRequest.Stream<NamespaceA_ServiceARequest>,
+              serializer: some MessageSerializer<NamespaceA_ServiceARequest>,
+              deserializer: some MessageDeserializer<NamespaceA_ServiceAResponse>,
               options: CallOptions = .defaults,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceA.Method.MethodA.Output>) async throws -> R
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.client.clientStreaming(
                   request: request,
@@ -209,24 +209,24 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       public protocol NamespaceA_ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
-              request: ClientRequest.Single<NamespaceA_ServiceA.Method.MethodA.Input>,
-              serializer: some MessageSerializer<NamespaceA_ServiceA.Method.MethodA.Input>,
-              deserializer: some MessageDeserializer<NamespaceA_ServiceA.Method.MethodA.Output>,
+              request: ClientRequest.Single<NamespaceA_ServiceARequest>,
+              serializer: some MessageSerializer<NamespaceA_ServiceARequest>,
+              deserializer: some MessageDeserializer<NamespaceA_ServiceAResponse>,
               options: CallOptions,
-              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA_ServiceA.Method.MethodA.Output>) async throws -> R
+              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable
       }
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
           public func methodA<R>(
-              request: ClientRequest.Single<NamespaceA_ServiceA.Method.MethodA.Input>,
+              request: ClientRequest.Single<NamespaceA_ServiceARequest>,
               options: CallOptions = .defaults,
-              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA_ServiceA.Method.MethodA.Output>) async throws -> R
+              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.methodA(
                   request: request,
-                  serializer: ProtobufSerializer<NamespaceA_ServiceA.Method.MethodA.Input>(),
-                  deserializer: ProtobufDeserializer<NamespaceA_ServiceA.Method.MethodA.Output>(),
+                  serializer: ProtobufSerializer<NamespaceA_ServiceARequest>(),
+                  deserializer: ProtobufDeserializer<NamespaceA_ServiceAResponse>(),
                   options: options,
                   body
               )
@@ -243,11 +243,11 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           
           /// Documentation for MethodA
           public func methodA<R>(
-              request: ClientRequest.Single<NamespaceA_ServiceA.Method.MethodA.Input>,
-              serializer: some MessageSerializer<NamespaceA_ServiceA.Method.MethodA.Input>,
-              deserializer: some MessageDeserializer<NamespaceA_ServiceA.Method.MethodA.Output>,
+              request: ClientRequest.Single<NamespaceA_ServiceARequest>,
+              serializer: some MessageSerializer<NamespaceA_ServiceARequest>,
+              deserializer: some MessageDeserializer<NamespaceA_ServiceAResponse>,
               options: CallOptions = .defaults,
-              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA_ServiceA.Method.MethodA.Output>) async throws -> R
+              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.client.serverStreaming(
                   request: request,
@@ -290,24 +290,24 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       public protocol NamespaceA_ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
-              request: ClientRequest.Stream<NamespaceA_ServiceA.Method.MethodA.Input>,
-              serializer: some MessageSerializer<NamespaceA_ServiceA.Method.MethodA.Input>,
-              deserializer: some MessageDeserializer<NamespaceA_ServiceA.Method.MethodA.Output>,
+              request: ClientRequest.Stream<NamespaceA_ServiceARequest>,
+              serializer: some MessageSerializer<NamespaceA_ServiceARequest>,
+              deserializer: some MessageDeserializer<NamespaceA_ServiceAResponse>,
               options: CallOptions,
-              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA_ServiceA.Method.MethodA.Output>) async throws -> R
+              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable
       }
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
           public func methodA<R>(
-              request: ClientRequest.Stream<NamespaceA_ServiceA.Method.MethodA.Input>,
+              request: ClientRequest.Stream<NamespaceA_ServiceARequest>,
               options: CallOptions = .defaults,
-              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA_ServiceA.Method.MethodA.Output>) async throws -> R
+              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.methodA(
                   request: request,
-                  serializer: ProtobufSerializer<NamespaceA_ServiceA.Method.MethodA.Input>(),
-                  deserializer: ProtobufDeserializer<NamespaceA_ServiceA.Method.MethodA.Output>(),
+                  serializer: ProtobufSerializer<NamespaceA_ServiceARequest>(),
+                  deserializer: ProtobufDeserializer<NamespaceA_ServiceAResponse>(),
                   options: options,
                   body
               )
@@ -324,11 +324,11 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           
           /// Documentation for MethodA
           public func methodA<R>(
-              request: ClientRequest.Stream<NamespaceA_ServiceA.Method.MethodA.Input>,
-              serializer: some MessageSerializer<NamespaceA_ServiceA.Method.MethodA.Input>,
-              deserializer: some MessageDeserializer<NamespaceA_ServiceA.Method.MethodA.Output>,
+              request: ClientRequest.Stream<NamespaceA_ServiceARequest>,
+              serializer: some MessageSerializer<NamespaceA_ServiceARequest>,
+              deserializer: some MessageDeserializer<NamespaceA_ServiceAResponse>,
               options: CallOptions = .defaults,
-              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA_ServiceA.Method.MethodA.Output>) async throws -> R
+              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.client.bidirectionalStreaming(
                   request: request,
@@ -379,47 +379,47 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       package protocol NamespaceA_ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
-              request: ClientRequest.Stream<NamespaceA_ServiceA.Method.MethodA.Input>,
-              serializer: some MessageSerializer<NamespaceA_ServiceA.Method.MethodA.Input>,
-              deserializer: some MessageDeserializer<NamespaceA_ServiceA.Method.MethodA.Output>,
+              request: ClientRequest.Stream<NamespaceA_ServiceARequest>,
+              serializer: some MessageSerializer<NamespaceA_ServiceARequest>,
+              deserializer: some MessageDeserializer<NamespaceA_ServiceAResponse>,
               options: CallOptions,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceA.Method.MethodA.Output>) async throws -> R
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable
           
           /// Documentation for MethodB
           func methodB<R>(
-              request: ClientRequest.Single<NamespaceA_ServiceA.Method.MethodB.Input>,
-              serializer: some MessageSerializer<NamespaceA_ServiceA.Method.MethodB.Input>,
-              deserializer: some MessageDeserializer<NamespaceA_ServiceA.Method.MethodB.Output>,
+              request: ClientRequest.Single<NamespaceA_ServiceARequest>,
+              serializer: some MessageSerializer<NamespaceA_ServiceARequest>,
+              deserializer: some MessageDeserializer<NamespaceA_ServiceAResponse>,
               options: CallOptions,
-              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA_ServiceA.Method.MethodB.Output>) async throws -> R
+              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable
       }
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
           package func methodA<R>(
-              request: ClientRequest.Stream<NamespaceA_ServiceA.Method.MethodA.Input>,
+              request: ClientRequest.Stream<NamespaceA_ServiceARequest>,
               options: CallOptions = .defaults,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceA.Method.MethodA.Output>) async throws -> R
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.methodA(
                   request: request,
-                  serializer: ProtobufSerializer<NamespaceA_ServiceA.Method.MethodA.Input>(),
-                  deserializer: ProtobufDeserializer<NamespaceA_ServiceA.Method.MethodA.Output>(),
+                  serializer: ProtobufSerializer<NamespaceA_ServiceARequest>(),
+                  deserializer: ProtobufDeserializer<NamespaceA_ServiceAResponse>(),
                   options: options,
                   body
               )
           }
           
           package func methodB<R>(
-              request: ClientRequest.Single<NamespaceA_ServiceA.Method.MethodB.Input>,
+              request: ClientRequest.Single<NamespaceA_ServiceARequest>,
               options: CallOptions = .defaults,
-              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA_ServiceA.Method.MethodB.Output>) async throws -> R
+              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.methodB(
                   request: request,
-                  serializer: ProtobufSerializer<NamespaceA_ServiceA.Method.MethodB.Input>(),
-                  deserializer: ProtobufDeserializer<NamespaceA_ServiceA.Method.MethodB.Output>(),
+                  serializer: ProtobufSerializer<NamespaceA_ServiceARequest>(),
+                  deserializer: ProtobufDeserializer<NamespaceA_ServiceAResponse>(),
                   options: options,
                   body
               )
@@ -436,11 +436,11 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           
           /// Documentation for MethodA
           package func methodA<R>(
-              request: ClientRequest.Stream<NamespaceA_ServiceA.Method.MethodA.Input>,
-              serializer: some MessageSerializer<NamespaceA_ServiceA.Method.MethodA.Input>,
-              deserializer: some MessageDeserializer<NamespaceA_ServiceA.Method.MethodA.Output>,
+              request: ClientRequest.Stream<NamespaceA_ServiceARequest>,
+              serializer: some MessageSerializer<NamespaceA_ServiceARequest>,
+              deserializer: some MessageDeserializer<NamespaceA_ServiceAResponse>,
               options: CallOptions = .defaults,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceA.Method.MethodA.Output>) async throws -> R
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.client.clientStreaming(
                   request: request,
@@ -454,11 +454,11 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           
           /// Documentation for MethodB
           package func methodB<R>(
-              request: ClientRequest.Single<NamespaceA_ServiceA.Method.MethodB.Input>,
-              serializer: some MessageSerializer<NamespaceA_ServiceA.Method.MethodB.Input>,
-              deserializer: some MessageDeserializer<NamespaceA_ServiceA.Method.MethodB.Output>,
+              request: ClientRequest.Single<NamespaceA_ServiceARequest>,
+              serializer: some MessageSerializer<NamespaceA_ServiceARequest>,
+              deserializer: some MessageDeserializer<NamespaceA_ServiceAResponse>,
               options: CallOptions = .defaults,
-              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA_ServiceA.Method.MethodB.Output>) async throws -> R
+              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.client.serverStreaming(
                   request: request,
@@ -501,24 +501,24 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       internal protocol ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
-              request: ClientRequest.Single<ServiceA.Method.MethodA.Input>,
-              serializer: some MessageSerializer<ServiceA.Method.MethodA.Input>,
-              deserializer: some MessageDeserializer<ServiceA.Method.MethodA.Output>,
+              request: ClientRequest.Single<ServiceARequest>,
+              serializer: some MessageSerializer<ServiceARequest>,
+              deserializer: some MessageDeserializer<ServiceAResponse>,
               options: CallOptions,
-              _ body: @Sendable @escaping (ClientResponse.Single<ServiceA.Method.MethodA.Output>) async throws -> R
+              _ body: @Sendable @escaping (ClientResponse.Single<ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable
       }
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       extension ServiceA.ClientProtocol {
           internal func methodA<R>(
-              request: ClientRequest.Single<ServiceA.Method.MethodA.Input>,
+              request: ClientRequest.Single<ServiceARequest>,
               options: CallOptions = .defaults,
-              _ body: @Sendable @escaping (ClientResponse.Single<ServiceA.Method.MethodA.Output>) async throws -> R
+              _ body: @Sendable @escaping (ClientResponse.Single<ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.methodA(
                   request: request,
-                  serializer: ProtobufSerializer<ServiceA.Method.MethodA.Input>(),
-                  deserializer: ProtobufDeserializer<ServiceA.Method.MethodA.Output>(),
+                  serializer: ProtobufSerializer<ServiceARequest>(),
+                  deserializer: ProtobufDeserializer<ServiceAResponse>(),
                   options: options,
                   body
               )
@@ -535,11 +535,11 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           
           /// Documentation for MethodA
           internal func methodA<R>(
-              request: ClientRequest.Single<ServiceA.Method.MethodA.Input>,
-              serializer: some MessageSerializer<ServiceA.Method.MethodA.Input>,
-              deserializer: some MessageDeserializer<ServiceA.Method.MethodA.Output>,
+              request: ClientRequest.Single<ServiceARequest>,
+              serializer: some MessageSerializer<ServiceARequest>,
+              deserializer: some MessageDeserializer<ServiceAResponse>,
               options: CallOptions = .defaults,
-              _ body: @Sendable @escaping (ClientResponse.Single<ServiceA.Method.MethodA.Output>) async throws -> R
+              _ body: @Sendable @escaping (ClientResponse.Single<ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.client.unary(
                   request: request,

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
@@ -54,7 +54,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       public protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for unaryMethod
-          func unary(request: ServerRequest.Stream<NamespaceA_ServiceA.Method.Unary.Input>) async throws -> ServerResponse.Stream<NamespaceA_ServiceA.Method.Unary.Output>
+          func unary(request: ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Stream<NamespaceA_ServiceAResponse>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
@@ -63,8 +63,8 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
                   forMethod: NamespaceA_ServiceA.Method.Unary.descriptor,
-                  deserializer: ProtobufDeserializer<NamespaceA_ServiceA.Method.Unary.Input>(),
-                  serializer: ProtobufSerializer<NamespaceA_ServiceA.Method.Unary.Output>(),
+                  deserializer: ProtobufDeserializer<NamespaceA_ServiceARequest>(),
+                  serializer: ProtobufSerializer<NamespaceA_ServiceAResponse>(),
                   handler: { request in
                       try await self.unary(request: request)
                   }
@@ -75,12 +75,12 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       public protocol NamespaceA_ServiceAServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
           /// Documentation for unaryMethod
-          func unary(request: ServerRequest.Single<NamespaceA_ServiceA.Method.Unary.Input>) async throws -> ServerResponse.Single<NamespaceA_ServiceA.Method.Unary.Output>
+          func unary(request: ServerRequest.Single<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Single<NamespaceA_ServiceAResponse>
       }
       /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       extension NamespaceA_ServiceA.ServiceProtocol {
-          public func unary(request: ServerRequest.Stream<NamespaceA_ServiceA.Method.Unary.Input>) async throws -> ServerResponse.Stream<NamespaceA_ServiceA.Method.Unary.Output> {
+          public func unary(request: ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Stream<NamespaceA_ServiceAResponse> {
               let response = try await self.unary(request: ServerRequest.Single(stream: request))
               return ServerResponse.Stream(single: response)
           }
@@ -123,7 +123,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       package protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for inputStreamingMethod
-          func inputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceA.Method.InputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA_ServiceA.Method.InputStreaming.Output>
+          func inputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Stream<NamespaceA_ServiceAResponse>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
@@ -132,8 +132,8 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           package func registerMethods(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
                   forMethod: NamespaceA_ServiceA.Method.InputStreaming.descriptor,
-                  deserializer: ProtobufDeserializer<NamespaceA_ServiceA.Method.InputStreaming.Input>(),
-                  serializer: ProtobufSerializer<NamespaceA_ServiceA.Method.InputStreaming.Output>(),
+                  deserializer: ProtobufDeserializer<NamespaceA_ServiceARequest>(),
+                  serializer: ProtobufSerializer<NamespaceA_ServiceAResponse>(),
                   handler: { request in
                       try await self.inputStreaming(request: request)
                   }
@@ -144,12 +144,12 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       package protocol NamespaceA_ServiceAServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
           /// Documentation for inputStreamingMethod
-          func inputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceA.Method.InputStreaming.Input>) async throws -> ServerResponse.Single<NamespaceA_ServiceA.Method.InputStreaming.Output>
+          func inputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Single<NamespaceA_ServiceAResponse>
       }
       /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       extension NamespaceA_ServiceA.ServiceProtocol {
-          package func inputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceA.Method.InputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA_ServiceA.Method.InputStreaming.Output> {
+          package func inputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Stream<NamespaceA_ServiceAResponse> {
               let response = try await self.inputStreaming(request: request)
               return ServerResponse.Stream(single: response)
           }
@@ -196,7 +196,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       public protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for outputStreamingMethod
-          func outputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceA.Method.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA_ServiceA.Method.OutputStreaming.Output>
+          func outputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Stream<NamespaceA_ServiceAResponse>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
@@ -205,8 +205,8 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
                   forMethod: NamespaceA_ServiceA.Method.OutputStreaming.descriptor,
-                  deserializer: ProtobufDeserializer<NamespaceA_ServiceA.Method.OutputStreaming.Input>(),
-                  serializer: ProtobufSerializer<NamespaceA_ServiceA.Method.OutputStreaming.Output>(),
+                  deserializer: ProtobufDeserializer<NamespaceA_ServiceARequest>(),
+                  serializer: ProtobufSerializer<NamespaceA_ServiceAResponse>(),
                   handler: { request in
                       try await self.outputStreaming(request: request)
                   }
@@ -217,12 +217,12 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       public protocol NamespaceA_ServiceAServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
           /// Documentation for outputStreamingMethod
-          func outputStreaming(request: ServerRequest.Single<NamespaceA_ServiceA.Method.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA_ServiceA.Method.OutputStreaming.Output>
+          func outputStreaming(request: ServerRequest.Single<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Stream<NamespaceA_ServiceAResponse>
       }
       /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       extension NamespaceA_ServiceA.ServiceProtocol {
-          public func outputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceA.Method.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA_ServiceA.Method.OutputStreaming.Output> {
+          public func outputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Stream<NamespaceA_ServiceAResponse> {
               let response = try await self.outputStreaming(request: ServerRequest.Single(stream: request))
               return response
           }
@@ -269,7 +269,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       package protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for bidirectionalStreamingMethod
-          func bidirectionalStreaming(request: ServerRequest.Stream<NamespaceA_ServiceA.Method.BidirectionalStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA_ServiceA.Method.BidirectionalStreaming.Output>
+          func bidirectionalStreaming(request: ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Stream<NamespaceA_ServiceAResponse>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
@@ -278,8 +278,8 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           package func registerMethods(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
                   forMethod: NamespaceA_ServiceA.Method.BidirectionalStreaming.descriptor,
-                  deserializer: ProtobufDeserializer<NamespaceA_ServiceA.Method.BidirectionalStreaming.Input>(),
-                  serializer: ProtobufSerializer<NamespaceA_ServiceA.Method.BidirectionalStreaming.Output>(),
+                  deserializer: ProtobufDeserializer<NamespaceA_ServiceARequest>(),
+                  serializer: ProtobufSerializer<NamespaceA_ServiceAResponse>(),
                   handler: { request in
                       try await self.bidirectionalStreaming(request: request)
                   }
@@ -290,7 +290,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       package protocol NamespaceA_ServiceAServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
           /// Documentation for bidirectionalStreamingMethod
-          func bidirectionalStreaming(request: ServerRequest.Stream<NamespaceA_ServiceA.Method.BidirectionalStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA_ServiceA.Method.BidirectionalStreaming.Output>
+          func bidirectionalStreaming(request: ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Stream<NamespaceA_ServiceAResponse>
       }
       /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
@@ -350,10 +350,10 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       internal protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for inputStreamingMethod
-          func inputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceA.Method.InputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA_ServiceA.Method.InputStreaming.Output>
+          func inputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Stream<NamespaceA_ServiceAResponse>
           
           /// Documentation for outputStreamingMethod
-          func outputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceA.Method.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA_ServiceA.Method.OutputStreaming.Output>
+          func outputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Stream<NamespaceA_ServiceAResponse>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
@@ -362,16 +362,16 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           internal func registerMethods(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
                   forMethod: NamespaceA_ServiceA.Method.InputStreaming.descriptor,
-                  deserializer: ProtobufDeserializer<NamespaceA_ServiceA.Method.InputStreaming.Input>(),
-                  serializer: ProtobufSerializer<NamespaceA_ServiceA.Method.InputStreaming.Output>(),
+                  deserializer: ProtobufDeserializer<NamespaceA_ServiceARequest>(),
+                  serializer: ProtobufSerializer<NamespaceA_ServiceAResponse>(),
                   handler: { request in
                       try await self.inputStreaming(request: request)
                   }
               )
               router.registerHandler(
                   forMethod: NamespaceA_ServiceA.Method.OutputStreaming.descriptor,
-                  deserializer: ProtobufDeserializer<NamespaceA_ServiceA.Method.OutputStreaming.Input>(),
-                  serializer: ProtobufSerializer<NamespaceA_ServiceA.Method.OutputStreaming.Output>(),
+                  deserializer: ProtobufDeserializer<NamespaceA_ServiceARequest>(),
+                  serializer: ProtobufSerializer<NamespaceA_ServiceAResponse>(),
                   handler: { request in
                       try await self.outputStreaming(request: request)
                   }
@@ -382,20 +382,20 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       internal protocol NamespaceA_ServiceAServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
           /// Documentation for inputStreamingMethod
-          func inputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceA.Method.InputStreaming.Input>) async throws -> ServerResponse.Single<NamespaceA_ServiceA.Method.InputStreaming.Output>
+          func inputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Single<NamespaceA_ServiceAResponse>
           
           /// Documentation for outputStreamingMethod
-          func outputStreaming(request: ServerRequest.Single<NamespaceA_ServiceA.Method.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA_ServiceA.Method.OutputStreaming.Output>
+          func outputStreaming(request: ServerRequest.Single<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Stream<NamespaceA_ServiceAResponse>
       }
       /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       extension NamespaceA_ServiceA.ServiceProtocol {
-          internal func inputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceA.Method.InputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA_ServiceA.Method.InputStreaming.Output> {
+          internal func inputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Stream<NamespaceA_ServiceAResponse> {
               let response = try await self.inputStreaming(request: request)
               return ServerResponse.Stream(single: response)
           }
           
-          internal func outputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceA.Method.OutputStreaming.Input>) async throws -> ServerResponse.Stream<NamespaceA_ServiceA.Method.OutputStreaming.Output> {
+          internal func outputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Stream<NamespaceA_ServiceAResponse> {
               let response = try await self.outputStreaming(request: ServerRequest.Single(stream: request))
               return response
           }
@@ -434,7 +434,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       internal protocol ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for MethodA
-          func methodA(request: ServerRequest.Stream<ServiceA.Method.MethodA.Input>) async throws -> ServerResponse.Stream<ServiceA.Method.MethodA.Output>
+          func methodA(request: ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Stream<NamespaceA_ServiceAResponse>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
@@ -443,8 +443,8 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           internal func registerMethods(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
                   forMethod: ServiceA.Method.MethodA.descriptor,
-                  deserializer: ProtobufDeserializer<ServiceA.Method.MethodA.Input>(),
-                  serializer: ProtobufSerializer<ServiceA.Method.MethodA.Output>(),
+                  deserializer: ProtobufDeserializer<NamespaceA_ServiceARequest>(),
+                  serializer: ProtobufSerializer<NamespaceA_ServiceAResponse>(),
                   handler: { request in
                       try await self.methodA(request: request)
                   }
@@ -455,12 +455,12 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       internal protocol ServiceAServiceProtocol: ServiceA.StreamingServiceProtocol {
           /// Documentation for MethodA
-          func methodA(request: ServerRequest.Single<ServiceA.Method.MethodA.Input>) async throws -> ServerResponse.Single<ServiceA.Method.MethodA.Output>
+          func methodA(request: ServerRequest.Single<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Single<NamespaceA_ServiceAResponse>
       }
       /// Partial conformance to `ServiceAStreamingServiceProtocol`.
       @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
       extension ServiceA.ServiceProtocol {
-          internal func methodA(request: ServerRequest.Stream<ServiceA.Method.MethodA.Input>) async throws -> ServerResponse.Stream<ServiceA.Method.MethodA.Output> {
+          internal func methodA(request: ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Stream<NamespaceA_ServiceAResponse> {
               let response = try await self.methodA(request: ServerRequest.Single(stream: request))
               return ServerResponse.Stream(single: response)
           }

--- a/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGeneratorTests.swift
+++ b/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGeneratorTests.swift
@@ -84,25 +84,25 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         internal protocol Hello_World_GreeterClientProtocol: Sendable {
             /// Sends a greeting.
             func sayHello<R>(
-                request: ClientRequest.Single<Hello_World_Greeter.Method.SayHello.Input>,
-                serializer: some MessageSerializer<Hello_World_Greeter.Method.SayHello.Input>,
-                deserializer: some MessageDeserializer<Hello_World_Greeter.Method.SayHello.Output>,
+                request: ClientRequest.Single<Hello_World_HelloRequest>,
+                serializer: some MessageSerializer<Hello_World_HelloRequest>,
+                deserializer: some MessageDeserializer<Hello_World_HelloReply>,
                 options: CallOptions,
-                _ body: @Sendable @escaping (ClientResponse.Single<Hello_World_Greeter.Method.SayHello.Output>) async throws -> R
+                _ body: @Sendable @escaping (ClientResponse.Single<Hello_World_HelloReply>) async throws -> R
             ) async throws -> R where R: Sendable
         }
 
         @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
         extension Hello_World_Greeter.ClientProtocol {
             internal func sayHello<R>(
-                request: ClientRequest.Single<Hello_World_Greeter.Method.SayHello.Input>,
+                request: ClientRequest.Single<Hello_World_HelloRequest>,
                 options: CallOptions = .defaults,
-                _ body: @Sendable @escaping (ClientResponse.Single<Hello_World_Greeter.Method.SayHello.Output>) async throws -> R
+                _ body: @Sendable @escaping (ClientResponse.Single<Hello_World_HelloReply>) async throws -> R
             ) async throws -> R where R: Sendable {
                 try await self.sayHello(
                     request: request,
-                    serializer: ProtobufSerializer<Hello_World_Greeter.Method.SayHello.Input>(),
-                    deserializer: ProtobufDeserializer<Hello_World_Greeter.Method.SayHello.Output>(),
+                    serializer: ProtobufSerializer<Hello_World_HelloRequest>(),
+                    deserializer: ProtobufDeserializer<Hello_World_HelloReply>(),
                     options: options,
                     body
                 )
@@ -120,11 +120,11 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
             
             /// Sends a greeting.
             internal func sayHello<R>(
-                request: ClientRequest.Single<Hello_World_Greeter.Method.SayHello.Input>,
-                serializer: some MessageSerializer<Hello_World_Greeter.Method.SayHello.Input>,
-                deserializer: some MessageDeserializer<Hello_World_Greeter.Method.SayHello.Output>,
+                request: ClientRequest.Single<Hello_World_HelloRequest>,
+                serializer: some MessageSerializer<Hello_World_HelloRequest>,
+                deserializer: some MessageDeserializer<Hello_World_HelloReply>,
                 options: CallOptions = .defaults,
-                _ body: @Sendable @escaping (ClientResponse.Single<Hello_World_Greeter.Method.SayHello.Output>) async throws -> R
+                _ body: @Sendable @escaping (ClientResponse.Single<Hello_World_HelloReply>) async throws -> R
             ) async throws -> R where R: Sendable {
                 try await self.client.unary(
                     request: request,
@@ -198,7 +198,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
         public protocol Helloworld_GreeterStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Sends a greeting.
-          func sayHello(request: ServerRequest.Stream<Helloworld_Greeter.Method.SayHello.Input>) async throws -> ServerResponse.Stream<Helloworld_Greeter.Method.SayHello.Output>
+          func sayHello(request: ServerRequest.Stream<Helloworld_HelloRequest>) async throws -> ServerResponse.Stream<Helloworld_HelloReply>
         }
 
         /// Conformance to `GRPCCore.RegistrableRPCService`.
@@ -208,8 +208,8 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {
             router.registerHandler(
               forMethod: Helloworld_Greeter.Method.SayHello.descriptor,
-              deserializer: ProtobufDeserializer<Helloworld_Greeter.Method.SayHello.Input>(),
-              serializer: ProtobufSerializer<Helloworld_Greeter.Method.SayHello.Output>(),
+              deserializer: ProtobufDeserializer<Helloworld_HelloRequest>(),
+              serializer: ProtobufSerializer<Helloworld_HelloReply>(),
               handler: { request in
                 try await self.sayHello(request: request)
               }
@@ -221,13 +221,13 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
         public protocol Helloworld_GreeterServiceProtocol: Helloworld_Greeter.StreamingServiceProtocol {
           /// Sends a greeting.
-          func sayHello(request: ServerRequest.Single<Helloworld_Greeter.Method.SayHello.Input>) async throws -> ServerResponse.Single<Helloworld_Greeter.Method.SayHello.Output>
+          func sayHello(request: ServerRequest.Single<Helloworld_HelloRequest>) async throws -> ServerResponse.Single<Helloworld_HelloReply>
         }
 
         /// Partial conformance to `Helloworld_GreeterStreamingServiceProtocol`.
         @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
         extension Helloworld_Greeter.ServiceProtocol {
-          public func sayHello(request: ServerRequest.Stream<Helloworld_Greeter.Method.SayHello.Input>) async throws -> ServerResponse.Stream<Helloworld_Greeter.Method.SayHello.Output> {
+          public func sayHello(request: ServerRequest.Stream<Helloworld_HelloRequest>) async throws -> ServerResponse.Stream<Helloworld_HelloReply> {
             let response = try await self.sayHello(request: ServerRequest.Single(stream: request))
             return ServerResponse.Stream(single: response)
           }
@@ -297,7 +297,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
         package protocol GreeterStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Sends a greeting.
-          func sayHello(request: ServerRequest.Stream<Greeter.Method.SayHello.Input>) async throws -> ServerResponse.Stream<Greeter.Method.SayHello.Output>
+          func sayHello(request: ServerRequest.Stream<HelloRequest>) async throws -> ServerResponse.Stream<HelloReply>
         }
 
         /// Conformance to `GRPCCore.RegistrableRPCService`.
@@ -307,8 +307,8 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
           package func registerMethods(with router: inout GRPCCore.RPCRouter) {
             router.registerHandler(
               forMethod: Greeter.Method.SayHello.descriptor,
-              deserializer: ProtobufDeserializer<Greeter.Method.SayHello.Input>(),
-              serializer: ProtobufSerializer<Greeter.Method.SayHello.Output>(),
+              deserializer: ProtobufDeserializer<HelloRequest>(),
+              serializer: ProtobufSerializer<HelloReply>(),
               handler: { request in
                 try await self.sayHello(request: request)
               }
@@ -320,13 +320,13 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
         package protocol GreeterServiceProtocol: Greeter.StreamingServiceProtocol {
           /// Sends a greeting.
-          func sayHello(request: ServerRequest.Single<Greeter.Method.SayHello.Input>) async throws -> ServerResponse.Single<Greeter.Method.SayHello.Output>
+          func sayHello(request: ServerRequest.Single<HelloRequest>) async throws -> ServerResponse.Single<HelloReply>
         }
 
         /// Partial conformance to `GreeterStreamingServiceProtocol`.
         @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
         extension Greeter.ServiceProtocol {
-          package func sayHello(request: ServerRequest.Stream<Greeter.Method.SayHello.Input>) async throws -> ServerResponse.Stream<Greeter.Method.SayHello.Output> {
+          package func sayHello(request: ServerRequest.Stream<HelloRequest>) async throws -> ServerResponse.Stream<HelloReply> {
             let response = try await self.sayHello(request: ServerRequest.Single(stream: request))
             return ServerResponse.Stream(single: response)
           }
@@ -337,25 +337,25 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         package protocol GreeterClientProtocol: Sendable {
           /// Sends a greeting.
           func sayHello<R>(
-            request: ClientRequest.Single<Greeter.Method.SayHello.Input>,
-            serializer: some MessageSerializer<Greeter.Method.SayHello.Input>,
-            deserializer: some MessageDeserializer<Greeter.Method.SayHello.Output>,
+            request: ClientRequest.Single<HelloRequest>,
+            serializer: some MessageSerializer<HelloRequest>,
+            deserializer: some MessageDeserializer<HelloReply>,
             options: CallOptions,
-            _ body: @Sendable @escaping (ClientResponse.Single<Greeter.Method.SayHello.Output>) async throws -> R
+            _ body: @Sendable @escaping (ClientResponse.Single<HelloReply>) async throws -> R
           ) async throws -> R where R: Sendable
         }
 
         @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
         extension Greeter.ClientProtocol {
           package func sayHello<R>(
-            request: ClientRequest.Single<Greeter.Method.SayHello.Input>,
+            request: ClientRequest.Single<HelloRequest>,
             options: CallOptions = .defaults,
-            _ body: @Sendable @escaping (ClientResponse.Single<Greeter.Method.SayHello.Output>) async throws -> R
+            _ body: @Sendable @escaping (ClientResponse.Single<HelloReply>) async throws -> R
           ) async throws -> R where R: Sendable {
             try await self.sayHello(
               request: request,
-              serializer: ProtobufSerializer<Greeter.Method.SayHello.Input>(),
-              deserializer: ProtobufDeserializer<Greeter.Method.SayHello.Output>(),
+              serializer: ProtobufSerializer<HelloRequest>(),
+              deserializer: ProtobufDeserializer<HelloReply>(),
               options: options,
               body
             )
@@ -373,11 +373,11 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
           
           /// Sends a greeting.
           package func sayHello<R>(
-            request: ClientRequest.Single<Greeter.Method.SayHello.Input>,
-            serializer: some MessageSerializer<Greeter.Method.SayHello.Input>,
-            deserializer: some MessageDeserializer<Greeter.Method.SayHello.Output>,
+            request: ClientRequest.Single<HelloRequest>,
+            serializer: some MessageSerializer<HelloRequest>,
+            deserializer: some MessageDeserializer<HelloReply>,
             options: CallOptions = .defaults,
-            _ body: @Sendable @escaping (ClientResponse.Single<Greeter.Method.SayHello.Output>) async throws -> R
+            _ body: @Sendable @escaping (ClientResponse.Single<HelloReply>) async throws -> R
           ) async throws -> R where R: Sendable {
             try await self.client.unary(
               request: request,


### PR DESCRIPTION
Motivation:

The generated code for v2 includes typealiases for the input/output types for each RPC method. These typealiases end up making things less clear to the end user as they must follow the typealias to know what type is being used.

Modifications:

- Adjust `GRPCCodeGen` (both for the client and server) to not generate typealiases for the input/output types.
- Adjust `TestService` to use the actual message types.
- Update the generated code examples in `ClientCodeTranslator` and `ServerCodeTranslator`.

Result:

The generated code will use the actual message types for the input/output types.