### PR TITLE
Add integ test for SwiftPM plugin

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -138,15 +138,15 @@ jobs:
       matrix:
         include:
           - image: swiftlang/swift:nightly-jammy
-            swift-tools-version: 6.0
+            swift-tools-version: '6.0'
           - image: swiftlang/swift:nightly-6.0-jammy
-            swift-tools-version: 6.0
+            swift-tools-version: '6.0'
           - image: swift:5.10.1-noble
-            swift-tools-version: 5.10
+            swift-tools-version: '5.10'
           - image: swift:5.9-jammy
-            swift-tools-version: 5.9
+            swift-tools-version: '5.9'
           - image: swift:5.8-focal
-            swift-tools-version: 5.8
+            swift-tools-version: '5.8'
     name: Integration Tests on ${{ matrix.image }}
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -154,7 +154,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: SwiftPM plugin test
-      run: ./scripts/run-plugin-tests.sh ${{ image.swift-tools-version }}
+      run: ./scripts/run-plugin-tests.sh ${{ matrix.swift-tools-version }}
     - name: Build without NIOSSL
       run: swift build
       env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -153,6 +153,8 @@ jobs:
       image: ${{ matrix.image }}
     steps:
     - uses: actions/checkout@v4
+    - name: Install protoc
+      run: apt update && apt install -y protobuf-compiler
     - name: SwiftPM plugin test
       run: ./scripts/run-plugin-tests.sh ${{ matrix.swift-tools-version }}
     - name: Build without NIOSSL

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -138,16 +138,23 @@ jobs:
       matrix:
         include:
           - image: swiftlang/swift:nightly-jammy
+            swift-tools-version: 6.0
           - image: swiftlang/swift:nightly-6.0-jammy
+            swift-tools-version: 6.0
           - image: swift:5.10.1-noble
+            swift-tools-version: 5.10
           - image: swift:5.9-jammy
+            swift-tools-version: 5.9
           - image: swift:5.8-focal
+            swift-tools-version: 5.8
     name: Integration Tests on ${{ matrix.image }}
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.image }}
     steps:
     - uses: actions/checkout@v4
+    - name: SwiftPM plugin test
+      run: ./scripts/run-plugin-tests.sh ${{ image.swift-tools-version }}
     - name: Build without NIOSSL
       run: swift build
       env:

--- a/scripts/run-plugin-tests.sh
+++ b/scripts/run-plugin-tests.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+# Copyright 2024, gRPC Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+GRPC_PATH="${HERE}/.."
+
+function generate_package_manifest {
+  local version=$1
+  local grpc_path=$2
+
+  echo "// swift-tools-version: $version"
+  echo "import PackageDescription"
+  echo ""
+  echo "let package = Package("
+  echo "  name: \"Foo\","
+  echo "  dependencies: ["
+  echo "    .package(path: \"$grpc_path\"),"
+  echo "    .package(url: \"https://github.com/apple/swift-protobuf\", from: \"1.26.0\")"
+  echo "  ],"
+  echo "  targets: ["
+  echo "    .executableTarget("
+  echo "      name: \"Foo\","
+  echo "      dependencies: ["
+  echo "        .product(name: \"GRPC\", package: \"grpc-swift\"),"
+  echo "      ],"
+  echo "      path: \"Sources/Foo\","
+  echo "      plugins: ["
+  echo "        .plugin(name: \"GRPCSwiftPlugin\", package: \"grpc-swift\"),"
+  echo "        .plugin(name: \"SwiftProtobufPlugin\", package: \"swift-protobuf\"),"
+  echo "      ]"
+  echo "    ),"
+  echo "  ]"
+  echo ")"
+}
+
+function generate_grpc_plugin_config {
+  cat <<EOF
+{
+  "invocations": [
+    {
+      "protoFiles": ["Foo.proto"],
+      "visibility": "internal"
+    }
+  ]
+}
+EOF
+}
+
+function generate_protobuf_plugin_config {
+  generate_grpc_plugin_config
+}
+
+function generate_proto {
+  cat <<EOF
+syntax = "proto3";
+
+service Foo {
+  rpc Bar(Baz) returns (Baz) {}
+}
+
+message Baz {}
+EOF
+}
+
+function generate_main {
+  echo "// This file was intentionally left blank."
+}
+
+function generate_and_build {
+  local version=$1
+  local grpc_path=$2
+  local protoc_path dir
+
+  protoc_path=$(which protoc)
+  dir=$(mktemp -d)
+
+  echo "Generating package in $dir ..."
+  echo "Swift tools version: $version"
+  echo "grpc-swift path: $grpc_path"
+  echo "protoc path: $protoc_path"
+  mkdir -p "$dir/Sources/Foo"
+
+  generate_package_manifest "$version" "$grpc_path" > "$dir/Package.swift"
+  generate_grpc_plugin_config > "$dir/Sources/Foo/grpc-swift-config.json"
+  generate_protobuf_plugin_config > "$dir/Sources/Foo/swift-protobuf-config.json"
+  generate_proto > "$dir/Sources/Foo/Foo.proto"
+  generate_main > "$dir/Sources/Foo/main.swift"
+
+  PROTOC_PATH=$protoc_path swift build --package-path "$dir"
+}
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 SWIFT_TOOLS_VERSION"
+  exit 1
+fi
+
+generate_and_build "$1" "${GRPC_PATH}"

--- a/scripts/run-plugin-tests.sh
+++ b/scripts/run-plugin-tests.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -eu
+set -eux
 
 HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 GRPC_PATH="${HERE}/.."


### PR DESCRIPTION
Motivation:

There's no integration test for the SwiftPM plugn. Add a basic test which generates and builds the package using the plugin.

Modifications:

- Add a script to generate a package using the plugin and build it
- Update CI

Result:

SwiftPM plugin has basic test