### PR TITLE
Use new protobuf API for (de)/serializing

### DIFF
--- a/Sources/GRPCProtobuf/Coding.swift
+++ b/Sources/GRPCProtobuf/Coding.swift
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import Foundation
 import GRPCCore
 import SwiftProtobuf
 
@@ -28,8 +27,7 @@ public struct ProtobufSerializer<Message: SwiftProtobuf.Message>: GRPCCore.Messa
   /// - Returns: An array of serialized bytes representing the message.
   public func serialize(_ message: Message) throws -> [UInt8] {
     do {
-      let data = try message.serializedData()
-      return Array(data)
+      return try message.serializedBytes()
     } catch let error {
       throw RPCError(
         code: .invalidArgument,
@@ -50,7 +48,7 @@ public struct ProtobufDeserializer<Message: SwiftProtobuf.Message>: GRPCCore.Mes
   /// - Returns: The deserialized message.
   public func deserialize(_ serializedMessageBytes: [UInt8]) throws -> Message {
     do {
-      let message = try Message(contiguousBytes: serializedMessageBytes)
+      let message = try Message(serializedBytes: serializedMessageBytes)
       return message
     } catch let error {
       throw RPCError(


### PR DESCRIPTION
Motivation:

Currently the protobuf serialization is to `Data` which is then copied into an `Array<UInt8>` as required by the grpc api. Protobuf has new API which allows us to serialize directly into `Array<UInt8>`.

Modifications:

- use the new API
- avoid the deprecated API

Result:

Fewer allocations