### PR TITLE
Avoid throwing from the stream state machine

### DIFF
--- a/Sources/GRPCHTTP2Core/GRPCStreamStateMachine.swift
+++ b/Sources/GRPCHTTP2Core/GRPCStreamStateMachine.swift
@@ -396,6 +396,13 @@ struct GRPCStreamStateMachine {
   private var configuration: GRPCStreamStateMachineConfiguration
   private var skipAssertions: Bool
 
+  struct InvalidState: Error {
+    var message: String
+    init(_ message: String) {
+      self.message = message
+    }
+  }
+
   init(
     configuration: GRPCStreamStateMachineConfiguration,
     maximumPayloadSize: Int,
@@ -406,7 +413,7 @@ struct GRPCStreamStateMachine {
     self.skipAssertions = skipAssertions
   }
 
-  mutating func send(metadata: Metadata) throws -> HPACKHeaders {
+  mutating func send(metadata: Metadata) throws(InvalidState) -> HPACKHeaders {
     switch self.configuration {
     case .client(let clientConfiguration):
       return try self.clientSend(metadata: metadata, configuration: clientConfiguration)
@@ -415,7 +422,7 @@ struct GRPCStreamStateMachine {
     }
   }
 
-  mutating func send(message: [UInt8], promise: EventLoopPromise<Void>?) throws {
+  mutating func send(message: [UInt8], promise: EventLoopPromise<Void>?) throws(InvalidState) {
     switch self.configuration {
     case .client:
       try self.clientSend(message: message, promise: promise)
@@ -424,7 +431,7 @@ struct GRPCStreamStateMachine {
     }
   }
 
-  mutating func closeOutbound() throws {
+  mutating func closeOutbound() throws(InvalidState) {
     switch self.configuration {
     case .client:
       try self.clientCloseOutbound()
@@ -436,7 +443,7 @@ struct GRPCStreamStateMachine {
   mutating func send(
     status: Status,
     metadata: Metadata
-  ) throws -> HPACKHeaders {
+  ) throws(InvalidState) -> HPACKHeaders {
     switch self.configuration {
     case .client:
       try self.invalidState(
@@ -452,17 +459,20 @@ struct GRPCStreamStateMachine {
 
   enum OnMetadataReceived: Equatable {
     case receivedMetadata(Metadata, MethodDescriptor?)
-
-    // Client-specific actions
-    case receivedStatusAndMetadata(status: Status, metadata: Metadata)
     case doNothing
 
+    // Client-specific actions
+    case receivedStatusAndMetadata_clientOnly(status: Status, metadata: Metadata)
+
     // Server-specific actions
-    case rejectRPC(trailers: HPACKHeaders)
-    case protocolViolation
+    case rejectRPC_serverOnly(trailers: HPACKHeaders)
+    case protocolViolation_serverOnly
   }
 
-  mutating func receive(headers: HPACKHeaders, endStream: Bool) throws -> OnMetadataReceived {
+  mutating func receive(
+    headers: HPACKHeaders,
+    endStream: Bool
+  ) throws(InvalidState) -> OnMetadataReceived {
     switch self.configuration {
     case .client(let clientConfiguration):
       return try self.clientReceive(
@@ -483,16 +493,19 @@ struct GRPCStreamStateMachine {
     case readInbound
     case doNothing
 
-    // Client-specific actions
-
     // This will be returned when the server sends a data frame with EOS set.
     // This is invalid as per the protocol specification, because the server
     // can only close by sending trailers, not by setting EOS when sending
     // a message.
-    case endRPCAndForwardErrorStatus(Status)
+    case endRPCAndForwardErrorStatus_clientOnly(Status)
+
+    case forwardErrorAndClose_serverOnly(RPCError)
   }
 
-  mutating func receive(buffer: ByteBuffer, endStream: Bool) throws -> OnBufferReceivedAction {
+  mutating func receive(
+    buffer: ByteBuffer,
+    endStream: Bool
+  ) throws(InvalidState) -> OnBufferReceivedAction {
     switch self.configuration {
     case .client:
       return try self.clientReceive(buffer: buffer, endStream: endStream)
@@ -513,9 +526,19 @@ struct GRPCStreamStateMachine {
       frame: ByteBuffer,
       promise: EventLoopPromise<Void>?
     )
+    case closeAndFailPromise(EventLoopPromise<Void>?, RPCError)
+
+    init(result: Result<ByteBuffer, RPCError>, promise: EventLoopPromise<Void>?) {
+      switch result {
+      case .success(let buffer):
+        self = .sendFrame(frame: buffer, promise: promise)
+      case .failure(let error):
+        self = .closeAndFailPromise(promise, error)
+      }
+    }
   }
 
-  mutating func nextOutboundFrame() throws -> OnNextOutboundFrame {
+  mutating func nextOutboundFrame() throws(InvalidState) -> OnNextOutboundFrame {
     switch self.configuration {
     case .client:
       return try self.clientNextOutboundFrame()
@@ -647,7 +670,7 @@ extension GRPCStreamStateMachine {
   private mutating func clientSend(
     metadata: Metadata,
     configuration: GRPCStreamStateMachineConfiguration.ClientConfiguration
-  ) throws -> HPACKHeaders {
+  ) throws(InvalidState) -> HPACKHeaders {
     // Client sends metadata only when opening the stream.
     switch self.state {
     case .clientIdleServerIdle(let state):
@@ -685,7 +708,10 @@ extension GRPCStreamStateMachine {
     }
   }
 
-  private mutating func clientSend(message: [UInt8], promise: EventLoopPromise<Void>?) throws {
+  private mutating func clientSend(
+    message: [UInt8],
+    promise: EventLoopPromise<Void>?
+  ) throws(InvalidState) {
     switch self.state {
     case .clientIdleServerIdle:
       try self.invalidState("Client not yet open.")
@@ -714,7 +740,7 @@ extension GRPCStreamStateMachine {
     }
   }
 
-  private mutating func clientCloseOutbound() throws {
+  private mutating func clientCloseOutbound() throws(InvalidState) {
     switch self.state {
     case .clientIdleServerIdle(let state):
       self.state = .clientClosedServerIdle(.init(previousState: state))
@@ -734,41 +760,52 @@ extension GRPCStreamStateMachine {
 
   /// Returns the client's next request to the server.
   /// - Returns: The request to be made to the server.
-  private mutating func clientNextOutboundFrame() throws -> OnNextOutboundFrame {
+  private mutating func clientNextOutboundFrame() throws(InvalidState) -> OnNextOutboundFrame {
+
     switch self.state {
     case .clientIdleServerIdle:
       try self.invalidState("Client is not open yet.")
 
     case .clientOpenServerIdle(var state):
       self.state = ._modifying
-      let request = try state.framer.next(compressor: state.compressor)
+      let next = state.framer.nextResult(compressor: state.compressor)
       self.state = .clientOpenServerIdle(state)
-      return request.map { .sendFrame(frame: $0.bytes, promise: $0.promise) }
-        ?? .awaitMoreMessages
+
+      if let next = next {
+        return OnNextOutboundFrame(result: next.result, promise: next.promise)
+      } else {
+        return .awaitMoreMessages
+      }
 
     case .clientOpenServerOpen(var state):
       self.state = ._modifying
-      let request = try state.framer.next(compressor: state.compressor)
+      let next = state.framer.nextResult(compressor: state.compressor)
       self.state = .clientOpenServerOpen(state)
-      return request.map { .sendFrame(frame: $0.bytes, promise: $0.promise) }
-        ?? .awaitMoreMessages
+
+      if let next = next {
+        return OnNextOutboundFrame(result: next.result, promise: next.promise)
+      } else {
+        return .awaitMoreMessages
+      }
 
     case .clientClosedServerIdle(var state):
       self.state = ._modifying
-      let request = try state.framer.next(compressor: state.compressor)
+      let next = state.framer.nextResult(compressor: state.compressor)
       self.state = .clientClosedServerIdle(state)
-      if let request {
-        return .sendFrame(frame: request.bytes, promise: request.promise)
+
+      if let next = next {
+        return OnNextOutboundFrame(result: next.result, promise: next.promise)
       } else {
         return .noMoreMessages
       }
 
     case .clientClosedServerOpen(var state):
       self.state = ._modifying
-      let request = try state.framer.next(compressor: state.compressor)
+      let next = state.framer.nextResult(compressor: state.compressor)
       self.state = .clientClosedServerOpen(state)
-      if let request {
-        return .sendFrame(frame: request.bytes, promise: request.promise)
+
+      if let next = next {
+        return OnNextOutboundFrame(result: next.result, promise: next.promise)
       } else {
         return .noMoreMessages
       }
@@ -806,7 +843,7 @@ extension GRPCStreamStateMachine {
 
       guard let httpStatusCode else {
         return .invalid(
-          .receivedStatusAndMetadata(
+          .receivedStatusAndMetadata_clientOnly(
             status: .init(code: .unknown, message: "HTTP Status Code is missing."),
             metadata: Metadata(headers: metadata)
           )
@@ -822,7 +859,7 @@ extension GRPCStreamStateMachine {
 
       // Forward the mapped status code.
       return .invalid(
-        .receivedStatusAndMetadata(
+        .receivedStatusAndMetadata_clientOnly(
           status: .init(
             code: Status.Code(httpStatusCode: httpStatusCode),
             message: "Unexpected non-200 HTTP Status Code."
@@ -835,7 +872,7 @@ extension GRPCStreamStateMachine {
     let contentTypeHeader = metadata.first(name: GRPCHTTP2Keys.contentType.rawValue)
     guard contentTypeHeader.flatMap(ContentType.init) != nil else {
       return .invalid(
-        .receivedStatusAndMetadata(
+        .receivedStatusAndMetadata_clientOnly(
           status: .init(
             code: .internalError,
             message: "Missing \(GRPCHTTP2Keys.contentType.rawValue) header"
@@ -863,7 +900,7 @@ extension GRPCStreamStateMachine {
         configuration.acceptedEncodings.contains(parsedEncoding)
       else {
         return .error(
-          .receivedStatusAndMetadata(
+          .receivedStatusAndMetadata_clientOnly(
             status: .init(
               code: .internalError,
               message:
@@ -881,38 +918,42 @@ extension GRPCStreamStateMachine {
   }
 
   private func validateAndReturnStatusAndMetadata(
-    _ metadata: HPACKHeaders
-  ) throws -> OnMetadataReceived {
-    let rawStatusCode = metadata.firstString(forKey: .grpcStatus)
-    guard let rawStatusCode,
-      let intStatusCode = Int(rawStatusCode),
-      let statusCode = Status.Code(rawValue: intStatusCode)
-    else {
-      let message =
-        "Non-initial metadata must be a trailer containing a valid grpc-status"
-        + (rawStatusCode.flatMap { "but was \($0)" } ?? "")
-      throw RPCError(code: .unknown, message: message)
+    _ trailers: HPACKHeaders
+  ) throws(InvalidState) -> OnMetadataReceived {
+    let statusValue = trailers.firstString(forKey: .grpcStatus)
+    let statusCode = statusValue.flatMap {
+      Int($0)
+    }.flatMap {
+      Status.Code(rawValue: $0)
     }
 
-    let statusMessage =
-      metadata.firstString(forKey: .grpcStatusMessage, canonicalForm: false)
-      .map { GRPCStatusMessageMarshaller.unmarshall($0) } ?? ""
+    let status: Status
+    if let code = statusCode {
+      let messageFieldValue = trailers.firstString(forKey: .grpcStatusMessage, canonicalForm: false)
+      let message = messageFieldValue.map { GRPCStatusMessageMarshaller.unmarshall($0) } ?? ""
+      status = Status(code: code, message: message)
+    } else {
+      let message: String
+      if let statusValue = statusValue {
+        message = "Invalid 'grpc-status' in trailers (\(statusValue))"
+      } else {
+        message = "No 'grpc-status' value in trailers"
+      }
+      status = Status(code: .unknown, message: message)
+    }
 
-    var convertedMetadata = Metadata(headers: metadata)
+    var convertedMetadata = Metadata(headers: trailers)
     convertedMetadata.removeAllValues(forKey: GRPCHTTP2Keys.grpcStatus.rawValue)
     convertedMetadata.removeAllValues(forKey: GRPCHTTP2Keys.grpcStatusMessage.rawValue)
 
-    return .receivedStatusAndMetadata(
-      status: Status(code: statusCode, message: statusMessage),
-      metadata: convertedMetadata
-    )
+    return .receivedStatusAndMetadata_clientOnly(status: status, metadata: convertedMetadata)
   }
 
   private mutating func clientReceive(
     headers: HPACKHeaders,
     endStream: Bool,
     configuration: GRPCStreamStateMachineConfiguration.ClientConfiguration
-  ) throws -> OnMetadataReceived {
+  ) throws(InvalidState) -> OnMetadataReceived {
     switch self.state {
     case .clientOpenServerIdle(let state):
       switch (self.clientValidateHeadersReceivedFromServer(headers), endStream) {
@@ -1031,7 +1072,7 @@ extension GRPCStreamStateMachine {
   private mutating func clientReceive(
     buffer: ByteBuffer,
     endStream: Bool
-  ) throws -> OnBufferReceivedAction {
+  ) throws(InvalidState) -> OnBufferReceivedAction {
     // This is a message received by the client, from the server.
     switch self.state {
     case .clientIdleServerIdle:
@@ -1051,7 +1092,7 @@ extension GRPCStreamStateMachine {
         // can only close by sending trailers, not by setting EOS when sending
         // a message.
         self.state = .clientClosedServerClosed(.init(previousState: state))
-        return .endRPCAndForwardErrorStatus(
+        return .endRPCAndForwardErrorStatus_clientOnly(
           Status(
             code: .internalError,
             message: """
@@ -1062,17 +1103,23 @@ extension GRPCStreamStateMachine {
         )
       }
 
-      try state.deframer.process(buffer: buffer) { deframedMessage in
-        state.inboundMessageBuffer.append(deframedMessage)
+      do {
+        try state.deframer.process(buffer: buffer) { deframedMessage in
+          state.inboundMessageBuffer.append(deframedMessage)
+        }
+        self.state = .clientOpenServerOpen(state)
+        return .readInbound
+      } catch {
+        self.state = .clientOpenServerOpen(state)
+        let status = Status(code: .internalError, message: "Failed to decode message")
+        return .endRPCAndForwardErrorStatus_clientOnly(status)
       }
-      self.state = .clientOpenServerOpen(state)
-      return .readInbound
 
     case .clientClosedServerOpen(var state):
       self.state = ._modifying
       if endStream {
         self.state = .clientClosedServerClosed(.init(previousState: state))
-        return .endRPCAndForwardErrorStatus(
+        return .endRPCAndForwardErrorStatus_clientOnly(
           Status(
             code: .internalError,
             message: """
@@ -1086,11 +1133,17 @@ extension GRPCStreamStateMachine {
       // The client may have sent the end stream and thus it's closed,
       // but the server may still be responding.
       // The client must have a deframer set up, so force-unwrap is okay.
-      try state.deframer!.process(buffer: buffer) { deframedMessage in
-        state.inboundMessageBuffer.append(deframedMessage)
+      do {
+        try state.deframer!.process(buffer: buffer) { deframedMessage in
+          state.inboundMessageBuffer.append(deframedMessage)
+        }
+        self.state = .clientClosedServerOpen(state)
+        return .readInbound
+      } catch {
+        self.state = .clientClosedServerOpen(state)
+        let status = Status(code: .internalError, message: "Failed to decode message")
+        return .endRPCAndForwardErrorStatus_clientOnly(status)
       }
-      self.state = .clientClosedServerOpen(state)
-      return .readInbound
 
     case .clientOpenServerClosed, .clientClosedServerClosed:
       try self.invalidState(
@@ -1136,11 +1189,11 @@ extension GRPCStreamStateMachine {
     }
   }
 
-  private func invalidState(_ message: String, line: UInt = #line) throws -> Never {
+  private func invalidState(_ message: String, line: UInt = #line) throws(InvalidState) -> Never {
     if !self.skipAssertions {
       assertionFailure(message, line: line)
     }
-    throw RPCError(code: .internalError, message: message)
+    throw InvalidState(message)
   }
 
   private mutating func clientUnexpectedInboundClose(
@@ -1207,7 +1260,7 @@ extension GRPCStreamStateMachine {
   private mutating func serverSend(
     metadata: Metadata,
     configuration: GRPCStreamStateMachineConfiguration.ServerConfiguration
-  ) throws -> HPACKHeaders {
+  ) throws(InvalidState) -> HPACKHeaders {
     // Server sends initial metadata
     switch self.state {
     case .clientOpenServerIdle(var state):
@@ -1262,7 +1315,10 @@ extension GRPCStreamStateMachine {
     }
   }
 
-  private mutating func serverSend(message: [UInt8], promise: EventLoopPromise<Void>?) throws {
+  private mutating func serverSend(
+    message: [UInt8],
+    promise: EventLoopPromise<Void>?
+  ) throws(InvalidState) {
     switch self.state {
     case .clientIdleServerIdle, .clientOpenServerIdle, .clientClosedServerIdle:
       try self.invalidState(
@@ -1291,7 +1347,7 @@ extension GRPCStreamStateMachine {
   private mutating func serverSend(
     status: Status,
     customMetadata: Metadata
-  ) throws -> HPACKHeaders {
+  ) throws(InvalidState) -> HPACKHeaders {
     // Close the server.
     switch self.state {
     case .clientOpenServerOpen(var state):
@@ -1335,7 +1391,7 @@ extension GRPCStreamStateMachine {
     headers: HPACKHeaders,
     endStream: Bool,
     configuration: GRPCStreamStateMachineConfiguration.ServerConfiguration
-  ) throws -> OnMetadataReceived {
+  ) throws(InvalidState) -> OnMetadataReceived {
     func closeServer(
       from state: GRPCStreamStateMachineState.ClientIdleServerIdleState,
       endStream: Bool
@@ -1357,12 +1413,12 @@ extension GRPCStreamStateMachine {
         // Respond with HTTP-level Unsupported Media Type status code.
         var trailers = HPACKHeaders()
         trailers.add("415", forKey: .status)
-        return .rejectRPC(trailers: trailers)
+        return .rejectRPC_serverOnly(trailers: trailers)
       }
 
       guard let pathHeader = headers.firstString(forKey: .path) else {
         self.state = closeServer(from: state, endStream: endStream)
-        return .rejectRPC(
+        return .rejectRPC_serverOnly(
           trailers: .trailersOnly(
             code: .invalidArgument,
             message: "No \(GRPCHTTP2Keys.path.rawValue) header has been set."
@@ -1372,7 +1428,7 @@ extension GRPCStreamStateMachine {
 
       guard let path = MethodDescriptor(path: pathHeader) else {
         self.state = closeServer(from: state, endStream: endStream)
-        return .rejectRPC(
+        return .rejectRPC_serverOnly(
           trailers: .trailersOnly(
             code: .unimplemented,
             message:
@@ -1385,7 +1441,7 @@ extension GRPCStreamStateMachine {
         .flatMap { GRPCStreamStateMachineConfiguration.Scheme(rawValue: $0) }
       if scheme == nil {
         self.state = closeServer(from: state, endStream: endStream)
-        return .rejectRPC(
+        return .rejectRPC_serverOnly(
           trailers: .trailersOnly(
             code: .invalidArgument,
             message: ":scheme header must be present and one of \"http\" or \"https\"."
@@ -1395,7 +1451,7 @@ extension GRPCStreamStateMachine {
 
       guard let method = headers.firstString(forKey: .method), method == "POST" else {
         self.state = closeServer(from: state, endStream: endStream)
-        return .rejectRPC(
+        return .rejectRPC_serverOnly(
           trailers: .trailersOnly(
             code: .invalidArgument,
             message: ":method header is expected to be present and have a value of \"POST\"."
@@ -1405,7 +1461,7 @@ extension GRPCStreamStateMachine {
 
       guard let te = headers.firstString(forKey: .te), te == "trailers" else {
         self.state = closeServer(from: state, endStream: endStream)
-        return .rejectRPC(
+        return .rejectRPC_serverOnly(
           trailers: .trailersOnly(
             code: .invalidArgument,
             message: "\"te\" header is expected to be present and have a value of \"trailers\"."
@@ -1424,7 +1480,7 @@ extension GRPCStreamStateMachine {
       if let rawEncoding = encodingValuesIterator.next() {
         guard encodingValuesIterator.next() == nil else {
           self.state = closeServer(from: state, endStream: endStream)
-          return .rejectRPC(
+          return .rejectRPC_serverOnly(
             trailers: .trailersOnly(
               code: .internalError,
               message: "\(GRPCHTTP2Keys.encoding) must contain no more than one value."
@@ -1448,7 +1504,7 @@ extension GRPCStreamStateMachine {
             trailers.add(name: GRPCHTTP2Keys.acceptEncoding.rawValue, value: acceptedEncoding.name)
           }
 
-          return .rejectRPC(trailers: trailers)
+          return .rejectRPC_serverOnly(trailers: trailers)
         }
 
         // Server supports client's encoding.
@@ -1509,7 +1565,7 @@ extension GRPCStreamStateMachine {
 
     case .clientOpenServerIdle, .clientOpenServerOpen, .clientOpenServerClosed:
       // Metadata has already been received, should only be sent once by clients.
-      return .protocolViolation
+      return .protocolViolation_serverOnly
 
     case .clientClosedServerIdle, .clientClosedServerOpen, .clientClosedServerClosed:
       try self.invalidState("Client can't have sent metadata if closed.")
@@ -1522,7 +1578,7 @@ extension GRPCStreamStateMachine {
   private mutating func serverReceive(
     buffer: ByteBuffer,
     endStream: Bool
-  ) throws -> OnBufferReceivedAction {
+  ) throws(InvalidState) -> OnBufferReceivedAction {
     let action: OnBufferReceivedAction
 
     switch self.state {
@@ -1533,8 +1589,15 @@ extension GRPCStreamStateMachine {
       self.state = ._modifying
       // Deframer must be present on the server side, as we know the decompression
       // algorithm from the moment the client opens.
-      try state.deframer!.process(buffer: buffer) { deframedMessage in
-        state.inboundMessageBuffer.append(deframedMessage)
+
+      do {
+        try state.deframer!.process(buffer: buffer) { deframedMessage in
+          state.inboundMessageBuffer.append(deframedMessage)
+        }
+        action = .readInbound
+      } catch {
+        let error = RPCError(code: .internalError, message: "Failed to decode message")
+        action = .forwardErrorAndClose_serverOnly(error)
       }
 
       if endStream {
@@ -1543,12 +1606,17 @@ extension GRPCStreamStateMachine {
         self.state = .clientOpenServerIdle(state)
       }
 
-      action = .readInbound
-
     case .clientOpenServerOpen(var state):
       self.state = ._modifying
-      try state.deframer.process(buffer: buffer) { deframedMessage in
-        state.inboundMessageBuffer.append(deframedMessage)
+
+      do {
+        try state.deframer.process(buffer: buffer) { deframedMessage in
+          state.inboundMessageBuffer.append(deframedMessage)
+        }
+        action = .readInbound
+      } catch {
+        let error = RPCError(code: .internalError, message: "Failed to decode message")
+        action = .forwardErrorAndClose_serverOnly(error)
       }
 
       if endStream {
@@ -1556,8 +1624,6 @@ extension GRPCStreamStateMachine {
       } else {
         self.state = .clientOpenServerOpen(state)
       }
-
-      action = .readInbound
 
     case .clientOpenServerClosed(let state):
       // Client is not done sending request, but server has already closed.
@@ -1579,44 +1645,55 @@ extension GRPCStreamStateMachine {
     return action
   }
 
-  private mutating func serverNextOutboundFrame() throws -> OnNextOutboundFrame {
+  private mutating func serverNextOutboundFrame() throws(InvalidState) -> OnNextOutboundFrame {
     switch self.state {
     case .clientIdleServerIdle, .clientOpenServerIdle, .clientClosedServerIdle:
       try self.invalidState("Server is not open yet.")
 
     case .clientOpenServerOpen(var state):
       self.state = ._modifying
-      let response = try state.framer.next(compressor: state.compressor)
+      let next = state.framer.nextResult(compressor: state.compressor)
       self.state = .clientOpenServerOpen(state)
-      return response.map { .sendFrame(frame: $0.bytes, promise: $0.promise) }
-        ?? .awaitMoreMessages
+
+      if let next = next {
+        return OnNextOutboundFrame(result: next.result, promise: next.promise)
+      } else {
+        return .awaitMoreMessages
+      }
 
     case .clientClosedServerOpen(var state):
       self.state = ._modifying
-      let response = try state.framer.next(compressor: state.compressor)
+      let next = state.framer.nextResult(compressor: state.compressor)
       self.state = .clientClosedServerOpen(state)
-      return response.map { .sendFrame(frame: $0.bytes, promise: $0.promise) }
-        ?? .awaitMoreMessages
+
+      if let next = next {
+        return OnNextOutboundFrame(result: next.result, promise: next.promise)
+      } else {
+        return .awaitMoreMessages
+      }
 
     case .clientOpenServerClosed(var state):
       self.state = ._modifying
-      let response = try state.framer?.next(compressor: state.compressor)
+      let next = state.framer?.nextResult(compressor: state.compressor)
       self.state = .clientOpenServerClosed(state)
-      if let response {
-        return .sendFrame(frame: response.bytes, promise: response.promise)
+
+      if let next = next {
+        return OnNextOutboundFrame(result: next.result, promise: next.promise)
       } else {
         return .noMoreMessages
       }
 
     case .clientClosedServerClosed(var state):
       self.state = ._modifying
-      let response = try state.framer?.next(compressor: state.compressor)
+      let next = state.framer?.nextResult(compressor: state.compressor)
       self.state = .clientClosedServerClosed(state)
-      if let response {
-        return .sendFrame(frame: response.bytes, promise: response.promise)
+
+      if let next = next {
+        return OnNextOutboundFrame(result: next.result, promise: next.promise)
       } else {
         return .noMoreMessages
       }
+
     case ._modifying:
       preconditionFailure()
     }
@@ -1858,5 +1935,12 @@ extension Status {
   @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
   fileprivate init(_ error: RPCError) {
     self = Status(code: Status.Code(error.code), message: error.message)
+  }
+}
+
+extension RPCError {
+  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+  init(_ invalidState: GRPCStreamStateMachine.InvalidState) {
+    self = RPCError(code: .internalError, message: "Invalid state", cause: invalidState)
   }
 }

--- a/Tests/GRPCHTTP2CoreTests/Client/GRPCClientStreamHandlerTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Client/GRPCClientStreamHandlerTests.swift
@@ -448,10 +448,10 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
     buffer.writeRepeatingByte(0, count: 42)  // message
     let serverDataPayload = HTTP2Frame.FramePayload.Data(data: .byteBuffer(buffer), endStream: true)
     XCTAssertThrowsError(
-      ofType: GRPCStreamStateMachine.InvalidState.self,
+      ofType: RPCError.self,
       try channel.writeInbound(HTTP2Frame.FramePayload.data(serverDataPayload))
     ) { error in
-      XCTAssertEqual(error.message, "Cannot have received anything from a closed server.")
+      XCTAssertEqual(error.message, "Invalid state")
     }
   }
 
@@ -529,10 +529,10 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
 
     // Make sure we cannot write anymore because client's closed.
     XCTAssertThrowsError(
-      ofType: GRPCStreamStateMachine.InvalidState.self,
+      ofType: RPCError.self,
       try channel.writeOutbound(RPCRequestPart.message(.init(repeating: 1, count: 42)))
     ) { error in
-      XCTAssertEqual(error.message, "Client is closed, cannot send a message.")
+      XCTAssertEqual(error.message, "Invalid state")
     }
 
     // This is needed to clear the EmbeddedChannel's stored error, otherwise
@@ -803,10 +803,10 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
 
     // We should now be closed: check we can't write anymore.
     XCTAssertThrowsError(
-      ofType: GRPCStreamStateMachine.InvalidState.self,
+      ofType: RPCError.self,
       try channel.writeOutbound(RPCRequestPart.metadata(Metadata()))
     ) { error in
-      XCTAssertEqual(error.message, "Client is closed: can't send metadata.")
+      XCTAssertEqual(error.message, "Invalid state")
     }
   }
 
@@ -848,10 +848,10 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
 
     // We should now be closed: check we can't write anymore.
     XCTAssertThrowsError(
-      ofType: GRPCStreamStateMachine.InvalidState.self,
+      ofType: RPCError.self,
       try channel.writeOutbound(RPCRequestPart.metadata(Metadata()))
     ) { error in
-      XCTAssertEqual(error.message, "Client is closed: can't send metadata.")
+      XCTAssertEqual(error.message, "Invalid state")
     }
   }
 
@@ -900,10 +900,10 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
 
     // We should now be closed: check we can't write anymore.
     XCTAssertThrowsError(
-      ofType: GRPCStreamStateMachine.InvalidState.self,
+      ofType: RPCError.self,
       try channel.writeOutbound(RPCRequestPart.metadata(Metadata()))
     ) { error in
-      XCTAssertEqual(error.message, "Client is closed: can't send metadata.")
+      XCTAssertEqual(error.message, "Invalid state")
     }
   }
 }

--- a/Tests/GRPCHTTP2CoreTests/Client/GRPCClientStreamHandlerTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Client/GRPCClientStreamHandlerTests.swift
@@ -533,6 +533,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
       ofType: RPCError.self,
       try channel.writeOutbound(RPCRequestPart.message(.init(repeating: 1, count: 42)))
     ) { error in
+      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Invalid state")
     }
 
@@ -807,6 +808,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
       ofType: RPCError.self,
       try channel.writeOutbound(RPCRequestPart.metadata(Metadata()))
     ) { error in
+      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Invalid state")
     }
   }
@@ -852,6 +854,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
       ofType: RPCError.self,
       try channel.writeOutbound(RPCRequestPart.metadata(Metadata()))
     ) { error in
+      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Invalid state")
     }
   }
@@ -904,6 +907,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
       ofType: RPCError.self,
       try channel.writeOutbound(RPCRequestPart.metadata(Metadata()))
     ) { error in
+      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Invalid state")
     }
   }

--- a/Tests/GRPCHTTP2CoreTests/Client/GRPCClientStreamHandlerTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Client/GRPCClientStreamHandlerTests.swift
@@ -451,6 +451,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
       ofType: RPCError.self,
       try channel.writeInbound(HTTP2Frame.FramePayload.data(serverDataPayload))
     ) { error in
+      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Invalid state")
     }
   }

--- a/Tests/GRPCHTTP2CoreTests/GRPCMessageDeframerTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/GRPCMessageDeframerTests.swift
@@ -217,3 +217,21 @@ final class GRPCMessageDeframerTests: XCTestCase {
     try self.testReadDecompressedMessageOverSizeLimit(method: .gzip)
   }
 }
+
+extension GRPCMessageFramer {
+  mutating func next(
+    compressor: Zlib.Compressor? = nil
+  ) throws(RPCError) -> (bytes: ByteBuffer, promise: EventLoopPromise<Void>?)? {
+    if let (result, promise) = self.nextResult(compressor: compressor) {
+      switch result {
+      case .success(let buffer):
+        return (bytes: buffer, promise: promise)
+      case .failure(let error):
+        promise?.fail(error)
+        throw error
+      }
+    } else {
+      return nil
+    }
+  }
+}

--- a/Tests/GRPCHTTP2CoreTests/GRPCStreamStateMachineTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/GRPCStreamStateMachineTests.swift
@@ -214,9 +214,11 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
       var stateMachine = self.makeClientStateMachine(targetState: targetState)
 
       // Try sending metadata again: should throw
-      XCTAssertThrowsError(ofType: RPCError.self, try stateMachine.send(metadata: .init())) {
+      XCTAssertThrowsError(
+        ofType: GRPCStreamStateMachine.InvalidState.self,
+        try stateMachine.send(metadata: .init())
+      ) {
         error in
-        XCTAssertEqual(error.code, .internalError)
         XCTAssertEqual(error.message, "Client is already open: shouldn't be sending metadata.")
       }
     }
@@ -230,9 +232,11 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
       var stateMachine = self.makeClientStateMachine(targetState: targetState)
 
       // Try sending metadata again: should throw
-      XCTAssertThrowsError(ofType: RPCError.self, try stateMachine.send(metadata: .init())) {
+      XCTAssertThrowsError(
+        ofType: GRPCStreamStateMachine.InvalidState.self,
+        try stateMachine.send(metadata: .init())
+      ) {
         error in
-        XCTAssertEqual(error.code, .internalError)
         XCTAssertEqual(error.message, "Client is closed: can't send metadata.")
       }
     }
@@ -245,10 +249,9 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
 
     // Try to send a message without opening (i.e. without sending initial metadata)
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try stateMachine.send(message: [], promise: nil)
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Client not yet open.")
     }
   }
@@ -273,10 +276,9 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
 
       // Try sending another message: it should fail
       XCTAssertThrowsError(
-        ofType: RPCError.self,
+        ofType: GRPCStreamStateMachine.InvalidState.self,
         try stateMachine.send(message: [], promise: nil)
       ) { error in
-        XCTAssertEqual(error.code, .internalError)
         XCTAssertEqual(error.message, "Client is closed, cannot send a message.")
       }
     }
@@ -290,13 +292,12 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
 
       // This operation is never allowed on the client.
       XCTAssertThrowsError(
-        ofType: RPCError.self,
+        ofType: GRPCStreamStateMachine.InvalidState.self,
         try stateMachine.send(
           status: Status(code: .ok, message: ""),
           metadata: .init()
         )
       ) { error in
-        XCTAssertEqual(error.code, .internalError)
         XCTAssertEqual(error.message, "Client cannot send status and trailer.")
       }
     }
@@ -308,10 +309,9 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
     var stateMachine = self.makeClientStateMachine(targetState: .clientIdleServerIdle)
 
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try stateMachine.receive(headers: .init(), endStream: false)
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Server cannot have sent metadata if the client is idle.")
     }
   }
@@ -330,7 +330,7 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
 
       XCTAssertEqual(
         action,
-        .receivedStatusAndMetadata(
+        .receivedStatusAndMetadata_clientOnly(
           status: .init(code: .unknown, message: "Unexpected non-200 HTTP Status Code."),
           metadata: [":status": "300"]
         )
@@ -353,7 +353,7 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
 
     XCTAssertEqual(
       action,
-      .receivedStatusAndMetadata(
+      .receivedStatusAndMetadata_clientOnly(
         status: Status(
           code: .internalError,
           message:
@@ -406,13 +406,14 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
 
     // Receiving compressed message with gzip (unsupported) should throw error
     let receivedGZIPCompressedBytes = try self.frameMessage(originalMessage, compression: .gzip)
-    XCTAssertThrowsError(
-      ofType: RPCError.self,
-      try stateMachine.receive(buffer: receivedGZIPCompressedBytes, endStream: false)
-    ) { error in
-      XCTAssertEqual(error.code, .internalError)
-      XCTAssertEqual(error.message, "Decompression error")
-    }
+    let action = try stateMachine.receive(buffer: receivedGZIPCompressedBytes, endStream: false)
+    XCTAssertEqual(
+      action,
+      .endRPCAndForwardErrorStatus_clientOnly(
+        Status(code: .internalError, message: "Failed to decode message")
+      )
+    )
+
     receivedAction = stateMachine.nextInboundMessage()
     switch receivedAction {
     case .awaitMoreMessages:
@@ -460,28 +461,33 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
       var stateMachine = self.makeClientStateMachine(targetState: targetState)
 
       // Receiving initial metadata again should throw if grpc-status is not present.
-      XCTAssertThrowsError(
-        ofType: RPCError.self,
-        try stateMachine.receive(
-          headers: [
-            GRPCHTTP2Keys.status.rawValue: "200",
-            GRPCHTTP2Keys.contentType.rawValue: ContentType.grpc.canonicalValue,
-            GRPCHTTP2Keys.encoding.rawValue: "deflate",
-            "custom": "123",
-            "custom-bin": String(base64Encoding: [42, 43, 44]),
-          ],
-          endStream: false
-        )
-      ) { error in
-        XCTAssertEqual(error.code, .unknown)
-        XCTAssertEqual(
-          error.message,
-          "Non-initial metadata must be a trailer containing a valid grpc-status"
-        )
-      }
+      let action1 = try stateMachine.receive(
+        headers: [
+          GRPCHTTP2Keys.status.rawValue: "200",
+          GRPCHTTP2Keys.contentType.rawValue: ContentType.grpc.canonicalValue,
+          GRPCHTTP2Keys.encoding.rawValue: "deflate",
+          "custom": "123",
+          "custom-bin": String(base64Encoding: [42, 43, 44]),
+        ],
+        endStream: false
+      )
+
+      let expectedStatus = Status(code: .unknown, message: "No 'grpc-status' value in trailers")
+      let expectedMetadata: Metadata = [
+        ":status": "200",
+        "content-type": "application/grpc",
+        "grpc-encoding": "deflate",
+        "custom": "123",
+        "custom-bin": .binary([42, 43, 44]),
+      ]
+
+      XCTAssertEqual(
+        action1,
+        .receivedStatusAndMetadata_clientOnly(status: expectedStatus, metadata: expectedMetadata)
+      )
 
       // Now make sure everything works well if we include grpc-status
-      let action = try stateMachine.receive(
+      let action2 = try stateMachine.receive(
         headers: [
           GRPCHTTP2Keys.status.rawValue: "200",
           GRPCHTTP2Keys.grpcStatus.rawValue: String(Status.Code.ok.rawValue),
@@ -493,17 +499,9 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
         endStream: false
       )
 
-      var expectedMetadata: Metadata = [
-        ":status": "200",
-        "content-type": "application/grpc",
-        "grpc-encoding": "deflate",
-        "custom": "123",
-      ]
-      expectedMetadata.removeAllValues(forKey: GRPCHTTP2Keys.grpcStatus.rawValue)
-      expectedMetadata.addBinary([42, 43, 44], forKey: "custom-bin")
       XCTAssertEqual(
-        action,
-        .receivedStatusAndMetadata(
+        action2,
+        .receivedStatusAndMetadata_clientOnly(
           status: Status(code: .ok, message: ""),
           metadata: expectedMetadata
         )
@@ -516,10 +514,9 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
       var stateMachine = self.makeClientStateMachine(targetState: targetState)
 
       XCTAssertThrowsError(
-        ofType: RPCError.self,
+        ofType: GRPCStreamStateMachine.InvalidState.self,
         try stateMachine.receive(headers: .init(), endStream: false)
       ) { error in
-        XCTAssertEqual(error.code, .internalError)
         XCTAssertEqual(error.message, "Server is closed, nothing could have been sent.")
       }
     }
@@ -532,10 +529,9 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
 
     // Receive an end trailer
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try stateMachine.receive(headers: .init(), endStream: true)
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Server cannot have sent metadata if the client is idle.")
     }
   }
@@ -555,7 +551,7 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
     ]
     let trailers = try stateMachine.receive(headers: trailersOnlyResponse, endStream: true)
     switch trailers {
-    case .receivedStatusAndMetadata(let status, let metadata):
+    case .receivedStatusAndMetadata_clientOnly(let status, let metadata):
       XCTAssertEqual(status, Status(code: .internalError, message: "Some, status, message"))
       XCTAssertEqual(
         metadata,
@@ -565,7 +561,7 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
           "custom-key": "custom-value",
         ]
       )
-    case .receivedMetadata, .doNothing, .rejectRPC, .protocolViolation:
+    case .receivedMetadata, .doNothing, .rejectRPC_serverOnly, .protocolViolation_serverOnly:
       XCTFail("Expected .receivedStatusAndMetadata")
     }
   }
@@ -594,7 +590,7 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
       ]
       XCTAssertEqual(
         action,
-        .receivedStatusAndMetadata(
+        .receivedStatusAndMetadata_clientOnly(
           status: .init(code: .ok, message: ""),
           metadata: expectedMetadata
         )
@@ -607,10 +603,9 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
 
     // Receive another end trailer
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try stateMachine.receive(headers: .init(), endStream: true)
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Server is closed, nothing could have been sent.")
     }
   }
@@ -630,7 +625,7 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
     ]
     let trailers = try stateMachine.receive(headers: trailersOnlyResponse, endStream: true)
     switch trailers {
-    case .receivedStatusAndMetadata(let status, let metadata):
+    case .receivedStatusAndMetadata_clientOnly(let status, let metadata):
       XCTAssertEqual(status, Status(code: .internalError, message: "Some status message"))
       XCTAssertEqual(
         metadata,
@@ -640,7 +635,7 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
           "custom-key": "custom-value",
         ]
       )
-    case .receivedMetadata, .doNothing, .rejectRPC, .protocolViolation:
+    case .receivedMetadata, .doNothing, .rejectRPC_serverOnly, .protocolViolation_serverOnly:
       XCTFail("Expected .receivedStatusAndMetadata")
     }
   }
@@ -660,10 +655,9 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
     var stateMachine = self.makeClientStateMachine(targetState: .clientIdleServerIdle)
 
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try stateMachine.receive(buffer: .init(), endStream: false)
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(
         error.message,
         "Cannot have received anything from server if client is not yet open."
@@ -676,10 +670,9 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
       var stateMachine = self.makeClientStateMachine(targetState: targetState)
 
       XCTAssertThrowsError(
-        ofType: RPCError.self,
+        ofType: GRPCStreamStateMachine.InvalidState.self,
         try stateMachine.receive(buffer: .init(), endStream: false)
       ) { error in
-        XCTAssertEqual(error.code, .internalError)
         XCTAssertEqual(
           error.message,
           "Server cannot have sent a message before sending the initial metadata."
@@ -698,7 +691,7 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
       )
       XCTAssertEqual(
         try stateMachine.receive(buffer: .init(), endStream: true),
-        .endRPCAndForwardErrorStatus(
+        .endRPCAndForwardErrorStatus_clientOnly(
           Status(
             code: .internalError,
             message: """
@@ -716,10 +709,9 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
       var stateMachine = self.makeClientStateMachine(targetState: targetState)
 
       XCTAssertThrowsError(
-        ofType: RPCError.self,
+        ofType: GRPCStreamStateMachine.InvalidState.self,
         try stateMachine.receive(buffer: .init(), endStream: false)
       ) { error in
-        XCTAssertEqual(error.code, .internalError)
         XCTAssertEqual(error.message, "Cannot have received anything from a closed server.")
       }
     }
@@ -731,10 +723,9 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
     var stateMachine = self.makeClientStateMachine(targetState: .clientIdleServerIdle)
 
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try stateMachine.nextOutboundFrame()
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Client is not open yet.")
     }
   }
@@ -1144,7 +1135,10 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
     }()
     XCTAssertEqual(
       metadataReceivedAction,
-      .receivedStatusAndMetadata(status: .init(code: .ok, message: ""), metadata: receivedMetadata)
+      .receivedStatusAndMetadata_clientOnly(
+        status: .init(code: .ok, message: ""),
+        metadata: receivedMetadata
+      )
     )
 
     XCTAssertEqual(try stateMachine.nextOutboundFrame(), .noMoreMessages)
@@ -1236,7 +1230,10 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
     }()
     XCTAssertEqual(
       metadataReceivedAction,
-      .receivedStatusAndMetadata(status: .init(code: .ok, message: ""), metadata: receivedMetadata)
+      .receivedStatusAndMetadata_clientOnly(
+        status: .init(code: .ok, message: ""),
+        metadata: receivedMetadata
+      )
     )
 
     XCTAssertEqual(try stateMachine.nextOutboundFrame(), .noMoreMessages)
@@ -1325,7 +1322,10 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
     }()
     XCTAssertEqual(
       metadataReceivedAction,
-      .receivedStatusAndMetadata(status: .init(code: .ok, message: ""), metadata: receivedMetadata)
+      .receivedStatusAndMetadata_clientOnly(
+        status: .init(code: .ok, message: ""),
+        metadata: receivedMetadata
+      )
     )
 
     XCTAssertEqual(try stateMachine.nextOutboundFrame(), .noMoreMessages)
@@ -1414,10 +1414,9 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
     var stateMachine = self.makeServerStateMachine(targetState: .clientIdleServerIdle)
 
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try stateMachine.send(metadata: .init())
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(
         error.message,
         "Client cannot be idle if server is sending initial metadata: it must have opened."
@@ -1461,10 +1460,9 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
 
     // Try sending metadata again: should throw
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try stateMachine.send(metadata: .init())
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Server has already sent initial metadata.")
     }
   }
@@ -1473,8 +1471,10 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
     var stateMachine = self.makeServerStateMachine(targetState: .clientOpenServerClosed)
 
     // Try sending metadata again: should throw
-    XCTAssertThrowsError(ofType: RPCError.self, try stateMachine.send(metadata: .init())) { error in
-      XCTAssertEqual(error.code, .internalError)
+    XCTAssertThrowsError(
+      ofType: GRPCStreamStateMachine.InvalidState.self,
+      try stateMachine.send(metadata: .init())
+    ) { error in
       XCTAssertEqual(error.message, "Server cannot send metadata if closed.")
     }
   }
@@ -1491,8 +1491,10 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
     var stateMachine = self.makeServerStateMachine(targetState: .clientClosedServerOpen)
 
     // Try sending metadata again: should throw
-    XCTAssertThrowsError(ofType: RPCError.self, try stateMachine.send(metadata: .init())) { error in
-      XCTAssertEqual(error.code, .internalError)
+    XCTAssertThrowsError(
+      ofType: GRPCStreamStateMachine.InvalidState.self,
+      try stateMachine.send(metadata: .init())
+    ) { error in
       XCTAssertEqual(error.message, "Server has already sent initial metadata.")
     }
   }
@@ -1501,8 +1503,10 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
     var stateMachine = self.makeServerStateMachine(targetState: .clientClosedServerClosed)
 
     // Try sending metadata again: should throw
-    XCTAssertThrowsError(ofType: RPCError.self, try stateMachine.send(metadata: .init())) { error in
-      XCTAssertEqual(error.code, .internalError)
+    XCTAssertThrowsError(
+      ofType: GRPCStreamStateMachine.InvalidState.self,
+      try stateMachine.send(metadata: .init())
+    ) { error in
       XCTAssertEqual(error.message, "Server cannot send metadata if closed.")
     }
   }
@@ -1513,10 +1517,9 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
     var stateMachine = self.makeServerStateMachine(targetState: .clientIdleServerIdle)
 
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try stateMachine.send(message: [], promise: nil)
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(
         error.message,
         "Server must have sent initial metadata before sending a message."
@@ -1529,10 +1532,9 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
 
     // Now send a message
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try stateMachine.send(message: [], promise: nil)
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(
         error.message,
         "Server must have sent initial metadata before sending a message."
@@ -1552,10 +1554,9 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
 
     // Try sending another message: it should fail
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try stateMachine.send(message: [], promise: nil)
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Server can't send a message if it's closed.")
     }
   }
@@ -1564,10 +1565,9 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
     var stateMachine = self.makeServerStateMachine(targetState: .clientClosedServerIdle)
 
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try stateMachine.send(message: [], promise: nil)
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(
         error.message,
         "Server must have sent initial metadata before sending a message."
@@ -1588,10 +1588,9 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
 
     // Try sending another message: it should fail
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try stateMachine.send(message: [], promise: nil)
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Server can't send a message if it's closed.")
     }
   }
@@ -1602,13 +1601,12 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
     var stateMachine = self.makeServerStateMachine(targetState: .clientIdleServerIdle)
 
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try stateMachine.send(
         status: .init(code: .ok, message: ""),
         metadata: .init()
       )
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Server can't send status if client is idle.")
     }
   }
@@ -1634,10 +1632,9 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
 
     // Try sending another message: it should fail because server is now closed.
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try stateMachine.send(message: [], promise: nil)
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Server can't send a message if it's closed.")
     }
   }
@@ -1656,10 +1653,9 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
 
     // Try sending another message: it should fail because server is now closed.
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try stateMachine.send(message: [], promise: nil)
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Server can't send a message if it's closed.")
     }
   }
@@ -1668,13 +1664,12 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
     var stateMachine = self.makeServerStateMachine(targetState: .clientOpenServerClosed)
 
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try stateMachine.send(
         status: .init(code: .ok, message: ""),
         metadata: .init()
       )
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Server can't send anything if closed.")
     }
   }
@@ -1700,10 +1695,9 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
 
     // Try sending another message: it should fail because server is now closed.
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try stateMachine.send(message: [], promise: nil)
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Server can't send a message if it's closed.")
     }
   }
@@ -1722,10 +1716,9 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
 
     // Try sending another message: it should fail because server is now closed.
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try stateMachine.send(message: [], promise: nil)
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Server can't send a message if it's closed.")
     }
   }
@@ -1734,13 +1727,12 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
     var stateMachine = self.makeServerStateMachine(targetState: .clientClosedServerClosed)
 
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try stateMachine.send(
         status: .init(code: .ok, message: ""),
         metadata: .init()
       )
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Server can't send anything if closed.")
     }
   }
@@ -2013,31 +2005,30 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
 
     // Try receiving initial metadata again - should be a protocol violation
     let action = try stateMachine.receive(headers: .clientInitialMetadata, endStream: false)
-    XCTAssertEqual(action, .protocolViolation)
+    XCTAssertEqual(action, .protocolViolation_serverOnly)
   }
 
   func testReceiveMetadataWhenClientOpenAndServerOpen() throws {
     var stateMachine = self.makeServerStateMachine(targetState: .clientOpenServerOpen)
 
     let action = try stateMachine.receive(headers: .clientInitialMetadata, endStream: false)
-    XCTAssertEqual(action, .protocolViolation)
+    XCTAssertEqual(action, .protocolViolation_serverOnly)
   }
 
   func testReceiveMetadataWhenClientOpenAndServerClosed() throws {
     var stateMachine = self.makeServerStateMachine(targetState: .clientOpenServerClosed)
 
     let action = try stateMachine.receive(headers: .clientInitialMetadata, endStream: false)
-    XCTAssertEqual(action, .protocolViolation)
+    XCTAssertEqual(action, .protocolViolation_serverOnly)
   }
 
   func testReceiveMetadataWhenClientClosedAndServerIdle() {
     var stateMachine = self.makeServerStateMachine(targetState: .clientClosedServerIdle)
 
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try stateMachine.receive(headers: .clientInitialMetadata, endStream: false)
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Client can't have sent metadata if closed.")
     }
   }
@@ -2046,10 +2037,9 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
     var stateMachine = self.makeServerStateMachine(targetState: .clientClosedServerOpen)
 
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try stateMachine.receive(headers: .clientInitialMetadata, endStream: false)
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Client can't have sent metadata if closed.")
     }
   }
@@ -2058,10 +2048,9 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
     var stateMachine = self.makeServerStateMachine(targetState: .clientClosedServerClosed)
 
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try stateMachine.receive(headers: .clientInitialMetadata, endStream: false)
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Client can't have sent metadata if closed.")
     }
   }
@@ -2072,10 +2061,9 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
     var stateMachine = self.makeServerStateMachine(targetState: .clientIdleServerIdle)
 
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try stateMachine.receive(buffer: .init(), endStream: false)
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Can't have received a message if client is idle.")
     }
   }
@@ -2089,10 +2077,9 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
 
     // Verify client is now closed
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try stateMachine.receive(buffer: .init(), endStream: false)
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Client can't send a message if closed.")
     }
   }
@@ -2106,10 +2093,9 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
 
     // Verify client is now closed
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try stateMachine.receive(buffer: .init(), endStream: false)
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Client can't send a message if closed.")
     }
   }
@@ -2152,13 +2138,14 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
 
     // Receiving compressed message with gzip (unsupported) should throw error
     let receivedGZIPCompressedBytes = try self.frameMessage(originalMessage, compression: .gzip)
-    XCTAssertThrowsError(
-      ofType: RPCError.self,
-      try stateMachine.receive(buffer: receivedGZIPCompressedBytes, endStream: false)
-    ) { error in
-      XCTAssertEqual(error.code, .internalError)
-      XCTAssertEqual(error.message, "Decompression error")
-    }
+    let action = try stateMachine.receive(buffer: receivedGZIPCompressedBytes, endStream: false)
+    XCTAssertEqual(
+      action,
+      .forwardErrorAndClose_serverOnly(
+        RPCError(code: .internalError, message: "Failed to decode message")
+      )
+    )
+
     receivedAction = stateMachine.nextInboundMessage()
     switch receivedAction {
     case .awaitMoreMessages:
@@ -2181,10 +2168,9 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
     var stateMachine = self.makeServerStateMachine(targetState: .clientClosedServerIdle)
 
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try stateMachine.receive(buffer: .init(), endStream: false)
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Client can't send a message if closed.")
     }
   }
@@ -2193,10 +2179,9 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
     var stateMachine = self.makeServerStateMachine(targetState: .clientClosedServerOpen)
 
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try stateMachine.receive(buffer: .init(), endStream: false)
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Client can't send a message if closed.")
     }
   }
@@ -2205,10 +2190,9 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
     var stateMachine = self.makeServerStateMachine(targetState: .clientClosedServerClosed)
 
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try stateMachine.receive(buffer: .init(), endStream: false)
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Client can't send a message if closed.")
     }
   }
@@ -2219,10 +2203,9 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
     var stateMachine = self.makeServerStateMachine(targetState: .clientIdleServerIdle)
 
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try stateMachine.nextOutboundFrame()
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Server is not open yet.")
     }
   }
@@ -2231,10 +2214,9 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
     var stateMachine = self.makeServerStateMachine(targetState: .clientOpenServerIdle)
 
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try stateMachine.nextOutboundFrame()
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Server is not open yet.")
     }
   }
@@ -2243,10 +2225,9 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
     var stateMachine = self.makeServerStateMachine(targetState: .clientOpenServerIdle)
 
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try stateMachine.nextOutboundFrame()
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Server is not open yet.")
     }
   }
@@ -2314,10 +2295,9 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
     var stateMachine = self.makeServerStateMachine(targetState: .clientClosedServerIdle)
 
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try stateMachine.nextOutboundFrame()
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Server is not open yet.")
     }
   }
@@ -2854,7 +2834,7 @@ extension XCTestCase {
     _ action: GRPCStreamStateMachine.OnMetadataReceived,
     expression: (HPACKHeaders) throws -> Void
   ) rethrows {
-    guard case .rejectRPC(let trailers) = action else {
+    guard case .rejectRPC_serverOnly(let trailers) = action else {
       XCTFail("RPC should have been rejected.")
       return
     }

--- a/Tests/GRPCHTTP2CoreTests/GRPCStreamStateMachineTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/GRPCStreamStateMachineTests.swift
@@ -460,7 +460,6 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
     ] {
       var stateMachine = self.makeClientStateMachine(targetState: targetState)
 
-      // Receiving initial metadata again should throw if grpc-status is not present.
       let action1 = try stateMachine.receive(
         headers: [
           GRPCHTTP2Keys.status.rawValue: "200",

--- a/Tests/GRPCHTTP2CoreTests/Server/GRPCServerStreamHandlerTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Server/GRPCServerStreamHandlerTests.swift
@@ -409,10 +409,10 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
     buffer.writeRepeatingByte(0, count: 42)  // message
     let clientDataPayload = HTTP2Frame.FramePayload.Data(data: .byteBuffer(buffer), endStream: true)
     XCTAssertThrowsError(
-      ofType: GRPCStreamStateMachine.InvalidState.self,
+      ofType: RPCError.self,
       try channel.writeInbound(HTTP2Frame.FramePayload.data(clientDataPayload))
     ) { error in
-      XCTAssertEqual(error.message, "Client can't send a message if closed.")
+      XCTAssertEqual(error.message, "Invalid state")
     }
   }
 
@@ -518,10 +518,10 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
     // Try writing and assert it throws to make sure we don't allow writes
     // after closing.
     XCTAssertThrowsError(
-      ofType: GRPCStreamStateMachine.InvalidState.self,
+      ofType: RPCError.self,
       try channel.writeOutbound(trailers)
     ) { error in
-      XCTAssertEqual(error.message, "Server can't send anything if closed.")
+      XCTAssertEqual(error.message, "Invalid state")
     }
   }
 
@@ -964,10 +964,10 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
 
     // We should now be closed: check we can't write anymore.
     XCTAssertThrowsError(
-      ofType: GRPCStreamStateMachine.InvalidState.self,
+      ofType: RPCError.self,
       try channel.writeOutbound(RPCResponsePart.metadata(Metadata()))
     ) { error in
-      XCTAssertEqual(error.message, "Server cannot send metadata if closed.")
+      XCTAssertEqual(error.message, "Invalid state")
     }
   }
 
@@ -1018,10 +1018,10 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
 
     // We should now be closed: check we can't write anymore.
     XCTAssertThrowsError(
-      ofType: GRPCStreamStateMachine.InvalidState.self,
+      ofType: RPCError.self,
       try channel.writeOutbound(RPCResponsePart.metadata(Metadata()))
     ) { error in
-      XCTAssertEqual(error.message, "Server cannot send metadata if closed.")
+      XCTAssertEqual(error.message, "Invalid state")
     }
   }
 
@@ -1072,10 +1072,10 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
 
     // We should now be closed: check we can't write anymore.
     XCTAssertThrowsError(
-      ofType: GRPCStreamStateMachine.InvalidState.self,
+      ofType: RPCError.self,
       try channel.writeOutbound(RPCResponsePart.metadata(Metadata()))
     ) { error in
-      XCTAssertEqual(error.message, "Server cannot send metadata if closed.")
+      XCTAssertEqual(error.message, "Invalid state")
     }
   }
 }

--- a/Tests/GRPCHTTP2CoreTests/Server/GRPCServerStreamHandlerTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Server/GRPCServerStreamHandlerTests.swift
@@ -342,11 +342,8 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
       ofType: RPCError.self,
       try channel.writeInbound(HTTP2Frame.FramePayload.data(clientDataPayload))
     ) { error in
-      XCTAssertEqual(error.code, .resourceExhausted)
-      XCTAssertEqual(
-        error.message,
-        "Message has exceeded the configured maximum payload size (max: 1, actual: 42)"
-      )
+      XCTAssertEqual(error.code, .internalError)
+      XCTAssertEqual(error.message, "Failed to decode message")
     }
 
     // Make sure we haven't sent a response back and that we didn't read the received message
@@ -412,10 +409,9 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
     buffer.writeRepeatingByte(0, count: 42)  // message
     let clientDataPayload = HTTP2Frame.FramePayload.Data(data: .byteBuffer(buffer), endStream: true)
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try channel.writeInbound(HTTP2Frame.FramePayload.data(clientDataPayload))
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Client can't send a message if closed.")
     }
   }
@@ -522,10 +518,9 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
     // Try writing and assert it throws to make sure we don't allow writes
     // after closing.
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try channel.writeOutbound(trailers)
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Server can't send anything if closed.")
     }
   }
@@ -969,10 +964,9 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
 
     // We should now be closed: check we can't write anymore.
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try channel.writeOutbound(RPCResponsePart.metadata(Metadata()))
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Server cannot send metadata if closed.")
     }
   }
@@ -1024,10 +1018,9 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
 
     // We should now be closed: check we can't write anymore.
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try channel.writeOutbound(RPCResponsePart.metadata(Metadata()))
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Server cannot send metadata if closed.")
     }
   }
@@ -1079,10 +1072,9 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
 
     // We should now be closed: check we can't write anymore.
     XCTAssertThrowsError(
-      ofType: RPCError.self,
+      ofType: GRPCStreamStateMachine.InvalidState.self,
       try channel.writeOutbound(RPCResponsePart.metadata(Metadata()))
     ) { error in
-      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Server cannot send metadata if closed.")
     }
   }

--- a/Tests/GRPCHTTP2CoreTests/Server/GRPCServerStreamHandlerTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Server/GRPCServerStreamHandlerTests.swift
@@ -412,6 +412,7 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
       ofType: RPCError.self,
       try channel.writeInbound(HTTP2Frame.FramePayload.data(clientDataPayload))
     ) { error in
+      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Invalid state")
     }
   }
@@ -521,6 +522,7 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
       ofType: RPCError.self,
       try channel.writeOutbound(trailers)
     ) { error in
+      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Invalid state")
     }
   }
@@ -967,6 +969,7 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
       ofType: RPCError.self,
       try channel.writeOutbound(RPCResponsePart.metadata(Metadata()))
     ) { error in
+      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Invalid state")
     }
   }
@@ -1021,6 +1024,7 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
       ofType: RPCError.self,
       try channel.writeOutbound(RPCResponsePart.metadata(Metadata()))
     ) { error in
+      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Invalid state")
     }
   }
@@ -1075,6 +1079,7 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
       ofType: RPCError.self,
       try channel.writeOutbound(RPCResponsePart.metadata(Metadata()))
     ) { error in
+      XCTAssertEqual(error.code, .internalError)
       XCTAssertEqual(error.message, "Invalid state")
     }
   }


### PR DESCRIPTION
Motivation:

The stream state machine throws on a number of paths rather than returning an action for the caller to execute. This extra flow control path can lead to the state not being correctly updated (and left in the modifying state).

The only valid error the stream state machine may throw is one for being in an invalid state. It's safe to throw this error as the state won't change when an invalid state is reached. This can be encoded using typed throws.

Modifications:

- Use typed throws in the stream state machine, this required pushing typed throws down into the compressor
- A few other parts of the state machine needed modifying to add new actions to avoid throwing

Result:

The only error the state machine may throw is for an invalid state.