### PR TITLE
Manually cleanup unix domain socket path in NIOTS test

### DIFF
--- a/Tests/GRPCHTTP2TransportTests/HTTP2TransportNIOTransportServicesTests.swift
+++ b/Tests/GRPCHTTP2TransportTests/HTTP2TransportNIOTransportServicesTests.swift
@@ -64,6 +64,10 @@ final class HTTP2TransportNIOTransportServicesTests: XCTestCase {
     let transport = GRPCHTTP2Core.HTTP2ServerTransport.TransportServices(
       address: .unixDomainSocket(path: "/tmp/niots-uds-test")
     )
+    defer {
+      // NIOTS does not unlink the UDS on close.
+      try? FileManager.default.removeItem(atPath: "/tmp/niots-uds-test")
+    }
 
     try await withThrowingDiscardingTaskGroup { group in
       group.addTask {


### PR DESCRIPTION
## Motivation

Running `HTTP2TransportNIOTransportServicesTests.testGetListeningAddress_UnixDomainSocket()` multiple times currently fails. This is because NIOTS does not unlink the UDS on close, unlike NIOPosix. 

## Modifications

Until such a time as NIOTS cleans it up, we can clean it up in the test.

## Result

Test can be run multiple times.