### PR TITLE
Expose listening address on NIOTS server transport

### DIFF
--- a/Sources/GRPCHTTP2TransportNIOPosix/HTTP2ServerTransport+Posix.swift
+++ b/Sources/GRPCHTTP2TransportNIOPosix/HTTP2ServerTransport+Posix.swift
@@ -34,7 +34,7 @@ extension HTTP2ServerTransport {
       case listening(EventLoopFuture<GRPCHTTP2Core.SocketAddress>)
       case closedOrInvalidAddress(RuntimeError)
 
-      public var listeningAddressFuture: EventLoopFuture<GRPCHTTP2Core.SocketAddress> {
+      var listeningAddressFuture: EventLoopFuture<GRPCHTTP2Core.SocketAddress> {
         get throws {
           switch self {
           case .idle(let eventLoopPromise):

--- a/Sources/GRPCHTTP2TransportNIOTransportServices/HTTP2ServerTransport+TransportServices.swift
+++ b/Sources/GRPCHTTP2TransportNIOTransportServices/HTTP2ServerTransport+TransportServices.swift
@@ -35,7 +35,7 @@ extension HTTP2ServerTransport {
       case listening(EventLoopFuture<GRPCHTTP2Core.SocketAddress>)
       case closedOrInvalidAddress(RuntimeError)
 
-      public var listeningAddressFuture: EventLoopFuture<GRPCHTTP2Core.SocketAddress> {
+      var listeningAddressFuture: EventLoopFuture<GRPCHTTP2Core.SocketAddress> {
         get throws {
           switch self {
           case .idle(let eventLoopPromise):

--- a/Sources/GRPCHTTP2TransportNIOTransportServices/HTTP2ServerTransport+TransportServices.swift
+++ b/Sources/GRPCHTTP2TransportNIOTransportServices/HTTP2ServerTransport+TransportServices.swift
@@ -59,10 +59,7 @@ extension HTTP2ServerTransport {
         )
       }
 
-      mutating func addressBound(
-        _ address: NIOCore.SocketAddress?,
-        userProvidedAddress: GRPCHTTP2Core.SocketAddress
-      ) -> OnBound {
+      mutating func addressBound(_ address: NIOCore.SocketAddress?) -> OnBound {
         switch self {
         case .idle(let listeningAddressPromise):
           if let address {
@@ -71,10 +68,6 @@ extension HTTP2ServerTransport {
               listeningAddressPromise,
               address: GRPCHTTP2Core.SocketAddress(address)
             )
-
-          } else if userProvidedAddress.virtualSocket != nil {
-            self = .listening(listeningAddressPromise.futureResult)
-            return .succeedPromise(listeningAddressPromise, address: userProvidedAddress)
 
           } else {
             assertionFailure("Unknown address type")
@@ -195,10 +188,7 @@ extension HTTP2ServerTransport {
         }
 
       let action = self.listeningAddressState.withLockedValue {
-        $0.addressBound(
-          serverChannel.channel.localAddress,
-          userProvidedAddress: self.address
-        )
+        $0.addressBound(serverChannel.channel.localAddress)
       }
       switch action {
       case .succeedPromise(let promise, let address):

--- a/Sources/GRPCHTTP2TransportNIOTransportServices/HTTP2ServerTransport+TransportServices.swift
+++ b/Sources/GRPCHTTP2TransportNIOTransportServices/HTTP2ServerTransport+TransportServices.swift
@@ -30,6 +30,118 @@ extension HTTP2ServerTransport {
     private let eventLoopGroup: NIOTSEventLoopGroup
     private let serverQuiescingHelper: ServerQuiescingHelper
 
+    private enum State {
+      case idle(EventLoopPromise<GRPCHTTP2Core.SocketAddress>)
+      case listening(EventLoopFuture<GRPCHTTP2Core.SocketAddress>)
+      case closedOrInvalidAddress(RuntimeError)
+
+      public var listeningAddressFuture: EventLoopFuture<GRPCHTTP2Core.SocketAddress> {
+        get throws {
+          switch self {
+          case .idle(let eventLoopPromise):
+            return eventLoopPromise.futureResult
+          case .listening(let eventLoopFuture):
+            return eventLoopFuture
+          case .closedOrInvalidAddress(let runtimeError):
+            throw runtimeError
+          }
+        }
+      }
+
+      enum OnBound {
+        case succeedPromise(
+          _ promise: EventLoopPromise<GRPCHTTP2Core.SocketAddress>,
+          address: GRPCHTTP2Core.SocketAddress
+        )
+        case failPromise(
+          _ promise: EventLoopPromise<GRPCHTTP2Core.SocketAddress>,
+          error: RuntimeError
+        )
+      }
+
+      mutating func addressBound(
+        _ address: NIOCore.SocketAddress?,
+        userProvidedAddress: GRPCHTTP2Core.SocketAddress
+      ) -> OnBound {
+        switch self {
+        case .idle(let listeningAddressPromise):
+          if let address {
+            self = .listening(listeningAddressPromise.futureResult)
+            return .succeedPromise(
+              listeningAddressPromise,
+              address: GRPCHTTP2Core.SocketAddress(address)
+            )
+
+          } else if userProvidedAddress.virtualSocket != nil {
+            self = .listening(listeningAddressPromise.futureResult)
+            return .succeedPromise(listeningAddressPromise, address: userProvidedAddress)
+
+          } else {
+            assertionFailure("Unknown address type")
+            let invalidAddressError = RuntimeError(
+              code: .transportError,
+              message: "Unknown address type returned by transport."
+            )
+            self = .closedOrInvalidAddress(invalidAddressError)
+            return .failPromise(listeningAddressPromise, error: invalidAddressError)
+          }
+
+        case .listening, .closedOrInvalidAddress:
+          fatalError(
+            "Invalid state: addressBound should only be called once and when in idle state"
+          )
+        }
+      }
+
+      enum OnClose {
+        case failPromise(
+          EventLoopPromise<GRPCHTTP2Core.SocketAddress>,
+          error: RuntimeError
+        )
+        case doNothing
+      }
+
+      mutating func close() -> OnClose {
+        let serverStoppedError = RuntimeError(
+          code: .serverIsStopped,
+          message: """
+            There is no listening address bound for this server: there may have been \
+            an error which caused the transport to close, or it may have shut down.
+            """
+        )
+
+        switch self {
+        case .idle(let listeningAddressPromise):
+          self = .closedOrInvalidAddress(serverStoppedError)
+          return .failPromise(listeningAddressPromise, error: serverStoppedError)
+
+        case .listening:
+          self = .closedOrInvalidAddress(serverStoppedError)
+          return .doNothing
+
+        case .closedOrInvalidAddress:
+          return .doNothing
+        }
+      }
+    }
+
+    private let listeningAddressState: _LockedValueBox<State>
+
+    /// The listening address for this server transport.
+    ///
+    /// It is an `async` property because it will only return once the address has been successfully bound.
+    ///
+    /// - Throws: A runtime error will be thrown if the address could not be bound or is not bound any
+    /// longer, because the transport isn't listening anymore. It can also throw if the transport returned an
+    /// invalid address.
+    public var listeningAddress: GRPCHTTP2Core.SocketAddress {
+      get async throws {
+        try await self.listeningAddressState
+          .withLockedValue { try $0.listeningAddressFuture }
+          .get()
+      }
+    }
+
     /// Create a new `TransportServices` transport.
     ///
     /// - Parameters:
@@ -45,11 +157,23 @@ extension HTTP2ServerTransport {
       self.config = config
       self.eventLoopGroup = eventLoopGroup
       self.serverQuiescingHelper = ServerQuiescingHelper(group: self.eventLoopGroup)
+
+      let eventLoop = eventLoopGroup.any()
+      self.listeningAddressState = _LockedValueBox(.idle(eventLoop.makePromise()))
     }
 
     public func listen(
       _ streamHandler: @escaping (RPCStream<Inbound, Outbound>) async -> Void
     ) async throws {
+      defer {
+        switch self.listeningAddressState.withLockedValue({ $0.close() }) {
+        case .failPromise(let promise, let error):
+          promise.fail(error)
+        case .doNothing:
+          ()
+        }
+      }
+
       let serverChannel = try await NIOTSListenerBootstrap(group: self.eventLoopGroup)
         .serverChannelInitializer { channel in
           let quiescingHandler = self.serverQuiescingHelper.makeServerChannelHandler(
@@ -69,6 +193,19 @@ extension HTTP2ServerTransport {
             )
           }
         }
+
+      let action = self.listeningAddressState.withLockedValue {
+        $0.addressBound(
+          serverChannel.channel.localAddress,
+          userProvidedAddress: self.address
+        )
+      }
+      switch action {
+      case .succeedPromise(let promise, let address):
+        promise.succeed(address)
+      case .failPromise(let promise, let error):
+        promise.fail(error)
+      }
 
       try await serverChannel.executeThenClose { inbound in
         try await withThrowingDiscardingTaskGroup { serverTaskGroup in
@@ -203,7 +340,7 @@ extension NIOTSListenerBootstrap {
     to address: GRPCHTTP2Core.SocketAddress,
     childChannelInitializer: @escaping @Sendable (Channel) -> EventLoopFuture<Output>
   ) async throws -> NIOAsyncChannel<Output, Never> {
-    if let virtualSocket = address.virtualSocket {
+    if address.virtualSocket != nil {
       throw RuntimeError(
         code: .transportError,
         message: """

--- a/Tests/GRPCHTTP2TransportTests/HTTP2TransportNIOPosixTests.swift
+++ b/Tests/GRPCHTTP2TransportTests/HTTP2TransportNIOPosixTests.swift
@@ -61,7 +61,7 @@ final class HTTP2TransportNIOPosixTests: XCTestCase {
 
   func testGetListeningAddress_UnixDomainSocket() async throws {
     let transport = GRPCHTTP2Core.HTTP2ServerTransport.Posix(
-      address: .unixDomainSocket(path: "/tmp/test")
+      address: .unixDomainSocket(path: "/tmp/posix-uds-test")
     )
 
     try await withThrowingDiscardingTaskGroup { group in
@@ -73,7 +73,7 @@ final class HTTP2TransportNIOPosixTests: XCTestCase {
         let address = try await transport.listeningAddress
         XCTAssertEqual(
           address.unixDomainSocket,
-          GRPCHTTP2Core.SocketAddress.UnixDomainSocket(path: "/tmp/test")
+          GRPCHTTP2Core.SocketAddress.UnixDomainSocket(path: "/tmp/posix-uds-test")
         )
         transport.stopListening()
       }

--- a/Tests/GRPCHTTP2TransportTests/HTTP2TransportNIOTransportServicesTests.swift
+++ b/Tests/GRPCHTTP2TransportTests/HTTP2TransportNIOTransportServicesTests.swift
@@ -62,7 +62,7 @@ final class HTTP2TransportNIOTransportServicesTests: XCTestCase {
 
   func testGetListeningAddress_UnixDomainSocket() async throws {
     let transport = GRPCHTTP2Core.HTTP2ServerTransport.TransportServices(
-      address: .unixDomainSocket(path: "/tmp/test")
+      address: .unixDomainSocket(path: "/tmp/niots-uds-test")
     )
 
     try await withThrowingDiscardingTaskGroup { group in
@@ -74,7 +74,7 @@ final class HTTP2TransportNIOTransportServicesTests: XCTestCase {
         let address = try await transport.listeningAddress
         XCTAssertEqual(
           address.unixDomainSocket,
-          GRPCHTTP2Core.SocketAddress.UnixDomainSocket(path: "/tmp/test")
+          GRPCHTTP2Core.SocketAddress.UnixDomainSocket(path: "/tmp/niots-uds-test")
         )
         transport.stopListening()
       }

--- a/Tests/GRPCHTTP2TransportTests/HTTP2TransportNIOTransportServicesTests.swift
+++ b/Tests/GRPCHTTP2TransportTests/HTTP2TransportNIOTransportServicesTests.swift
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
+#if canImport(Network)
 import GRPCCore
 import GRPCHTTP2Core
 import GRPCHTTP2TransportNIOTransportServices
 import XCTest
 
-#if canImport(Network)
 @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 final class HTTP2TransportNIOTransportServicesTests: XCTestCase {
   func testGetListeningAddress_IPv4() async throws {
@@ -76,26 +76,6 @@ final class HTTP2TransportNIOTransportServicesTests: XCTestCase {
           address.unixDomainSocket,
           GRPCHTTP2Core.SocketAddress.UnixDomainSocket(path: "/tmp/test")
         )
-        transport.stopListening()
-      }
-    }
-  }
-
-  func testGetListeningAddress_Vsock() async throws {
-    try XCTSkipUnless(self.vsockAvailable(), "Vsock unavailable")
-
-    let transport = GRPCHTTP2Core.HTTP2ServerTransport.TransportServices(
-      address: .vsock(contextID: .any, port: .any)
-    )
-
-    try await withThrowingDiscardingTaskGroup { group in
-      group.addTask {
-        try await transport.listen { _ in }
-      }
-
-      group.addTask {
-        let address = try await transport.listeningAddress
-        XCTAssertNotNil(address.virtualSocket)
         transport.stopListening()
       }
     }

--- a/Tests/GRPCHTTP2TransportTests/HTTP2TransportNIOTransportServicesTests.swift
+++ b/Tests/GRPCHTTP2TransportTests/HTTP2TransportNIOTransportServicesTests.swift
@@ -19,6 +19,7 @@ import GRPCHTTP2Core
 import GRPCHTTP2TransportNIOTransportServices
 import XCTest
 
+#if canImport(Network)
 @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 final class HTTP2TransportNIOTransportServicesTests: XCTestCase {
   func testGetListeningAddress_IPv4() async throws {
@@ -160,3 +161,4 @@ final class HTTP2TransportNIOTransportServicesTests: XCTestCase {
     }
   }
 }
+#endif

--- a/Tests/GRPCHTTP2TransportTests/HTTP2TransportNIOTransportServicesTests.swift
+++ b/Tests/GRPCHTTP2TransportTests/HTTP2TransportNIOTransportServicesTests.swift
@@ -16,13 +16,13 @@
 
 import GRPCCore
 import GRPCHTTP2Core
-import GRPCHTTP2TransportNIOPosix
+import GRPCHTTP2TransportNIOTransportServices
 import XCTest
 
 @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
-final class HTTP2TransportNIOPosixTests: XCTestCase {
+final class HTTP2TransportNIOTransportServicesTests: XCTestCase {
   func testGetListeningAddress_IPv4() async throws {
-    let transport = GRPCHTTP2Core.HTTP2ServerTransport.Posix(
+    let transport = GRPCHTTP2Core.HTTP2ServerTransport.TransportServices(
       address: .ipv4(host: "0.0.0.0", port: 0)
     )
 
@@ -41,7 +41,7 @@ final class HTTP2TransportNIOPosixTests: XCTestCase {
   }
 
   func testGetListeningAddress_IPv6() async throws {
-    let transport = GRPCHTTP2Core.HTTP2ServerTransport.Posix(
+    let transport = GRPCHTTP2Core.HTTP2ServerTransport.TransportServices(
       address: .ipv6(host: "::1", port: 0)
     )
 
@@ -60,7 +60,7 @@ final class HTTP2TransportNIOPosixTests: XCTestCase {
   }
 
   func testGetListeningAddress_UnixDomainSocket() async throws {
-    let transport = GRPCHTTP2Core.HTTP2ServerTransport.Posix(
+    let transport = GRPCHTTP2Core.HTTP2ServerTransport.TransportServices(
       address: .unixDomainSocket(path: "/tmp/test")
     )
 
@@ -83,7 +83,7 @@ final class HTTP2TransportNIOPosixTests: XCTestCase {
   func testGetListeningAddress_Vsock() async throws {
     try XCTSkipUnless(self.vsockAvailable(), "Vsock unavailable")
 
-    let transport = GRPCHTTP2Core.HTTP2ServerTransport.Posix(
+    let transport = GRPCHTTP2Core.HTTP2ServerTransport.TransportServices(
       address: .vsock(contextID: .any, port: .any)
     )
 
@@ -101,7 +101,7 @@ final class HTTP2TransportNIOPosixTests: XCTestCase {
   }
 
   func testGetListeningAddress_InvalidAddress() async {
-    let transport = GRPCHTTP2Core.HTTP2ServerTransport.Posix(
+    let transport = GRPCHTTP2Core.HTTP2ServerTransport.TransportServices(
       address: .unixDomainSocket(path: "/this/should/be/an/invalid/path")
     )
 
@@ -129,7 +129,7 @@ final class HTTP2TransportNIOPosixTests: XCTestCase {
   }
 
   func testGetListeningAddress_StoppedListening() async throws {
-    let transport = GRPCHTTP2Core.HTTP2ServerTransport.Posix(
+    let transport = GRPCHTTP2Core.HTTP2ServerTransport.TransportServices(
       address: .ipv4(host: "0.0.0.0", port: 0)
     )
 


### PR DESCRIPTION
## Motivation
Follow-up of https://github.com/grpc/grpc-swift/pull/1934.

## Modifications
Same as https://github.com/grpc/grpc-swift/pull/1933 for the NIOPosix implementation of the server transport, this PR adds a `listeningAddress` property to the NIOTS server transport implementation.

## Result
We can now know what address our server transport's listening on for requests.