### PR TITLE
Enable so_reuseaddr on server transport implementations

### DIFF
--- a/Sources/GRPCHTTP2TransportNIOPosix/HTTP2ServerTransport+Posix.swift
+++ b/Sources/GRPCHTTP2TransportNIOPosix/HTTP2ServerTransport+Posix.swift
@@ -174,6 +174,10 @@ extension HTTP2ServerTransport {
       }
 
       let serverChannel = try await ServerBootstrap(group: self.eventLoopGroup)
+        .serverChannelOption(
+          ChannelOptions.socketOption(.so_reuseaddr),
+          value: 1
+        )
         .serverChannelInitializer { channel in
           let quiescingHandler = self.serverQuiescingHelper.makeServerChannelHandler(
             channel: channel

--- a/Sources/GRPCHTTP2TransportNIOTransportServices/HTTP2ServerTransport+TransportServices.swift
+++ b/Sources/GRPCHTTP2TransportNIOTransportServices/HTTP2ServerTransport+TransportServices.swift
@@ -168,6 +168,10 @@ extension HTTP2ServerTransport {
       }
 
       let serverChannel = try await NIOTSListenerBootstrap(group: self.eventLoopGroup)
+        .serverChannelOption(
+          ChannelOptions.socketOption(.so_reuseaddr),
+          value: 1
+        )
         .serverChannelInitializer { channel in
           let quiescingHandler = self.serverQuiescingHelper.makeServerChannelHandler(
             channel: channel


### PR DESCRIPTION
## Motivation
We are not setting the `so_reuseaddr` on the server channel, meaning it's possible we get binding failures when bootstrapping the server if the provided address is already in use.

## Modifications
Set the `so_reuseaddr` option when bootstrapping the server in both the NIOPosix and NIOTS implementations.
This is already done in v1.

## Result
No more binding failures for reused ports.