### PR TITLE
Simplify client rpc execution

### DIFF
--- a/Sources/GRPCCore/Call/Client/ClientInterceptor.swift
+++ b/Sources/GRPCCore/Call/Client/ClientInterceptor.swift
@@ -102,7 +102,7 @@ public protocol ClientInterceptor: Sendable {
   func intercept<Input: Sendable, Output: Sendable>(
     request: ClientRequest.Stream<Input>,
     context: ClientInterceptorContext,
-    next: @Sendable (
+    next: (
       _ request: ClientRequest.Stream<Input>,
       _ context: ClientInterceptorContext
     ) async throws -> ClientResponse.Stream<Output>

--- a/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor+HedgingExecutor.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor+HedgingExecutor.swift
@@ -103,12 +103,7 @@ extension ClientRPCExecutor.HedgingExecutor {
       }
 
       group.addTask {
-        var metadata = request.metadata
-        if let deadline = self.deadline {
-          metadata.timeout = ContinuousClock.now.duration(to: deadline)
-        }
-
-        let replayableRequest = ClientRequest.Stream(metadata: metadata) { writer in
+        let replayableRequest = ClientRequest.Stream(metadata: request.metadata) { writer in
           try await writer.write(contentsOf: broadcast.stream)
         }
 
@@ -243,6 +238,10 @@ extension ClientRPCExecutor.HedgingExecutor {
             ()
           }
 
+        case .attemptPicked:
+          // Not used by this task group.
+          fatalError("Internal inconsistency")
+
         case .attemptCompleted(let outcome):
           switch outcome {
           case .usableResponse(let response):
@@ -327,7 +326,7 @@ extension ClientRPCExecutor.HedgingExecutor {
         descriptor: method,
         options: options
       ) { stream -> _HedgingAttemptTaskResult<R, Output>.AttemptResult in
-        return await withTaskGroup(of: _HedgingAttemptSubtaskResult<Output>.self) { group in
+        return await withTaskGroup(of: _HedgingAttemptTaskResult<R, Output>.self) { group in
           group.addTask {
             do {
               // The picker stream will have at most one element.
@@ -340,35 +339,26 @@ extension ClientRPCExecutor.HedgingExecutor {
             }
           }
 
-          let processor = ClientStreamExecutor(transport: self.transport)
-
           group.addTask {
-            await processor.run()
-            return .processorFinished
-          }
-
-          group.addTask {
-            let response = await ClientRPCExecutor.unsafeExecute(
-              request: request,
-              method: method,
-              attempt: attempt,
-              serializer: self.serializer,
-              deserializer: self.deserializer,
-              interceptors: self.interceptors,
-              streamProcessor: processor,
-              stream: stream
-            )
-            return .response(response)
-          }
-
-          for await next in group {
-            switch next {
-            case .attemptPicked(let wasPicked):
-              if !wasPicked {
-                group.cancelAll()
+            let result = await withDiscardingTaskGroup(
+              returning: _HedgingAttemptTaskResult<R, Output>.AttemptResult.self
+            ) { group in
+              var request = request
+              if let deadline = self.deadline {
+                request.metadata.timeout = ContinuousClock.now.duration(to: deadline)
               }
 
-            case .response(let response):
+              let response = await ClientRPCExecutor._execute(
+                in: &group,
+                request: request,
+                method: method,
+                attempt: attempt,
+                serializer: self.serializer,
+                deserializer: self.deserializer,
+                interceptors: self.interceptors,
+                stream: stream
+              )
+
               switch response.accepted {
               case .success:
                 self.transport.retryThrottle?.recordSuccess()
@@ -405,10 +395,25 @@ extension ClientRPCExecutor.HedgingExecutor {
                   }
                 }
               }
+            }
 
-            case .processorFinished:
-              // Processor finished, wait for the response outcome.
-              ()
+            return .attemptCompleted(result)
+          }
+
+          for await next in group {
+            switch next {
+            case .attemptPicked(let wasPicked):
+              if !wasPicked {
+                group.cancelAll()
+              }
+
+            case .attemptCompleted(let result):
+              group.cancelAll()
+              return result
+
+            case .scheduledAttemptFired:
+              // Not used by this task group.
+              fatalError("Internal inconsistency")
             }
           }
 
@@ -516,6 +521,7 @@ enum _HedgingTaskResult<R> {
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 @usableFromInline
 enum _HedgingAttemptTaskResult<R, Output> {
+  case attemptPicked(Bool)
   case attemptCompleted(AttemptResult)
   case scheduledAttemptFired(ScheduleEvent)
 
@@ -531,12 +537,4 @@ enum _HedgingAttemptTaskResult<R, Output> {
     case ran
     case cancelled
   }
-}
-
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-@usableFromInline
-enum _HedgingAttemptSubtaskResult<Output> {
-  case attemptPicked(Bool)
-  case processorFinished
-  case response(ClientResponse.Stream<Output>)
 }

--- a/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor.swift
@@ -104,9 +104,6 @@ enum ClientRPCExecutor {
 extension ClientRPCExecutor {
   /// Executes a request on a given stream processor.
   ///
-  /// - Warning: This method is "unsafe" because the `streamProcessor` must be running in a task
-  ///   while this function is executing.
-  ///
   /// - Parameters:
   ///   - request: The request to execute.
   ///   - method: A description of the method to execute the request against.
@@ -115,44 +112,44 @@ extension ClientRPCExecutor {
   ///   - deserializer: A deserializer to convert bytes to output messages.
   ///   - interceptors: An array of interceptors which the request and response pass through. The
   ///       interceptors will be called in the order of the array.
-  ///   - streamProcessor: A processor which executes the serialized request.
   /// - Returns: The deserialized response.
-  @inlinable
-  static func unsafeExecute<Transport: ClientTransport, Input: Sendable, Output: Sendable>(
+  @inlinable  // would be private
+  static func _execute<Input: Sendable, Output: Sendable>(
+    in group: inout DiscardingTaskGroup,
     request: ClientRequest.Stream<Input>,
     method: MethodDescriptor,
     attempt: Int,
     serializer: some MessageSerializer<Input>,
     deserializer: some MessageDeserializer<Output>,
     interceptors: [any ClientInterceptor],
-    streamProcessor: ClientStreamExecutor<Transport>,
-    stream: RPCStream<Transport.Inbound, Transport.Outbound>
+    stream: RPCStream<ClientTransport.Inbound, ClientTransport.Outbound>
   ) async -> ClientResponse.Stream<Output> {
     let context = ClientInterceptorContext(descriptor: method)
 
     if interceptors.isEmpty {
-      return await Self._runRPC(
+      return await ClientStreamExecutor.execute(
+        in: &group,
         request: request,
         context: context,
         attempt: attempt,
         serializer: serializer,
         deserializer: deserializer,
-        streamProcessor: streamProcessor,
         stream: stream
       )
     } else {
       return await Self._intercept(
+        in: &group,
         request: request,
         context: context,
-        interceptors: interceptors
-      ) { request, context in
-        return await Self._runRPC(
+        iterator: interceptors.makeIterator()
+      ) { group, request, context in
+        return await ClientStreamExecutor.execute(
+          in: &group,
           request: request,
           context: context,
           attempt: attempt,
           serializer: serializer,
           deserializer: deserializer,
-          streamProcessor: streamProcessor,
           stream: stream
         )
       }
@@ -160,71 +157,13 @@ extension ClientRPCExecutor {
   }
 
   @inlinable
-  static func _runRPC<Transport: ClientTransport, Input: Sendable, Output: Sendable>(
-    request: ClientRequest.Stream<Input>,
-    context: ClientInterceptorContext,
-    attempt: Int,
-    serializer: some MessageSerializer<Input>,
-    deserializer: some MessageDeserializer<Output>,
-    streamProcessor: ClientStreamExecutor<Transport>,
-    stream: RPCStream<Transport.Inbound, Transport.Outbound>
-  ) async -> ClientResponse.Stream<Output> {
-    // Let the server know this is a retry.
-    var metadata = request.metadata
-    if attempt > 1 {
-      metadata.previousRPCAttempts = attempt &- 1
-    }
-
-    var response = await streamProcessor.execute(
-      request: ClientRequest.Stream<[UInt8]>(metadata: metadata) { writer in
-        try await request.producer(.serializing(into: writer, with: serializer))
-      },
-      method: context.descriptor,
-      stream: stream
-    )
-
-    // Attach the number of previous attempts, it can be useful information for callers.
-    if attempt > 1 {
-      switch response.accepted {
-      case .success(var contents):
-        contents.metadata.previousRPCAttempts = attempt &- 1
-        response.accepted = .success(contents)
-
-      case .failure(var error):
-        error.metadata.previousRPCAttempts = attempt &- 1
-        response.accepted = .failure(error)
-      }
-    }
-
-    return response.map { bytes in
-      try deserializer.deserialize(bytes)
-    }
-  }
-
-  @inlinable
   static func _intercept<Input, Output>(
-    request: ClientRequest.Stream<Input>,
-    context: ClientInterceptorContext,
-    interceptors: [any ClientInterceptor],
-    finally: @Sendable (
-      _ request: ClientRequest.Stream<Input>,
-      _ context: ClientInterceptorContext
-    ) async -> ClientResponse.Stream<Output>
-  ) async -> ClientResponse.Stream<Output> {
-    return await self._intercept(
-      request: request,
-      context: context,
-      iterator: interceptors.makeIterator(),
-      finally: finally
-    )
-  }
-
-  @inlinable
-  static func _intercept<Input, Output>(
+    in group: inout DiscardingTaskGroup,
     request: ClientRequest.Stream<Input>,
     context: ClientInterceptorContext,
     iterator: Array<any ClientInterceptor>.Iterator,
-    finally: @Sendable (
+    finally: (
+      _ group: inout DiscardingTaskGroup,
       _ request: ClientRequest.Stream<Input>,
       _ context: ClientInterceptorContext
     ) async -> ClientResponse.Stream<Output>
@@ -236,7 +175,13 @@ extension ClientRPCExecutor {
       let iter = iterator
       do {
         return try await interceptor.intercept(request: request, context: context) {
-          await self._intercept(request: $0, context: $1, iterator: iter, finally: finally)
+          await self._intercept(
+            in: &group,
+            request: $0,
+            context: $1,
+            iterator: iter,
+            finally: finally
+          )
         }
       } catch let error as RPCError {
         return ClientResponse.Stream(error: error)
@@ -246,7 +191,7 @@ extension ClientRPCExecutor {
       }
 
     case .none:
-      return await finally(request, context)
+      return await finally(&group, request, context)
     }
   }
 }

--- a/Sources/GRPCInterceptors/ClientTracingInterceptor.swift
+++ b/Sources/GRPCInterceptors/ClientTracingInterceptor.swift
@@ -46,8 +46,10 @@ public struct ClientTracingInterceptor: ClientInterceptor {
   public func intercept<Input, Output>(
     request: ClientRequest.Stream<Input>,
     context: ClientInterceptorContext,
-    next: @Sendable (ClientRequest.Stream<Input>, ClientInterceptorContext) async throws ->
-      ClientResponse.Stream<Output>
+    next: (
+      ClientRequest.Stream<Input>,
+      ClientInterceptorContext
+    ) async throws -> ClientResponse.Stream<Output>
   ) async throws -> ClientResponse.Stream<Output> where Input: Sendable, Output: Sendable {
     var request = request
     let tracer = InstrumentationSystem.tracer

--- a/Tests/GRPCCoreTests/Test Utilities/Call/Client/ClientInterceptors.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/Call/Client/ClientInterceptors.swift
@@ -52,7 +52,7 @@ struct RejectAllClientInterceptor: ClientInterceptor {
   func intercept<Input: Sendable, Output: Sendable>(
     request: ClientRequest.Stream<Input>,
     context: ClientInterceptorContext,
-    next: @Sendable (
+    next: (
       ClientRequest.Stream<Input>,
       ClientInterceptorContext
     ) async throws -> ClientResponse.Stream<Output>
@@ -77,7 +77,7 @@ struct RequestCountingClientInterceptor: ClientInterceptor {
   func intercept<Input: Sendable, Output: Sendable>(
     request: ClientRequest.Stream<Input>,
     context: ClientInterceptorContext,
-    next: @Sendable (
+    next: (
       ClientRequest.Stream<Input>,
       ClientInterceptorContext
     ) async throws -> ClientResponse.Stream<Output>


### PR DESCRIPTION
Motivation:

The existing code for executing RPCs on the client is layered, the one-shot, retry and hedging executors serialize the messages of the requests they're processing into bytes. These 'raw' requests are processed by the stream executor which is structured in such a way as requiring a task group of events it needs to handled. These events are handled in a run method (which is in turn another task for the caller to run). This requires quite a bit of machinery (and allocations) for it to work.

Modifications:

- Push the serialization/deserialization of messages down into the stream executor. This lets a typed request be transformed directly to `RPCRequestPart`s and for `RPCResponsePart`s to be transformed directly to a typed response (rather than via an intermediary request/response typed to `[UInt8]`).
- Remove the sendability requirement from the `next` function for client interceptors. This makes sense: interceptors should be straight-line code so shouldn't be shuffled off into a subtask. This unlocks the ability to remove the task group and event stream previously used by the stream executor as it can add child tasks to a provided task group (rather than needing a separate task group with an event stream).
- Apply this change to the one-shot, hedging, and retry executors.

Result:

- ~35% reduction in allocations for unary RPCs on the client