### PR TITLE
Add underscored products for v2

### DIFF
--- a/Package@swift-6.swift
+++ b/Package@swift-6.swift
@@ -260,6 +260,19 @@ extension Target {
     )
   }
 
+  static var grpcHTTP2Transport: Target {
+    .target(
+      name: "GRPCHTTP2Transport",
+      dependencies: [
+        .grpcCore,
+        .grpcHTTP2Core,
+        .grpcHTTP2TransportNIOPosix,
+        .grpcHTTP2TransportNIOTransportServices,
+      ],
+      swiftSettings: [.swiftLanguageVersion(.v6), .enableUpcomingFeature("ExistentialAny")]
+    )
+  }
+
   static var cgrpcZlib: Target {
     .target(
       name: cgrpcZlibTargetName,
@@ -853,6 +866,20 @@ extension Product {
     )
   }
 
+  static var _grpcInProcessTransport: Product {
+    .library(
+      name: "_GRPCInProcessTransport",
+      targets: ["GRPCInProcessTransport"]
+    )
+  }
+
+  static var _grpcHTTP2Transport: Product {
+    .library(
+      name: "_GRPCHTTP2Transport",
+      targets: ["GRPCHTTP2Transport"]
+    )
+  }
+
   static var cgrpcZlib: Product {
     .library(
       name: cgrpcZlibProductName,
@@ -896,6 +923,8 @@ let package = Package(
     // v2
     ._grpcCore,
     ._grpcProtobuf,
+    ._grpcHTTP2Transport,
+    ._grpcInProcessTransport,
   ],
   dependencies: packageDependencies,
   targets: [
@@ -930,20 +959,29 @@ let package = Package(
 
     // v2
     .grpcCore,
-    .grpcInProcessTransport,
     .grpcCodeGen,
-    .grpcInterceptors,
+
+    // v2 transports
+    .grpcInProcessTransport,
     .grpcHTTP2Core,
     .grpcHTTP2TransportNIOPosix,
     .grpcHTTP2TransportNIOTransportServices,
+    .grpcHTTP2Transport,
+
+    // v2 Protobuf support
     .grpcProtobuf,
     .grpcProtobufCodeGen,
+
+    // v2 add-ons
+    .grpcInterceptors,
     .grpcHealth,
+
+    // v2 integration testing
     .interoperabilityTestImplementation,
     .interoperabilityTestsExecutable,
     .performanceWorker,
 
-    // v2 tests
+    // v2 unit tests
     .grpcCoreTests,
     .grpcInProcessTransportTests,
     .grpcCodeGenTests,

--- a/Sources/GRPCHTTP2Transport/Exports.swift
+++ b/Sources/GRPCHTTP2Transport/Exports.swift
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@_exported import GRPCCore
+@_exported import GRPCHTTP2Core
+@_exported import GRPCHTTP2TransportNIOPosix
+@_exported import GRPCHTTP2TransportNIOTransportServices

--- a/Sources/GRPCHTTP2TransportNIOPosix/Exports.swift
+++ b/Sources/GRPCHTTP2TransportNIOPosix/Exports.swift
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@_exported import GRPCCore
+@_exported import GRPCHTTP2Core

--- a/Sources/GRPCHTTP2TransportNIOTransportServices/Exports.swift
+++ b/Sources/GRPCHTTP2TransportNIOTransportServices/Exports.swift
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@_exported import GRPCCore
+@_exported import GRPCHTTP2Core

--- a/Sources/GRPCInProcessTransport/Exports.swift
+++ b/Sources/GRPCInProcessTransport/Exports.swift
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@_exported import GRPCCore


### PR DESCRIPTION
Motivation:

Some users want to kick the tyres of v2, to do that they need a product to depend on.

Modifications:

- Add a general 'GRPCHTTP2Transport' target which exports the both NIOPosix transport and the NIOTS transport.
- Add a '_GRPCHTTP2Transport' product
- Add a '_GRPCInProcessTransport' product
- Add exported imports to the h2 transport and in-process transport so the core module isn't explicitly required

Result:

Users can depend on pre-release products which lack stable API guarantees