### PR TITLE
Enable SwiftPM build plugin to use the new code generator plugin

### DIFF
--- a/Plugins/GRPCSwiftPlugin/plugin.swift
+++ b/Plugins/GRPCSwiftPlugin/plugin.swift
@@ -202,6 +202,10 @@ struct GRPCSwiftPlugin {
       protocArgs.append("--grpc-swift_opt=KeepMethodCasing=\(keepMethodCasingOption)")
     }
 
+    if let v2 {
+      protocArgs.append("--grpc-swift_opt=_V2=\(v2)")
+    }
+
     var inputFiles = [Path]()
     var outputFiles = [Path]()
 
@@ -227,10 +231,6 @@ struct GRPCSwiftPlugin {
         let reflectionOutputPath = outputDirectory.appending(file)
         outputFiles.append(reflectionOutputPath)
       }
-    }
-
-    if let v2 {
-      protocArgs.append("--grpc-swift_opt=_V2=\(v2)")
     }
 
     // Construct the command. Specifying the input and output paths lets the build

--- a/Plugins/GRPCSwiftPlugin/plugin.swift
+++ b/Plugins/GRPCSwiftPlugin/plugin.swift
@@ -69,6 +69,8 @@ struct GRPCSwiftPlugin {
       var reflectionData: Bool?
       /// Determines whether the casing of generated function names is kept.
       var keepMethodCasing: Bool?
+      /// Whether the invocation is for `grpc-swift` v2.
+      var _V2: Bool?
     }
 
     /// Specify the directory in which to search for
@@ -85,9 +87,6 @@ struct GRPCSwiftPlugin {
 
     /// A list of invocations of `protoc` with the `GRPCSwiftPlugin`.
     var invocations: [Invocation]
-
-    /// Whether this configuration is for `grpc-swift` v2.
-    var _V2: Bool?
   }
 
   static let configurationFileName = "grpc-swift-config.json"
@@ -145,8 +144,7 @@ struct GRPCSwiftPlugin {
         protocPath: protocPath,
         protocGenGRPCSwiftPath: protocGenGRPCSwiftPath,
         outputDirectory: pluginWorkDirectory,
-        importPaths: importPaths,
-        v2: configuration._V2
+        importPaths: importPaths
       )
     }
   }
@@ -160,7 +158,6 @@ struct GRPCSwiftPlugin {
   ///   - protocGenSwiftPath: The path to the `protoc-gen-swift` binary.
   ///   - outputDirectory: The output directory for the generated files.
   ///   - importPaths: List of paths to pass with "-I <path>" to `protoc`.
-  ///   - v2: Whether the invocation is for `grpc-swift` v2.
   /// - Returns: The build command configured based on the arguments
   private func invokeProtoc(
     directory: Path,
@@ -168,8 +165,7 @@ struct GRPCSwiftPlugin {
     protocPath: Path,
     protocGenGRPCSwiftPath: Path,
     outputDirectory: Path,
-    importPaths: [Path],
-    v2: Bool?
+    importPaths: [Path]
   ) -> Command {
     // Construct the `protoc` arguments.
     var protocArgs = [
@@ -202,7 +198,7 @@ struct GRPCSwiftPlugin {
       protocArgs.append("--grpc-swift_opt=KeepMethodCasing=\(keepMethodCasingOption)")
     }
 
-    if let v2 {
+    if let v2 = invocation._V2 {
       protocArgs.append("--grpc-swift_opt=_V2=\(v2)")
     }
 

--- a/Plugins/GRPCSwiftPlugin/plugin.swift
+++ b/Plugins/GRPCSwiftPlugin/plugin.swift
@@ -85,6 +85,9 @@ struct GRPCSwiftPlugin {
 
     /// A list of invocations of `protoc` with the `GRPCSwiftPlugin`.
     var invocations: [Invocation]
+
+    /// Whether this configuration is for `grpc-swift` v2.
+    var _V2: Bool?
   }
 
   static let configurationFileName = "grpc-swift-config.json"
@@ -142,7 +145,8 @@ struct GRPCSwiftPlugin {
         protocPath: protocPath,
         protocGenGRPCSwiftPath: protocGenGRPCSwiftPath,
         outputDirectory: pluginWorkDirectory,
-        importPaths: importPaths
+        importPaths: importPaths,
+        v2: configuration._V2
       )
     }
   }
@@ -155,7 +159,8 @@ struct GRPCSwiftPlugin {
   ///   - protocPath: The path to the `protoc` binary.
   ///   - protocGenSwiftPath: The path to the `protoc-gen-swift` binary.
   ///   - outputDirectory: The output directory for the generated files.
-  ///   - importPaths: List of paths to pass with "-I <path>" to `protoc`
+  ///   - importPaths: List of paths to pass with "-I <path>" to `protoc`.
+  ///   - v2: Whether the invocation is for `grpc-swift` v2.
   /// - Returns: The build command configured based on the arguments
   private func invokeProtoc(
     directory: Path,
@@ -163,7 +168,8 @@ struct GRPCSwiftPlugin {
     protocPath: Path,
     protocGenGRPCSwiftPath: Path,
     outputDirectory: Path,
-    importPaths: [Path]
+    importPaths: [Path],
+    v2: Bool?
   ) -> Command {
     // Construct the `protoc` arguments.
     var protocArgs = [
@@ -221,6 +227,10 @@ struct GRPCSwiftPlugin {
         let reflectionOutputPath = outputDirectory.appending(file)
         outputFiles.append(reflectionOutputPath)
       }
+    }
+
+    if let v2 {
+      protocArgs.append("--grpc-swift_opt=_V2=\(v2)")
     }
 
     // Construct the command. Specifying the input and output paths lets the build


### PR DESCRIPTION
Motivation:

The SwiftPM build plugin could not be configured to use the new code generator plugin.

Modifications:

- Add a `_V2` boolean option to the SwiftPM build plugin configuration. If this option is set, it is passed to protoc-gen-grpc-swift which then uses the new code generator plugin.

Result:

The SwiftPM build plugin can now be configured use the new code generator plugin.