### PR TITLE
Better closing control over GOAWAYs

### DIFF
--- a/Tests/GRPCHTTP2CoreTests/Client/Connection/ClientConnectionHandlerStateMachineTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Client/Connection/ClientConnectionHandlerStateMachineTests.swift
@@ -44,6 +44,13 @@ final class ClientConnectionHandlerStateMachineTests: XCTestCase {
     XCTAssertEqual(state.streamClosed(1), .close)
   }
 
+  func testCloseWhenAlreadyClosingGracefully() {
+    var state = self.makeStateMachine()
+    state.streamOpened(1)
+    XCTAssertEqual(state.beginGracefulShutdown(promise: nil), .sendGoAway(false))
+    XCTAssertTrue(state.beginClosing())
+  }
+
   func testOpenAndCloseStreamWhenClosed() {
     var state = self.makeStateMachine()
     _ = state.closed()
@@ -104,4 +111,5 @@ final class ClientConnectionHandlerStateMachineTests: XCTestCase {
     // Close immediately, not streams are open.
     XCTAssertEqual(state.beginGracefulShutdown(promise: nil), .sendGoAway(true))
   }
+
 }


### PR DESCRIPTION
Motivation:

The v2 client treats all GOAWAY frames equally and, if not already closing, will stop creating streams on that connection. This is okay in the 'normal' case where the error code is NO_ERROR. However if there's a protocol violation or some other connection level error the connection should be closed.

Modifications:

- Have the closing state record whether it's closing gracefully allowing for closes to be 'upgraded' (from graceful to not-so-graceful).
- Check whether the error code in the GOAWAY frame is NO_ERROR and take the non-graceful path if the code isn't NO_ERROR.
- Add missing 'fireChannelInactive'
- Add tests

Result:

Client will close shut down on a protocol error