### PR TITLE
Fix broken symlinks

### DIFF
--- a/FuzzTesting/Package.swift
+++ b/FuzzTesting/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.8
 /*
  * Copyright 2021, gRPC Authors All rights reserved.
  *

--- a/FuzzTesting/Sources/EchoImplementation
+++ b/FuzzTesting/Sources/EchoImplementation
@@ -1,1 +1,1 @@
-../../Sources/Examples/Echo/Implementation
+../../Sources/Examples/v1/Echo/Implementation

--- a/FuzzTesting/Sources/EchoModel
+++ b/FuzzTesting/Sources/EchoModel
@@ -1,1 +1,1 @@
-../../Sources/Examples/Echo/Model
+../../Sources/Examples/v1/Echo/Model


### PR DESCRIPTION
Motivation:

Reshuffling the example code in f77ea808 broke some symlinks which fuzzing relied on.

Modifications:

- Fix broken symlinks
- Bump tools version

Result:

Fuzzing builds