### PR TITLE
Use plugin work directory URL

### DIFF
--- a/Plugins/GRPCSwiftPlugin/plugin.swift
+++ b/Plugins/GRPCSwiftPlugin/plugin.swift
@@ -393,7 +393,7 @@ extension GRPCSwiftPlugin: XcodeBuildToolPlugin {
     #if compiler(<6.0)
     let workDirectory = PathLike(context.pluginWorkDirectory)
     #else
-    let workDirectory = PathLike(URL(string: String(describing: context.pluginWorkDirectory))!)
+    let workDirectory = PathLike(context.pluginWorkDirectoryURL)
     #endif
 
     return try self.createBuildCommands(


### PR DESCRIPTION
Motivation:

The `Path` API in the plugins is deprecated from Swift 6. This was only deprecated in Xcode 16 Beta 4.

Modifications:

- Use the newly added URL API

Result:

Fewer warnings