### PR TITLE
Make Subchannel internal state handling clearer

### DIFF
--- a/Sources/GRPCHTTP2Core/Client/Connection/LoadBalancers/PickFirstLoadBalancer.swift
+++ b/Sources/GRPCHTTP2Core/Client/Connection/LoadBalancers/PickFirstLoadBalancer.swift
@@ -185,7 +185,7 @@ extension PickFirstLoadBalancer {
     switch onUpdate {
     case .connect(let newSubchannel, close: let oldSubchannel):
       self.runSubchannel(newSubchannel, in: &group)
-      oldSubchannel?.close()
+      oldSubchannel?.shutDown()
 
     case .none:
       ()
@@ -226,9 +226,9 @@ extension PickFirstLoadBalancer {
 
     switch onUpdateState {
     case .close(let subchannel):
-      subchannel.close()
+      subchannel.shutDown()
     case .closeAndPublishStateChange(let subchannel, let connectivityState):
-      subchannel.close()
+      subchannel.shutDown()
       self.event.continuation.yield(.connectivityStateChanged(connectivityState))
     case .publishStateChange(let connectivityState):
       self.event.continuation.yield(.connectivityStateChanged(connectivityState))
@@ -251,8 +251,8 @@ extension PickFirstLoadBalancer {
     switch onClose {
     case .closeSubchannels(let subchannel1, let subchannel2):
       self.event.continuation.yield(.connectivityStateChanged(.shutdown))
-      subchannel1.close()
-      subchannel2?.close()
+      subchannel1.shutDown()
+      subchannel2?.shutDown()
 
     case .closed:
       self.event.continuation.yield(.connectivityStateChanged(.shutdown))

--- a/Sources/GRPCHTTP2Core/Client/Connection/LoadBalancers/RoundRobinLoadBalancer.swift
+++ b/Sources/GRPCHTTP2Core/Client/Connection/LoadBalancers/RoundRobinLoadBalancer.swift
@@ -245,7 +245,7 @@ extension RoundRobinLoadBalancer {
     // present if there are more to remove than to add. These are the excess subchannels which
     // are closed now.
     for subchannel in removed {
-      subchannel.close()
+      subchannel.shutDown()
     }
   }
 
@@ -288,10 +288,10 @@ extension RoundRobinLoadBalancer {
 
     case .closeAndPublishStateChange(let subchannel, let aggregateState):
       self.event.continuation.yield(.connectivityStateChanged(aggregateState))
-      subchannel.close()
+      subchannel.shutDown()
 
     case .close(let subchannel):
-      subchannel.close()
+      subchannel.shutDown()
 
     case .closed:
       // All subchannels are closed; finish the streams so the run loop exits.
@@ -306,7 +306,7 @@ extension RoundRobinLoadBalancer {
   private func handleSubchannelGoingAway(key: EndpointKey) {
     switch self.state.withLockedValue({ $0.parkSubchannel(withKey: key) }) {
     case .closeAndUpdateState(let subchannel, let connectivityState):
-      subchannel.close()
+      subchannel.shutDown()
       if let connectivityState = connectivityState {
         self.event.continuation.yield(.connectivityStateChanged(connectivityState))
       }
@@ -323,7 +323,7 @@ extension RoundRobinLoadBalancer {
 
       // Close the subchannels.
       for subchannel in subchannels {
-        subchannel.close()
+        subchannel.shutDown()
       }
 
     case .closed:

--- a/Tests/GRPCHTTP2CoreTests/Client/Connection/GRPCChannelTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Client/Connection/GRPCChannelTests.swift
@@ -749,9 +749,6 @@ final class GRPCChannelTests: XCTestCase {
   }
 
   func testQueueRequestsThenClose() async throws {
-    let (resolver, continuation) = NameResolver.dynamic(updateMode: .push)
-    continuation.yield(.init(endpoints: [Endpoint()], serviceConfig: nil))
-
     // Set a high backoff so the channel stays in transient failure for long enough.
     var config = GRPCChannel.Config.defaults
     config.backoff.initial = .seconds(120)

--- a/Tests/GRPCHTTP2CoreTests/Client/Connection/LoadBalancers/SubchannelTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Client/Connection/LoadBalancers/SubchannelTests.swift
@@ -35,7 +35,7 @@ final class SubchannelTests: XCTestCase {
       XCTAssertEqual(error.code, .unavailable)
     }
 
-    subchannel.close()
+    subchannel.shutDown()
   }
 
   func testMakeStreamOnShutdownSubchannel() async throws {
@@ -48,7 +48,7 @@ final class SubchannelTests: XCTestCase {
       connector: .never
     )
 
-    subchannel.close()
+    subchannel.shutDown()
     await subchannel.run()
 
     await XCTAssertThrowsErrorAsync(ofType: RPCError.self) {
@@ -105,7 +105,7 @@ final class SubchannelTests: XCTestCase {
               }
             }
           }
-          subchannel.close()
+          subchannel.shutDown()
 
         default:
           ()
@@ -121,7 +121,7 @@ final class SubchannelTests: XCTestCase {
     let subchannel = self.makeSubchannel(
       address: .unixDomainSocket(path: path),
       connector: .posix(),
-      backoff: .fixed(at: .milliseconds(100))
+      backoff: .fixed(at: .milliseconds(10))
     )
 
     await withThrowingTaskGroup(of: Void.self) { group in
@@ -150,7 +150,7 @@ final class SubchannelTests: XCTestCase {
           }
 
         case .connectivityStateChanged(.ready):
-          subchannel.close()
+          subchannel.shutDown()
 
         case .connectivityStateChanged(.shutdown):
           group.cancelAll()
@@ -212,7 +212,7 @@ final class SubchannelTests: XCTestCase {
         case .connectivityStateChanged(.idle):
           subchannel.connect()
         case .connectivityStateChanged(.ready):
-          subchannel.close()
+          subchannel.shutDown()
         case .connectivityStateChanged(.shutdown):
           group.cancelAll()
         default:
@@ -263,7 +263,7 @@ final class SubchannelTests: XCTestCase {
           }
 
         case .connectivityStateChanged(.ready):
-          subchannel.close()
+          subchannel.shutDown()
 
         case .connectivityStateChanged(.shutdown):
           group.cancelAll()
@@ -304,7 +304,7 @@ final class SubchannelTests: XCTestCase {
           if idleCount == 1 {
             subchannel.connect()
           } else {
-            subchannel.close()
+            subchannel.shutDown()
           }
 
         case .connectivityStateChanged(.shutdown):
@@ -356,7 +356,7 @@ final class SubchannelTests: XCTestCase {
           case 1:
             subchannel.connect()
           case 2:
-            subchannel.close()
+            subchannel.shutDown()
           default:
             XCTFail("Unexpected idle")
           }
@@ -430,7 +430,7 @@ final class SubchannelTests: XCTestCase {
               let _ = try await iterator.next()
             }
           } else if readyCount == 2 {
-            subchannel.close()
+            subchannel.shutDown()
           }
 
         case .connectivityStateChanged(.shutdown):
@@ -484,7 +484,7 @@ final class SubchannelTests: XCTestCase {
           if idleCount == 1 {
             subchannel.connect()
           } else if idleCount == 2 {
-            subchannel.close()
+            subchannel.shutDown()
           }
 
         case .connectivityStateChanged(.ready):


### PR DESCRIPTION
Motivation:

The subchannel conflates closing (recoverable) with shutting down (terminal). Shutting down is initiated by a higher level (load-balancer, user) while closing happens when the subchannel closes unexpectedtly or is no longer required (i.e. becomes idle). A closed subchannel can be re-opeend, a shutdown subchannel can't. This distinction isn't clear enough in the state handling.

Modifications:

- Rename 'close' to 'shutDown' where applicable
- Add a new 'shutting down' state and renaming the 'closing' state to 'going away'.
- Add a state machine diagram
- Fix up a few state transitions

Result:

More robust state handling