### PR TITLE
Change visibility of `_makeBackpressuredStream` to `package`

### DIFF
--- a/Sources/GRPCCore/Streaming/Internal/RPCAsyncSequence+Buffered.swift
+++ b/Sources/GRPCCore/Streaming/Internal/RPCAsyncSequence+Buffered.swift
@@ -30,7 +30,7 @@ extension RPCAsyncSequence where Failure == any Error {
   }
 
   @inlinable
-  public static func _makeBackpressuredStream(
+  package static func _makeBackpressuredStream(
     of elementType: Element.Type = Element.self,
     watermarks: (low: Int, high: Int)
   ) -> (stream: Self, writer: RPCWriter<Element>.Closable) {

--- a/Sources/GRPCCore/Streaming/Internal/RPCAsyncSequence+Buffered.swift
+++ b/Sources/GRPCCore/Streaming/Internal/RPCAsyncSequence+Buffered.swift
@@ -17,7 +17,7 @@
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension RPCAsyncSequence where Failure == any Error {
   @inlinable
-  static func makeBackpressuredStream(
+  package static func makeBackpressuredStream(
     of elementType: Element.Type = Element.self,
     watermarks: (low: Int, high: Int)
   ) -> (stream: Self, writer: RPCWriter<Element>.Closable) {
@@ -27,13 +27,5 @@ extension RPCAsyncSequence where Failure == any Error {
     )
 
     return (RPCAsyncSequence(wrapping: stream), RPCWriter.Closable(wrapping: continuation))
-  }
-
-  @inlinable
-  package static func _makeBackpressuredStream(
-    of elementType: Element.Type = Element.self,
-    watermarks: (low: Int, high: Int)
-  ) -> (stream: Self, writer: RPCWriter<Element>.Closable) {
-    return Self.makeBackpressuredStream(of: elementType, watermarks: watermarks)
   }
 }

--- a/Sources/GRPCInProcessTransport/InProcessClientTransport.swift
+++ b/Sources/GRPCInProcessTransport/InProcessClientTransport.swift
@@ -233,10 +233,10 @@ public struct InProcessClientTransport: ClientTransport {
     options: CallOptions,
     _ closure: (RPCStream<Inbound, Outbound>) async throws -> T
   ) async throws -> T {
-    let request = RPCAsyncSequence<RPCRequestPart, any Error>._makeBackpressuredStream(
+    let request = RPCAsyncSequence<RPCRequestPart, any Error>.makeBackpressuredStream(
       watermarks: (16, 32)
     )
-    let response = RPCAsyncSequence<RPCResponsePart, any Error>._makeBackpressuredStream(
+    let response = RPCAsyncSequence<RPCResponsePart, any Error>.makeBackpressuredStream(
       watermarks: (16, 32)
     )
 


### PR DESCRIPTION
We were using `public` as the access modifier because we started not supporting Swift 6 only. We can now change the visibility to be `package`.