### PR TITLE
Swift 6 lang mode simple fixes

### DIFF
--- a/Package@swift-6.swift
+++ b/Package@swift-6.swift
@@ -426,7 +426,7 @@ extension Target {
         .grpcCore,
         .protobuf
       ],
-      swiftSettings: [.swiftLanguageVersion(.v5)]
+      swiftSettings: [.swiftLanguageVersion(.v6)]
     )
   }
 

--- a/Package@swift-6.swift
+++ b/Package@swift-6.swift
@@ -242,7 +242,7 @@ extension Target {
         .nioPosix,
         .nioExtras
       ],
-      swiftSettings: [.swiftLanguageVersion(.v5)]
+      swiftSettings: [.swiftLanguageVersion(.v6)]
     )
   }
 

--- a/Package@swift-6.swift
+++ b/Package@swift-6.swift
@@ -770,7 +770,7 @@ extension Target {
     .target(
       name: "GRPCCodeGen",
       path: "Sources/GRPCCodeGen",
-      swiftSettings: [.swiftLanguageVersion(.v5)]
+      swiftSettings: [.swiftLanguageVersion(.v6)]
     )
   }
 

--- a/Package@swift-6.swift
+++ b/Package@swift-6.swift
@@ -298,7 +298,7 @@ extension Target {
         .nioFileSystem,
         .argumentParser
       ],
-      swiftSettings: [.swiftLanguageVersion(.v5)]
+      swiftSettings: [.swiftLanguageVersion(.v6)]
     )
   }
 

--- a/Package@swift-6.swift
+++ b/Package@swift-6.swift
@@ -203,7 +203,7 @@ extension Target {
       dependencies: [
         .grpcCore
       ],
-      swiftSettings: [.swiftLanguageVersion(.v5)]
+      swiftSettings: [.swiftLanguageVersion(.v6)]
     )
   }
 

--- a/Package@swift-6.swift
+++ b/Package@swift-6.swift
@@ -256,7 +256,7 @@ extension Target {
         .nioExtras,
         .nioTransportServices
       ],
-      swiftSettings: [.swiftLanguageVersion(.v5)]
+      swiftSettings: [.swiftLanguageVersion(.v6)]
     )
   }
 

--- a/Package@swift-6.swift
+++ b/Package@swift-6.swift
@@ -439,7 +439,7 @@ extension Target {
         .protobuf,
         .protobufPluginLibrary
       ],
-      swiftSettings: [.swiftLanguageVersion(.v5)]
+      swiftSettings: [.swiftLanguageVersion(.v6)]
     )
   }
 

--- a/Package@swift-6.swift
+++ b/Package@swift-6.swift
@@ -497,7 +497,7 @@ extension Target {
         .interoperabilityTests,
         .argumentParser
       ],
-      swiftSettings: [.swiftLanguageVersion(.v5)]
+      swiftSettings: [.swiftLanguageVersion(.v6)]
     )
   }
 

--- a/Package@swift-6.swift
+++ b/Package@swift-6.swift
@@ -214,7 +214,7 @@ extension Target {
         .grpcCore,
         .tracing
       ],
-      swiftSettings: [.swiftLanguageVersion(.v5)]
+      swiftSettings: [.swiftLanguageVersion(.v6)]
     )
   }
 

--- a/Package@swift-6.swift
+++ b/Package@swift-6.swift
@@ -782,7 +782,7 @@ extension Target {
         .protobuf,
       ],
       path: "Sources/GRPCProtobuf",
-      swiftSettings: [.swiftLanguageVersion(.v5)]
+      swiftSettings: [.swiftLanguageVersion(.v6)]
     )
   }
 

--- a/Package@swift-6.swift
+++ b/Package@swift-6.swift
@@ -795,7 +795,7 @@ extension Target {
         .grpcCodeGen
       ],
       path: "Sources/GRPCProtobufCodeGen",
-      swiftSettings: [.swiftLanguageVersion(.v5)]
+      swiftSettings: [.swiftLanguageVersion(.v6)]
     )
   }
 }

--- a/Package@swift-6.swift
+++ b/Package@swift-6.swift
@@ -229,7 +229,7 @@ extension Target {
         .dequeModule,
         .atomics
       ],
-      swiftSettings: [.swiftLanguageVersion(.v5)]
+      swiftSettings: [.swiftLanguageVersion(.v6)]
     )
   }
 

--- a/Sources/GRPCCore/Transport/ClientTransport.swift
+++ b/Sources/GRPCCore/Transport/ClientTransport.swift
@@ -61,7 +61,7 @@ public protocol ClientTransport: Sendable {
   ///   - options: Options specific to the stream.
   ///   - closure: A closure that takes the opened stream as parameter.
   /// - Returns: Whatever value was returned from `closure`.
-  func withStream<T>(
+  func withStream<T: Sendable>(
     descriptor: MethodDescriptor,
     options: CallOptions,
     _ closure: (_ stream: RPCStream<Inbound, Outbound>) async throws -> T

--- a/Sources/GRPCCore/Transport/ServerTransport.swift
+++ b/Sources/GRPCCore/Transport/ServerTransport.swift
@@ -31,7 +31,7 @@ public protocol ServerTransport: Sendable {
   /// period after which any open streams may be cancelled. You can also cancel the task running
   /// ``listen()`` to abruptly close connections and streams.
   func listen(
-    _ streamHandler: @escaping (RPCStream<Inbound, Outbound>) async -> Void
+    _ streamHandler: @escaping @Sendable (RPCStream<Inbound, Outbound>) async -> Void
   ) async throws
 
   /// Indicates to the transport that no new streams should be accepted.

--- a/Sources/GRPCHTTP2Core/Client/Connection/ClientConnectionHandler.swift
+++ b/Sources/GRPCHTTP2Core/Client/Connection/ClientConnectionHandler.swift
@@ -277,14 +277,17 @@ extension ClientConnectionHandler {
     }
 
     func keepaliveTimerFired() {
+      self.context.eventLoop.assertInEventLoop()
       self.handler.keepaliveTimerFired(context: self.context)
     }
 
     func keepaliveTimeoutExpired() {
+      self.context.eventLoop.assertInEventLoop()
       self.handler.keepaliveTimeoutExpired(context: self.context)
     }
 
     func maxIdleTimerFired() {
+      self.context.eventLoop.assertInEventLoop()
       self.handler.maxIdleTimerFired(context: self.context)
     }
   }

--- a/Sources/GRPCHTTP2Core/Client/Connection/ClientConnectionHandler.swift
+++ b/Sources/GRPCHTTP2Core/Client/Connection/ClientConnectionHandler.swift
@@ -198,9 +198,10 @@ final class ClientConnectionHandler: ChannelInboundHandler, ChannelOutboundHandl
       // Pings are ack'd by the HTTP/2 handler so we only pay attention to acks here, and in
       // particular only those carrying the keep-alive data.
       if ack, data == self.keepalivePingData {
+        let loopBound = LoopBoundView(handler: self, context: context)
         self.keepaliveTimeoutTimer.cancel()
         self.keepaliveTimer?.schedule(on: context.eventLoop) {
-          self.keepaliveTimerFired(context: context)
+          loopBound.keepaliveTimerFired()
         }
       }
 
@@ -211,12 +212,13 @@ final class ClientConnectionHandler: ChannelInboundHandler, ChannelOutboundHandl
       // becoming active is insufficient as, for example, a TLS handshake may fail after
       // establishing the TCP connection, or the server isn't configured for gRPC (or HTTP/2).
       if isInitialSettings {
+        let loopBound = LoopBoundView(handler: self, context: context)
         self.keepaliveTimer?.schedule(on: context.eventLoop) {
-          self.keepaliveTimerFired(context: context)
+          loopBound.keepaliveTimerFired()
         }
 
         self.maxIdleTimer?.schedule(on: context.eventLoop) {
-          self.maxIdleTimerFired(context: context)
+          loopBound.maxIdleTimerFired()
         }
 
         context.fireChannelRead(self.wrapInboundOut(.ready))
@@ -260,6 +262,30 @@ final class ClientConnectionHandler: ChannelInboundHandler, ChannelOutboundHandl
       }
     } else {
       context.triggerUserOutboundEvent(event, promise: promise)
+    }
+  }
+}
+
+extension ClientConnectionHandler {
+  struct LoopBoundView: @unchecked Sendable {
+    private let handler: ClientConnectionHandler
+    private let context: ChannelHandlerContext
+
+    init(handler: ClientConnectionHandler, context: ChannelHandlerContext) {
+      self.handler = handler
+      self.context = context
+    }
+
+    func keepaliveTimerFired() {
+      self.handler.keepaliveTimerFired(context: self.context)
+    }
+
+    func keepaliveTimeoutExpired() {
+      self.handler.keepaliveTimeoutExpired(context: self.context)
+    }
+
+    func maxIdleTimerFired() {
+      self.handler.maxIdleTimerFired(context: self.context)
     }
   }
 }
@@ -315,8 +341,9 @@ extension ClientConnectionHandler {
     case .startIdleTimer(let cancelKeepalive):
       // All streams are closed, restart the idle timer, and stop the keep-alive timer (it may
       // not stop if keep-alive is allowed when there are no active calls).
+      let loopBound = LoopBoundView(handler: self, context: context)
       self.maxIdleTimer?.schedule(on: context.eventLoop) {
-        self.maxIdleTimerFired(context: context)
+        loopBound.maxIdleTimerFired()
       }
 
       if cancelKeepalive {
@@ -355,8 +382,9 @@ extension ClientConnectionHandler {
     self.maybeFlush(context: context)
 
     // Schedule a timeout on waiting for the response.
+    let loopBound = LoopBoundView(handler: self, context: context)
     self.keepaliveTimeoutTimer.schedule(on: context.eventLoop) {
-      self.keepaliveTimeoutExpired(context: context)
+      loopBound.keepaliveTimeoutExpired()
     }
   }
 

--- a/Sources/GRPCHTTP2Core/Client/Connection/ConnectionFactory.swift
+++ b/Sources/GRPCHTTP2Core/Client/Connection/ConnectionFactory.swift
@@ -26,7 +26,7 @@ public protocol HTTP2Connector: Sendable {
 
 @_spi(Package)
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-public struct HTTP2Connection {
+public struct HTTP2Connection: Sendable {
   /// The underlying TCP connection wrapped up for use with gRPC.
   var channel: NIOAsyncChannel<ClientConnectionEvent, Void>
 

--- a/Sources/GRPCHTTP2Core/Client/Connection/GRPCChannel.swift
+++ b/Sources/GRPCHTTP2Core/Client/Connection/GRPCChannel.swift
@@ -189,7 +189,7 @@ public struct GRPCChannel: ClientTransport {
   }
 
   /// Opens a stream using the transport, and uses it as input into a user-provided closure.
-  public func withStream<T>(
+  public func withStream<T: Sendable>(
     descriptor: MethodDescriptor,
     options: CallOptions,
     _ closure: (_ stream: RPCStream<Inbound, Outbound>) async throws -> T

--- a/Sources/GRPCHTTP2Core/Internal/ConstantAsyncSequence.swift
+++ b/Sources/GRPCHTTP2Core/Internal/ConstantAsyncSequence.swift
@@ -17,7 +17,7 @@
 import GRPCCore
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-private struct ConstantAsyncSequence<Element: Sendable>: AsyncSequence {
+private struct ConstantAsyncSequence<Element: Sendable>: AsyncSequence, Sendable {
   private let element: Element
 
   init(element: Element) {
@@ -42,7 +42,7 @@ private struct ConstantAsyncSequence<Element: Sendable>: AsyncSequence {
 }
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-extension RPCAsyncSequence {
+extension RPCAsyncSequence where Element: Sendable {
   static func constant(_ element: Element) -> RPCAsyncSequence<Element> {
     return RPCAsyncSequence(wrapping: ConstantAsyncSequence(element: element))
   }

--- a/Sources/GRPCHTTP2Core/Internal/DiscardingTaskGroup+CancellableHandle.swift
+++ b/Sources/GRPCHTTP2Core/Internal/DiscardingTaskGroup+CancellableHandle.swift
@@ -55,7 +55,7 @@ extension DiscardingTaskGroup {
   }
 
   @usableFromInline
-  enum FinishedOrCancelled {
+  enum FinishedOrCancelled: Sendable {
     case finished
     case cancelled
   }

--- a/Sources/GRPCHTTP2Core/Internal/Timer.swift
+++ b/Sources/GRPCHTTP2Core/Internal/Timer.swift
@@ -45,7 +45,7 @@ struct Timer {
   }
 
   /// Schedule a task on the given `EventLoop`.
-  mutating func schedule(on eventLoop: EventLoop, work: @escaping () throws -> Void) {
+  mutating func schedule(on eventLoop: EventLoop, work: @escaping @Sendable () throws -> Void) {
     self.task?.cancel()
 
     if self.repeat {

--- a/Sources/GRPCHTTP2Core/Server/Connection/ServerConnectionManagementHandler.swift
+++ b/Sources/GRPCHTTP2Core/Server/Connection/ServerConnectionManagementHandler.swift
@@ -347,10 +347,12 @@ extension ServerConnectionManagementHandler {
     }
 
     func initiateGracefulShutdown() {
+      self.context.eventLoop.assertInEventLoop()
       self.handler.initiateGracefulShutdown(context: self.context)
     }
 
     func keepaliveTimerFired() {
+      self.context.eventLoop.assertInEventLoop()
       self.handler.keepaliveTimerFired(context: self.context)
     }
 

--- a/Sources/GRPCHTTP2Core/Server/Connection/ServerConnectionManagementHandler.swift
+++ b/Sources/GRPCHTTP2Core/Server/Connection/ServerConnectionManagementHandler.swift
@@ -247,16 +247,18 @@ final class ServerConnectionManagementHandler: ChannelDuplexHandler {
   }
 
   func channelActive(context: ChannelHandlerContext) {
+    let view = LoopBoundView(handler: self, context: context)
+
     self.maxAgeTimer?.schedule(on: context.eventLoop) {
-      self.initiateGracefulShutdown(context: context)
+      view.initiateGracefulShutdown()
     }
 
     self.maxIdleTimer?.schedule(on: context.eventLoop) {
-      self.initiateGracefulShutdown(context: context)
+      view.initiateGracefulShutdown()
     }
 
     self.keepaliveTimer?.schedule(on: context.eventLoop) {
-      self.keepaliveTimerFired(context: context)
+      view.keepaliveTimerFired()
     }
 
     context.fireChannelActive()
@@ -321,8 +323,9 @@ final class ServerConnectionManagementHandler: ChannelDuplexHandler {
     self.inReadLoop = false
 
     // Done reading: schedule the keep-alive timer.
+    let view = LoopBoundView(handler: self, context: context)
     self.keepaliveTimer?.schedule(on: context.eventLoop) {
-      self.keepaliveTimerFired(context: context)
+      view.keepaliveTimerFired()
     }
 
     context.fireChannelReadComplete()
@@ -330,6 +333,27 @@ final class ServerConnectionManagementHandler: ChannelDuplexHandler {
 
   func flush(context: ChannelHandlerContext) {
     self.maybeFlush(context: context)
+  }
+}
+
+extension ServerConnectionManagementHandler {
+  struct LoopBoundView: @unchecked Sendable {
+    private let handler: ServerConnectionManagementHandler
+    private let context: ChannelHandlerContext
+
+    init(handler: ServerConnectionManagementHandler, context: ChannelHandlerContext) {
+      self.handler = handler
+      self.context = context
+    }
+
+    func initiateGracefulShutdown() {
+      self.handler.initiateGracefulShutdown(context: self.context)
+    }
+
+    func keepaliveTimerFired() {
+      self.handler.keepaliveTimerFired(context: self.context)
+    }
+
   }
 }
 
@@ -379,8 +403,9 @@ extension ServerConnectionManagementHandler {
 
     switch self.state.streamClosed(id) {
     case .startIdleTimer:
+      let loopBound = LoopBoundView(handler: self, context: context)
       self.maxIdleTimer?.schedule(on: context.eventLoop) {
-        self.initiateGracefulShutdown(context: context)
+        loopBound.initiateGracefulShutdown()
       }
 
     case .close:
@@ -481,8 +506,9 @@ extension ServerConnectionManagementHandler {
       } else {
         // RPCs may have a grace period for finishing once the second GOAWAY frame has finished.
         // If this is set close the connection abruptly once the grace period passes.
+        let loopBound = NIOLoopBound(context, eventLoop: context.eventLoop)
         self.maxGraceTimer?.schedule(on: context.eventLoop) {
-          context.close(promise: nil)
+          loopBound.value.close(promise: nil)
         }
       }
 
@@ -497,8 +523,9 @@ extension ServerConnectionManagementHandler {
     self.maybeFlush(context: context)
 
     // Schedule a timeout on waiting for the response.
+    let loopBound = LoopBoundView(handler: self, context: context)
     self.keepaliveTimeoutTimer.schedule(on: context.eventLoop) {
-      self.initiateGracefulShutdown(context: context)
+      loopBound.initiateGracefulShutdown()
     }
   }
 }

--- a/Sources/GRPCHTTP2TransportNIOPosix/HTTP2ClientTransport+Posix.swift
+++ b/Sources/GRPCHTTP2TransportNIOPosix/HTTP2ClientTransport+Posix.swift
@@ -109,7 +109,7 @@ extension HTTP2ClientTransport {
       self.channel.close()
     }
 
-    public func withStream<T>(
+    public func withStream<T: Sendable>(
       descriptor: MethodDescriptor,
       options: CallOptions,
       _ closure: (RPCStream<Inbound, Outbound>) async throws -> T

--- a/Sources/GRPCHTTP2TransportNIOPosix/HTTP2ServerTransport+Posix.swift
+++ b/Sources/GRPCHTTP2TransportNIOPosix/HTTP2ServerTransport+Posix.swift
@@ -162,7 +162,7 @@ extension HTTP2ServerTransport {
     }
 
     public func listen(
-      _ streamHandler: @escaping (RPCStream<Inbound, Outbound>) async -> Void
+      _ streamHandler: @escaping @Sendable (RPCStream<Inbound, Outbound>) async -> Void
     ) async throws {
       defer {
         switch self.listeningAddressState.withLockedValue({ $0.close() }) {

--- a/Sources/GRPCHTTP2TransportNIOPosix/NIOClientBootstrap+SocketAddress.swift
+++ b/Sources/GRPCHTTP2TransportNIOPosix/NIOClientBootstrap+SocketAddress.swift
@@ -21,7 +21,7 @@ import NIOPosix
 
 extension ClientBootstrap {
   @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-  func connect<Result>(
+  func connect<Result: Sendable>(
     to address: GRPCHTTP2Core.SocketAddress,
     _ configure: @Sendable @escaping (Channel) -> EventLoopFuture<Result>
   ) async throws -> Result {

--- a/Sources/GRPCHTTP2TransportNIOTransportServices/HTTP2ServerTransport+TransportServices.swift
+++ b/Sources/GRPCHTTP2TransportNIOTransportServices/HTTP2ServerTransport+TransportServices.swift
@@ -156,7 +156,7 @@ extension HTTP2ServerTransport {
     }
 
     public func listen(
-      _ streamHandler: @escaping (RPCStream<Inbound, Outbound>) async -> Void
+      _ streamHandler: @escaping @Sendable (RPCStream<Inbound, Outbound>) async -> Void
     ) async throws {
       defer {
         switch self.listeningAddressState.withLockedValue({ $0.close() }) {

--- a/Sources/GRPCInProcessTransport/InProcessServerTransport.swift
+++ b/Sources/GRPCInProcessTransport/InProcessServerTransport.swift
@@ -56,7 +56,7 @@ public struct InProcessServerTransport: ServerTransport, Sendable {
   }
 
   public func listen(
-    _ streamHandler: @escaping (RPCStream<Inbound, Outbound>) async -> Void
+    _ streamHandler: @escaping @Sendable (RPCStream<Inbound, Outbound>) async -> Void
   ) async throws {
     await withDiscardingTaskGroup { group in
       for await stream in self.newStreams {

--- a/Sources/GRPCInterceptors/OnFinishAsyncSequence.swift
+++ b/Sources/GRPCInterceptors/OnFinishAsyncSequence.swift
@@ -20,8 +20,8 @@ struct OnFinishAsyncSequence<Element: Sendable>: AsyncSequence, Sendable {
 
   init<S: AsyncSequence>(
     wrapping other: S,
-    onFinish: @escaping () -> Void
-  ) where S.Element == Element {
+    onFinish: @escaping @Sendable () -> Void
+  ) where S.Element == Element, S: Sendable {
     self._makeAsyncIterator = {
       AsyncIterator(wrapping: other.makeAsyncIterator(), onFinish: onFinish)
     }
@@ -33,11 +33,11 @@ struct OnFinishAsyncSequence<Element: Sendable>: AsyncSequence, Sendable {
 
   struct AsyncIterator: AsyncIteratorProtocol {
     private var iterator: any AsyncIteratorProtocol
-    private var onFinish: (() -> Void)?
+    private var onFinish: (@Sendable () -> Void)?
 
     fileprivate init<Iterator>(
       wrapping other: Iterator,
-      onFinish: @escaping () -> Void
+      onFinish: @escaping @Sendable () -> Void
     ) where Iterator: AsyncIteratorProtocol, Iterator.Element == Element {
       self.iterator = other
       self.onFinish = onFinish

--- a/Sources/interoperability-tests/InteroperabilityTestsExecutable.swift
+++ b/Sources/interoperability-tests/InteroperabilityTestsExecutable.swift
@@ -24,13 +24,13 @@ import NIOPosix
 @main
 @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 struct InteroperabilityTestsExecutable: AsyncParsableCommand {
-  static var configuration = CommandConfiguration(
+  static let configuration = CommandConfiguration(
     abstract: "gRPC Swift Interoperability Runner",
     subcommands: [StartServer.self, ListTests.self, RunTests.self]
   )
 
   struct StartServer: AsyncParsableCommand {
-    static var configuration = CommandConfiguration(
+    static let configuration = CommandConfiguration(
       abstract: "Start the gRPC Swift interoperability test server."
     )
 
@@ -50,7 +50,7 @@ struct InteroperabilityTestsExecutable: AsyncParsableCommand {
   }
 
   struct ListTests: ParsableCommand {
-    static var configuration = CommandConfiguration(
+    static let configuration = CommandConfiguration(
       abstract: "List all interoperability test names."
     )
 
@@ -62,7 +62,7 @@ struct InteroperabilityTestsExecutable: AsyncParsableCommand {
   }
 
   struct RunTests: AsyncParsableCommand {
-    static var configuration = CommandConfiguration(
+    static let configuration = CommandConfiguration(
       abstract: """
           Run gRPC interoperability tests using a gRPC Swift client.
           You can specify a test name as an argument to run a single test.

--- a/Tests/GRPCInterceptorsTests/TracingInterceptorTests.swift
+++ b/Tests/GRPCInterceptorsTests/TracingInterceptorTests.swift
@@ -175,8 +175,9 @@ final class TracingInterceptorTests: XCTestCase {
       method: "testServerInterceptorErrorResponse"
     )
     let interceptor = ServerTracingInterceptor(emitEventOnEachWrite: false)
+    let single = ServerRequest.Single(metadata: ["trace-id": "some-trace-id"], message: [UInt8]())
     let response = try await interceptor.intercept(
-      request: .init(single: .init(metadata: ["trace-id": "some-trace-id"], message: [])),
+      request: .init(single: single),
       context: .init(descriptor: methodDescriptor)
     ) { _, _ in
       ServerResponse.Stream<String>(error: .init(code: .unknown, message: "Test error"))
@@ -203,8 +204,9 @@ final class TracingInterceptorTests: XCTestCase {
     )
     let (stream, continuation) = AsyncStream<String>.makeStream()
     let interceptor = ServerTracingInterceptor(emitEventOnEachWrite: false)
+    let single = ServerRequest.Single(metadata: ["trace-id": "some-trace-id"], message: [UInt8]())
     let response = try await interceptor.intercept(
-      request: .init(single: .init(metadata: ["trace-id": "some-trace-id"], message: [])),
+      request: .init(single: single),
       context: .init(descriptor: methodDescriptor)
     ) { _, _ in
       { [serviceContext = ServiceContext.current] in
@@ -267,8 +269,9 @@ final class TracingInterceptorTests: XCTestCase {
     )
     let (stream, continuation) = AsyncStream<String>.makeStream()
     let interceptor = ServerTracingInterceptor(emitEventOnEachWrite: true)
+    let single = ServerRequest.Single(metadata: ["trace-id": "some-trace-id"], message: [UInt8]())
     let response = try await interceptor.intercept(
-      request: .init(single: .init(metadata: ["trace-id": "some-trace-id"], message: [])),
+      request: .init(single: single),
       context: .init(descriptor: methodDescriptor)
     ) { _, _ in
       { [serviceContext = ServiceContext.current] in

--- a/Tests/GRPCInterceptorsTests/TracingTestsUtilities.swift
+++ b/Tests/GRPCInterceptorsTests/TracingTestsUtilities.swift
@@ -21,10 +21,11 @@ import Tracing
 final class TestTracer: Tracer {
   typealias Span = TestSpan
 
-  private var testSpans: NIOLockedValueBox<[String: TestSpan]> = .init([:])
+  private let testSpans: NIOLockedValueBox<[String: TestSpan]> = .init([:])
 
   func getEventsForTestSpan(ofOperationName operationName: String) -> [SpanEvent] {
-    self.testSpans.withLockedValue({ $0[operationName] })?.events ?? []
+    let span = self.testSpans.withLockedValue({ $0[operationName] })
+    return span?.events ?? []
   }
 
   func extract<Carrier, Extract>(
@@ -67,13 +68,35 @@ final class TestTracer: Tracer {
   }
 }
 
-class TestSpan: Span {
-  var context: ServiceContextModule.ServiceContext
-  var operationName: String
-  var attributes: Tracing.SpanAttributes
-  var isRecording: Bool
-  private(set) var status: Tracing.SpanStatus?
-  private(set) var events: [Tracing.SpanEvent] = []
+struct TestSpan: Span {
+  private struct State {
+    var context: ServiceContextModule.ServiceContext
+    var operationName: String
+    var attributes: Tracing.SpanAttributes
+    var status: Tracing.SpanStatus?
+    var events: [Tracing.SpanEvent] = []
+  }
+
+  private let state: NIOLockedValueBox<State>
+  let isRecording: Bool
+
+  var context: ServiceContextModule.ServiceContext {
+    self.state.withLockedValue { $0.context }
+  }
+
+  var operationName: String {
+    get { self.state.withLockedValue { $0.operationName } }
+    nonmutating set { self.state.withLockedValue { $0.operationName = newValue }}
+  }
+
+  var attributes: Tracing.SpanAttributes {
+    get { self.state.withLockedValue { $0.attributes } }
+    nonmutating set { self.state.withLockedValue { $0.attributes = newValue }}
+  }
+
+  var events: [Tracing.SpanEvent] {
+    self.state.withLockedValue { $0.events }
+  }
 
   init(
     context: ServiceContextModule.ServiceContext,
@@ -81,18 +104,17 @@ class TestSpan: Span {
     attributes: Tracing.SpanAttributes = [:],
     isRecording: Bool = true
   ) {
-    self.context = context
-    self.operationName = operationName
-    self.attributes = attributes
+    let state = State(context: context, operationName: operationName, attributes: attributes)
+    self.state = NIOLockedValueBox(state)
     self.isRecording = isRecording
   }
 
   func setStatus(_ status: Tracing.SpanStatus) {
-    self.status = status
+    self.state.withLockedValue { $0.status = status }
   }
 
   func addEvent(_ event: Tracing.SpanEvent) {
-    self.events.append(event)
+    self.state.withLockedValue { $0.events.append(event) }
   }
 
   func recordError<Instant>(
@@ -109,7 +131,9 @@ class TestSpan: Span {
   }
 
   func addLink(_ link: Tracing.SpanLink) {
-    self.context.spanLinks?.append(link)
+    self.state.withLockedValue {
+      $0.context.spanLinks?.append(link)
+    }
   }
 
   func end<Instant>(at instant: @autoclosure () -> Instant) where Instant: Tracing.TracerInstant {
@@ -150,7 +174,7 @@ extension ServiceContext {
 }
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-struct TestWriter<WriterElement>: RPCWriterProtocol {
+struct TestWriter<WriterElement: Sendable>: RPCWriterProtocol {
   typealias Element = WriterElement
 
   private let streamContinuation: AsyncStream<Element>.Continuation

--- a/Tests/GRPCInterceptorsTests/TracingTestsUtilities.swift
+++ b/Tests/GRPCInterceptorsTests/TracingTestsUtilities.swift
@@ -86,12 +86,12 @@ struct TestSpan: Span {
 
   var operationName: String {
     get { self.state.withLockedValue { $0.operationName } }
-    nonmutating set { self.state.withLockedValue { $0.operationName = newValue }}
+    nonmutating set { self.state.withLockedValue { $0.operationName = newValue } }
   }
 
   var attributes: Tracing.SpanAttributes {
     get { self.state.withLockedValue { $0.attributes } }
-    nonmutating set { self.state.withLockedValue { $0.attributes = newValue }}
+    nonmutating set { self.state.withLockedValue { $0.attributes = newValue } }
   }
 
   var events: [Tracing.SpanEvent] {

--- a/Tests/GRPCInterceptorsTests/TracingTestsUtilities.swift
+++ b/Tests/GRPCInterceptorsTests/TracingTestsUtilities.swift
@@ -68,7 +68,7 @@ final class TestTracer: Tracer {
   }
 }
 
-struct TestSpan: Span {
+struct TestSpan: Span, Sendable {
   private struct State {
     var context: ServiceContextModule.ServiceContext
     var operationName: String

--- a/Tests/GRPCProtobufTests/ProtobufCodingTests.swift
+++ b/Tests/GRPCProtobufTests/ProtobufCodingTests.swift
@@ -76,7 +76,7 @@ final class ProtobufCodingTests: XCTestCase {
 struct TestMessage: SwiftProtobuf.Message {
   var text: String = ""
   var unknownFields = SwiftProtobuf.UnknownStorage()
-  static var protoMessageName: String = "Test" + ".ServiceRequest"
+  static let protoMessageName: String = "Test.ServiceRequest"
   init() {}
 
   mutating func decodeMessage<D>(decoder: inout D) throws where D: SwiftProtobuf.Decoder {


### PR DESCRIPTION
Motivation:

v2 will eventually require the v6 language, doing this in one go is a
reasonably large change so adopt a few targets at a time.

Modifications:

- Fixup warnings/errors in the following targets:
  - GRPCInterceptors
  - GRPCInProcessTransport
  - GRPCHTTP2Core
  - GRPCHTTP2TransportNIOPosix
  - GRPCHTTP2TransportNIOTransportServices
  - GRPCCodeGen
  - GRPCProtobufCodeGenTests
  - GRPCProtobufCodeGen
  - GRPCProtobufTests
  - GRPCProtobuf
  - interoperability-tests
  - performance-worker
- Fixup warnings/errors but remain in the v5 language mode for the
  following:
  - GRPCInterceptorsTests

Result:

More modules use v6 language mode