### PR TITLE
Update to protobuf 1.27.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -52,7 +52,7 @@ let packageDependencies: [Package.Dependency] = [
   ),
   .package(
     url: "https://github.com/apple/swift-protobuf.git",
-    from: "1.20.2"
+    from: "1.27.0"
   ),
   .package(
     url: "https://github.com/apple/swift-log.git",

--- a/Package@swift-6.swift
+++ b/Package@swift-6.swift
@@ -56,7 +56,7 @@ let packageDependencies: [Package.Dependency] = [
   ),
   .package(
     url: "https://github.com/apple/swift-protobuf.git",
-    from: "1.20.2"
+    from: "1.27.0"
   ),
   .package(
     url: "https://github.com/apple/swift-log.git",

--- a/Sources/Examples/v1/Echo/Model/echo.pb.swift
+++ b/Sources/Examples/v1/Echo/Model/echo.pb.swift
@@ -34,7 +34,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-public struct Echo_EchoRequest {
+public struct Echo_EchoRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -47,7 +47,7 @@ public struct Echo_EchoRequest {
   public init() {}
 }
 
-public struct Echo_EchoResponse {
+public struct Echo_EchoResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -59,11 +59,6 @@ public struct Echo_EchoResponse {
 
   public init() {}
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension Echo_EchoRequest: @unchecked Sendable {}
-extension Echo_EchoResponse: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Sources/Examples/v1/HelloWorld/Model/helloworld.pb.swift
+++ b/Sources/Examples/v1/HelloWorld/Model/helloworld.pb.swift
@@ -35,7 +35,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 }
 
 /// The request message containing the user's name.
-public struct Helloworld_HelloRequest {
+public struct Helloworld_HelloRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -48,7 +48,7 @@ public struct Helloworld_HelloRequest {
 }
 
 /// The response message containing the greetings
-public struct Helloworld_HelloReply {
+public struct Helloworld_HelloReply: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -59,11 +59,6 @@ public struct Helloworld_HelloReply {
 
   public init() {}
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension Helloworld_HelloRequest: @unchecked Sendable {}
-extension Helloworld_HelloReply: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Sources/Examples/v1/RouteGuide/Model/route_guide.pb.swift
+++ b/Sources/Examples/v1/RouteGuide/Model/route_guide.pb.swift
@@ -38,7 +38,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 /// (degrees multiplied by 10**7 and rounded to the nearest integer).
 /// Latitudes should be in the range +/- 90 degrees and longitude should be in
 /// the range +/- 180 degrees (inclusive).
-public struct Routeguide_Point {
+public struct Routeguide_Point: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -54,7 +54,7 @@ public struct Routeguide_Point {
 
 /// A latitude-longitude rectangle, represented as two diagonally opposite
 /// points "lo" and "hi".
-public struct Routeguide_Rectangle {
+public struct Routeguide_Rectangle: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -90,7 +90,7 @@ public struct Routeguide_Rectangle {
 /// A feature names something at a given point.
 ///
 /// If a feature could not be named, the name is empty.
-public struct Routeguide_Feature {
+public struct Routeguide_Feature: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -116,7 +116,7 @@ public struct Routeguide_Feature {
 }
 
 /// A RouteNote is a message sent while at a given point.
-public struct Routeguide_RouteNote {
+public struct Routeguide_RouteNote: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -146,7 +146,7 @@ public struct Routeguide_RouteNote {
 /// It contains the number of individual points received, the number of
 /// detected features, and the total distance covered as the cumulative sum of
 /// the distance between each point.
-public struct Routeguide_RouteSummary {
+public struct Routeguide_RouteSummary: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -167,14 +167,6 @@ public struct Routeguide_RouteSummary {
 
   public init() {}
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension Routeguide_Point: @unchecked Sendable {}
-extension Routeguide_Rectangle: @unchecked Sendable {}
-extension Routeguide_Feature: @unchecked Sendable {}
-extension Routeguide_RouteNote: @unchecked Sendable {}
-extension Routeguide_RouteSummary: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Sources/Examples/v2/Echo/Generated/echo.pb.swift
+++ b/Sources/Examples/v2/Echo/Generated/echo.pb.swift
@@ -34,7 +34,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-struct Echo_EchoRequest {
+struct Echo_EchoRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -47,7 +47,7 @@ struct Echo_EchoRequest {
   init() {}
 }
 
-struct Echo_EchoResponse {
+struct Echo_EchoResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -59,11 +59,6 @@ struct Echo_EchoResponse {
 
   init() {}
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension Echo_EchoRequest: @unchecked Sendable {}
-extension Echo_EchoResponse: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Sources/GRPCReflectionService/v1/reflection-v1.pb.swift
+++ b/Sources/GRPCReflectionService/v1/reflection-v1.pb.swift
@@ -42,7 +42,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 }
 
 /// The message sent by the client when calling ServerReflectionInfo method.
-public struct Grpc_Reflection_V1_ServerReflectionRequest {
+public struct Grpc_Reflection_V1_ServerReflectionRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -115,7 +115,7 @@ public struct Grpc_Reflection_V1_ServerReflectionRequest {
   /// To use reflection service, the client should set one of the following
   /// fields in message_request. The server distinguishes requests by their
   /// defined field and then handles them using corresponding methods.
-  public enum OneOf_MessageRequest: Equatable {
+  public enum OneOf_MessageRequest: Equatable, Sendable {
     /// Find a proto file by the file name.
     case fileByFilename(String)
     /// Find the proto file that declares the given fully-qualified symbol name.
@@ -138,36 +138,6 @@ public struct Grpc_Reflection_V1_ServerReflectionRequest {
     /// checked.
     case listServices(String)
 
-  #if !swift(>=4.1)
-    public static func ==(lhs: Grpc_Reflection_V1_ServerReflectionRequest.OneOf_MessageRequest, rhs: Grpc_Reflection_V1_ServerReflectionRequest.OneOf_MessageRequest) -> Bool {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch (lhs, rhs) {
-      case (.fileByFilename, .fileByFilename): return {
-        guard case .fileByFilename(let l) = lhs, case .fileByFilename(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.fileContainingSymbol, .fileContainingSymbol): return {
-        guard case .fileContainingSymbol(let l) = lhs, case .fileContainingSymbol(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.fileContainingExtension, .fileContainingExtension): return {
-        guard case .fileContainingExtension(let l) = lhs, case .fileContainingExtension(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.allExtensionNumbersOfType, .allExtensionNumbersOfType): return {
-        guard case .allExtensionNumbersOfType(let l) = lhs, case .allExtensionNumbersOfType(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.listServices, .listServices): return {
-        guard case .listServices(let l) = lhs, case .listServices(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      default: return false
-      }
-    }
-  #endif
   }
 
   public init() {}
@@ -175,7 +145,7 @@ public struct Grpc_Reflection_V1_ServerReflectionRequest {
 
 /// The type name and extension number sent by the client when requesting
 /// file_containing_extension.
-public struct Grpc_Reflection_V1_ExtensionRequest {
+public struct Grpc_Reflection_V1_ExtensionRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -191,7 +161,7 @@ public struct Grpc_Reflection_V1_ExtensionRequest {
 }
 
 /// The message sent by the server to answer ServerReflectionInfo method.
-public struct Grpc_Reflection_V1_ServerReflectionResponse {
+public struct Grpc_Reflection_V1_ServerReflectionResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -256,7 +226,7 @@ public struct Grpc_Reflection_V1_ServerReflectionResponse {
 
   /// The server sets one of the following fields according to the message_request
   /// in the request.
-  public enum OneOf_MessageResponse: Equatable {
+  public enum OneOf_MessageResponse: Equatable, Sendable {
     /// This message is used to answer file_by_filename, file_containing_symbol,
     /// file_containing_extension requests with transitive dependencies.
     /// As the repeated label is not allowed in oneof fields, we use a
@@ -271,32 +241,6 @@ public struct Grpc_Reflection_V1_ServerReflectionResponse {
     /// This message is used when an error occurs.
     case errorResponse(Grpc_Reflection_V1_ErrorResponse)
 
-  #if !swift(>=4.1)
-    public static func ==(lhs: Grpc_Reflection_V1_ServerReflectionResponse.OneOf_MessageResponse, rhs: Grpc_Reflection_V1_ServerReflectionResponse.OneOf_MessageResponse) -> Bool {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch (lhs, rhs) {
-      case (.fileDescriptorResponse, .fileDescriptorResponse): return {
-        guard case .fileDescriptorResponse(let l) = lhs, case .fileDescriptorResponse(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.allExtensionNumbersResponse, .allExtensionNumbersResponse): return {
-        guard case .allExtensionNumbersResponse(let l) = lhs, case .allExtensionNumbersResponse(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.listServicesResponse, .listServicesResponse): return {
-        guard case .listServicesResponse(let l) = lhs, case .listServicesResponse(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.errorResponse, .errorResponse): return {
-        guard case .errorResponse(let l) = lhs, case .errorResponse(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      default: return false
-      }
-    }
-  #endif
   }
 
   public init() {}
@@ -307,7 +251,7 @@ public struct Grpc_Reflection_V1_ServerReflectionResponse {
 /// Serialized FileDescriptorProto messages sent by the server answering
 /// a file_by_filename, file_containing_symbol, or file_containing_extension
 /// request.
-public struct Grpc_Reflection_V1_FileDescriptorResponse {
+public struct Grpc_Reflection_V1_FileDescriptorResponse: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -324,7 +268,7 @@ public struct Grpc_Reflection_V1_FileDescriptorResponse {
 
 /// A list of extension numbers sent by the server answering
 /// all_extension_numbers_of_type request.
-public struct Grpc_Reflection_V1_ExtensionNumberResponse {
+public struct Grpc_Reflection_V1_ExtensionNumberResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -341,7 +285,7 @@ public struct Grpc_Reflection_V1_ExtensionNumberResponse {
 }
 
 /// A list of ServiceResponse sent by the server answering list_services request.
-public struct Grpc_Reflection_V1_ListServiceResponse {
+public struct Grpc_Reflection_V1_ListServiceResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -357,7 +301,7 @@ public struct Grpc_Reflection_V1_ListServiceResponse {
 
 /// The information of a single service used by ListServiceResponse to answer
 /// list_services request.
-public struct Grpc_Reflection_V1_ServiceResponse {
+public struct Grpc_Reflection_V1_ServiceResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -372,7 +316,7 @@ public struct Grpc_Reflection_V1_ServiceResponse {
 }
 
 /// The error code and error message sent by the server when an error occurs.
-public struct Grpc_Reflection_V1_ErrorResponse {
+public struct Grpc_Reflection_V1_ErrorResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -386,19 +330,6 @@ public struct Grpc_Reflection_V1_ErrorResponse {
 
   public init() {}
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension Grpc_Reflection_V1_ServerReflectionRequest: @unchecked Sendable {}
-extension Grpc_Reflection_V1_ServerReflectionRequest.OneOf_MessageRequest: @unchecked Sendable {}
-extension Grpc_Reflection_V1_ExtensionRequest: @unchecked Sendable {}
-extension Grpc_Reflection_V1_ServerReflectionResponse: @unchecked Sendable {}
-extension Grpc_Reflection_V1_ServerReflectionResponse.OneOf_MessageResponse: @unchecked Sendable {}
-extension Grpc_Reflection_V1_FileDescriptorResponse: @unchecked Sendable {}
-extension Grpc_Reflection_V1_ExtensionNumberResponse: @unchecked Sendable {}
-extension Grpc_Reflection_V1_ListServiceResponse: @unchecked Sendable {}
-extension Grpc_Reflection_V1_ServiceResponse: @unchecked Sendable {}
-extension Grpc_Reflection_V1_ErrorResponse: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Sources/GRPCReflectionService/v1Alpha/reflection-v1alpha.pb.swift
+++ b/Sources/GRPCReflectionService/v1Alpha/reflection-v1alpha.pb.swift
@@ -39,7 +39,9 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 }
 
 /// The message sent by the client when calling ServerReflectionInfo method.
-public struct Grpc_Reflection_V1alpha_ServerReflectionRequest {
+///
+/// NOTE: The whole .proto file that defined this message was marked as deprecated.
+public struct Grpc_Reflection_V1alpha_ServerReflectionRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -112,7 +114,7 @@ public struct Grpc_Reflection_V1alpha_ServerReflectionRequest {
   /// To use reflection service, the client should set one of the following
   /// fields in message_request. The server distinguishes requests by their
   /// defined field and then handles them using corresponding methods.
-  public enum OneOf_MessageRequest: Equatable {
+  public enum OneOf_MessageRequest: Equatable, Sendable {
     /// Find a proto file by the file name.
     case fileByFilename(String)
     /// Find the proto file that declares the given fully-qualified symbol name.
@@ -135,36 +137,6 @@ public struct Grpc_Reflection_V1alpha_ServerReflectionRequest {
     /// checked.
     case listServices(String)
 
-  #if !swift(>=4.1)
-    public static func ==(lhs: Grpc_Reflection_V1alpha_ServerReflectionRequest.OneOf_MessageRequest, rhs: Grpc_Reflection_V1alpha_ServerReflectionRequest.OneOf_MessageRequest) -> Bool {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch (lhs, rhs) {
-      case (.fileByFilename, .fileByFilename): return {
-        guard case .fileByFilename(let l) = lhs, case .fileByFilename(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.fileContainingSymbol, .fileContainingSymbol): return {
-        guard case .fileContainingSymbol(let l) = lhs, case .fileContainingSymbol(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.fileContainingExtension, .fileContainingExtension): return {
-        guard case .fileContainingExtension(let l) = lhs, case .fileContainingExtension(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.allExtensionNumbersOfType, .allExtensionNumbersOfType): return {
-        guard case .allExtensionNumbersOfType(let l) = lhs, case .allExtensionNumbersOfType(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.listServices, .listServices): return {
-        guard case .listServices(let l) = lhs, case .listServices(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      default: return false
-      }
-    }
-  #endif
   }
 
   public init() {}
@@ -172,7 +144,9 @@ public struct Grpc_Reflection_V1alpha_ServerReflectionRequest {
 
 /// The type name and extension number sent by the client when requesting
 /// file_containing_extension.
-public struct Grpc_Reflection_V1alpha_ExtensionRequest {
+///
+/// NOTE: The whole .proto file that defined this message was marked as deprecated.
+public struct Grpc_Reflection_V1alpha_ExtensionRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -188,7 +162,9 @@ public struct Grpc_Reflection_V1alpha_ExtensionRequest {
 }
 
 /// The message sent by the server to answer ServerReflectionInfo method.
-public struct Grpc_Reflection_V1alpha_ServerReflectionResponse {
+///
+/// NOTE: The whole .proto file that defined this message was marked as deprecated.
+public struct Grpc_Reflection_V1alpha_ServerReflectionResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -253,7 +229,7 @@ public struct Grpc_Reflection_V1alpha_ServerReflectionResponse {
 
   /// The server set one of the following fields according to the message_request
   /// in the request.
-  public enum OneOf_MessageResponse: Equatable {
+  public enum OneOf_MessageResponse: Equatable, Sendable {
     /// This message is used to answer file_by_filename, file_containing_symbol,
     /// file_containing_extension requests with transitive dependencies. As
     /// the repeated label is not allowed in oneof fields, we use a
@@ -268,32 +244,6 @@ public struct Grpc_Reflection_V1alpha_ServerReflectionResponse {
     /// This message is used when an error occurs.
     case errorResponse(Grpc_Reflection_V1alpha_ErrorResponse)
 
-  #if !swift(>=4.1)
-    public static func ==(lhs: Grpc_Reflection_V1alpha_ServerReflectionResponse.OneOf_MessageResponse, rhs: Grpc_Reflection_V1alpha_ServerReflectionResponse.OneOf_MessageResponse) -> Bool {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch (lhs, rhs) {
-      case (.fileDescriptorResponse, .fileDescriptorResponse): return {
-        guard case .fileDescriptorResponse(let l) = lhs, case .fileDescriptorResponse(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.allExtensionNumbersResponse, .allExtensionNumbersResponse): return {
-        guard case .allExtensionNumbersResponse(let l) = lhs, case .allExtensionNumbersResponse(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.listServicesResponse, .listServicesResponse): return {
-        guard case .listServicesResponse(let l) = lhs, case .listServicesResponse(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.errorResponse, .errorResponse): return {
-        guard case .errorResponse(let l) = lhs, case .errorResponse(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      default: return false
-      }
-    }
-  #endif
   }
 
   public init() {}
@@ -304,7 +254,9 @@ public struct Grpc_Reflection_V1alpha_ServerReflectionResponse {
 /// Serialized FileDescriptorProto messages sent by the server answering
 /// a file_by_filename, file_containing_symbol, or file_containing_extension
 /// request.
-public struct Grpc_Reflection_V1alpha_FileDescriptorResponse {
+///
+/// NOTE: The whole .proto file that defined this message was marked as deprecated.
+public struct Grpc_Reflection_V1alpha_FileDescriptorResponse: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -321,7 +273,9 @@ public struct Grpc_Reflection_V1alpha_FileDescriptorResponse {
 
 /// A list of extension numbers sent by the server answering
 /// all_extension_numbers_of_type request.
-public struct Grpc_Reflection_V1alpha_ExtensionNumberResponse {
+///
+/// NOTE: The whole .proto file that defined this message was marked as deprecated.
+public struct Grpc_Reflection_V1alpha_ExtensionNumberResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -338,7 +292,9 @@ public struct Grpc_Reflection_V1alpha_ExtensionNumberResponse {
 }
 
 /// A list of ServiceResponse sent by the server answering list_services request.
-public struct Grpc_Reflection_V1alpha_ListServiceResponse {
+///
+/// NOTE: The whole .proto file that defined this message was marked as deprecated.
+public struct Grpc_Reflection_V1alpha_ListServiceResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -354,7 +310,9 @@ public struct Grpc_Reflection_V1alpha_ListServiceResponse {
 
 /// The information of a single service used by ListServiceResponse to answer
 /// list_services request.
-public struct Grpc_Reflection_V1alpha_ServiceResponse {
+///
+/// NOTE: The whole .proto file that defined this message was marked as deprecated.
+public struct Grpc_Reflection_V1alpha_ServiceResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -369,7 +327,9 @@ public struct Grpc_Reflection_V1alpha_ServiceResponse {
 }
 
 /// The error code and error message sent by the server when an error occurs.
-public struct Grpc_Reflection_V1alpha_ErrorResponse {
+///
+/// NOTE: The whole .proto file that defined this message was marked as deprecated.
+public struct Grpc_Reflection_V1alpha_ErrorResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -383,19 +343,6 @@ public struct Grpc_Reflection_V1alpha_ErrorResponse {
 
   public init() {}
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension Grpc_Reflection_V1alpha_ServerReflectionRequest: @unchecked Sendable {}
-extension Grpc_Reflection_V1alpha_ServerReflectionRequest.OneOf_MessageRequest: @unchecked Sendable {}
-extension Grpc_Reflection_V1alpha_ExtensionRequest: @unchecked Sendable {}
-extension Grpc_Reflection_V1alpha_ServerReflectionResponse: @unchecked Sendable {}
-extension Grpc_Reflection_V1alpha_ServerReflectionResponse.OneOf_MessageResponse: @unchecked Sendable {}
-extension Grpc_Reflection_V1alpha_FileDescriptorResponse: @unchecked Sendable {}
-extension Grpc_Reflection_V1alpha_ExtensionNumberResponse: @unchecked Sendable {}
-extension Grpc_Reflection_V1alpha_ListServiceResponse: @unchecked Sendable {}
-extension Grpc_Reflection_V1alpha_ServiceResponse: @unchecked Sendable {}
-extension Grpc_Reflection_V1alpha_ErrorResponse: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Sources/InteroperabilityTests/Generated/empty.pb.swift
+++ b/Sources/InteroperabilityTests/Generated/empty.pb.swift
@@ -41,7 +41,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 ///   service Foo {
 ///     rpc Bar (grpc.testing.Empty) returns (grpc.testing.Empty) { };
 ///   };
-public struct Grpc_Testing_Empty {
+public struct Grpc_Testing_Empty: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -50,10 +50,6 @@ public struct Grpc_Testing_Empty {
 
   public init() {}
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension Grpc_Testing_Empty: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
@@ -64,8 +60,8 @@ extension Grpc_Testing_Empty: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let _ = try decoder.nextFieldNumber() {
-    }
+    // Load everything into unknown fields
+    while try decoder.nextFieldNumber() != nil {}
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {

--- a/Sources/InteroperabilityTests/Generated/messages.pb.swift
+++ b/Sources/InteroperabilityTests/Generated/messages.pb.swift
@@ -37,7 +37,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 }
 
 /// The type of payload that should be returned.
-public enum Grpc_Testing_PayloadType: SwiftProtobuf.Enum {
+public enum Grpc_Testing_PayloadType: SwiftProtobuf.Enum, Swift.CaseIterable {
   public typealias RawValue = Int
 
   /// Compressable text format.
@@ -62,23 +62,17 @@ public enum Grpc_Testing_PayloadType: SwiftProtobuf.Enum {
     }
   }
 
-}
-
-#if swift(>=4.2)
-
-extension Grpc_Testing_PayloadType: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
   public static let allCases: [Grpc_Testing_PayloadType] = [
     .compressable,
   ]
-}
 
-#endif  // swift(>=4.2)
+}
 
 /// TODO(dgq): Go back to using well-known types once
 /// https://github.com/grpc/grpc/issues/6980 has been fixed.
 /// import "google/protobuf/wrappers.proto";
-public struct Grpc_Testing_BoolValue {
+public struct Grpc_Testing_BoolValue: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -92,7 +86,7 @@ public struct Grpc_Testing_BoolValue {
 }
 
 /// A block of data, to simply increase gRPC message size.
-public struct Grpc_Testing_Payload {
+public struct Grpc_Testing_Payload: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -110,7 +104,7 @@ public struct Grpc_Testing_Payload {
 
 /// A protobuf representation for grpc status. This is used by test
 /// clients to specify a status that the server should attempt to return.
-public struct Grpc_Testing_EchoStatus {
+public struct Grpc_Testing_EchoStatus: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -125,7 +119,7 @@ public struct Grpc_Testing_EchoStatus {
 }
 
 /// Unary request.
-public struct Grpc_Testing_SimpleRequest {
+public struct Grpc_Testing_SimpleRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -197,7 +191,7 @@ public struct Grpc_Testing_SimpleRequest {
 }
 
 /// Unary response, as configured by the request.
-public struct Grpc_Testing_SimpleResponse {
+public struct Grpc_Testing_SimpleResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -227,7 +221,7 @@ public struct Grpc_Testing_SimpleResponse {
 }
 
 /// Client-streaming request.
-public struct Grpc_Testing_StreamingInputCallRequest {
+public struct Grpc_Testing_StreamingInputCallRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -264,7 +258,7 @@ public struct Grpc_Testing_StreamingInputCallRequest {
 }
 
 /// Client-streaming response.
-public struct Grpc_Testing_StreamingInputCallResponse {
+public struct Grpc_Testing_StreamingInputCallResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -278,7 +272,7 @@ public struct Grpc_Testing_StreamingInputCallResponse {
 }
 
 /// Configuration for a particular response.
-public struct Grpc_Testing_ResponseParameters {
+public struct Grpc_Testing_ResponseParameters: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -311,7 +305,7 @@ public struct Grpc_Testing_ResponseParameters {
 }
 
 /// Server-streaming request.
-public struct Grpc_Testing_StreamingOutputCallRequest {
+public struct Grpc_Testing_StreamingOutputCallRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -354,7 +348,7 @@ public struct Grpc_Testing_StreamingOutputCallRequest {
 }
 
 /// Server-streaming response, as configured by the request and parameters.
-public struct Grpc_Testing_StreamingOutputCallResponse {
+public struct Grpc_Testing_StreamingOutputCallResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -378,7 +372,7 @@ public struct Grpc_Testing_StreamingOutputCallResponse {
 
 /// For reconnect interop test only.
 /// Client tells server what reconnection parameters it used.
-public struct Grpc_Testing_ReconnectParams {
+public struct Grpc_Testing_ReconnectParams: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -393,7 +387,7 @@ public struct Grpc_Testing_ReconnectParams {
 /// For reconnect interop test only.
 /// Server tells client whether its reconnects are following the spec and the
 /// reconnect backoffs it saw.
-public struct Grpc_Testing_ReconnectInfo {
+public struct Grpc_Testing_ReconnectInfo: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -406,22 +400,6 @@ public struct Grpc_Testing_ReconnectInfo {
 
   public init() {}
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension Grpc_Testing_PayloadType: @unchecked Sendable {}
-extension Grpc_Testing_BoolValue: @unchecked Sendable {}
-extension Grpc_Testing_Payload: @unchecked Sendable {}
-extension Grpc_Testing_EchoStatus: @unchecked Sendable {}
-extension Grpc_Testing_SimpleRequest: @unchecked Sendable {}
-extension Grpc_Testing_SimpleResponse: @unchecked Sendable {}
-extension Grpc_Testing_StreamingInputCallRequest: @unchecked Sendable {}
-extension Grpc_Testing_StreamingInputCallResponse: @unchecked Sendable {}
-extension Grpc_Testing_ResponseParameters: @unchecked Sendable {}
-extension Grpc_Testing_StreamingOutputCallRequest: @unchecked Sendable {}
-extension Grpc_Testing_StreamingOutputCallResponse: @unchecked Sendable {}
-extension Grpc_Testing_ReconnectParams: @unchecked Sendable {}
-extension Grpc_Testing_ReconnectInfo: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Sources/Services/Health/Generated/health.pb.swift
+++ b/Sources/Services/Health/Generated/health.pb.swift
@@ -37,7 +37,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-struct Grpc_Health_V1_HealthCheckRequest {
+struct Grpc_Health_V1_HealthCheckRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -49,7 +49,7 @@ struct Grpc_Health_V1_HealthCheckRequest {
   init() {}
 }
 
-struct Grpc_Health_V1_HealthCheckResponse {
+struct Grpc_Health_V1_HealthCheckResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -58,7 +58,7 @@ struct Grpc_Health_V1_HealthCheckResponse {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum ServingStatus: SwiftProtobuf.Enum {
+  enum ServingStatus: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
     case unknown // = 0
     case serving // = 1
@@ -92,30 +92,18 @@ struct Grpc_Health_V1_HealthCheckResponse {
       }
     }
 
+    // The compiler won't synthesize support with the UNRECOGNIZED case.
+    static let allCases: [Grpc_Health_V1_HealthCheckResponse.ServingStatus] = [
+      .unknown,
+      .serving,
+      .notServing,
+      .serviceUnknown,
+    ]
+
   }
 
   init() {}
 }
-
-#if swift(>=4.2)
-
-extension Grpc_Health_V1_HealthCheckResponse.ServingStatus: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  static let allCases: [Grpc_Health_V1_HealthCheckResponse.ServingStatus] = [
-    .unknown,
-    .serving,
-    .notServing,
-    .serviceUnknown,
-  ]
-}
-
-#endif  // swift(>=4.2)
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension Grpc_Health_V1_HealthCheckRequest: @unchecked Sendable {}
-extension Grpc_Health_V1_HealthCheckResponse: @unchecked Sendable {}
-extension Grpc_Health_V1_HealthCheckResponse.ServingStatus: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Sources/performance-worker/Generated/grpc_core_stats.pb.swift
+++ b/Sources/performance-worker/Generated/grpc_core_stats.pb.swift
@@ -34,7 +34,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-struct Grpc_Core_Bucket {
+struct Grpc_Core_Bucket: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -48,7 +48,7 @@ struct Grpc_Core_Bucket {
   init() {}
 }
 
-struct Grpc_Core_Histogram {
+struct Grpc_Core_Histogram: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -60,7 +60,7 @@ struct Grpc_Core_Histogram {
   init() {}
 }
 
-struct Grpc_Core_Metric {
+struct Grpc_Core_Metric: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -87,34 +87,16 @@ struct Grpc_Core_Metric {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_Value: Equatable {
+  enum OneOf_Value: Equatable, Sendable {
     case count(UInt64)
     case histogram(Grpc_Core_Histogram)
 
-  #if !swift(>=4.1)
-    static func ==(lhs: Grpc_Core_Metric.OneOf_Value, rhs: Grpc_Core_Metric.OneOf_Value) -> Bool {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch (lhs, rhs) {
-      case (.count, .count): return {
-        guard case .count(let l) = lhs, case .count(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.histogram, .histogram): return {
-        guard case .histogram(let l) = lhs, case .histogram(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      default: return false
-      }
-    }
-  #endif
   }
 
   init() {}
 }
 
-struct Grpc_Core_Stats {
+struct Grpc_Core_Stats: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -125,14 +107,6 @@ struct Grpc_Core_Stats {
 
   init() {}
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension Grpc_Core_Bucket: @unchecked Sendable {}
-extension Grpc_Core_Histogram: @unchecked Sendable {}
-extension Grpc_Core_Metric: @unchecked Sendable {}
-extension Grpc_Core_Metric.OneOf_Value: @unchecked Sendable {}
-extension Grpc_Core_Stats: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
@@ -159,7 +133,7 @@ extension Grpc_Core_Bucket: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if self.start != 0 {
+    if self.start.bitPattern != 0 {
       try visitor.visitSingularDoubleField(value: self.start, fieldNumber: 1)
     }
     if self.count != 0 {

--- a/Sources/performance-worker/Generated/grpc_testing_control.pb.swift
+++ b/Sources/performance-worker/Generated/grpc_testing_control.pb.swift
@@ -34,7 +34,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-enum Grpc_Testing_ClientType: SwiftProtobuf.Enum {
+enum Grpc_Testing_ClientType: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
 
   /// Many languages support a basic distinction between using
@@ -71,11 +71,6 @@ enum Grpc_Testing_ClientType: SwiftProtobuf.Enum {
     }
   }
 
-}
-
-#if swift(>=4.2)
-
-extension Grpc_Testing_ClientType: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
   static let allCases: [Grpc_Testing_ClientType] = [
     .syncClient,
@@ -83,11 +78,10 @@ extension Grpc_Testing_ClientType: CaseIterable {
     .otherClient,
     .callbackClient,
   ]
+
 }
 
-#endif  // swift(>=4.2)
-
-enum Grpc_Testing_ServerType: SwiftProtobuf.Enum {
+enum Grpc_Testing_ServerType: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case syncServer // = 0
   case asyncServer // = 1
@@ -124,11 +118,6 @@ enum Grpc_Testing_ServerType: SwiftProtobuf.Enum {
     }
   }
 
-}
-
-#if swift(>=4.2)
-
-extension Grpc_Testing_ServerType: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
   static let allCases: [Grpc_Testing_ServerType] = [
     .syncServer,
@@ -137,11 +126,10 @@ extension Grpc_Testing_ServerType: CaseIterable {
     .otherServer,
     .callbackServer,
   ]
+
 }
 
-#endif  // swift(>=4.2)
-
-enum Grpc_Testing_RpcType: SwiftProtobuf.Enum {
+enum Grpc_Testing_RpcType: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case unary // = 0
   case streaming // = 1
@@ -176,11 +164,6 @@ enum Grpc_Testing_RpcType: SwiftProtobuf.Enum {
     }
   }
 
-}
-
-#if swift(>=4.2)
-
-extension Grpc_Testing_RpcType: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
   static let allCases: [Grpc_Testing_RpcType] = [
     .unary,
@@ -189,13 +172,12 @@ extension Grpc_Testing_RpcType: CaseIterable {
     .streamingFromServer,
     .streamingBothWays,
   ]
-}
 
-#endif  // swift(>=4.2)
+}
 
 /// Parameters of poisson process distribution, which is a good representation
 /// of activity coming in from independent identical stationary sources.
-struct Grpc_Testing_PoissonParams {
+struct Grpc_Testing_PoissonParams: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -210,7 +192,7 @@ struct Grpc_Testing_PoissonParams {
 
 /// Once an RPC finishes, immediately start a new one.
 /// No configuration parameters needed.
-struct Grpc_Testing_ClosedLoopParams {
+struct Grpc_Testing_ClosedLoopParams: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -220,7 +202,7 @@ struct Grpc_Testing_ClosedLoopParams {
   init() {}
 }
 
-struct Grpc_Testing_LoadParams {
+struct Grpc_Testing_LoadParams: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -245,35 +227,17 @@ struct Grpc_Testing_LoadParams {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_Load: Equatable {
+  enum OneOf_Load: Equatable, Sendable {
     case closedLoop(Grpc_Testing_ClosedLoopParams)
     case poisson(Grpc_Testing_PoissonParams)
 
-  #if !swift(>=4.1)
-    static func ==(lhs: Grpc_Testing_LoadParams.OneOf_Load, rhs: Grpc_Testing_LoadParams.OneOf_Load) -> Bool {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch (lhs, rhs) {
-      case (.closedLoop, .closedLoop): return {
-        guard case .closedLoop(let l) = lhs, case .closedLoop(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.poisson, .poisson): return {
-        guard case .poisson(let l) = lhs, case .poisson(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      default: return false
-      }
-    }
-  #endif
   }
 
   init() {}
 }
 
 /// presence of SecurityParams implies use of TLS
-struct Grpc_Testing_SecurityParams {
+struct Grpc_Testing_SecurityParams: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -289,7 +253,7 @@ struct Grpc_Testing_SecurityParams {
   init() {}
 }
 
-struct Grpc_Testing_ChannelArg {
+struct Grpc_Testing_ChannelArg: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -316,34 +280,16 @@ struct Grpc_Testing_ChannelArg {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_Value: Equatable {
+  enum OneOf_Value: Equatable, Sendable {
     case strValue(String)
     case intValue(Int32)
 
-  #if !swift(>=4.1)
-    static func ==(lhs: Grpc_Testing_ChannelArg.OneOf_Value, rhs: Grpc_Testing_ChannelArg.OneOf_Value) -> Bool {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch (lhs, rhs) {
-      case (.strValue, .strValue): return {
-        guard case .strValue(let l) = lhs, case .strValue(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.intValue, .intValue): return {
-        guard case .intValue(let l) = lhs, case .intValue(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      default: return false
-      }
-    }
-  #endif
   }
 
   init() {}
 }
 
-struct Grpc_Testing_ClientConfig {
+struct Grpc_Testing_ClientConfig: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -481,7 +427,7 @@ struct Grpc_Testing_ClientConfig {
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
-struct Grpc_Testing_ClientStatus {
+struct Grpc_Testing_ClientStatus: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -503,7 +449,7 @@ struct Grpc_Testing_ClientStatus {
 }
 
 /// Request current stats
-struct Grpc_Testing_Mark {
+struct Grpc_Testing_Mark: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -516,7 +462,7 @@ struct Grpc_Testing_Mark {
   init() {}
 }
 
-struct Grpc_Testing_ClientArgs {
+struct Grpc_Testing_ClientArgs: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -541,34 +487,16 @@ struct Grpc_Testing_ClientArgs {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_Argtype: Equatable {
+  enum OneOf_Argtype: Equatable, Sendable {
     case setup(Grpc_Testing_ClientConfig)
     case mark(Grpc_Testing_Mark)
 
-  #if !swift(>=4.1)
-    static func ==(lhs: Grpc_Testing_ClientArgs.OneOf_Argtype, rhs: Grpc_Testing_ClientArgs.OneOf_Argtype) -> Bool {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch (lhs, rhs) {
-      case (.setup, .setup): return {
-        guard case .setup(let l) = lhs, case .setup(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.mark, .mark): return {
-        guard case .mark(let l) = lhs, case .mark(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      default: return false
-      }
-    }
-  #endif
   }
 
   init() {}
 }
 
-struct Grpc_Testing_ServerConfig {
+struct Grpc_Testing_ServerConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -631,7 +559,7 @@ struct Grpc_Testing_ServerConfig {
   fileprivate var _payloadConfig: Grpc_Testing_PayloadConfig? = nil
 }
 
-struct Grpc_Testing_ServerArgs {
+struct Grpc_Testing_ServerArgs: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -656,34 +584,16 @@ struct Grpc_Testing_ServerArgs {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_Argtype: Equatable {
+  enum OneOf_Argtype: Equatable, Sendable {
     case setup(Grpc_Testing_ServerConfig)
     case mark(Grpc_Testing_Mark)
 
-  #if !swift(>=4.1)
-    static func ==(lhs: Grpc_Testing_ServerArgs.OneOf_Argtype, rhs: Grpc_Testing_ServerArgs.OneOf_Argtype) -> Bool {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch (lhs, rhs) {
-      case (.setup, .setup): return {
-        guard case .setup(let l) = lhs, case .setup(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.mark, .mark): return {
-        guard case .mark(let l) = lhs, case .mark(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      default: return false
-      }
-    }
-  #endif
   }
 
   init() {}
 }
 
-struct Grpc_Testing_ServerStatus {
+struct Grpc_Testing_ServerStatus: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -710,7 +620,7 @@ struct Grpc_Testing_ServerStatus {
   fileprivate var _stats: Grpc_Testing_ServerStats? = nil
 }
 
-struct Grpc_Testing_CoreRequest {
+struct Grpc_Testing_CoreRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -720,7 +630,7 @@ struct Grpc_Testing_CoreRequest {
   init() {}
 }
 
-struct Grpc_Testing_CoreResponse {
+struct Grpc_Testing_CoreResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -733,7 +643,7 @@ struct Grpc_Testing_CoreResponse {
   init() {}
 }
 
-struct Grpc_Testing_Void {
+struct Grpc_Testing_Void: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -744,7 +654,7 @@ struct Grpc_Testing_Void {
 }
 
 /// A single performance scenario: input to qps_json_driver
-struct Grpc_Testing_Scenario {
+struct Grpc_Testing_Scenario: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -813,7 +723,7 @@ struct Grpc_Testing_Scenario {
 }
 
 /// A set of scenarios to be run with qps_json_driver
-struct Grpc_Testing_Scenarios {
+struct Grpc_Testing_Scenarios: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -827,7 +737,7 @@ struct Grpc_Testing_Scenarios {
 
 /// Basic summary that can be computed from ClientStats and ServerStats
 /// once the scenario has finished.
-struct Grpc_Testing_ScenarioResultSummary {
+struct Grpc_Testing_ScenarioResultSummary: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -965,7 +875,7 @@ struct Grpc_Testing_ScenarioResultSummary {
 }
 
 /// Results of a single benchmark scenario.
-struct Grpc_Testing_ScenarioResult {
+struct Grpc_Testing_ScenarioResult: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1026,35 +936,6 @@ struct Grpc_Testing_ScenarioResult {
   fileprivate var _summary: Grpc_Testing_ScenarioResultSummary? = nil
 }
 
-#if swift(>=5.5) && canImport(_Concurrency)
-extension Grpc_Testing_ClientType: @unchecked Sendable {}
-extension Grpc_Testing_ServerType: @unchecked Sendable {}
-extension Grpc_Testing_RpcType: @unchecked Sendable {}
-extension Grpc_Testing_PoissonParams: @unchecked Sendable {}
-extension Grpc_Testing_ClosedLoopParams: @unchecked Sendable {}
-extension Grpc_Testing_LoadParams: @unchecked Sendable {}
-extension Grpc_Testing_LoadParams.OneOf_Load: @unchecked Sendable {}
-extension Grpc_Testing_SecurityParams: @unchecked Sendable {}
-extension Grpc_Testing_ChannelArg: @unchecked Sendable {}
-extension Grpc_Testing_ChannelArg.OneOf_Value: @unchecked Sendable {}
-extension Grpc_Testing_ClientConfig: @unchecked Sendable {}
-extension Grpc_Testing_ClientStatus: @unchecked Sendable {}
-extension Grpc_Testing_Mark: @unchecked Sendable {}
-extension Grpc_Testing_ClientArgs: @unchecked Sendable {}
-extension Grpc_Testing_ClientArgs.OneOf_Argtype: @unchecked Sendable {}
-extension Grpc_Testing_ServerConfig: @unchecked Sendable {}
-extension Grpc_Testing_ServerArgs: @unchecked Sendable {}
-extension Grpc_Testing_ServerArgs.OneOf_Argtype: @unchecked Sendable {}
-extension Grpc_Testing_ServerStatus: @unchecked Sendable {}
-extension Grpc_Testing_CoreRequest: @unchecked Sendable {}
-extension Grpc_Testing_CoreResponse: @unchecked Sendable {}
-extension Grpc_Testing_Void: @unchecked Sendable {}
-extension Grpc_Testing_Scenario: @unchecked Sendable {}
-extension Grpc_Testing_Scenarios: @unchecked Sendable {}
-extension Grpc_Testing_ScenarioResultSummary: @unchecked Sendable {}
-extension Grpc_Testing_ScenarioResult: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
-
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "grpc.testing"
@@ -1107,7 +988,7 @@ extension Grpc_Testing_PoissonParams: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if self.offeredLoad != 0 {
+    if self.offeredLoad.bitPattern != 0 {
       try visitor.visitSingularDoubleField(value: self.offeredLoad, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
@@ -1125,8 +1006,8 @@ extension Grpc_Testing_ClosedLoopParams: SwiftProtobuf.Message, SwiftProtobuf._M
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let _ = try decoder.nextFieldNumber() {
-    }
+    // Load everything into unknown fields
+    while try decoder.nextFieldNumber() != nil {}
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
@@ -1902,8 +1783,8 @@ extension Grpc_Testing_CoreRequest: SwiftProtobuf.Message, SwiftProtobuf._Messag
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let _ = try decoder.nextFieldNumber() {
-    }
+    // Load everything into unknown fields
+    while try decoder.nextFieldNumber() != nil {}
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
@@ -1953,8 +1834,8 @@ extension Grpc_Testing_Void: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let _ = try decoder.nextFieldNumber() {
-    }
+    // Load everything into unknown fields
+    while try decoder.nextFieldNumber() != nil {}
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
@@ -2261,58 +2142,58 @@ extension Grpc_Testing_ScenarioResultSummary: SwiftProtobuf.Message, SwiftProtob
       // allocates stack space for every if/case branch local when no optimizations
       // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
       // https://github.com/apple/swift-protobuf/issues/1182
-      if _storage._qps != 0 {
+      if _storage._qps.bitPattern != 0 {
         try visitor.visitSingularDoubleField(value: _storage._qps, fieldNumber: 1)
       }
-      if _storage._qpsPerServerCore != 0 {
+      if _storage._qpsPerServerCore.bitPattern != 0 {
         try visitor.visitSingularDoubleField(value: _storage._qpsPerServerCore, fieldNumber: 2)
       }
-      if _storage._serverSystemTime != 0 {
+      if _storage._serverSystemTime.bitPattern != 0 {
         try visitor.visitSingularDoubleField(value: _storage._serverSystemTime, fieldNumber: 3)
       }
-      if _storage._serverUserTime != 0 {
+      if _storage._serverUserTime.bitPattern != 0 {
         try visitor.visitSingularDoubleField(value: _storage._serverUserTime, fieldNumber: 4)
       }
-      if _storage._clientSystemTime != 0 {
+      if _storage._clientSystemTime.bitPattern != 0 {
         try visitor.visitSingularDoubleField(value: _storage._clientSystemTime, fieldNumber: 5)
       }
-      if _storage._clientUserTime != 0 {
+      if _storage._clientUserTime.bitPattern != 0 {
         try visitor.visitSingularDoubleField(value: _storage._clientUserTime, fieldNumber: 6)
       }
-      if _storage._latency50 != 0 {
+      if _storage._latency50.bitPattern != 0 {
         try visitor.visitSingularDoubleField(value: _storage._latency50, fieldNumber: 7)
       }
-      if _storage._latency90 != 0 {
+      if _storage._latency90.bitPattern != 0 {
         try visitor.visitSingularDoubleField(value: _storage._latency90, fieldNumber: 8)
       }
-      if _storage._latency95 != 0 {
+      if _storage._latency95.bitPattern != 0 {
         try visitor.visitSingularDoubleField(value: _storage._latency95, fieldNumber: 9)
       }
-      if _storage._latency99 != 0 {
+      if _storage._latency99.bitPattern != 0 {
         try visitor.visitSingularDoubleField(value: _storage._latency99, fieldNumber: 10)
       }
-      if _storage._latency999 != 0 {
+      if _storage._latency999.bitPattern != 0 {
         try visitor.visitSingularDoubleField(value: _storage._latency999, fieldNumber: 11)
       }
-      if _storage._serverCpuUsage != 0 {
+      if _storage._serverCpuUsage.bitPattern != 0 {
         try visitor.visitSingularDoubleField(value: _storage._serverCpuUsage, fieldNumber: 12)
       }
-      if _storage._successfulRequestsPerSecond != 0 {
+      if _storage._successfulRequestsPerSecond.bitPattern != 0 {
         try visitor.visitSingularDoubleField(value: _storage._successfulRequestsPerSecond, fieldNumber: 13)
       }
-      if _storage._failedRequestsPerSecond != 0 {
+      if _storage._failedRequestsPerSecond.bitPattern != 0 {
         try visitor.visitSingularDoubleField(value: _storage._failedRequestsPerSecond, fieldNumber: 14)
       }
-      if _storage._clientPollsPerRequest != 0 {
+      if _storage._clientPollsPerRequest.bitPattern != 0 {
         try visitor.visitSingularDoubleField(value: _storage._clientPollsPerRequest, fieldNumber: 15)
       }
-      if _storage._serverPollsPerRequest != 0 {
+      if _storage._serverPollsPerRequest.bitPattern != 0 {
         try visitor.visitSingularDoubleField(value: _storage._serverPollsPerRequest, fieldNumber: 16)
       }
-      if _storage._serverQueriesPerCpuSec != 0 {
+      if _storage._serverQueriesPerCpuSec.bitPattern != 0 {
         try visitor.visitSingularDoubleField(value: _storage._serverQueriesPerCpuSec, fieldNumber: 17)
       }
-      if _storage._clientQueriesPerCpuSec != 0 {
+      if _storage._clientQueriesPerCpuSec.bitPattern != 0 {
         try visitor.visitSingularDoubleField(value: _storage._clientQueriesPerCpuSec, fieldNumber: 18)
       }
       try { if let v = _storage._startTime {

--- a/Sources/performance-worker/Generated/grpc_testing_messages.pb.swift
+++ b/Sources/performance-worker/Generated/grpc_testing_messages.pb.swift
@@ -37,7 +37,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 }
 
 /// The type of payload that should be returned.
-enum Grpc_Testing_PayloadType: SwiftProtobuf.Enum {
+enum Grpc_Testing_PayloadType: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
 
   /// Compressable text format.
@@ -62,18 +62,12 @@ enum Grpc_Testing_PayloadType: SwiftProtobuf.Enum {
     }
   }
 
-}
-
-#if swift(>=4.2)
-
-extension Grpc_Testing_PayloadType: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
   static let allCases: [Grpc_Testing_PayloadType] = [
     .compressable,
   ]
-}
 
-#endif  // swift(>=4.2)
+}
 
 /// The type of route that a client took to reach a server w.r.t. gRPCLB.
 /// The server must fill in "fallback" if it detects that the RPC reached
@@ -81,7 +75,7 @@ extension Grpc_Testing_PayloadType: CaseIterable {
 /// that the RPC reached the server via "gRPCLB backend" path (i.e. if it got
 /// the address of this server from the gRPCLB server BalanceLoad RPC). Exactly
 /// how this detection is done is context and server dependent.
-enum Grpc_Testing_GrpclbRouteType: SwiftProtobuf.Enum {
+enum Grpc_Testing_GrpclbRouteType: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
 
   /// Server didn't detect the route that a client took to reach it.
@@ -116,25 +110,19 @@ enum Grpc_Testing_GrpclbRouteType: SwiftProtobuf.Enum {
     }
   }
 
-}
-
-#if swift(>=4.2)
-
-extension Grpc_Testing_GrpclbRouteType: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
   static let allCases: [Grpc_Testing_GrpclbRouteType] = [
     .unknown,
     .fallback,
     .backend,
   ]
-}
 
-#endif  // swift(>=4.2)
+}
 
 /// TODO(dgq): Go back to using well-known types once
 /// https://github.com/grpc/grpc/issues/6980 has been fixed.
 /// import "google/protobuf/wrappers.proto";
-struct Grpc_Testing_BoolValue {
+struct Grpc_Testing_BoolValue: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -148,7 +136,7 @@ struct Grpc_Testing_BoolValue {
 }
 
 /// A block of data, to simply increase gRPC message size.
-struct Grpc_Testing_Payload {
+struct Grpc_Testing_Payload: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -166,7 +154,7 @@ struct Grpc_Testing_Payload {
 
 /// A protobuf representation for grpc status. This is used by test
 /// clients to specify a status that the server should attempt to return.
-struct Grpc_Testing_EchoStatus {
+struct Grpc_Testing_EchoStatus: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -181,7 +169,7 @@ struct Grpc_Testing_EchoStatus {
 }
 
 /// Unary request.
-struct Grpc_Testing_SimpleRequest {
+struct Grpc_Testing_SimpleRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -270,7 +258,7 @@ struct Grpc_Testing_SimpleRequest {
 }
 
 /// Unary response, as configured by the request.
-struct Grpc_Testing_SimpleResponse {
+struct Grpc_Testing_SimpleResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -310,7 +298,7 @@ struct Grpc_Testing_SimpleResponse {
 }
 
 /// Client-streaming request.
-struct Grpc_Testing_StreamingInputCallRequest {
+struct Grpc_Testing_StreamingInputCallRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -347,7 +335,7 @@ struct Grpc_Testing_StreamingInputCallRequest {
 }
 
 /// Client-streaming response.
-struct Grpc_Testing_StreamingInputCallResponse {
+struct Grpc_Testing_StreamingInputCallResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -361,7 +349,7 @@ struct Grpc_Testing_StreamingInputCallResponse {
 }
 
 /// Configuration for a particular response.
-struct Grpc_Testing_ResponseParameters {
+struct Grpc_Testing_ResponseParameters: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -394,7 +382,7 @@ struct Grpc_Testing_ResponseParameters {
 }
 
 /// Server-streaming request.
-struct Grpc_Testing_StreamingOutputCallRequest {
+struct Grpc_Testing_StreamingOutputCallRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -448,7 +436,7 @@ struct Grpc_Testing_StreamingOutputCallRequest {
 }
 
 /// Server-streaming response, as configured by the request and parameters.
-struct Grpc_Testing_StreamingOutputCallResponse {
+struct Grpc_Testing_StreamingOutputCallResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -472,7 +460,7 @@ struct Grpc_Testing_StreamingOutputCallResponse {
 
 /// For reconnect interop test only.
 /// Client tells server what reconnection parameters it used.
-struct Grpc_Testing_ReconnectParams {
+struct Grpc_Testing_ReconnectParams: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -487,7 +475,7 @@ struct Grpc_Testing_ReconnectParams {
 /// For reconnect interop test only.
 /// Server tells client whether its reconnects are following the spec and the
 /// reconnect backoffs it saw.
-struct Grpc_Testing_ReconnectInfo {
+struct Grpc_Testing_ReconnectInfo: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -501,7 +489,7 @@ struct Grpc_Testing_ReconnectInfo {
   init() {}
 }
 
-struct Grpc_Testing_LoadBalancerStatsRequest {
+struct Grpc_Testing_LoadBalancerStatsRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -522,7 +510,7 @@ struct Grpc_Testing_LoadBalancerStatsRequest {
   init() {}
 }
 
-struct Grpc_Testing_LoadBalancerStatsResponse {
+struct Grpc_Testing_LoadBalancerStatsResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -540,7 +528,7 @@ struct Grpc_Testing_LoadBalancerStatsResponse {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum MetadataType: SwiftProtobuf.Enum {
+  enum MetadataType: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
     case unknown // = 0
     case initial // = 1
@@ -569,9 +557,16 @@ struct Grpc_Testing_LoadBalancerStatsResponse {
       }
     }
 
+    // The compiler won't synthesize support with the UNRECOGNIZED case.
+    static let allCases: [Grpc_Testing_LoadBalancerStatsResponse.MetadataType] = [
+      .unknown,
+      .initial,
+      .trailing,
+    ]
+
   }
 
-  struct MetadataEntry {
+  struct MetadataEntry: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -591,7 +586,7 @@ struct Grpc_Testing_LoadBalancerStatsResponse {
     init() {}
   }
 
-  struct RpcMetadata {
+  struct RpcMetadata: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -605,7 +600,7 @@ struct Grpc_Testing_LoadBalancerStatsResponse {
     init() {}
   }
 
-  struct MetadataByPeer {
+  struct MetadataByPeer: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -618,7 +613,7 @@ struct Grpc_Testing_LoadBalancerStatsResponse {
     init() {}
   }
 
-  struct RpcsByPeer {
+  struct RpcsByPeer: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -634,21 +629,8 @@ struct Grpc_Testing_LoadBalancerStatsResponse {
   init() {}
 }
 
-#if swift(>=4.2)
-
-extension Grpc_Testing_LoadBalancerStatsResponse.MetadataType: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  static let allCases: [Grpc_Testing_LoadBalancerStatsResponse.MetadataType] = [
-    .unknown,
-    .initial,
-    .trailing,
-  ]
-}
-
-#endif  // swift(>=4.2)
-
 /// Request for retrieving a test client's accumulated stats.
-struct Grpc_Testing_LoadBalancerAccumulatedStatsRequest {
+struct Grpc_Testing_LoadBalancerAccumulatedStatsRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -659,21 +641,27 @@ struct Grpc_Testing_LoadBalancerAccumulatedStatsRequest {
 }
 
 /// Accumulated stats for RPCs sent by a test client.
-struct Grpc_Testing_LoadBalancerAccumulatedStatsResponse {
+struct Grpc_Testing_LoadBalancerAccumulatedStatsResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
   /// The total number of RPCs have ever issued for each type.
   /// Deprecated: use stats_per_method.rpcs_started instead.
+  ///
+  /// NOTE: This field was marked as deprecated in the .proto file.
   var numRpcsStartedByMethod: Dictionary<String,Int32> = [:]
 
   /// The total number of RPCs have ever completed successfully for each type.
   /// Deprecated: use stats_per_method.result instead.
+  ///
+  /// NOTE: This field was marked as deprecated in the .proto file.
   var numRpcsSucceededByMethod: Dictionary<String,Int32> = [:]
 
   /// The total number of RPCs have ever failed for each type.
   /// Deprecated: use stats_per_method.result instead.
+  ///
+  /// NOTE: This field was marked as deprecated in the .proto file.
   var numRpcsFailedByMethod: Dictionary<String,Int32> = [:]
 
   /// Per-method RPC statistics.  The key is the RpcType in string form; e.g.
@@ -682,7 +670,7 @@ struct Grpc_Testing_LoadBalancerAccumulatedStatsResponse {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct MethodStats {
+  struct MethodStats: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -703,7 +691,7 @@ struct Grpc_Testing_LoadBalancerAccumulatedStatsResponse {
 }
 
 /// Configurations for a test client.
-struct Grpc_Testing_ClientConfigureRequest {
+struct Grpc_Testing_ClientConfigureRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -721,7 +709,7 @@ struct Grpc_Testing_ClientConfigureRequest {
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// Type of RPCs to send.
-  enum RpcType: SwiftProtobuf.Enum {
+  enum RpcType: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
     case emptyCall // = 0
     case unaryCall // = 1
@@ -747,10 +735,16 @@ struct Grpc_Testing_ClientConfigureRequest {
       }
     }
 
+    // The compiler won't synthesize support with the UNRECOGNIZED case.
+    static let allCases: [Grpc_Testing_ClientConfigureRequest.RpcType] = [
+      .emptyCall,
+      .unaryCall,
+    ]
+
   }
 
   /// Metadata to be attached for the given type of RPCs.
-  struct Metadata {
+  struct Metadata: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -769,20 +763,8 @@ struct Grpc_Testing_ClientConfigureRequest {
   init() {}
 }
 
-#if swift(>=4.2)
-
-extension Grpc_Testing_ClientConfigureRequest.RpcType: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  static let allCases: [Grpc_Testing_ClientConfigureRequest.RpcType] = [
-    .emptyCall,
-    .unaryCall,
-  ]
-}
-
-#endif  // swift(>=4.2)
-
 /// Response for updating a test client's configuration.
-struct Grpc_Testing_ClientConfigureResponse {
+struct Grpc_Testing_ClientConfigureResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -792,7 +774,7 @@ struct Grpc_Testing_ClientConfigureResponse {
   init() {}
 }
 
-struct Grpc_Testing_MemorySize {
+struct Grpc_Testing_MemorySize: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -807,7 +789,7 @@ struct Grpc_Testing_MemorySize {
 /// Metrics data the server will update and send to the client. It mirrors orca load report
 /// https://github.com/cncf/xds/blob/eded343319d09f30032952beda9840bbd3dcf7ac/xds/data/orca/v3/orca_load_report.proto#L15,
 /// but avoids orca dependency. Used by both per-query and out-of-band reporting tests.
-struct Grpc_Testing_TestOrcaReport {
+struct Grpc_Testing_TestOrcaReport: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -826,7 +808,7 @@ struct Grpc_Testing_TestOrcaReport {
 }
 
 /// Status that will be return to callers of the Hook method
-struct Grpc_Testing_SetReturnStatusRequest {
+struct Grpc_Testing_SetReturnStatusRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -840,7 +822,7 @@ struct Grpc_Testing_SetReturnStatusRequest {
   init() {}
 }
 
-struct Grpc_Testing_HookRequest {
+struct Grpc_Testing_HookRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -856,7 +838,7 @@ struct Grpc_Testing_HookRequest {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum HookRequestCommand: SwiftProtobuf.Enum {
+  enum HookRequestCommand: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
 
     /// Default value
@@ -896,26 +878,20 @@ struct Grpc_Testing_HookRequest {
       }
     }
 
+    // The compiler won't synthesize support with the UNRECOGNIZED case.
+    static let allCases: [Grpc_Testing_HookRequest.HookRequestCommand] = [
+      .unspecified,
+      .start,
+      .stop,
+      .return,
+    ]
+
   }
 
   init() {}
 }
 
-#if swift(>=4.2)
-
-extension Grpc_Testing_HookRequest.HookRequestCommand: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  static let allCases: [Grpc_Testing_HookRequest.HookRequestCommand] = [
-    .unspecified,
-    .start,
-    .stop,
-    .return,
-  ]
-}
-
-#endif  // swift(>=4.2)
-
-struct Grpc_Testing_HookResponse {
+struct Grpc_Testing_HookResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -924,43 +900,6 @@ struct Grpc_Testing_HookResponse {
 
   init() {}
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension Grpc_Testing_PayloadType: @unchecked Sendable {}
-extension Grpc_Testing_GrpclbRouteType: @unchecked Sendable {}
-extension Grpc_Testing_BoolValue: @unchecked Sendable {}
-extension Grpc_Testing_Payload: @unchecked Sendable {}
-extension Grpc_Testing_EchoStatus: @unchecked Sendable {}
-extension Grpc_Testing_SimpleRequest: @unchecked Sendable {}
-extension Grpc_Testing_SimpleResponse: @unchecked Sendable {}
-extension Grpc_Testing_StreamingInputCallRequest: @unchecked Sendable {}
-extension Grpc_Testing_StreamingInputCallResponse: @unchecked Sendable {}
-extension Grpc_Testing_ResponseParameters: @unchecked Sendable {}
-extension Grpc_Testing_StreamingOutputCallRequest: @unchecked Sendable {}
-extension Grpc_Testing_StreamingOutputCallResponse: @unchecked Sendable {}
-extension Grpc_Testing_ReconnectParams: @unchecked Sendable {}
-extension Grpc_Testing_ReconnectInfo: @unchecked Sendable {}
-extension Grpc_Testing_LoadBalancerStatsRequest: @unchecked Sendable {}
-extension Grpc_Testing_LoadBalancerStatsResponse: @unchecked Sendable {}
-extension Grpc_Testing_LoadBalancerStatsResponse.MetadataType: @unchecked Sendable {}
-extension Grpc_Testing_LoadBalancerStatsResponse.MetadataEntry: @unchecked Sendable {}
-extension Grpc_Testing_LoadBalancerStatsResponse.RpcMetadata: @unchecked Sendable {}
-extension Grpc_Testing_LoadBalancerStatsResponse.MetadataByPeer: @unchecked Sendable {}
-extension Grpc_Testing_LoadBalancerStatsResponse.RpcsByPeer: @unchecked Sendable {}
-extension Grpc_Testing_LoadBalancerAccumulatedStatsRequest: @unchecked Sendable {}
-extension Grpc_Testing_LoadBalancerAccumulatedStatsResponse: @unchecked Sendable {}
-extension Grpc_Testing_LoadBalancerAccumulatedStatsResponse.MethodStats: @unchecked Sendable {}
-extension Grpc_Testing_ClientConfigureRequest: @unchecked Sendable {}
-extension Grpc_Testing_ClientConfigureRequest.RpcType: @unchecked Sendable {}
-extension Grpc_Testing_ClientConfigureRequest.Metadata: @unchecked Sendable {}
-extension Grpc_Testing_ClientConfigureResponse: @unchecked Sendable {}
-extension Grpc_Testing_MemorySize: @unchecked Sendable {}
-extension Grpc_Testing_TestOrcaReport: @unchecked Sendable {}
-extension Grpc_Testing_SetReturnStatusRequest: @unchecked Sendable {}
-extension Grpc_Testing_HookRequest: @unchecked Sendable {}
-extension Grpc_Testing_HookRequest.HookRequestCommand: @unchecked Sendable {}
-extension Grpc_Testing_HookResponse: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
@@ -1785,8 +1724,8 @@ extension Grpc_Testing_LoadBalancerAccumulatedStatsRequest: SwiftProtobuf.Messag
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let _ = try decoder.nextFieldNumber() {
-    }
+    // Load everything into unknown fields
+    while try decoder.nextFieldNumber() != nil {}
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
@@ -1987,8 +1926,8 @@ extension Grpc_Testing_ClientConfigureResponse: SwiftProtobuf.Message, SwiftProt
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let _ = try decoder.nextFieldNumber() {
-    }
+    // Load everything into unknown fields
+    while try decoder.nextFieldNumber() != nil {}
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
@@ -2058,10 +1997,10 @@ extension Grpc_Testing_TestOrcaReport: SwiftProtobuf.Message, SwiftProtobuf._Mes
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if self.cpuUtilization != 0 {
+    if self.cpuUtilization.bitPattern != 0 {
       try visitor.visitSingularDoubleField(value: self.cpuUtilization, fieldNumber: 1)
     }
-    if self.memoryUtilization != 0 {
+    if self.memoryUtilization.bitPattern != 0 {
       try visitor.visitSingularDoubleField(value: self.memoryUtilization, fieldNumber: 2)
     }
     if !self.requestCost.isEmpty {
@@ -2185,8 +2124,8 @@ extension Grpc_Testing_HookResponse: SwiftProtobuf.Message, SwiftProtobuf._Messa
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let _ = try decoder.nextFieldNumber() {
-    }
+    // Load everything into unknown fields
+    while try decoder.nextFieldNumber() != nil {}
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {

--- a/Sources/performance-worker/Generated/grpc_testing_payloads.pb.swift
+++ b/Sources/performance-worker/Generated/grpc_testing_payloads.pb.swift
@@ -34,7 +34,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-struct Grpc_Testing_ByteBufferParams {
+struct Grpc_Testing_ByteBufferParams: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -48,7 +48,7 @@ struct Grpc_Testing_ByteBufferParams {
   init() {}
 }
 
-struct Grpc_Testing_SimpleProtoParams {
+struct Grpc_Testing_SimpleProtoParams: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -64,7 +64,7 @@ struct Grpc_Testing_SimpleProtoParams {
 
 /// TODO (vpai): Fill this in once the details of complex, representative
 ///              protos are decided
-struct Grpc_Testing_ComplexProtoParams {
+struct Grpc_Testing_ComplexProtoParams: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -74,7 +74,7 @@ struct Grpc_Testing_ComplexProtoParams {
   init() {}
 }
 
-struct Grpc_Testing_PayloadConfig {
+struct Grpc_Testing_PayloadConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -107,45 +107,15 @@ struct Grpc_Testing_PayloadConfig {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_Payload: Equatable {
+  enum OneOf_Payload: Equatable, Sendable {
     case bytebufParams(Grpc_Testing_ByteBufferParams)
     case simpleParams(Grpc_Testing_SimpleProtoParams)
     case complexParams(Grpc_Testing_ComplexProtoParams)
 
-  #if !swift(>=4.1)
-    static func ==(lhs: Grpc_Testing_PayloadConfig.OneOf_Payload, rhs: Grpc_Testing_PayloadConfig.OneOf_Payload) -> Bool {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch (lhs, rhs) {
-      case (.bytebufParams, .bytebufParams): return {
-        guard case .bytebufParams(let l) = lhs, case .bytebufParams(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.simpleParams, .simpleParams): return {
-        guard case .simpleParams(let l) = lhs, case .simpleParams(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.complexParams, .complexParams): return {
-        guard case .complexParams(let l) = lhs, case .complexParams(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      default: return false
-      }
-    }
-  #endif
   }
 
   init() {}
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension Grpc_Testing_ByteBufferParams: @unchecked Sendable {}
-extension Grpc_Testing_SimpleProtoParams: @unchecked Sendable {}
-extension Grpc_Testing_ComplexProtoParams: @unchecked Sendable {}
-extension Grpc_Testing_PayloadConfig: @unchecked Sendable {}
-extension Grpc_Testing_PayloadConfig.OneOf_Payload: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
@@ -232,8 +202,8 @@ extension Grpc_Testing_ComplexProtoParams: SwiftProtobuf.Message, SwiftProtobuf.
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let _ = try decoder.nextFieldNumber() {
-    }
+    // Load everything into unknown fields
+    while try decoder.nextFieldNumber() != nil {}
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {

--- a/Sources/performance-worker/Generated/grpc_testing_stats.pb.swift
+++ b/Sources/performance-worker/Generated/grpc_testing_stats.pb.swift
@@ -34,7 +34,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-struct Grpc_Testing_ServerStats {
+struct Grpc_Testing_ServerStats: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -76,7 +76,7 @@ struct Grpc_Testing_ServerStats {
 }
 
 /// Histogram params based on grpc/support/histogram.c
-struct Grpc_Testing_HistogramParams {
+struct Grpc_Testing_HistogramParams: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -93,7 +93,7 @@ struct Grpc_Testing_HistogramParams {
 }
 
 /// Histogram data based on grpc/support/histogram.c
-struct Grpc_Testing_HistogramData {
+struct Grpc_Testing_HistogramData: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -115,7 +115,7 @@ struct Grpc_Testing_HistogramData {
   init() {}
 }
 
-struct Grpc_Testing_RequestResultCount {
+struct Grpc_Testing_RequestResultCount: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -129,7 +129,7 @@ struct Grpc_Testing_RequestResultCount {
   init() {}
 }
 
-struct Grpc_Testing_ClientStats {
+struct Grpc_Testing_ClientStats: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -175,14 +175,6 @@ struct Grpc_Testing_ClientStats {
   fileprivate var _coreStats: Grpc_Core_Stats? = nil
 }
 
-#if swift(>=5.5) && canImport(_Concurrency)
-extension Grpc_Testing_ServerStats: @unchecked Sendable {}
-extension Grpc_Testing_HistogramParams: @unchecked Sendable {}
-extension Grpc_Testing_HistogramData: @unchecked Sendable {}
-extension Grpc_Testing_RequestResultCount: @unchecked Sendable {}
-extension Grpc_Testing_ClientStats: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
-
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "grpc.testing"
@@ -222,13 +214,13 @@ extension Grpc_Testing_ServerStats: SwiftProtobuf.Message, SwiftProtobuf._Messag
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
     // https://github.com/apple/swift-protobuf/issues/1182
-    if self.timeElapsed != 0 {
+    if self.timeElapsed.bitPattern != 0 {
       try visitor.visitSingularDoubleField(value: self.timeElapsed, fieldNumber: 1)
     }
-    if self.timeUser != 0 {
+    if self.timeUser.bitPattern != 0 {
       try visitor.visitSingularDoubleField(value: self.timeUser, fieldNumber: 2)
     }
-    if self.timeSystem != 0 {
+    if self.timeSystem.bitPattern != 0 {
       try visitor.visitSingularDoubleField(value: self.timeSystem, fieldNumber: 3)
     }
     if self.totalCpuTime != 0 {
@@ -280,10 +272,10 @@ extension Grpc_Testing_HistogramParams: SwiftProtobuf.Message, SwiftProtobuf._Me
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if self.resolution != 0 {
+    if self.resolution.bitPattern != 0 {
       try visitor.visitSingularDoubleField(value: self.resolution, fieldNumber: 1)
     }
-    if self.maxPossible != 0 {
+    if self.maxPossible.bitPattern != 0 {
       try visitor.visitSingularDoubleField(value: self.maxPossible, fieldNumber: 2)
     }
     try unknownFields.traverse(visitor: &visitor)
@@ -329,19 +321,19 @@ extension Grpc_Testing_HistogramData: SwiftProtobuf.Message, SwiftProtobuf._Mess
     if !self.bucket.isEmpty {
       try visitor.visitPackedUInt32Field(value: self.bucket, fieldNumber: 1)
     }
-    if self.minSeen != 0 {
+    if self.minSeen.bitPattern != 0 {
       try visitor.visitSingularDoubleField(value: self.minSeen, fieldNumber: 2)
     }
-    if self.maxSeen != 0 {
+    if self.maxSeen.bitPattern != 0 {
       try visitor.visitSingularDoubleField(value: self.maxSeen, fieldNumber: 3)
     }
-    if self.sum != 0 {
+    if self.sum.bitPattern != 0 {
       try visitor.visitSingularDoubleField(value: self.sum, fieldNumber: 4)
     }
-    if self.sumOfSquares != 0 {
+    if self.sumOfSquares.bitPattern != 0 {
       try visitor.visitSingularDoubleField(value: self.sumOfSquares, fieldNumber: 5)
     }
-    if self.count != 0 {
+    if self.count.bitPattern != 0 {
       try visitor.visitSingularDoubleField(value: self.count, fieldNumber: 6)
     }
     try unknownFields.traverse(visitor: &visitor)
@@ -435,13 +427,13 @@ extension Grpc_Testing_ClientStats: SwiftProtobuf.Message, SwiftProtobuf._Messag
     try { if let v = self._latencies {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     } }()
-    if self.timeElapsed != 0 {
+    if self.timeElapsed.bitPattern != 0 {
       try visitor.visitSingularDoubleField(value: self.timeElapsed, fieldNumber: 2)
     }
-    if self.timeUser != 0 {
+    if self.timeUser.bitPattern != 0 {
       try visitor.visitSingularDoubleField(value: self.timeUser, fieldNumber: 3)
     }
-    if self.timeSystem != 0 {
+    if self.timeSystem.bitPattern != 0 {
       try visitor.visitSingularDoubleField(value: self.timeSystem, fieldNumber: 4)
     }
     if !self.requestResults.isEmpty {

--- a/Tests/GRPCCoreTests/Configuration/Generated/code.pb.swift
+++ b/Tests/GRPCCoreTests/Configuration/Generated/code.pb.swift
@@ -41,7 +41,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 /// the most specific error code that applies.  For example, prefer
 /// `OUT_OF_RANGE` over `FAILED_PRECONDITION` if both codes apply.
 /// Similarly prefer `NOT_FOUND` or `ALREADY_EXISTS` over `FAILED_PRECONDITION`.
-enum Google_Rpc_Code: SwiftProtobuf.Enum {
+enum Google_Rpc_Code: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
 
   /// Not an error; returned on success.
@@ -249,11 +249,6 @@ enum Google_Rpc_Code: SwiftProtobuf.Enum {
     }
   }
 
-}
-
-#if swift(>=4.2)
-
-extension Google_Rpc_Code: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
   static let allCases: [Google_Rpc_Code] = [
     .ok,
@@ -274,13 +269,8 @@ extension Google_Rpc_Code: CaseIterable {
     .unavailable,
     .dataLoss,
   ]
+
 }
-
-#endif  // swift(>=4.2)
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension Google_Rpc_Code: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Tests/GRPCCoreTests/Configuration/Generated/rls.pb.swift
+++ b/Tests/GRPCCoreTests/Configuration/Generated/rls.pb.swift
@@ -34,7 +34,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-struct Grpc_Lookup_V1_RouteLookupRequest {
+struct Grpc_Lookup_V1_RouteLookupRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -58,7 +58,7 @@ struct Grpc_Lookup_V1_RouteLookupRequest {
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// Possible reasons for making a request.
-  enum Reason: SwiftProtobuf.Enum {
+  enum Reason: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
 
     /// Unused
@@ -93,25 +93,19 @@ struct Grpc_Lookup_V1_RouteLookupRequest {
       }
     }
 
+    // The compiler won't synthesize support with the UNRECOGNIZED case.
+    static let allCases: [Grpc_Lookup_V1_RouteLookupRequest.Reason] = [
+      .unknown,
+      .miss,
+      .stale,
+    ]
+
   }
 
   init() {}
 }
 
-#if swift(>=4.2)
-
-extension Grpc_Lookup_V1_RouteLookupRequest.Reason: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  static let allCases: [Grpc_Lookup_V1_RouteLookupRequest.Reason] = [
-    .unknown,
-    .miss,
-    .stale,
-  ]
-}
-
-#endif  // swift(>=4.2)
-
-struct Grpc_Lookup_V1_RouteLookupResponse {
+struct Grpc_Lookup_V1_RouteLookupResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -133,12 +127,6 @@ struct Grpc_Lookup_V1_RouteLookupResponse {
 
   init() {}
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension Grpc_Lookup_V1_RouteLookupRequest: @unchecked Sendable {}
-extension Grpc_Lookup_V1_RouteLookupRequest.Reason: @unchecked Sendable {}
-extension Grpc_Lookup_V1_RouteLookupResponse: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Tests/GRPCCoreTests/Configuration/Generated/rls_config.pb.swift
+++ b/Tests/GRPCCoreTests/Configuration/Generated/rls_config.pb.swift
@@ -38,7 +38,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 /// name).  The name must match one of the names listed in the "name" field.  If
 /// the "required_match" field is true, one of the specified names must be
 /// present for the keybuilder to match.
-struct Grpc_Lookup_V1_NameMatcher {
+struct Grpc_Lookup_V1_NameMatcher: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -63,7 +63,7 @@ struct Grpc_Lookup_V1_NameMatcher {
 }
 
 /// A GrpcKeyBuilder applies to a given gRPC service, name, and headers.
-struct Grpc_Lookup_V1_GrpcKeyBuilder {
+struct Grpc_Lookup_V1_GrpcKeyBuilder: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -96,7 +96,7 @@ struct Grpc_Lookup_V1_GrpcKeyBuilder {
   /// fields are specified as fixed strings.  The service name is required and
   /// includes the proto package name.  The method name may be omitted, in
   /// which case any method on the given service is matched.
-  struct Name {
+  struct Name: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -116,7 +116,7 @@ struct Grpc_Lookup_V1_GrpcKeyBuilder {
   /// If this submessage is specified, the normal host/path fields will be left
   /// unset in the RouteLookupRequest. We are deprecating host/path in the
   /// RouteLookupRequest, so services should migrate to the ExtraKeys approach.
-  struct ExtraKeys {
+  struct ExtraKeys: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -153,7 +153,7 @@ struct Grpc_Lookup_V1_GrpcKeyBuilder {
 /// the id and the second segment as the object. If the host has a subdomain, the
 /// subdomain will be used as the id and the first segment as the object. If
 /// neither pattern matches, no keys will be extracted.
-struct Grpc_Lookup_V1_HttpKeyBuilder {
+struct Grpc_Lookup_V1_HttpKeyBuilder: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -226,7 +226,7 @@ struct Grpc_Lookup_V1_HttpKeyBuilder {
   init() {}
 }
 
-struct Grpc_Lookup_V1_RouteLookupConfig {
+struct Grpc_Lookup_V1_RouteLookupConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -314,7 +314,7 @@ struct Grpc_Lookup_V1_RouteLookupConfig {
 
 /// RouteLookupClusterSpecifier is used in xDS to represent a cluster specifier
 /// plugin for RLS.
-struct Grpc_Lookup_V1_RouteLookupClusterSpecifier {
+struct Grpc_Lookup_V1_RouteLookupClusterSpecifier: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -335,16 +335,6 @@ struct Grpc_Lookup_V1_RouteLookupClusterSpecifier {
 
   fileprivate var _routeLookupConfig: Grpc_Lookup_V1_RouteLookupConfig? = nil
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension Grpc_Lookup_V1_NameMatcher: @unchecked Sendable {}
-extension Grpc_Lookup_V1_GrpcKeyBuilder: @unchecked Sendable {}
-extension Grpc_Lookup_V1_GrpcKeyBuilder.Name: @unchecked Sendable {}
-extension Grpc_Lookup_V1_GrpcKeyBuilder.ExtraKeys: @unchecked Sendable {}
-extension Grpc_Lookup_V1_HttpKeyBuilder: @unchecked Sendable {}
-extension Grpc_Lookup_V1_RouteLookupConfig: @unchecked Sendable {}
-extension Grpc_Lookup_V1_RouteLookupClusterSpecifier: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Tests/GRPCCoreTests/Configuration/Generated/service_config.pb.swift
+++ b/Tests/GRPCCoreTests/Configuration/Generated/service_config.pb.swift
@@ -49,7 +49,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 }
 
 /// Configuration for a method.
-struct Grpc_ServiceConfig_MethodConfig {
+struct Grpc_ServiceConfig_MethodConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -165,28 +165,10 @@ struct Grpc_ServiceConfig_MethodConfig {
 
   /// Only one of retry_policy or hedging_policy may be set. If neither is set,
   /// RPCs will not be retried or hedged.
-  enum OneOf_RetryOrHedgingPolicy: Equatable {
+  enum OneOf_RetryOrHedgingPolicy: Equatable, Sendable {
     case retryPolicy(Grpc_ServiceConfig_MethodConfig.RetryPolicy)
     case hedgingPolicy(Grpc_ServiceConfig_MethodConfig.HedgingPolicy)
 
-  #if !swift(>=4.1)
-    static func ==(lhs: Grpc_ServiceConfig_MethodConfig.OneOf_RetryOrHedgingPolicy, rhs: Grpc_ServiceConfig_MethodConfig.OneOf_RetryOrHedgingPolicy) -> Bool {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch (lhs, rhs) {
-      case (.retryPolicy, .retryPolicy): return {
-        guard case .retryPolicy(let l) = lhs, case .retryPolicy(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.hedgingPolicy, .hedgingPolicy): return {
-        guard case .hedgingPolicy(let l) = lhs, case .hedgingPolicy(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      default: return false
-      }
-    }
-  #endif
   }
 
   /// The names of the methods to which this configuration applies.
@@ -216,7 +198,7 @@ struct Grpc_ServiceConfig_MethodConfig {
   /// - { "service": "s" }
   /// - { "service": "s", "method": null }
   /// - { "service": "s", "method": "" }
-  struct Name {
+  struct Name: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -232,7 +214,7 @@ struct Grpc_ServiceConfig_MethodConfig {
   }
 
   /// The retry policy for outgoing RPCs.
-  struct RetryPolicy {
+  struct RetryPolicy: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -286,7 +268,7 @@ struct Grpc_ServiceConfig_MethodConfig {
   /// The hedging policy for outgoing RPCs. Hedged RPCs may execute more than
   /// once on the server, so only idempotent methods should specify a hedging
   /// policy.
-  struct HedgingPolicy {
+  struct HedgingPolicy: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -335,7 +317,7 @@ struct Grpc_ServiceConfig_MethodConfig {
 }
 
 /// Configuration for pick_first LB policy.
-struct Grpc_ServiceConfig_PickFirstConfig {
+struct Grpc_ServiceConfig_PickFirstConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -351,7 +333,7 @@ struct Grpc_ServiceConfig_PickFirstConfig {
 }
 
 /// Configuration for round_robin LB policy.
-struct Grpc_ServiceConfig_RoundRobinConfig {
+struct Grpc_ServiceConfig_RoundRobinConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -362,7 +344,7 @@ struct Grpc_ServiceConfig_RoundRobinConfig {
 }
 
 /// Configuration for weighted_round_robin LB policy.
-struct Grpc_ServiceConfig_WeightedRoundRobinLbConfig {
+struct Grpc_ServiceConfig_WeightedRoundRobinLbConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -455,7 +437,7 @@ struct Grpc_ServiceConfig_WeightedRoundRobinLbConfig {
 }
 
 /// Configuration for outlier_detection LB policy
-struct Grpc_ServiceConfig_OutlierDetectionLoadBalancingConfig {
+struct Grpc_ServiceConfig_OutlierDetectionLoadBalancingConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -534,7 +516,7 @@ struct Grpc_ServiceConfig_OutlierDetectionLoadBalancingConfig {
   /// Parameters for the success rate ejection algorithm.
   /// This algorithm monitors the request success rate for all endpoints and
   /// ejects individual endpoints whose success rates are statistical outliers.
-  struct SuccessRateEjection {
+  struct SuccessRateEjection: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -607,7 +589,7 @@ struct Grpc_ServiceConfig_OutlierDetectionLoadBalancingConfig {
   /// Parameters for the failure percentage algorithm.
   /// This algorithm ejects individual endpoints whose failure rate is greater than
   /// some threshold, independently of any other endpoint.
-  struct FailurePercentageEjection {
+  struct FailurePercentageEjection: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -682,7 +664,7 @@ struct Grpc_ServiceConfig_OutlierDetectionLoadBalancingConfig {
 }
 
 /// Configuration for grpclb LB policy.
-struct Grpc_ServiceConfig_GrpcLbConfig {
+struct Grpc_ServiceConfig_GrpcLbConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -718,7 +700,7 @@ struct Grpc_ServiceConfig_GrpcLbConfig {
 }
 
 /// Configuration for priority LB policy.
-struct Grpc_ServiceConfig_PriorityLoadBalancingPolicyConfig {
+struct Grpc_ServiceConfig_PriorityLoadBalancingPolicyConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -735,7 +717,7 @@ struct Grpc_ServiceConfig_PriorityLoadBalancingPolicyConfig {
   /// The names are used to allow the priority policy to update
   /// existing child policies instead of creating new ones every
   /// time it receives a config update.
-  struct Child {
+  struct Child: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -754,7 +736,7 @@ struct Grpc_ServiceConfig_PriorityLoadBalancingPolicyConfig {
 }
 
 /// Configuration for weighted_target LB policy.
-struct Grpc_ServiceConfig_WeightedTargetLoadBalancingPolicyConfig {
+struct Grpc_ServiceConfig_WeightedTargetLoadBalancingPolicyConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -763,7 +745,7 @@ struct Grpc_ServiceConfig_WeightedTargetLoadBalancingPolicyConfig {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct Target {
+  struct Target: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -781,7 +763,7 @@ struct Grpc_ServiceConfig_WeightedTargetLoadBalancingPolicyConfig {
 }
 
 /// Config for RLS LB policy.
-struct Grpc_ServiceConfig_RlsLoadBalancingPolicyConfig {
+struct Grpc_ServiceConfig_RlsLoadBalancingPolicyConfig: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -824,7 +806,7 @@ struct Grpc_ServiceConfig_RlsLoadBalancingPolicyConfig {
 }
 
 /// Configuration for xds_cluster_manager_experimental LB policy.
-struct Grpc_ServiceConfig_XdsClusterManagerLoadBalancingPolicyConfig {
+struct Grpc_ServiceConfig_XdsClusterManagerLoadBalancingPolicyConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -833,7 +815,7 @@ struct Grpc_ServiceConfig_XdsClusterManagerLoadBalancingPolicyConfig {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct Child {
+  struct Child: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -849,7 +831,7 @@ struct Grpc_ServiceConfig_XdsClusterManagerLoadBalancingPolicyConfig {
 }
 
 /// Configuration for the cds LB policy.
-struct Grpc_ServiceConfig_CdsConfig {
+struct Grpc_ServiceConfig_CdsConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -866,7 +848,7 @@ struct Grpc_ServiceConfig_CdsConfig {
 }
 
 /// Configuration for xds_cluster_impl LB policy.
-struct Grpc_ServiceConfig_XdsClusterImplLoadBalancingPolicyConfig {
+struct Grpc_ServiceConfig_XdsClusterImplLoadBalancingPolicyConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -880,6 +862,8 @@ struct Grpc_ServiceConfig_XdsClusterImplLoadBalancingPolicyConfig {
   /// EDS service name.
   /// Not set if cluster is not an EDS cluster or if it does not
   /// specify an EDS service name.
+  ///
+  /// NOTE: This field was marked as deprecated in the .proto file.
   var edsServiceName: String = String()
 
   /// Server to send load reports to.
@@ -887,6 +871,8 @@ struct Grpc_ServiceConfig_XdsClusterImplLoadBalancingPolicyConfig {
   /// If set to empty string, load reporting will be sent to the same
   /// server as we are getting xds data from.
   /// DEPRECATED: Use new lrs_load_reporting_server field instead.
+  ///
+  /// NOTE: This field was marked as deprecated in the .proto file.
   var lrsLoadReportingServerName: SwiftProtobuf.Google_Protobuf_StringValue {
     get {return _lrsLoadReportingServerName ?? SwiftProtobuf.Google_Protobuf_StringValue()}
     set {_lrsLoadReportingServerName = newValue}
@@ -899,6 +885,8 @@ struct Grpc_ServiceConfig_XdsClusterImplLoadBalancingPolicyConfig {
   /// LRS server to send load reports to.
   /// If not present, load reporting will be disabled.
   /// Supercedes lrs_load_reporting_server_name field.
+  ///
+  /// NOTE: This field was marked as deprecated in the .proto file.
   var lrsLoadReportingServer: Grpc_ServiceConfig_XdsServer {
     get {return _lrsLoadReportingServer ?? Grpc_ServiceConfig_XdsServer()}
     set {_lrsLoadReportingServer = newValue}
@@ -910,6 +898,8 @@ struct Grpc_ServiceConfig_XdsClusterImplLoadBalancingPolicyConfig {
 
   /// Maximum number of outstanding requests can be made to the upstream cluster.
   /// Default is 1024.
+  ///
+  /// NOTE: This field was marked as deprecated in the .proto file.
   var maxConcurrentRequests: SwiftProtobuf.Google_Protobuf_UInt32Value {
     get {return _maxConcurrentRequests ?? SwiftProtobuf.Google_Protobuf_UInt32Value()}
     set {_maxConcurrentRequests = newValue}
@@ -919,15 +909,18 @@ struct Grpc_ServiceConfig_XdsClusterImplLoadBalancingPolicyConfig {
   /// Clears the value of `maxConcurrentRequests`. Subsequent reads from it will return its default value.
   mutating func clearMaxConcurrentRequests() {self._maxConcurrentRequests = nil}
 
+  /// NOTE: This field was marked as deprecated in the .proto file.
   var dropCategories: [Grpc_ServiceConfig_XdsClusterImplLoadBalancingPolicyConfig.DropCategory] = []
 
   /// Telemetry labels associated with this cluster
+  ///
+  /// NOTE: This field was marked as deprecated in the .proto file.
   var telemetryLabels: Dictionary<String,String> = [:]
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// Drop configuration.
-  struct DropCategory {
+  struct DropCategory: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -949,7 +942,7 @@ struct Grpc_ServiceConfig_XdsClusterImplLoadBalancingPolicyConfig {
 }
 
 /// Configuration for ring_hash LB policy.
-struct Grpc_ServiceConfig_RingHashLoadBalancingConfig {
+struct Grpc_ServiceConfig_RingHashLoadBalancingConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -968,7 +961,7 @@ struct Grpc_ServiceConfig_RingHashLoadBalancingConfig {
 }
 
 /// Configuration for the xds_wrr_locality load balancing policy.
-struct Grpc_ServiceConfig_XdsWrrLocalityLoadBalancingPolicyConfig {
+struct Grpc_ServiceConfig_XdsWrrLocalityLoadBalancingPolicyConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -981,7 +974,7 @@ struct Grpc_ServiceConfig_XdsWrrLocalityLoadBalancingPolicyConfig {
 }
 
 /// Configuration for the least_request LB policy.
-struct Grpc_ServiceConfig_LeastRequestLocalityLoadBalancingPolicyConfig {
+struct Grpc_ServiceConfig_LeastRequestLocalityLoadBalancingPolicyConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -994,7 +987,7 @@ struct Grpc_ServiceConfig_LeastRequestLocalityLoadBalancingPolicyConfig {
 }
 
 /// Configuration for the xds_override_host LB policy.
-struct Grpc_ServiceConfig_OverrideHostLoadBalancingPolicyConfig {
+struct Grpc_ServiceConfig_OverrideHostLoadBalancingPolicyConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1006,11 +999,13 @@ struct Grpc_ServiceConfig_OverrideHostLoadBalancingPolicyConfig {
   /// valid health status for hosts that are considered when using
   /// xds_override_host_experimental policy.
   /// Default is [UNKNOWN, HEALTHY]
+  ///
+  /// NOTE: This field was marked as deprecated in the .proto file.
   var overrideHostStatus: [Grpc_ServiceConfig_OverrideHostLoadBalancingPolicyConfig.HealthStatus] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum HealthStatus: SwiftProtobuf.Enum {
+  enum HealthStatus: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
     case unknown // = 0
     case healthy // = 1
@@ -1039,23 +1034,17 @@ struct Grpc_ServiceConfig_OverrideHostLoadBalancingPolicyConfig {
       }
     }
 
+    // The compiler won't synthesize support with the UNRECOGNIZED case.
+    static let allCases: [Grpc_ServiceConfig_OverrideHostLoadBalancingPolicyConfig.HealthStatus] = [
+      .unknown,
+      .healthy,
+      .draining,
+    ]
+
   }
 
   init() {}
 }
-
-#if swift(>=4.2)
-
-extension Grpc_ServiceConfig_OverrideHostLoadBalancingPolicyConfig.HealthStatus: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  static let allCases: [Grpc_ServiceConfig_OverrideHostLoadBalancingPolicyConfig.HealthStatus] = [
-    .unknown,
-    .healthy,
-    .draining,
-  ]
-}
-
-#endif  // swift(>=4.2)
 
 /// Selects LB policy and provides corresponding configuration.
 ///
@@ -1068,7 +1057,7 @@ extension Grpc_ServiceConfig_OverrideHostLoadBalancingPolicyConfig.HealthStatus:
 ///   config is invalid.
 /// - If the list doesn't contain any supported policy, the whole service config
 ///   is invalid.
-struct Grpc_ServiceConfig_LoadBalancingConfig {
+struct Grpc_ServiceConfig_LoadBalancingConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1201,6 +1190,8 @@ struct Grpc_ServiceConfig_LoadBalancingConfig {
   }
 
   /// Deprecated xDS-related policies.
+  ///
+  /// NOTE: This field was marked as deprecated in the .proto file.
   var xdsClusterResolverExperimental: Grpc_ServiceConfig_XdsClusterResolverLoadBalancingPolicyConfig {
     get {
       if case .xdsClusterResolverExperimental(let v)? = policy {return v}
@@ -1209,6 +1200,7 @@ struct Grpc_ServiceConfig_LoadBalancingConfig {
     set {policy = .xdsClusterResolverExperimental(newValue)}
   }
 
+  /// NOTE: This field was marked as deprecated in the .proto file.
   var lrsExperimental: Grpc_ServiceConfig_LrsLoadBalancingPolicyConfig {
     get {
       if case .lrsExperimental(let v)? = policy {return v}
@@ -1217,6 +1209,7 @@ struct Grpc_ServiceConfig_LoadBalancingConfig {
     set {policy = .lrsExperimental(newValue)}
   }
 
+  /// NOTE: This field was marked as deprecated in the .proto file.
   var edsExperimental: Grpc_ServiceConfig_EdsLoadBalancingPolicyConfig {
     get {
       if case .edsExperimental(let v)? = policy {return v}
@@ -1225,6 +1218,7 @@ struct Grpc_ServiceConfig_LoadBalancingConfig {
     set {policy = .edsExperimental(newValue)}
   }
 
+  /// NOTE: This field was marked as deprecated in the .proto file.
   var xds: Grpc_ServiceConfig_XdsConfig {
     get {
       if case .xds(let v)? = policy {return v}
@@ -1233,6 +1227,7 @@ struct Grpc_ServiceConfig_LoadBalancingConfig {
     set {policy = .xds(newValue)}
   }
 
+  /// NOTE: This field was marked as deprecated in the .proto file.
   var xdsExperimental: Grpc_ServiceConfig_XdsConfig {
     get {
       if case .xdsExperimental(let v)? = policy {return v}
@@ -1244,7 +1239,7 @@ struct Grpc_ServiceConfig_LoadBalancingConfig {
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// Exactly one LB policy may be configured.
-  enum OneOf_Policy: Equatable {
+  enum OneOf_Policy: Equatable, Sendable {
     case pickFirst(Grpc_ServiceConfig_PickFirstConfig)
     case roundRobin(Grpc_ServiceConfig_RoundRobinConfig)
     case weightedRoundRobin(Grpc_ServiceConfig_WeightedRoundRobinLbConfig)
@@ -1265,102 +1260,18 @@ struct Grpc_ServiceConfig_LoadBalancingConfig {
     case ringHashExperimental(Grpc_ServiceConfig_RingHashLoadBalancingConfig)
     case leastRequestExperimental(Grpc_ServiceConfig_LeastRequestLocalityLoadBalancingPolicyConfig)
     /// Deprecated xDS-related policies.
+    ///
+    /// NOTE: This field was marked as deprecated in the .proto file.
     case xdsClusterResolverExperimental(Grpc_ServiceConfig_XdsClusterResolverLoadBalancingPolicyConfig)
+    /// NOTE: This field was marked as deprecated in the .proto file.
     case lrsExperimental(Grpc_ServiceConfig_LrsLoadBalancingPolicyConfig)
+    /// NOTE: This field was marked as deprecated in the .proto file.
     case edsExperimental(Grpc_ServiceConfig_EdsLoadBalancingPolicyConfig)
+    /// NOTE: This field was marked as deprecated in the .proto file.
     case xds(Grpc_ServiceConfig_XdsConfig)
+    /// NOTE: This field was marked as deprecated in the .proto file.
     case xdsExperimental(Grpc_ServiceConfig_XdsConfig)
 
-  #if !swift(>=4.1)
-    static func ==(lhs: Grpc_ServiceConfig_LoadBalancingConfig.OneOf_Policy, rhs: Grpc_ServiceConfig_LoadBalancingConfig.OneOf_Policy) -> Bool {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch (lhs, rhs) {
-      case (.pickFirst, .pickFirst): return {
-        guard case .pickFirst(let l) = lhs, case .pickFirst(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.roundRobin, .roundRobin): return {
-        guard case .roundRobin(let l) = lhs, case .roundRobin(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.weightedRoundRobin, .weightedRoundRobin): return {
-        guard case .weightedRoundRobin(let l) = lhs, case .weightedRoundRobin(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.grpclb, .grpclb): return {
-        guard case .grpclb(let l) = lhs, case .grpclb(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.priorityExperimental, .priorityExperimental): return {
-        guard case .priorityExperimental(let l) = lhs, case .priorityExperimental(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.weightedTargetExperimental, .weightedTargetExperimental): return {
-        guard case .weightedTargetExperimental(let l) = lhs, case .weightedTargetExperimental(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.outlierDetection, .outlierDetection): return {
-        guard case .outlierDetection(let l) = lhs, case .outlierDetection(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.rls, .rls): return {
-        guard case .rls(let l) = lhs, case .rls(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.xdsClusterManagerExperimental, .xdsClusterManagerExperimental): return {
-        guard case .xdsClusterManagerExperimental(let l) = lhs, case .xdsClusterManagerExperimental(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.cdsExperimental, .cdsExperimental): return {
-        guard case .cdsExperimental(let l) = lhs, case .cdsExperimental(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.xdsClusterImplExperimental, .xdsClusterImplExperimental): return {
-        guard case .xdsClusterImplExperimental(let l) = lhs, case .xdsClusterImplExperimental(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.overrideHostExperimental, .overrideHostExperimental): return {
-        guard case .overrideHostExperimental(let l) = lhs, case .overrideHostExperimental(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.xdsWrrLocalityExperimental, .xdsWrrLocalityExperimental): return {
-        guard case .xdsWrrLocalityExperimental(let l) = lhs, case .xdsWrrLocalityExperimental(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.ringHashExperimental, .ringHashExperimental): return {
-        guard case .ringHashExperimental(let l) = lhs, case .ringHashExperimental(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.leastRequestExperimental, .leastRequestExperimental): return {
-        guard case .leastRequestExperimental(let l) = lhs, case .leastRequestExperimental(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.xdsClusterResolverExperimental, .xdsClusterResolverExperimental): return {
-        guard case .xdsClusterResolverExperimental(let l) = lhs, case .xdsClusterResolverExperimental(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.lrsExperimental, .lrsExperimental): return {
-        guard case .lrsExperimental(let l) = lhs, case .lrsExperimental(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.edsExperimental, .edsExperimental): return {
-        guard case .edsExperimental(let l) = lhs, case .edsExperimental(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.xds, .xds): return {
-        guard case .xds(let l) = lhs, case .xds(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.xdsExperimental, .xdsExperimental): return {
-        guard case .xdsExperimental(let l) = lhs, case .xdsExperimental(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      default: return false
-      }
-    }
-  #endif
   }
 
   init() {}
@@ -1368,11 +1279,12 @@ struct Grpc_ServiceConfig_LoadBalancingConfig {
 
 /// A ServiceConfig represents information about a service but is not specific to
 /// any name resolver.
-struct Grpc_ServiceConfig_ServiceConfig {
+struct Grpc_ServiceConfig_ServiceConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
+  /// NOTE: This field was marked as deprecated in the .proto file.
   var loadBalancingPolicy: Grpc_ServiceConfig_ServiceConfig.LoadBalancingPolicy = .unspecified
 
   /// Multiple LB policies can be specified; clients will iterate through
@@ -1421,7 +1333,7 @@ struct Grpc_ServiceConfig_ServiceConfig {
   /// returns at least one backend address in addition to the balancer
   /// address(es), the client may fall back to the requested policy if it
   /// is unable to reach any of the grpclb load balancers.
-  enum LoadBalancingPolicy: SwiftProtobuf.Enum {
+  enum LoadBalancingPolicy: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
     case unspecified // = 0
     case roundRobin // = 1
@@ -1447,6 +1359,12 @@ struct Grpc_ServiceConfig_ServiceConfig {
       }
     }
 
+    // The compiler won't synthesize support with the UNRECOGNIZED case.
+    static let allCases: [Grpc_ServiceConfig_ServiceConfig.LoadBalancingPolicy] = [
+      .unspecified,
+      .roundRobin,
+    ]
+
   }
 
   /// If a RetryThrottlingPolicy is provided, gRPC will automatically throttle
@@ -1462,7 +1380,7 @@ struct Grpc_ServiceConfig_ServiceConfig {
   ///
   /// If token_count is less than or equal to max_tokens / 2, then RPCs will not
   /// be retried and hedged RPCs will not be sent.
-  struct RetryThrottlingPolicy {
+  struct RetryThrottlingPolicy: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1485,7 +1403,7 @@ struct Grpc_ServiceConfig_ServiceConfig {
     init() {}
   }
 
-  struct HealthCheckConfig {
+  struct HealthCheckConfig: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1513,21 +1431,9 @@ struct Grpc_ServiceConfig_ServiceConfig {
   fileprivate var _healthCheckConfig: Grpc_ServiceConfig_ServiceConfig.HealthCheckConfig? = nil
 }
 
-#if swift(>=4.2)
-
-extension Grpc_ServiceConfig_ServiceConfig.LoadBalancingPolicy: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  static let allCases: [Grpc_ServiceConfig_ServiceConfig.LoadBalancingPolicy] = [
-    .unspecified,
-    .roundRobin,
-  ]
-}
-
-#endif  // swift(>=4.2)
-
 /// Represents an xDS server.
 /// Deprecated.
-struct Grpc_ServiceConfig_XdsServer {
+struct Grpc_ServiceConfig_XdsServer: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1543,7 +1449,7 @@ struct Grpc_ServiceConfig_XdsServer {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct ChannelCredentials {
+  struct ChannelCredentials: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1573,7 +1479,7 @@ struct Grpc_ServiceConfig_XdsServer {
 
 /// Configuration for xds_cluster_resolver LB policy.
 /// Deprecated.
-struct Grpc_ServiceConfig_XdsClusterResolverLoadBalancingPolicyConfig {
+struct Grpc_ServiceConfig_XdsClusterResolverLoadBalancingPolicyConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1595,7 +1501,7 @@ struct Grpc_ServiceConfig_XdsClusterResolverLoadBalancingPolicyConfig {
   /// CDS policy.
   /// For aggregate clusters, there will be one DiscoveryMechanism for each
   /// underlying cluster.
-  struct DiscoveryMechanism {
+  struct DiscoveryMechanism: @unchecked Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1611,6 +1517,8 @@ struct Grpc_ServiceConfig_XdsClusterResolverLoadBalancingPolicyConfig {
     /// If set to the empty string, load reporting will be sent to the same
     /// server that we obtained CDS data from.
     /// DEPRECATED: Use new lrs_load_reporting_server field instead.
+    ///
+    /// NOTE: This field was marked as deprecated in the .proto file.
     var lrsLoadReportingServerName: SwiftProtobuf.Google_Protobuf_StringValue {
       get {return _storage._lrsLoadReportingServerName ?? SwiftProtobuf.Google_Protobuf_StringValue()}
       set {_uniqueStorage()._lrsLoadReportingServerName = newValue}
@@ -1688,7 +1596,7 @@ struct Grpc_ServiceConfig_XdsClusterResolverLoadBalancingPolicyConfig {
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    enum TypeEnum: SwiftProtobuf.Enum {
+    enum TypeEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
       typealias RawValue = Int
       case unknown // = 0
       case eds // = 1
@@ -1717,6 +1625,13 @@ struct Grpc_ServiceConfig_XdsClusterResolverLoadBalancingPolicyConfig {
         }
       }
 
+      // The compiler won't synthesize support with the UNRECOGNIZED case.
+      static let allCases: [Grpc_ServiceConfig_XdsClusterResolverLoadBalancingPolicyConfig.DiscoveryMechanism.TypeEnum] = [
+        .unknown,
+        .eds,
+        .logicalDns,
+      ]
+
     }
 
     init() {}
@@ -1727,22 +1642,9 @@ struct Grpc_ServiceConfig_XdsClusterResolverLoadBalancingPolicyConfig {
   init() {}
 }
 
-#if swift(>=4.2)
-
-extension Grpc_ServiceConfig_XdsClusterResolverLoadBalancingPolicyConfig.DiscoveryMechanism.TypeEnum: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  static let allCases: [Grpc_ServiceConfig_XdsClusterResolverLoadBalancingPolicyConfig.DiscoveryMechanism.TypeEnum] = [
-    .unknown,
-    .eds,
-    .logicalDns,
-  ]
-}
-
-#endif  // swift(>=4.2)
-
 /// Configuration for lrs LB policy.
 /// Deprecated.
-struct Grpc_ServiceConfig_LrsLoadBalancingPolicyConfig {
+struct Grpc_ServiceConfig_LrsLoadBalancingPolicyConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1774,7 +1676,7 @@ struct Grpc_ServiceConfig_LrsLoadBalancingPolicyConfig {
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// The locality for which this policy will report load.  Required.
-  struct Locality {
+  struct Locality: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1797,7 +1699,7 @@ struct Grpc_ServiceConfig_LrsLoadBalancingPolicyConfig {
 
 /// Configuration for eds LB policy.
 /// Deprecated.
-struct Grpc_ServiceConfig_EdsLoadBalancingPolicyConfig {
+struct Grpc_ServiceConfig_EdsLoadBalancingPolicyConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1845,12 +1747,14 @@ struct Grpc_ServiceConfig_EdsLoadBalancingPolicyConfig {
 
 /// Configuration for xds LB policy.
 /// Deprecated.
-struct Grpc_ServiceConfig_XdsConfig {
+struct Grpc_ServiceConfig_XdsConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
   /// Name of balancer to connect to.
+  ///
+  /// NOTE: This field was marked as deprecated in the .proto file.
   var balancerName: String = String()
 
   /// Optional.  What LB policy to use for intra-locality routing.
@@ -1888,51 +1792,6 @@ struct Grpc_ServiceConfig_XdsConfig {
 
   fileprivate var _lrsLoadReportingServerName: SwiftProtobuf.Google_Protobuf_StringValue? = nil
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension Grpc_ServiceConfig_MethodConfig: @unchecked Sendable {}
-extension Grpc_ServiceConfig_MethodConfig.OneOf_RetryOrHedgingPolicy: @unchecked Sendable {}
-extension Grpc_ServiceConfig_MethodConfig.Name: @unchecked Sendable {}
-extension Grpc_ServiceConfig_MethodConfig.RetryPolicy: @unchecked Sendable {}
-extension Grpc_ServiceConfig_MethodConfig.HedgingPolicy: @unchecked Sendable {}
-extension Grpc_ServiceConfig_PickFirstConfig: @unchecked Sendable {}
-extension Grpc_ServiceConfig_RoundRobinConfig: @unchecked Sendable {}
-extension Grpc_ServiceConfig_WeightedRoundRobinLbConfig: @unchecked Sendable {}
-extension Grpc_ServiceConfig_OutlierDetectionLoadBalancingConfig: @unchecked Sendable {}
-extension Grpc_ServiceConfig_OutlierDetectionLoadBalancingConfig.SuccessRateEjection: @unchecked Sendable {}
-extension Grpc_ServiceConfig_OutlierDetectionLoadBalancingConfig.FailurePercentageEjection: @unchecked Sendable {}
-extension Grpc_ServiceConfig_GrpcLbConfig: @unchecked Sendable {}
-extension Grpc_ServiceConfig_PriorityLoadBalancingPolicyConfig: @unchecked Sendable {}
-extension Grpc_ServiceConfig_PriorityLoadBalancingPolicyConfig.Child: @unchecked Sendable {}
-extension Grpc_ServiceConfig_WeightedTargetLoadBalancingPolicyConfig: @unchecked Sendable {}
-extension Grpc_ServiceConfig_WeightedTargetLoadBalancingPolicyConfig.Target: @unchecked Sendable {}
-extension Grpc_ServiceConfig_RlsLoadBalancingPolicyConfig: @unchecked Sendable {}
-extension Grpc_ServiceConfig_XdsClusterManagerLoadBalancingPolicyConfig: @unchecked Sendable {}
-extension Grpc_ServiceConfig_XdsClusterManagerLoadBalancingPolicyConfig.Child: @unchecked Sendable {}
-extension Grpc_ServiceConfig_CdsConfig: @unchecked Sendable {}
-extension Grpc_ServiceConfig_XdsClusterImplLoadBalancingPolicyConfig: @unchecked Sendable {}
-extension Grpc_ServiceConfig_XdsClusterImplLoadBalancingPolicyConfig.DropCategory: @unchecked Sendable {}
-extension Grpc_ServiceConfig_RingHashLoadBalancingConfig: @unchecked Sendable {}
-extension Grpc_ServiceConfig_XdsWrrLocalityLoadBalancingPolicyConfig: @unchecked Sendable {}
-extension Grpc_ServiceConfig_LeastRequestLocalityLoadBalancingPolicyConfig: @unchecked Sendable {}
-extension Grpc_ServiceConfig_OverrideHostLoadBalancingPolicyConfig: @unchecked Sendable {}
-extension Grpc_ServiceConfig_OverrideHostLoadBalancingPolicyConfig.HealthStatus: @unchecked Sendable {}
-extension Grpc_ServiceConfig_LoadBalancingConfig: @unchecked Sendable {}
-extension Grpc_ServiceConfig_LoadBalancingConfig.OneOf_Policy: @unchecked Sendable {}
-extension Grpc_ServiceConfig_ServiceConfig: @unchecked Sendable {}
-extension Grpc_ServiceConfig_ServiceConfig.LoadBalancingPolicy: @unchecked Sendable {}
-extension Grpc_ServiceConfig_ServiceConfig.RetryThrottlingPolicy: @unchecked Sendable {}
-extension Grpc_ServiceConfig_ServiceConfig.HealthCheckConfig: @unchecked Sendable {}
-extension Grpc_ServiceConfig_XdsServer: @unchecked Sendable {}
-extension Grpc_ServiceConfig_XdsServer.ChannelCredentials: @unchecked Sendable {}
-extension Grpc_ServiceConfig_XdsClusterResolverLoadBalancingPolicyConfig: @unchecked Sendable {}
-extension Grpc_ServiceConfig_XdsClusterResolverLoadBalancingPolicyConfig.DiscoveryMechanism: @unchecked Sendable {}
-extension Grpc_ServiceConfig_XdsClusterResolverLoadBalancingPolicyConfig.DiscoveryMechanism.TypeEnum: @unchecked Sendable {}
-extension Grpc_ServiceConfig_LrsLoadBalancingPolicyConfig: @unchecked Sendable {}
-extension Grpc_ServiceConfig_LrsLoadBalancingPolicyConfig.Locality: @unchecked Sendable {}
-extension Grpc_ServiceConfig_EdsLoadBalancingPolicyConfig: @unchecked Sendable {}
-extension Grpc_ServiceConfig_XdsConfig: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
@@ -2116,7 +1975,7 @@ extension Grpc_ServiceConfig_MethodConfig.RetryPolicy: SwiftProtobuf.Message, Sw
     try { if let v = self._maxBackoff {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
     } }()
-    if self.backoffMultiplier != 0 {
+    if self.backoffMultiplier.bitPattern != 0 {
       try visitor.visitSingularFloatField(value: self.backoffMultiplier, fieldNumber: 4)
     }
     if !self.retryableStatusCodes.isEmpty {
@@ -2221,8 +2080,8 @@ extension Grpc_ServiceConfig_RoundRobinConfig: SwiftProtobuf.Message, SwiftProto
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let _ = try decoder.nextFieldNumber() {
-    }
+    // Load everything into unknown fields
+    while try decoder.nextFieldNumber() != nil {}
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
@@ -3632,7 +3491,7 @@ extension Grpc_ServiceConfig_ServiceConfig.RetryThrottlingPolicy: SwiftProtobuf.
     if self.maxTokens != 0 {
       try visitor.visitSingularUInt32Field(value: self.maxTokens, fieldNumber: 1)
     }
-    if self.tokenRatio != 0 {
+    if self.tokenRatio.bitPattern != 0 {
       try visitor.visitSingularFloatField(value: self.tokenRatio, fieldNumber: 2)
     }
     try unknownFields.traverse(visitor: &visitor)

--- a/Tests/GRPCHTTP2TransportTests/Generated/control.pb.swift
+++ b/Tests/GRPCHTTP2TransportTests/Generated/control.pb.swift
@@ -35,7 +35,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-enum StatusCode: SwiftProtobuf.Enum {
+enum StatusCode: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case ok // = 0
   case cancelled // = 1
@@ -106,11 +106,6 @@ enum StatusCode: SwiftProtobuf.Enum {
     }
   }
 
-}
-
-#if swift(>=4.2)
-
-extension StatusCode: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
   static let allCases: [StatusCode] = [
     .ok,
@@ -131,11 +126,10 @@ extension StatusCode: CaseIterable {
     .dataLoss,
     .unauthenticated,
   ]
+
 }
 
-#endif  // swift(>=4.2)
-
-struct ControlInput {
+struct ControlInput: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -208,7 +202,7 @@ struct ControlInput {
   fileprivate var _status: RPCStatus? = nil
 }
 
-struct RPCStatus {
+struct RPCStatus: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -224,7 +218,7 @@ struct RPCStatus {
   init() {}
 }
 
-struct PayloadParameters {
+struct PayloadParameters: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -240,7 +234,7 @@ struct PayloadParameters {
   init() {}
 }
 
-struct ControlOutput {
+struct ControlOutput: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -251,14 +245,6 @@ struct ControlOutput {
 
   init() {}
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension StatusCode: @unchecked Sendable {}
-extension ControlInput: @unchecked Sendable {}
-extension RPCStatus: @unchecked Sendable {}
-extension PayloadParameters: @unchecked Sendable {}
-extension ControlOutput: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGenParserTests.swift
+++ b/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGenParserTests.swift
@@ -348,7 +348,7 @@ extension Google_Protobuf_FileDescriptorProto {
       $0.name = "helloworld.proto"
       $0.package = "helloworld"
       $0.dependency = ["same-module.proto", "different-module.proto"]
-      $0.publicDependency = [1, 2]
+      $0.publicDependency = [0, 1]
       $0.messageType = [requestType, responseType]
       $0.service = [service]
       $0.sourceCodeInfo = Google_Protobuf_SourceCodeInfo.with {

--- a/Tests/GRPCTests/Codegen/Normalization/normalization.pb.swift
+++ b/Tests/GRPCTests/Codegen/Normalization/normalization.pb.swift
@@ -34,7 +34,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-struct Normalization_FunctionName {
+struct Normalization_FunctionName: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -46,10 +46,6 @@ struct Normalization_FunctionName {
 
   init() {}
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension Normalization_FunctionName: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Tests/GRPCTests/GRPCReflectionServiceTests/Generated/v1/reflection-v1.pb.swift
+++ b/Tests/GRPCTests/GRPCReflectionServiceTests/Generated/v1/reflection-v1.pb.swift
@@ -42,7 +42,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 }
 
 /// The message sent by the client when calling ServerReflectionInfo method.
-struct Grpc_Reflection_V1_ServerReflectionRequest {
+struct Grpc_Reflection_V1_ServerReflectionRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -115,7 +115,7 @@ struct Grpc_Reflection_V1_ServerReflectionRequest {
   /// To use reflection service, the client should set one of the following
   /// fields in message_request. The server distinguishes requests by their
   /// defined field and then handles them using corresponding methods.
-  enum OneOf_MessageRequest: Equatable {
+  enum OneOf_MessageRequest: Equatable, Sendable {
     /// Find a proto file by the file name.
     case fileByFilename(String)
     /// Find the proto file that declares the given fully-qualified symbol name.
@@ -138,36 +138,6 @@ struct Grpc_Reflection_V1_ServerReflectionRequest {
     /// checked.
     case listServices(String)
 
-  #if !swift(>=4.1)
-    static func ==(lhs: Grpc_Reflection_V1_ServerReflectionRequest.OneOf_MessageRequest, rhs: Grpc_Reflection_V1_ServerReflectionRequest.OneOf_MessageRequest) -> Bool {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch (lhs, rhs) {
-      case (.fileByFilename, .fileByFilename): return {
-        guard case .fileByFilename(let l) = lhs, case .fileByFilename(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.fileContainingSymbol, .fileContainingSymbol): return {
-        guard case .fileContainingSymbol(let l) = lhs, case .fileContainingSymbol(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.fileContainingExtension, .fileContainingExtension): return {
-        guard case .fileContainingExtension(let l) = lhs, case .fileContainingExtension(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.allExtensionNumbersOfType, .allExtensionNumbersOfType): return {
-        guard case .allExtensionNumbersOfType(let l) = lhs, case .allExtensionNumbersOfType(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.listServices, .listServices): return {
-        guard case .listServices(let l) = lhs, case .listServices(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      default: return false
-      }
-    }
-  #endif
   }
 
   init() {}
@@ -175,7 +145,7 @@ struct Grpc_Reflection_V1_ServerReflectionRequest {
 
 /// The type name and extension number sent by the client when requesting
 /// file_containing_extension.
-struct Grpc_Reflection_V1_ExtensionRequest {
+struct Grpc_Reflection_V1_ExtensionRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -191,7 +161,7 @@ struct Grpc_Reflection_V1_ExtensionRequest {
 }
 
 /// The message sent by the server to answer ServerReflectionInfo method.
-struct Grpc_Reflection_V1_ServerReflectionResponse {
+struct Grpc_Reflection_V1_ServerReflectionResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -256,7 +226,7 @@ struct Grpc_Reflection_V1_ServerReflectionResponse {
 
   /// The server sets one of the following fields according to the message_request
   /// in the request.
-  enum OneOf_MessageResponse: Equatable {
+  enum OneOf_MessageResponse: Equatable, Sendable {
     /// This message is used to answer file_by_filename, file_containing_symbol,
     /// file_containing_extension requests with transitive dependencies.
     /// As the repeated label is not allowed in oneof fields, we use a
@@ -271,32 +241,6 @@ struct Grpc_Reflection_V1_ServerReflectionResponse {
     /// This message is used when an error occurs.
     case errorResponse(Grpc_Reflection_V1_ErrorResponse)
 
-  #if !swift(>=4.1)
-    static func ==(lhs: Grpc_Reflection_V1_ServerReflectionResponse.OneOf_MessageResponse, rhs: Grpc_Reflection_V1_ServerReflectionResponse.OneOf_MessageResponse) -> Bool {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch (lhs, rhs) {
-      case (.fileDescriptorResponse, .fileDescriptorResponse): return {
-        guard case .fileDescriptorResponse(let l) = lhs, case .fileDescriptorResponse(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.allExtensionNumbersResponse, .allExtensionNumbersResponse): return {
-        guard case .allExtensionNumbersResponse(let l) = lhs, case .allExtensionNumbersResponse(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.listServicesResponse, .listServicesResponse): return {
-        guard case .listServicesResponse(let l) = lhs, case .listServicesResponse(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.errorResponse, .errorResponse): return {
-        guard case .errorResponse(let l) = lhs, case .errorResponse(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      default: return false
-      }
-    }
-  #endif
   }
 
   init() {}
@@ -307,7 +251,7 @@ struct Grpc_Reflection_V1_ServerReflectionResponse {
 /// Serialized FileDescriptorProto messages sent by the server answering
 /// a file_by_filename, file_containing_symbol, or file_containing_extension
 /// request.
-struct Grpc_Reflection_V1_FileDescriptorResponse {
+struct Grpc_Reflection_V1_FileDescriptorResponse: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -324,7 +268,7 @@ struct Grpc_Reflection_V1_FileDescriptorResponse {
 
 /// A list of extension numbers sent by the server answering
 /// all_extension_numbers_of_type request.
-struct Grpc_Reflection_V1_ExtensionNumberResponse {
+struct Grpc_Reflection_V1_ExtensionNumberResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -341,7 +285,7 @@ struct Grpc_Reflection_V1_ExtensionNumberResponse {
 }
 
 /// A list of ServiceResponse sent by the server answering list_services request.
-struct Grpc_Reflection_V1_ListServiceResponse {
+struct Grpc_Reflection_V1_ListServiceResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -357,7 +301,7 @@ struct Grpc_Reflection_V1_ListServiceResponse {
 
 /// The information of a single service used by ListServiceResponse to answer
 /// list_services request.
-struct Grpc_Reflection_V1_ServiceResponse {
+struct Grpc_Reflection_V1_ServiceResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -372,7 +316,7 @@ struct Grpc_Reflection_V1_ServiceResponse {
 }
 
 /// The error code and error message sent by the server when an error occurs.
-struct Grpc_Reflection_V1_ErrorResponse {
+struct Grpc_Reflection_V1_ErrorResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -386,19 +330,6 @@ struct Grpc_Reflection_V1_ErrorResponse {
 
   init() {}
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension Grpc_Reflection_V1_ServerReflectionRequest: @unchecked Sendable {}
-extension Grpc_Reflection_V1_ServerReflectionRequest.OneOf_MessageRequest: @unchecked Sendable {}
-extension Grpc_Reflection_V1_ExtensionRequest: @unchecked Sendable {}
-extension Grpc_Reflection_V1_ServerReflectionResponse: @unchecked Sendable {}
-extension Grpc_Reflection_V1_ServerReflectionResponse.OneOf_MessageResponse: @unchecked Sendable {}
-extension Grpc_Reflection_V1_FileDescriptorResponse: @unchecked Sendable {}
-extension Grpc_Reflection_V1_ExtensionNumberResponse: @unchecked Sendable {}
-extension Grpc_Reflection_V1_ListServiceResponse: @unchecked Sendable {}
-extension Grpc_Reflection_V1_ServiceResponse: @unchecked Sendable {}
-extension Grpc_Reflection_V1_ErrorResponse: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Tests/GRPCTests/GRPCReflectionServiceTests/Generated/v1Alpha/reflection-v1alpha.pb.swift
+++ b/Tests/GRPCTests/GRPCReflectionServiceTests/Generated/v1Alpha/reflection-v1alpha.pb.swift
@@ -39,7 +39,9 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 }
 
 /// The message sent by the client when calling ServerReflectionInfo method.
-struct Grpc_Reflection_V1alpha_ServerReflectionRequest {
+///
+/// NOTE: The whole .proto file that defined this message was marked as deprecated.
+struct Grpc_Reflection_V1alpha_ServerReflectionRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -112,7 +114,7 @@ struct Grpc_Reflection_V1alpha_ServerReflectionRequest {
   /// To use reflection service, the client should set one of the following
   /// fields in message_request. The server distinguishes requests by their
   /// defined field and then handles them using corresponding methods.
-  enum OneOf_MessageRequest: Equatable {
+  enum OneOf_MessageRequest: Equatable, Sendable {
     /// Find a proto file by the file name.
     case fileByFilename(String)
     /// Find the proto file that declares the given fully-qualified symbol name.
@@ -135,36 +137,6 @@ struct Grpc_Reflection_V1alpha_ServerReflectionRequest {
     /// checked.
     case listServices(String)
 
-  #if !swift(>=4.1)
-    static func ==(lhs: Grpc_Reflection_V1alpha_ServerReflectionRequest.OneOf_MessageRequest, rhs: Grpc_Reflection_V1alpha_ServerReflectionRequest.OneOf_MessageRequest) -> Bool {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch (lhs, rhs) {
-      case (.fileByFilename, .fileByFilename): return {
-        guard case .fileByFilename(let l) = lhs, case .fileByFilename(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.fileContainingSymbol, .fileContainingSymbol): return {
-        guard case .fileContainingSymbol(let l) = lhs, case .fileContainingSymbol(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.fileContainingExtension, .fileContainingExtension): return {
-        guard case .fileContainingExtension(let l) = lhs, case .fileContainingExtension(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.allExtensionNumbersOfType, .allExtensionNumbersOfType): return {
-        guard case .allExtensionNumbersOfType(let l) = lhs, case .allExtensionNumbersOfType(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.listServices, .listServices): return {
-        guard case .listServices(let l) = lhs, case .listServices(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      default: return false
-      }
-    }
-  #endif
   }
 
   init() {}
@@ -172,7 +144,9 @@ struct Grpc_Reflection_V1alpha_ServerReflectionRequest {
 
 /// The type name and extension number sent by the client when requesting
 /// file_containing_extension.
-struct Grpc_Reflection_V1alpha_ExtensionRequest {
+///
+/// NOTE: The whole .proto file that defined this message was marked as deprecated.
+struct Grpc_Reflection_V1alpha_ExtensionRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -188,7 +162,9 @@ struct Grpc_Reflection_V1alpha_ExtensionRequest {
 }
 
 /// The message sent by the server to answer ServerReflectionInfo method.
-struct Grpc_Reflection_V1alpha_ServerReflectionResponse {
+///
+/// NOTE: The whole .proto file that defined this message was marked as deprecated.
+struct Grpc_Reflection_V1alpha_ServerReflectionResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -253,7 +229,7 @@ struct Grpc_Reflection_V1alpha_ServerReflectionResponse {
 
   /// The server set one of the following fields according to the message_request
   /// in the request.
-  enum OneOf_MessageResponse: Equatable {
+  enum OneOf_MessageResponse: Equatable, Sendable {
     /// This message is used to answer file_by_filename, file_containing_symbol,
     /// file_containing_extension requests with transitive dependencies. As
     /// the repeated label is not allowed in oneof fields, we use a
@@ -268,32 +244,6 @@ struct Grpc_Reflection_V1alpha_ServerReflectionResponse {
     /// This message is used when an error occurs.
     case errorResponse(Grpc_Reflection_V1alpha_ErrorResponse)
 
-  #if !swift(>=4.1)
-    static func ==(lhs: Grpc_Reflection_V1alpha_ServerReflectionResponse.OneOf_MessageResponse, rhs: Grpc_Reflection_V1alpha_ServerReflectionResponse.OneOf_MessageResponse) -> Bool {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch (lhs, rhs) {
-      case (.fileDescriptorResponse, .fileDescriptorResponse): return {
-        guard case .fileDescriptorResponse(let l) = lhs, case .fileDescriptorResponse(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.allExtensionNumbersResponse, .allExtensionNumbersResponse): return {
-        guard case .allExtensionNumbersResponse(let l) = lhs, case .allExtensionNumbersResponse(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.listServicesResponse, .listServicesResponse): return {
-        guard case .listServicesResponse(let l) = lhs, case .listServicesResponse(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.errorResponse, .errorResponse): return {
-        guard case .errorResponse(let l) = lhs, case .errorResponse(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      default: return false
-      }
-    }
-  #endif
   }
 
   init() {}
@@ -304,7 +254,9 @@ struct Grpc_Reflection_V1alpha_ServerReflectionResponse {
 /// Serialized FileDescriptorProto messages sent by the server answering
 /// a file_by_filename, file_containing_symbol, or file_containing_extension
 /// request.
-struct Grpc_Reflection_V1alpha_FileDescriptorResponse {
+///
+/// NOTE: The whole .proto file that defined this message was marked as deprecated.
+struct Grpc_Reflection_V1alpha_FileDescriptorResponse: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -321,7 +273,9 @@ struct Grpc_Reflection_V1alpha_FileDescriptorResponse {
 
 /// A list of extension numbers sent by the server answering
 /// all_extension_numbers_of_type request.
-struct Grpc_Reflection_V1alpha_ExtensionNumberResponse {
+///
+/// NOTE: The whole .proto file that defined this message was marked as deprecated.
+struct Grpc_Reflection_V1alpha_ExtensionNumberResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -338,7 +292,9 @@ struct Grpc_Reflection_V1alpha_ExtensionNumberResponse {
 }
 
 /// A list of ServiceResponse sent by the server answering list_services request.
-struct Grpc_Reflection_V1alpha_ListServiceResponse {
+///
+/// NOTE: The whole .proto file that defined this message was marked as deprecated.
+struct Grpc_Reflection_V1alpha_ListServiceResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -354,7 +310,9 @@ struct Grpc_Reflection_V1alpha_ListServiceResponse {
 
 /// The information of a single service used by ListServiceResponse to answer
 /// list_services request.
-struct Grpc_Reflection_V1alpha_ServiceResponse {
+///
+/// NOTE: The whole .proto file that defined this message was marked as deprecated.
+struct Grpc_Reflection_V1alpha_ServiceResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -369,7 +327,9 @@ struct Grpc_Reflection_V1alpha_ServiceResponse {
 }
 
 /// The error code and error message sent by the server when an error occurs.
-struct Grpc_Reflection_V1alpha_ErrorResponse {
+///
+/// NOTE: The whole .proto file that defined this message was marked as deprecated.
+struct Grpc_Reflection_V1alpha_ErrorResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -383,19 +343,6 @@ struct Grpc_Reflection_V1alpha_ErrorResponse {
 
   init() {}
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension Grpc_Reflection_V1alpha_ServerReflectionRequest: @unchecked Sendable {}
-extension Grpc_Reflection_V1alpha_ServerReflectionRequest.OneOf_MessageRequest: @unchecked Sendable {}
-extension Grpc_Reflection_V1alpha_ExtensionRequest: @unchecked Sendable {}
-extension Grpc_Reflection_V1alpha_ServerReflectionResponse: @unchecked Sendable {}
-extension Grpc_Reflection_V1alpha_ServerReflectionResponse.OneOf_MessageResponse: @unchecked Sendable {}
-extension Grpc_Reflection_V1alpha_FileDescriptorResponse: @unchecked Sendable {}
-extension Grpc_Reflection_V1alpha_ExtensionNumberResponse: @unchecked Sendable {}
-extension Grpc_Reflection_V1alpha_ListServiceResponse: @unchecked Sendable {}
-extension Grpc_Reflection_V1alpha_ServiceResponse: @unchecked Sendable {}
-extension Grpc_Reflection_V1alpha_ErrorResponse: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 


### PR DESCRIPTION
Motivation:

SwiftProtobuf just released a 1.27.0 containing a few years worth of
changes and fixes.

Modifications:

- Update min version
- Fix test
- Regenerate protos

Result:

Protobuf is more up-to-date