### PR TITLE
Propagate timeout to server

### DIFF
--- a/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor.swift
@@ -42,11 +42,13 @@ enum ClientRPCExecutor {
     interceptors: [any ClientInterceptor],
     handler: @Sendable @escaping (ClientResponse.Stream<Output>) async throws -> Result
   ) async throws -> Result {
+    let deadline = options.timeout.map { ContinuousClock.now + $0 }
+
     switch options.executionPolicy?.wrapped {
     case .none:
       let oneShotExecutor = OneShotExecutor(
         transport: transport,
-        timeout: options.timeout,
+        deadline: deadline,
         interceptors: interceptors,
         serializer: serializer,
         deserializer: deserializer
@@ -63,7 +65,7 @@ enum ClientRPCExecutor {
       let retryExecutor = RetryExecutor(
         transport: transport,
         policy: policy,
-        timeout: options.timeout,
+        deadline: deadline,
         interceptors: interceptors,
         serializer: serializer,
         deserializer: deserializer,
@@ -81,7 +83,7 @@ enum ClientRPCExecutor {
       let hedging = HedgingExecutor(
         transport: transport,
         policy: policy,
-        timeout: options.timeout,
+        deadline: deadline,
         interceptors: interceptors,
         serializer: serializer,
         deserializer: deserializer,

--- a/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTestSupport/ClientRPCExecutorTestHarness+ServerBehavior.swift
+++ b/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTestSupport/ClientRPCExecutorTestHarness+ServerBehavior.swift
@@ -51,8 +51,7 @@ extension ClientRPCExecutorTestHarness {
 @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 extension ClientRPCExecutorTestHarness.ServerStreamHandler {
   static var echo: Self {
-    return Self {
-      stream in
+    return Self { stream in
       let response = stream.inbound.map { part -> RPCResponsePart in
         switch part {
         case .metadata(let metadata):

--- a/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests.swift
+++ b/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests.swift
@@ -227,6 +227,7 @@ final class ClientRPCExecutorTests: XCTestCase {
   }
 
   func testTimeoutIsPropagated() async throws {
+    // 'nil' means no retires or hedging, just try to execute the RPC once.
     var policies: [RPCExecutionPolicy?] = [nil]
 
     let retryPolicy = RetryPolicy(

--- a/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests.swift
+++ b/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests.swift
@@ -13,8 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import GRPCCore
+
 import XCTest
+
+@testable import GRPCCore
 
 @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 final class ClientRPCExecutorTests: XCTestCase {
@@ -222,5 +224,48 @@ final class ClientRPCExecutorTests: XCTestCase {
     XCTAssertEqual(tester.clientStreamsOpened, 0)
     XCTAssertEqual(tester.clientStreamOpenFailures, 1)
     XCTAssertEqual(tester.serverStreamsAccepted, 0)
+  }
+
+  func testTimeoutIsPropagated() async throws {
+    var policies: [RPCExecutionPolicy?] = [nil]
+
+    let retryPolicy = RetryPolicy(
+      maximumAttempts: 5,
+      initialBackoff: .seconds(1),
+      maximumBackoff: .seconds(1),
+      backoffMultiplier: 1.6,
+      retryableStatusCodes: [.unavailable]
+    )
+    policies.append(.retry(retryPolicy))
+
+    let hedgingPolicy = HedgingPolicy(
+      maximumAttempts: 5,
+      hedgingDelay: .seconds(1),
+      nonFatalStatusCodes: [.unavailable]
+    )
+    policies.append(.hedge(hedgingPolicy))
+
+    for policy in policies {
+      let timeout = Duration.seconds(120)
+      var options = CallOptions.defaults
+      options.timeout = timeout
+      options.executionPolicy = policy
+
+      let tester = ClientRPCExecutorTestHarness(transport: .inProcess, server: .echo)
+      try await tester.unary(
+        request: ClientRequest.Single(message: []),
+        options: options
+      ) { response in
+        let timeoutMetadata = Array(response.metadata[stringValues: "grpc-timeout"])
+        let parsed = try XCTUnwrap(timeoutMetadata.first.flatMap { Timeout(decoding: $0) })
+
+        // The timeout is handled as a deadline internally and gets converted back to a timeout
+        // when transmitted as metadata, so allow some leeway when checking the value.
+        let leeway = Duration.seconds(1)
+        let acceptable: ClosedRange<Duration> = timeout - leeway ... timeout + leeway
+
+        XCTAssert(acceptable.contains(parsed.duration))
+      }
+    }
   }
 }


### PR DESCRIPTION
Motivation:

gRPC timeouts can be propagated to the server via the 'grpc-timeout' metadata field. The server can then also choose to enforce the timeout. At the moment this value isn't propagated, but it should be.

Modifications:

- Convert the timeout to a deadline when it's passed to the rpc executor and use this internally. Compute a timeout from the deadline and current time when executing an RPC.

Result:

Timeout is propagated to server