### PR TITLE
Eliminate unnecessary allocations by using single-element writes

### DIFF
--- a/Sources/GRPCCore/Streaming/Internal/RPCWriter+Map.swift
+++ b/Sources/GRPCCore/Streaming/Internal/RPCWriter+Map.swift
@@ -32,6 +32,11 @@ struct MapRPCWriter<Value, Mapped>: RPCWriterProtocol {
   }
 
   @inlinable
+  func write(_ element: Element) async throws {
+    try await self.base.write(self.transform(element))
+  }
+
+  @inlinable
   func write(contentsOf elements: some Sequence<Value>) async throws {
     let transformed = elements.lazy.map { self.transform($0) }
     try await self.base.write(contentsOf: transformed)

--- a/Sources/GRPCCore/Streaming/Internal/RPCWriter+MessageToRPCResponsePart.swift
+++ b/Sources/GRPCCore/Streaming/Internal/RPCWriter+MessageToRPCResponsePart.swift
@@ -32,6 +32,11 @@ struct MessageToRPCResponsePartWriter<Serializer: MessageSerializer>: RPCWriterP
   }
 
   @inlinable
+  func write(_ element: Element) async throws {
+    try await self.base.write(.message(self.serializer.serialize(element)))
+  }
+
+  @inlinable
   func write(contentsOf elements: some Sequence<Serializer.Message>) async throws {
     let requestParts = try elements.map { message -> RPCResponsePart in
       .message(try self.serializer.serialize(message))

--- a/Sources/GRPCCore/Streaming/Internal/RPCWriter+Serialize.swift
+++ b/Sources/GRPCCore/Streaming/Internal/RPCWriter+Serialize.swift
@@ -32,6 +32,11 @@ struct SerializingRPCWriter<Serializer: MessageSerializer>: RPCWriterProtocol {
   }
 
   @inlinable
+  func write(_ element: Element) async throws {
+    try await self.base.write(self.serializer.serialize(element))
+  }
+
+  @inlinable
   func write(contentsOf elements: some Sequence<Serializer.Message>) async throws {
     let requestParts = try elements.map { message in
       try self.serializer.serialize(message)

--- a/Sources/GRPCCore/Streaming/RPCWriter+Closable.swift
+++ b/Sources/GRPCCore/Streaming/RPCWriter+Closable.swift
@@ -30,7 +30,7 @@ extension RPCWriter {
 
     /// Writes a single element.
     ///
-    /// This function suspends until the element has been accepted. Implements can use this
+    /// This function suspends until the element has been accepted. Implementers can use this
     /// to exert backpressure on callers.
     ///
     /// - Parameter element: The element to write.
@@ -41,7 +41,7 @@ extension RPCWriter {
 
     /// Writes a sequence of elements.
     ///
-    /// This function suspends until the elements have been accepted. Implements can use this
+    /// This function suspends until the elements have been accepted. Implementers can use this
     /// to exert backpressure on callers.
     ///
     /// - Parameter elements: The elements to write.

--- a/Sources/GRPCCore/Streaming/RPCWriter+Closable.swift
+++ b/Sources/GRPCCore/Streaming/RPCWriter+Closable.swift
@@ -28,6 +28,17 @@ extension RPCWriter {
       self.writer = other
     }
 
+    /// Writes a single element.
+    ///
+    /// This function suspends until the element has been accepted. Implements can use this
+    /// to exert backpressure on callers.
+    ///
+    /// - Parameter element: The element to write.
+    @inlinable
+    public func write(_ element: Element) async throws {
+      try await self.writer.write(element)
+    }
+
     /// Writes a sequence of elements.
     ///
     /// This function suspends until the elements have been accepted. Implements can use this

--- a/Sources/GRPCCore/Streaming/RPCWriter.swift
+++ b/Sources/GRPCCore/Streaming/RPCWriter.swift
@@ -28,7 +28,7 @@ public struct RPCWriter<Element>: Sendable, RPCWriterProtocol {
 
   /// Writes a single element.
   ///
-  /// This function suspends until the element has been accepted. Implements can use this
+  /// This function suspends until the element has been accepted. Implementers can use this
   /// to exert backpressure on callers.
   ///
   /// - Parameter element: The element to write.
@@ -38,7 +38,7 @@ public struct RPCWriter<Element>: Sendable, RPCWriterProtocol {
 
   /// Writes a sequence of elements.
   ///
-  /// This function suspends until the elements have been accepted. Implements can use this
+  /// This function suspends until the elements have been accepted. Implementers can use this
   /// to exert backpressure on callers.
   ///
   /// - Parameter elements: The elements to write.

--- a/Sources/GRPCCore/Streaming/RPCWriter.swift
+++ b/Sources/GRPCCore/Streaming/RPCWriter.swift
@@ -26,6 +26,16 @@ public struct RPCWriter<Element>: Sendable, RPCWriterProtocol {
     self.writer = other
   }
 
+  /// Writes a single element.
+  ///
+  /// This function suspends until the element has been accepted. Implements can use this
+  /// to exert backpressure on callers.
+  ///
+  /// - Parameter element: The element to write.
+  public func write(_ element: Element) async throws {
+    try await self.writer.write(element)
+  }
+
   /// Writes a sequence of elements.
   ///
   /// This function suspends until the elements have been accepted. Implements can use this

--- a/Sources/GRPCCore/Streaming/RPCWriterProtocol.swift
+++ b/Sources/GRPCCore/Streaming/RPCWriterProtocol.swift
@@ -20,6 +20,14 @@ public protocol RPCWriterProtocol<Element>: Sendable {
   /// The type of value written.
   associatedtype Element
 
+  /// Writes a single element.
+  ///
+  /// This function suspends until the element has been accepted. Implements can use this
+  /// to exert backpressure on callers.
+  ///
+  /// - Parameter element: The element to write.
+  func write(_ element: Element) async throws
+
   /// Writes a sequence of elements.
   ///
   /// This function suspends until the elements have been accepted. Implements can use this
@@ -31,13 +39,6 @@ public protocol RPCWriterProtocol<Element>: Sendable {
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension RPCWriterProtocol {
-  /// Writes a single element into the sink.
-  ///
-  /// - Parameter element: The element to write.
-  public func write(_ element: Element) async throws {
-    try await self.write(contentsOf: CollectionOfOne(element))
-  }
-
   /// Writes an `AsyncSequence` of values into the sink.
   ///
   /// - Parameter elements: The elements to write.

--- a/Sources/GRPCCore/Streaming/RPCWriterProtocol.swift
+++ b/Sources/GRPCCore/Streaming/RPCWriterProtocol.swift
@@ -22,7 +22,7 @@ public protocol RPCWriterProtocol<Element>: Sendable {
 
   /// Writes a single element.
   ///
-  /// This function suspends until the element has been accepted. Implements can use this
+  /// This function suspends until the element has been accepted. Implementers can use this
   /// to exert backpressure on callers.
   ///
   /// - Parameter element: The element to write.
@@ -30,7 +30,7 @@ public protocol RPCWriterProtocol<Element>: Sendable {
 
   /// Writes a sequence of elements.
   ///
-  /// This function suspends until the elements have been accepted. Implements can use this
+  /// This function suspends until the elements have been accepted. Implementers can use this
   /// to exert backpressure on callers.
   ///
   /// - Parameter elements: The elements to write.

--- a/Sources/GRPCHTTP2Core/Client/Connection/Connection.swift
+++ b/Sources/GRPCHTTP2Core/Client/Connection/Connection.swift
@@ -366,6 +366,10 @@ extension Connection {
         self.http2Stream = http2Stream
       }
 
+      func write(_ element: RPCRequestPart) async throws {
+        try await self.requestWriter.write(element)
+      }
+
       func write(contentsOf elements: some Sequence<Self.Element>) async throws {
         try await self.requestWriter.write(contentsOf: elements)
       }

--- a/Sources/GRPCHTTP2Core/Server/Connection/ServerConnection.swift
+++ b/Sources/GRPCHTTP2Core/Server/Connection/ServerConnection.swift
@@ -35,6 +35,10 @@ public enum ServerConnection {
         self.http2Stream = http2Stream
       }
 
+      public func write(_ element: RPCResponsePart) async throws {
+        try await self.responseWriter.write(element)
+      }
+
       public func write(contentsOf elements: some Sequence<Self.Element>) async throws {
         try await self.responseWriter.write(contentsOf: elements)
       }

--- a/Sources/GRPCInterceptors/HookedWriter.swift
+++ b/Sources/GRPCInterceptors/HookedWriter.swift
@@ -32,6 +32,12 @@ struct HookedWriter<Element>: RPCWriterProtocol {
     self.afterEachWrite = afterEachWrite
   }
 
+  func write(_ element: Element) async throws {
+    self.beforeEachWrite()
+    try await self.writer.write(element)
+    self.afterEachWrite()
+  }
+
   func write(contentsOf elements: some Sequence<Element>) async throws {
     self.beforeEachWrite()
     try await self.writer.write(contentsOf: elements)

--- a/Tests/GRPCCoreTests/Test Utilities/RPCWriter+Utilities.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/RPCWriter+Utilities.swift
@@ -31,6 +31,10 @@ extension RPCWriter {
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 private struct FailOnWrite<Element>: RPCWriterProtocol {
+  func write(_ element: Element) async throws {
+    XCTFail("Unexpected write")
+  }
+
   func write(contentsOf elements: some Sequence<Element>) async throws {
     XCTFail("Unexpected write")
   }
@@ -44,9 +48,13 @@ private struct AsyncStreamGatheringWriter<Element>: RPCWriterProtocol {
     self.continuation = continuation
   }
 
-  func write(contentsOf elements: some Sequence<Element>) async throws {
+  func write(_ element: Element) {
+    self.continuation.yield(element)
+  }
+
+  func write(contentsOf elements: some Sequence<Element>) {
     for element in elements {
-      self.continuation.yield(element)
+      self.write(element)
     }
   }
 }

--- a/Tests/GRPCInterceptorsTests/TracingTestsUtilities.swift
+++ b/Tests/GRPCInterceptorsTests/TracingTestsUtilities.swift
@@ -183,9 +183,13 @@ struct TestWriter<WriterElement: Sendable>: RPCWriterProtocol {
     self.streamContinuation = streamContinuation
   }
 
-  func write(contentsOf elements: some Sequence<Self.Element>) async throws {
+  func write(_ element: WriterElement) {
+    self.streamContinuation.yield(element)
+  }
+
+  func write(contentsOf elements: some Sequence<Self.Element>) {
     elements.forEach { element in
-      self.streamContinuation.yield(element)
+      self.write(element)
     }
   }
 }


### PR DESCRIPTION
## Motivation
Using the collection-based write was wrapping single elements into a collection and `write(contentsOf:)` was being called. This always results in the element being wrapped in a `Deque` in the `NIOAsyncWriter`. 

## Modifications
This commit moves the write(element:) method to be required for the RPCWriter protocol so that we can call the single element write and avoid this boxing.

## Result
Fewer allocations.