### PR TITLE
Enable `InternalImportsByDefault` in v2 modules

### DIFF
--- a/Package@swift-6.swift
+++ b/Package@swift-6.swift
@@ -207,7 +207,11 @@ extension Target {
         .atomics
       ],
       path: "Sources/GRPCCore",
-      swiftSettings: [._swiftLanguageMode(.v5), .enableUpcomingFeature("ExistentialAny")]
+      swiftSettings: [
+        ._swiftLanguageMode(.v5),
+        .enableUpcomingFeature("ExistentialAny"),
+        .enableUpcomingFeature("InternalImportsByDefault")
+      ]
     )
   }
 
@@ -217,7 +221,11 @@ extension Target {
       dependencies: [
         .grpcCore
       ],
-      swiftSettings: [._swiftLanguageMode(.v6), .enableUpcomingFeature("ExistentialAny")]
+      swiftSettings: [
+        ._swiftLanguageMode(.v6),
+        .enableUpcomingFeature("ExistentialAny"),
+        .enableUpcomingFeature("InternalImportsByDefault")
+      ]
     )
   }
 
@@ -228,7 +236,11 @@ extension Target {
         .grpcCore,
         .tracing
       ],
-      swiftSettings: [._swiftLanguageMode(.v6), .enableUpcomingFeature("ExistentialAny")]
+      swiftSettings: [
+        ._swiftLanguageMode(.v6),
+        .enableUpcomingFeature("ExistentialAny"),
+        .enableUpcomingFeature("InternalImportsByDefault")
+      ]
     )
   }
 
@@ -243,7 +255,11 @@ extension Target {
         .dequeModule,
         .atomics
       ],
-      swiftSettings: [._swiftLanguageMode(.v6), .enableUpcomingFeature("ExistentialAny")]
+      swiftSettings: [
+        ._swiftLanguageMode(.v6),
+        .enableUpcomingFeature("ExistentialAny"),
+        .enableUpcomingFeature("InternalImportsByDefault")
+      ]
     )
   }
 
@@ -256,7 +272,11 @@ extension Target {
         .nioPosix,
         .nioExtras
       ],
-      swiftSettings: [._swiftLanguageMode(.v6), .enableUpcomingFeature("ExistentialAny")]
+      swiftSettings: [
+        ._swiftLanguageMode(.v6),
+        .enableUpcomingFeature("ExistentialAny"),
+        .enableUpcomingFeature("InternalImportsByDefault")
+      ]
     )
   }
 
@@ -270,7 +290,11 @@ extension Target {
         .nioExtras,
         .nioTransportServices
       ],
-      swiftSettings: [._swiftLanguageMode(.v6), .enableUpcomingFeature("ExistentialAny")]
+      swiftSettings: [
+        ._swiftLanguageMode(.v6),
+        .enableUpcomingFeature("ExistentialAny"),
+        .enableUpcomingFeature("InternalImportsByDefault")
+      ]
     )
   }
 
@@ -283,7 +307,11 @@ extension Target {
         .grpcHTTP2TransportNIOPosix,
         .grpcHTTP2TransportNIOTransportServices,
       ],
-      swiftSettings: [._swiftLanguageMode(.v6), .enableUpcomingFeature("ExistentialAny")]
+      swiftSettings: [
+        ._swiftLanguageMode(.v6),
+        .enableUpcomingFeature("ExistentialAny"),
+        .enableUpcomingFeature("InternalImportsByDefault")
+      ]
     )
   }
 
@@ -510,7 +538,7 @@ extension Target {
         .grpcCore,
         .grpcProtobuf
       ],
-      swiftSettings: [._swiftLanguageMode(.v5), .enableUpcomingFeature("ExistentialAny")]
+      swiftSettings: [._swiftLanguageMode(.v6), .enableUpcomingFeature("ExistentialAny")]
     )
   }
 
@@ -814,7 +842,11 @@ extension Target {
     .target(
       name: "GRPCCodeGen",
       path: "Sources/GRPCCodeGen",
-      swiftSettings: [._swiftLanguageMode(.v6), .enableUpcomingFeature("ExistentialAny")]
+      swiftSettings: [
+        ._swiftLanguageMode(.v6),
+        .enableUpcomingFeature("ExistentialAny"),
+        .enableUpcomingFeature("InternalImportsByDefault")
+      ]
     )
   }
 
@@ -826,7 +858,11 @@ extension Target {
         .protobuf,
       ],
       path: "Sources/GRPCProtobuf",
-      swiftSettings: [._swiftLanguageMode(.v6), .enableUpcomingFeature("ExistentialAny")]
+      swiftSettings: [
+        ._swiftLanguageMode(.v6),
+        .enableUpcomingFeature("ExistentialAny"),
+        .enableUpcomingFeature("InternalImportsByDefault")
+      ]
     )
   }
 
@@ -839,7 +875,11 @@ extension Target {
         .grpcCodeGen
       ],
       path: "Sources/GRPCProtobufCodeGen",
-      swiftSettings: [._swiftLanguageMode(.v6), .enableUpcomingFeature("ExistentialAny")]
+      swiftSettings: [
+        ._swiftLanguageMode(.v6),
+        .enableUpcomingFeature("ExistentialAny"),
+        .enableUpcomingFeature("InternalImportsByDefault")
+      ]
     )
   }
 
@@ -851,7 +891,11 @@ extension Target {
         .grpcProtobuf
       ],
       path: "Sources/Services/Health",
-      swiftSettings: [._swiftLanguageMode(.v6)]
+      swiftSettings: [
+        ._swiftLanguageMode(.v6),
+        .enableUpcomingFeature("ExistentialAny"),
+        .enableUpcomingFeature("InternalImportsByDefault")
+      ]
     )
   }
 }

--- a/Sources/GRPCCore/Call/Client/Internal/RetryDelaySequence.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/RetryDelaySequence.swift
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 #if canImport(Darwin)
-public import Darwin // should be @usableFromInline
+public import Darwin  // should be @usableFromInline
 #else
-public import Glibc // should be @usableFromInline
+public import Glibc  // should be @usableFromInline
 #endif
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)

--- a/Sources/GRPCCore/Call/Client/Internal/RetryDelaySequence.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/RetryDelaySequence.swift
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 #if canImport(Darwin)
-import Darwin
+public import Darwin // should be @usableFromInline
 #else
-import Glibc
+public import Glibc // should be @usableFromInline
 #endif
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)

--- a/Sources/GRPCCore/GRPCClient.swift
+++ b/Sources/GRPCCore/GRPCClient.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import Atomics
+internal import Atomics
 
 /// A gRPC client.
 ///

--- a/Sources/GRPCCore/GRPCServer.swift
+++ b/Sources/GRPCCore/GRPCServer.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import Atomics
+internal import Atomics
 
 /// A gRPC server.
 ///

--- a/Sources/GRPCCore/Internal/Concurrency Primitives/Lock.swift
+++ b/Sources/GRPCCore/Internal/Concurrency Primitives/Lock.swift
@@ -28,9 +28,9 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(Darwin)
-import Darwin
+public import Darwin // should be @usableFromInline
 #elseif canImport(Glibc)
-import Glibc
+public import Glibc // should be @usableFromInline
 #endif
 
 @usableFromInline

--- a/Sources/GRPCCore/Internal/Concurrency Primitives/Lock.swift
+++ b/Sources/GRPCCore/Internal/Concurrency Primitives/Lock.swift
@@ -28,9 +28,9 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(Darwin)
-public import Darwin // should be @usableFromInline
+public import Darwin  // should be @usableFromInline
 #elseif canImport(Glibc)
-public import Glibc // should be @usableFromInline
+public import Glibc  // should be @usableFromInline
 #endif
 
 @usableFromInline

--- a/Sources/GRPCCore/Streaming/Internal/AsyncIteratorSequence.swift
+++ b/Sources/GRPCCore/Streaming/Internal/AsyncIteratorSequence.swift
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Atomics
+
+public import Atomics // should be @usableFromInline
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 @usableFromInline

--- a/Sources/GRPCCore/Streaming/Internal/AsyncIteratorSequence.swift
+++ b/Sources/GRPCCore/Streaming/Internal/AsyncIteratorSequence.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-public import Atomics // should be @usableFromInline
+public import Atomics  // should be @usableFromInline
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 @usableFromInline

--- a/Sources/GRPCCore/Streaming/Internal/BroadcastAsyncSequence.swift
+++ b/Sources/GRPCCore/Streaming/Internal/BroadcastAsyncSequence.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-public import DequeModule // should be @usableFromInline
+public import DequeModule  // should be @usableFromInline
 
 /// An `AsyncSequence` which can broadcast its values to multiple consumers concurrently.
 ///

--- a/Sources/GRPCCore/Streaming/Internal/BroadcastAsyncSequence.swift
+++ b/Sources/GRPCCore/Streaming/Internal/BroadcastAsyncSequence.swift
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import DequeModule
+
+public import DequeModule // should be @usableFromInline
 
 /// An `AsyncSequence` which can broadcast its values to multiple consumers concurrently.
 ///

--- a/Sources/GRPCCore/Streaming/Internal/BufferedStream.swift
+++ b/Sources/GRPCCore/Streaming/Internal/BufferedStream.swift
@@ -25,7 +25,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public import DequeModule // should be @usableFromInline
+public import DequeModule  // should be @usableFromInline
 
 /// An asynchronous sequence generated from an error-throwing closure that
 /// calls a continuation to produce new elements.

--- a/Sources/GRPCCore/Streaming/Internal/BufferedStream.swift
+++ b/Sources/GRPCCore/Streaming/Internal/BufferedStream.swift
@@ -25,7 +25,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import DequeModule
+public import DequeModule // should be @usableFromInline
 
 /// An asynchronous sequence generated from an error-throwing closure that
 /// calls a continuation to produce new elements.

--- a/Sources/GRPCCore/Timeout.swift
+++ b/Sources/GRPCCore/Timeout.swift
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Dispatch
+
+internal import Dispatch
 
 /// A timeout for a gRPC call.
 ///

--- a/Sources/GRPCHTTP2Core/Client/Connection/ClientConnectionHandler.swift
+++ b/Sources/GRPCHTTP2Core/Client/Connection/ClientConnectionHandler.swift
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import NIOCore
-import NIOHTTP2
+package import NIOCore
+package import NIOHTTP2
 
 /// An event which happens on a client's HTTP/2 connection.
 package enum ClientConnectionEvent: Sendable {

--- a/Sources/GRPCHTTP2Core/Client/Connection/Connection.swift
+++ b/Sources/GRPCHTTP2Core/Client/Connection/Connection.swift
@@ -15,10 +15,9 @@
  */
 
 package import GRPCCore
-package import NIOHTTP2
-package import NIOCore
-
 import NIOConcurrencyHelpers
+package import NIOCore
+package import NIOHTTP2
 
 /// A `Connection` provides communication to a single remote peer.
 ///

--- a/Sources/GRPCHTTP2Core/Client/Connection/Connection.swift
+++ b/Sources/GRPCHTTP2Core/Client/Connection/Connection.swift
@@ -15,7 +15,7 @@
  */
 
 package import GRPCCore
-import NIOConcurrencyHelpers
+internal import NIOConcurrencyHelpers
 package import NIOCore
 package import NIOHTTP2
 

--- a/Sources/GRPCHTTP2Core/Client/Connection/Connection.swift
+++ b/Sources/GRPCHTTP2Core/Client/Connection/Connection.swift
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-import GRPCCore
+package import GRPCCore
+package import NIOHTTP2
+package import NIOCore
+
 import NIOConcurrencyHelpers
-import NIOCore
-import NIOHTTP2
 
 /// A `Connection` provides communication to a single remote peer.
 ///

--- a/Sources/GRPCHTTP2Core/Client/Connection/ConnectionFactory.swift
+++ b/Sources/GRPCHTTP2Core/Client/Connection/ConnectionFactory.swift
@@ -16,7 +16,7 @@
 
 package import NIOCore
 package import NIOHTTP2
-import NIOPosix
+internal import NIOPosix
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 package protocol HTTP2Connector: Sendable {

--- a/Sources/GRPCHTTP2Core/Client/Connection/ConnectionFactory.swift
+++ b/Sources/GRPCHTTP2Core/Client/Connection/ConnectionFactory.swift
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import NIOCore
-import NIOHTTP2
+package import NIOCore
+package import NIOHTTP2
+
 import NIOPosix
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)

--- a/Sources/GRPCHTTP2Core/Client/Connection/ConnectionFactory.swift
+++ b/Sources/GRPCHTTP2Core/Client/Connection/ConnectionFactory.swift
@@ -16,7 +16,6 @@
 
 package import NIOCore
 package import NIOHTTP2
-
 import NIOPosix
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)

--- a/Sources/GRPCHTTP2Core/Client/Connection/GRPCChannel.swift
+++ b/Sources/GRPCHTTP2Core/Client/Connection/GRPCChannel.swift
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import Atomics
-import DequeModule
+internal import Atomics
+internal import DequeModule
 package import GRPCCore
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)

--- a/Sources/GRPCHTTP2Core/Client/Connection/GRPCChannel.swift
+++ b/Sources/GRPCHTTP2Core/Client/Connection/GRPCChannel.swift
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
+package import GRPCCore
+
 import Atomics
 import DequeModule
-import GRPCCore
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 package struct GRPCChannel: ClientTransport {

--- a/Sources/GRPCHTTP2Core/Client/Connection/GRPCChannel.swift
+++ b/Sources/GRPCHTTP2Core/Client/Connection/GRPCChannel.swift
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-package import GRPCCore
-
 import Atomics
 import DequeModule
+package import GRPCCore
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 package struct GRPCChannel: ClientTransport {

--- a/Sources/GRPCHTTP2Core/Client/Connection/LoadBalancers/PickFirstLoadBalancer.swift
+++ b/Sources/GRPCHTTP2Core/Client/Connection/LoadBalancers/PickFirstLoadBalancer.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import GRPCCore
+package import GRPCCore
 
 /// A load-balancer which has a single subchannel.
 ///

--- a/Sources/GRPCHTTP2Core/Client/Connection/LoadBalancers/RoundRobinLoadBalancer.swift
+++ b/Sources/GRPCHTTP2Core/Client/Connection/LoadBalancers/RoundRobinLoadBalancer.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import GRPCCore
+package import GRPCCore
 
 /// A load-balancer which maintains to a set of subchannels and uses round-robin to pick a
 /// subchannel when picking a subchannel to use.

--- a/Sources/GRPCHTTP2Core/Client/Connection/LoadBalancers/Subchannel.swift
+++ b/Sources/GRPCHTTP2Core/Client/Connection/LoadBalancers/Subchannel.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import GRPCCore
+package import GRPCCore
 import NIOConcurrencyHelpers
 
 /// A ``Subchannel`` provides communication to a single ``Endpoint``.

--- a/Sources/GRPCHTTP2Core/Client/Connection/LoadBalancers/Subchannel.swift
+++ b/Sources/GRPCHTTP2Core/Client/Connection/LoadBalancers/Subchannel.swift
@@ -15,7 +15,7 @@
  */
 
 package import GRPCCore
-import NIOConcurrencyHelpers
+internal import NIOConcurrencyHelpers
 
 /// A ``Subchannel`` provides communication to a single ``Endpoint``.
 ///

--- a/Sources/GRPCHTTP2Core/Client/Connection/RequestQueue.swift
+++ b/Sources/GRPCHTTP2Core/Client/Connection/RequestQueue.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import DequeModule
+internal import DequeModule
 
 @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 struct RequestQueue {

--- a/Sources/GRPCHTTP2Core/Client/GRPCClientStreamHandler.swift
+++ b/Sources/GRPCHTTP2Core/Client/GRPCClientStreamHandler.swift
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import GRPCCore
-import NIOCore
-import NIOHTTP2
+internal import GRPCCore
+internal import NIOCore
+internal import NIOHTTP2
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 final class GRPCClientStreamHandler: ChannelDuplexHandler {

--- a/Sources/GRPCHTTP2Core/Client/HTTP2ClientTransport.swift
+++ b/Sources/GRPCHTTP2Core/Client/HTTP2ClientTransport.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import GRPCCore
+public import GRPCCore
 
 /// A namespace for the HTTP/2 client transport.
 public enum HTTP2ClientTransport {}

--- a/Sources/GRPCHTTP2Core/Client/Resolver/NameResolver+IPv4.swift
+++ b/Sources/GRPCHTTP2Core/Client/Resolver/NameResolver+IPv4.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import GRPCCore
+internal import GRPCCore
 
 extension ResolvableTargets {
   /// A resolvable target for IPv4 addresses.

--- a/Sources/GRPCHTTP2Core/Client/Resolver/NameResolver+IPv6.swift
+++ b/Sources/GRPCHTTP2Core/Client/Resolver/NameResolver+IPv6.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import GRPCCore
+internal import GRPCCore
 
 extension ResolvableTargets {
   /// A resolvable target for IPv4 addresses.

--- a/Sources/GRPCHTTP2Core/Client/Resolver/NameResolver+UDS.swift
+++ b/Sources/GRPCHTTP2Core/Client/Resolver/NameResolver+UDS.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import GRPCCore
+internal import GRPCCore
 
 extension ResolvableTargets {
   /// A resolvable target for Unix Domain Socket address.

--- a/Sources/GRPCHTTP2Core/Client/Resolver/NameResolver+VSOCK.swift
+++ b/Sources/GRPCHTTP2Core/Client/Resolver/NameResolver+VSOCK.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import GRPCCore
+internal import GRPCCore
 
 extension ResolvableTargets {
   /// A resolvable target for Virtual Socket addresses.

--- a/Sources/GRPCHTTP2Core/Client/Resolver/NameResolver.swift
+++ b/Sources/GRPCHTTP2Core/Client/Resolver/NameResolver.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import GRPCCore
+public import GRPCCore
 
 /// A name resolver can provide resolved addresses and service configuration values over time.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)

--- a/Sources/GRPCHTTP2Core/Compression/CompressionAlgorithm.swift
+++ b/Sources/GRPCHTTP2Core/Compression/CompressionAlgorithm.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import GRPCCore
+internal import GRPCCore
 
 extension CompressionAlgorithm {
   init?(name: String) {

--- a/Sources/GRPCHTTP2Core/Compression/Zlib.swift
+++ b/Sources/GRPCHTTP2Core/Compression/Zlib.swift
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import CGRPCZlib
-import GRPCCore
-import NIOCore
+internal import CGRPCZlib
+internal import GRPCCore
+internal import NIOCore
 
 enum Zlib {
   enum Method {

--- a/Sources/GRPCHTTP2Core/GRPCMessageDecoder.swift
+++ b/Sources/GRPCHTTP2Core/GRPCMessageDecoder.swift
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package import NIOCore
-
 import GRPCCore
+package import NIOCore
 
 /// A ``GRPCMessageDecoder`` helps with the deframing of gRPC data frames:
 /// - It reads the frame's metadata to know whether the message payload is compressed or not, and its length

--- a/Sources/GRPCHTTP2Core/GRPCMessageDecoder.swift
+++ b/Sources/GRPCHTTP2Core/GRPCMessageDecoder.swift
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
+package import NIOCore
+
 import GRPCCore
-import NIOCore
 
 /// A ``GRPCMessageDecoder`` helps with the deframing of gRPC data frames:
 /// - It reads the frame's metadata to know whether the message payload is compressed or not, and its length

--- a/Sources/GRPCHTTP2Core/GRPCMessageDecoder.swift
+++ b/Sources/GRPCHTTP2Core/GRPCMessageDecoder.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import GRPCCore
+internal import GRPCCore
 package import NIOCore
 
 /// A ``GRPCMessageDecoder`` helps with the deframing of gRPC data frames:

--- a/Sources/GRPCHTTP2Core/GRPCMessageFramer.swift
+++ b/Sources/GRPCHTTP2Core/GRPCMessageFramer.swift
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import GRPCCore
-import NIOCore
+internal import GRPCCore
+internal import NIOCore
 
 /// A ``GRPCMessageFramer`` helps with the framing of gRPC data frames:
 /// - It prepends data with the required metadata (compression flag and message length).

--- a/Sources/GRPCHTTP2Core/GRPCStreamStateMachine.swift
+++ b/Sources/GRPCHTTP2Core/GRPCStreamStateMachine.swift
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import GRPCCore
-import NIOCore
-import NIOHPACK
-import NIOHTTP1
+internal import GRPCCore
+internal import NIOCore
+internal import NIOHPACK
+internal import NIOHTTP1
 
 package enum Scheme: String {
   case http

--- a/Sources/GRPCHTTP2Core/Internal/ConstantAsyncSequence.swift
+++ b/Sources/GRPCHTTP2Core/Internal/ConstantAsyncSequence.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import GRPCCore
+internal import GRPCCore
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 private struct ConstantAsyncSequence<Element: Sendable>: AsyncSequence, Sendable {

--- a/Sources/GRPCHTTP2Core/Internal/NIOChannelPipeline+GRPC.swift
+++ b/Sources/GRPCHTTP2Core/Internal/NIOChannelPipeline+GRPC.swift
@@ -16,7 +16,7 @@
 
 package import GRPCCore
 package import NIOCore
-import NIOHPACK
+internal import NIOHPACK
 package import NIOHTTP2
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)

--- a/Sources/GRPCHTTP2Core/Internal/NIOChannelPipeline+GRPC.swift
+++ b/Sources/GRPCHTTP2Core/Internal/NIOChannelPipeline+GRPC.swift
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-import GRPCCore
-import NIOCore
+package import GRPCCore
+package import NIOCore
+package import NIOHTTP2
+
 import NIOHPACK
-import NIOHTTP2
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension ChannelPipeline.SynchronousOperations {

--- a/Sources/GRPCHTTP2Core/Internal/NIOChannelPipeline+GRPC.swift
+++ b/Sources/GRPCHTTP2Core/Internal/NIOChannelPipeline+GRPC.swift
@@ -16,9 +16,8 @@
 
 package import GRPCCore
 package import NIOCore
-package import NIOHTTP2
-
 import NIOHPACK
+package import NIOHTTP2
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension ChannelPipeline.SynchronousOperations {

--- a/Sources/GRPCHTTP2Core/Internal/NIOSocketAddress+GRPCSocketAddress.swift
+++ b/Sources/GRPCHTTP2Core/Internal/NIOSocketAddress+GRPCSocketAddress.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import NIOCore
+package import NIOCore
 
 extension GRPCHTTP2Core.SocketAddress {
   package init(_ nioSocketAddress: NIOCore.SocketAddress) {

--- a/Sources/GRPCHTTP2Core/Internal/ProcessUniqueID.swift
+++ b/Sources/GRPCHTTP2Core/Internal/ProcessUniqueID.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import Atomics
+internal import Atomics
 
 /// An ID which is unique within this process.
 struct ProcessUniqueID: Hashable, Sendable, CustomStringConvertible {

--- a/Sources/GRPCHTTP2Core/Internal/Timer.swift
+++ b/Sources/GRPCHTTP2Core/Internal/Timer.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import NIOCore
+package import NIOCore
 
 package struct Timer {
   /// The delay to wait before running the task.

--- a/Sources/GRPCHTTP2Core/OneOrManyQueue.swift
+++ b/Sources/GRPCHTTP2Core/OneOrManyQueue.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import DequeModule
+internal import DequeModule
 
 /// A FIFO-queue which allows for a single element to be stored on the stack and defers to a
 /// heap-implementation if further elements are added.

--- a/Sources/GRPCHTTP2Core/Server/Connection/GRPCServerFlushNotificationHandler.swift
+++ b/Sources/GRPCHTTP2Core/Server/Connection/GRPCServerFlushNotificationHandler.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import NIOCore
+internal import NIOCore
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 final class GRPCServerFlushNotificationHandler: ChannelOutboundHandler {

--- a/Sources/GRPCHTTP2Core/Server/Connection/ServerConnection.swift
+++ b/Sources/GRPCHTTP2Core/Server/Connection/ServerConnection.swift
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import GRPCCore
-import NIOCore
+package import GRPCCore
+package import NIOCore
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public enum ServerConnection {

--- a/Sources/GRPCHTTP2Core/Server/Connection/ServerConnectionManagementHandler+StateMachine.swift
+++ b/Sources/GRPCHTTP2Core/Server/Connection/ServerConnectionManagementHandler+StateMachine.swift
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import NIOCore
-import NIOHTTP2
+internal import NIOCore
+internal import NIOHTTP2
 
 extension ServerConnectionManagementHandler {
   /// Tracks the state of TCP connections at the server.

--- a/Sources/GRPCHTTP2Core/Server/Connection/ServerConnectionManagementHandler.swift
+++ b/Sources/GRPCHTTP2Core/Server/Connection/ServerConnectionManagementHandler.swift
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import NIOCore
-import NIOHTTP2
+internal import NIOCore
+internal import NIOHTTP2
 
 /// A `ChannelHandler` which manages the lifecycle of a gRPC connection over HTTP/2.
 ///

--- a/Sources/GRPCHTTP2Core/Server/GRPCServerStreamHandler.swift
+++ b/Sources/GRPCHTTP2Core/Server/GRPCServerStreamHandler.swift
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import GRPCCore
-import NIOCore
-import NIOHTTP2
+package import GRPCCore
+package import NIOCore
+package import NIOHTTP2
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 package final class GRPCServerStreamHandler: ChannelDuplexHandler, RemovableChannelHandler {

--- a/Sources/GRPCHTTP2Core/Server/HTTP2ServerTransport.swift
+++ b/Sources/GRPCHTTP2Core/Server/HTTP2ServerTransport.swift
@@ -15,7 +15,7 @@
  */
 
 public import GRPCCore
-import NIOHTTP2
+internal import NIOHTTP2
 
 /// A namespace for the HTTP/2 server transport.
 public enum HTTP2ServerTransport {}

--- a/Sources/GRPCHTTP2Core/Server/HTTP2ServerTransport.swift
+++ b/Sources/GRPCHTTP2Core/Server/HTTP2ServerTransport.swift
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import GRPCCore
+public import GRPCCore
+
 import NIOHTTP2
 
 /// A namespace for the HTTP/2 server transport.

--- a/Sources/GRPCHTTP2Core/Server/HTTP2ServerTransport.swift
+++ b/Sources/GRPCHTTP2Core/Server/HTTP2ServerTransport.swift
@@ -15,7 +15,6 @@
  */
 
 public import GRPCCore
-
 import NIOHTTP2
 
 /// A namespace for the HTTP/2 server transport.

--- a/Sources/GRPCHTTP2TransportNIOPosix/HTTP2ClientTransport+Posix.swift
+++ b/Sources/GRPCHTTP2TransportNIOPosix/HTTP2ClientTransport+Posix.swift
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import GRPCCore
-import GRPCHTTP2Core
-import NIOCore
-import NIOPosix
+public import GRPCHTTP2Core // should be @usableFromInline
+public import GRPCCore
+public import NIOCore
+public import NIOPosix // has to be public because of default argument value in init
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension HTTP2ClientTransport {

--- a/Sources/GRPCHTTP2TransportNIOPosix/HTTP2ClientTransport+Posix.swift
+++ b/Sources/GRPCHTTP2TransportNIOPosix/HTTP2ClientTransport+Posix.swift
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-public import GRPCHTTP2Core // should be @usableFromInline
 public import GRPCCore
+public import GRPCHTTP2Core  // should be @usableFromInline
 public import NIOCore
-public import NIOPosix // has to be public because of default argument value in init
+public import NIOPosix  // has to be public because of default argument value in init
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension HTTP2ClientTransport {

--- a/Sources/GRPCHTTP2TransportNIOPosix/HTTP2ServerTransport+Posix.swift
+++ b/Sources/GRPCHTTP2TransportNIOPosix/HTTP2ServerTransport+Posix.swift
@@ -16,11 +16,10 @@
 
 public import GRPCCore
 public import GRPCHTTP2Core
-public import NIOPosix // has to be public because of default argument value in init
-
 import NIOCore
 import NIOExtras
 import NIOHTTP2
+public import NIOPosix  // has to be public because of default argument value in init
 
 extension HTTP2ServerTransport {
   /// A NIOPosix-backed implementation of a server transport.

--- a/Sources/GRPCHTTP2TransportNIOPosix/HTTP2ServerTransport+Posix.swift
+++ b/Sources/GRPCHTTP2TransportNIOPosix/HTTP2ServerTransport+Posix.swift
@@ -16,9 +16,9 @@
 
 public import GRPCCore
 public import GRPCHTTP2Core
-import NIOCore
-import NIOExtras
-import NIOHTTP2
+internal import NIOCore
+internal import NIOExtras
+internal import NIOHTTP2
 public import NIOPosix  // has to be public because of default argument value in init
 
 extension HTTP2ServerTransport {

--- a/Sources/GRPCHTTP2TransportNIOPosix/HTTP2ServerTransport+Posix.swift
+++ b/Sources/GRPCHTTP2TransportNIOPosix/HTTP2ServerTransport+Posix.swift
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-import GRPCCore
-import GRPCHTTP2Core
+public import GRPCCore
+public import GRPCHTTP2Core
+public import NIOPosix // has to be public because of default argument value in init
+
 import NIOCore
 import NIOExtras
 import NIOHTTP2
-import NIOPosix
 
 extension HTTP2ServerTransport {
   /// A NIOPosix-backed implementation of a server transport.

--- a/Sources/GRPCHTTP2TransportNIOPosix/NIOClientBootstrap+SocketAddress.swift
+++ b/Sources/GRPCHTTP2TransportNIOPosix/NIOClientBootstrap+SocketAddress.swift
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import GRPCCore
-import GRPCHTTP2Core
-import NIOCore
-import NIOPosix
+internal import GRPCCore
+internal import GRPCHTTP2Core
+internal import NIOCore
+internal import NIOPosix
 
 extension ClientBootstrap {
   @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)

--- a/Sources/GRPCHTTP2TransportNIOTransportServices/HTTP2ServerTransport+TransportServices.swift
+++ b/Sources/GRPCHTTP2TransportNIOTransportServices/HTTP2ServerTransport+TransportServices.swift
@@ -15,12 +15,13 @@
  */
 
 #if canImport(Network)
-import GRPCCore
-import GRPCHTTP2Core
+public import GRPCCore
+public import NIOTransportServices // has to be public because of default argument value in init
+public import GRPCHTTP2Core
+
 import NIOCore
 import NIOExtras
 import NIOHTTP2
-import NIOTransportServices
 
 extension HTTP2ServerTransport {
   /// A NIO Transport Services-backed implementation of a server transport.

--- a/Sources/GRPCHTTP2TransportNIOTransportServices/HTTP2ServerTransport+TransportServices.swift
+++ b/Sources/GRPCHTTP2TransportNIOTransportServices/HTTP2ServerTransport+TransportServices.swift
@@ -19,9 +19,9 @@ public import GRPCCore
 public import NIOTransportServices  // has to be public because of default argument value in init
 public import GRPCHTTP2Core
 
-import NIOCore
-import NIOExtras
-import NIOHTTP2
+internal import NIOCore
+internal import NIOExtras
+internal import NIOHTTP2
 
 extension HTTP2ServerTransport {
   /// A NIO Transport Services-backed implementation of a server transport.

--- a/Sources/GRPCHTTP2TransportNIOTransportServices/HTTP2ServerTransport+TransportServices.swift
+++ b/Sources/GRPCHTTP2TransportNIOTransportServices/HTTP2ServerTransport+TransportServices.swift
@@ -16,7 +16,7 @@
 
 #if canImport(Network)
 public import GRPCCore
-public import NIOTransportServices // has to be public because of default argument value in init
+public import NIOTransportServices  // has to be public because of default argument value in init
 public import GRPCHTTP2Core
 
 import NIOCore

--- a/Sources/GRPCInProcessTransport/InProcessClientTransport.swift
+++ b/Sources/GRPCInProcessTransport/InProcessClientTransport.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import GRPCCore
+public import GRPCCore
 
 /// An in-process implementation of a ``ClientTransport``.
 ///

--- a/Sources/GRPCInProcessTransport/InProcessServerTransport.swift
+++ b/Sources/GRPCInProcessTransport/InProcessServerTransport.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import GRPCCore
+public import GRPCCore
 
 /// An in-process implementation of a ``ServerTransport``.
 ///

--- a/Sources/GRPCInProcessTransport/InProcessTransport.swift
+++ b/Sources/GRPCInProcessTransport/InProcessTransport.swift
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import GRPCCore
+
+public import GRPCCore
 
 public enum InProcessTransport {
   /// Returns a pair containing an ``InProcessServerTransport`` and an ``InProcessClientTransport``.

--- a/Sources/GRPCInterceptors/ClientTracingInterceptor.swift
+++ b/Sources/GRPCInterceptors/ClientTracingInterceptor.swift
@@ -15,7 +15,7 @@
  */
 
 public import GRPCCore
-import Tracing
+internal import Tracing
 
 /// A client interceptor that injects tracing information into the request.
 ///

--- a/Sources/GRPCInterceptors/ClientTracingInterceptor.swift
+++ b/Sources/GRPCInterceptors/ClientTracingInterceptor.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import GRPCCore
+public import GRPCCore
 import Tracing
 
 /// A client interceptor that injects tracing information into the request.

--- a/Sources/GRPCInterceptors/HookedWriter.swift
+++ b/Sources/GRPCInterceptors/HookedWriter.swift
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import GRPCCore
-import Tracing
+internal import GRPCCore
+internal import Tracing
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 struct HookedWriter<Element>: RPCWriterProtocol {

--- a/Sources/GRPCInterceptors/ServerTracingInterceptor.swift
+++ b/Sources/GRPCInterceptors/ServerTracingInterceptor.swift
@@ -15,7 +15,7 @@
  */
 
 public import GRPCCore
-import Tracing
+internal import Tracing
 
 /// A server interceptor that extracts tracing information from the request.
 ///

--- a/Sources/GRPCInterceptors/ServerTracingInterceptor.swift
+++ b/Sources/GRPCInterceptors/ServerTracingInterceptor.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import GRPCCore
+public import GRPCCore
 import Tracing
 
 /// A server interceptor that extracts tracing information from the request.

--- a/Sources/GRPCProtobuf/Coding.swift
+++ b/Sources/GRPCProtobuf/Coding.swift
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import GRPCCore
-import SwiftProtobuf
+public import GRPCCore
+public import SwiftProtobuf
 
 /// Serializes a Protobuf message into a sequence of bytes.
 public struct ProtobufSerializer<Message: SwiftProtobuf.Message>: GRPCCore.MessageSerializer {

--- a/Sources/GRPCProtobufCodeGen/ProtobufCodeGenParser.swift
+++ b/Sources/GRPCProtobufCodeGen/ProtobufCodeGenParser.swift
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import Foundation
-import SwiftProtobuf
-import SwiftProtobufPluginLibrary
+internal import Foundation
+internal import SwiftProtobuf
+internal import SwiftProtobufPluginLibrary
 
-import struct GRPCCodeGen.CodeGenerationRequest
+internal import struct GRPCCodeGen.CodeGenerationRequest
 
 /// Parses a ``FileDescriptor`` object into a ``CodeGenerationRequest`` object.
 internal struct ProtobufCodeGenParser {

--- a/Sources/GRPCProtobufCodeGen/ProtobufCodeGenerator.swift
+++ b/Sources/GRPCProtobufCodeGen/ProtobufCodeGenerator.swift
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import GRPCCodeGen
-import SwiftProtobufPluginLibrary
+public import GRPCCodeGen
+public import SwiftProtobufPluginLibrary
 
 public struct ProtobufCodeGenerator {
   internal var configuration: SourceGenerator.Configuration


### PR DESCRIPTION
Starting with Swift 5.10, `InternalImportsByDefault` is an optional feature flag to make all `import` statements be `internal` by default, instead of `public`, which has been the default since the beginning in Swift.
With a future language mode, this will become the new default, and all imports will be `internal` unless otherwise specified. The main reason for this change is to minimise dependency creep.

This PR enables the feature flag on v2 modules, and adds `public`/`package` access modifiers to `import`s where required.

Note that sadly, `@usableFromInline` has not been implemented for `import` statements, so in `@inlinable`/`@usableFromInline` contexts where non-publicly-imported types are used, the only workaround for now is to import the module as `public`. I've left a comment next to these imports.