### PR TITLE
Save an allocation in BufferedStream

### DIFF
--- a/Sources/GRPCCore/Streaming/Internal/BufferedStream.swift
+++ b/Sources/GRPCCore/Streaming/Internal/BufferedStream.swift
@@ -635,16 +635,14 @@ extension BufferedStream {
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension BufferedStream {
-  // We are unchecked Sendable since we are protecting our state with a lock.
   @usableFromInline
-  final class _BackPressuredStorage: Sendable {
-    /// The state machine
+  struct _BackPressuredStorage: Sendable {
     @usableFromInline
     let _stateMachine: _ManagedCriticalState<_StateMachine>
 
     @usableFromInline
     var onTermination: (@Sendable () -> Void)? {
-      set {
+      nonmutating set {
         self._stateMachine.withCriticalRegion {
           $0._onTermination = newValue
         }


### PR DESCRIPTION
## Motivation
One of the backing types is unnecessarily a class.

## Modifications
Turned the class into a struct and marked the setter for a computed var as `nonmutating` (to preserve Sendability).

## Result
One less allocation per `BufferedStream`