### PR TITLE
Update generated code to use service descriptors

### DIFF
--- a/Sources/Examples/v2/Echo/Generated/echo.grpc.swift
+++ b/Sources/Examples/v2/Echo/Generated/echo.grpc.swift
@@ -25,7 +25,7 @@ import GRPCCore
 import GRPCProtobuf
 
 internal enum Echo_Echo {
-    internal static let serviceDescriptor = ServiceDescriptor(
+    internal static let descriptor = ServiceDescriptor(
         package: "echo",
         service: "Echo"
     )
@@ -34,7 +34,7 @@ internal enum Echo_Echo {
             internal typealias Input = Echo_EchoRequest
             internal typealias Output = Echo_EchoResponse
             internal static let descriptor = MethodDescriptor(
-                service: Echo_Echo.serviceDescriptor.fullyQualifiedService,
+                service: Echo_Echo.descriptor.fullyQualifiedService,
                 method: "Get"
             )
         }
@@ -42,7 +42,7 @@ internal enum Echo_Echo {
             internal typealias Input = Echo_EchoRequest
             internal typealias Output = Echo_EchoResponse
             internal static let descriptor = MethodDescriptor(
-                service: Echo_Echo.serviceDescriptor.fullyQualifiedService,
+                service: Echo_Echo.descriptor.fullyQualifiedService,
                 method: "Expand"
             )
         }
@@ -50,7 +50,7 @@ internal enum Echo_Echo {
             internal typealias Input = Echo_EchoRequest
             internal typealias Output = Echo_EchoResponse
             internal static let descriptor = MethodDescriptor(
-                service: Echo_Echo.serviceDescriptor.fullyQualifiedService,
+                service: Echo_Echo.descriptor.fullyQualifiedService,
                 method: "Collect"
             )
         }
@@ -58,7 +58,7 @@ internal enum Echo_Echo {
             internal typealias Input = Echo_EchoRequest
             internal typealias Output = Echo_EchoResponse
             internal static let descriptor = MethodDescriptor(
-                service: Echo_Echo.serviceDescriptor.fullyQualifiedService,
+                service: Echo_Echo.descriptor.fullyQualifiedService,
                 method: "Update"
             )
         }
@@ -80,7 +80,7 @@ internal enum Echo_Echo {
 }
 
 extension ServiceDescriptor {
-    internal static let echo_Echo: ServiceDescriptor = Echo_Echo.serviceDescriptor
+    internal static let echo_Echo: ServiceDescriptor = Echo_Echo.descriptor
 }
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)

--- a/Sources/Examples/v2/Echo/Generated/echo.grpc.swift
+++ b/Sources/Examples/v2/Echo/Generated/echo.grpc.swift
@@ -25,12 +25,16 @@ import GRPCCore
 import GRPCProtobuf
 
 internal enum Echo_Echo {
+    internal static let serviceDescriptor = ServiceDescriptor(
+        package: "echo",
+        service: "Echo"
+    )
     internal enum Method {
         internal enum Get {
             internal typealias Input = Echo_EchoRequest
             internal typealias Output = Echo_EchoResponse
             internal static let descriptor = MethodDescriptor(
-                service: "echo.Echo",
+                service: Echo_Echo.serviceDescriptor.fullyQualifiedService,
                 method: "Get"
             )
         }
@@ -38,7 +42,7 @@ internal enum Echo_Echo {
             internal typealias Input = Echo_EchoRequest
             internal typealias Output = Echo_EchoResponse
             internal static let descriptor = MethodDescriptor(
-                service: "echo.Echo",
+                service: Echo_Echo.serviceDescriptor.fullyQualifiedService,
                 method: "Expand"
             )
         }
@@ -46,7 +50,7 @@ internal enum Echo_Echo {
             internal typealias Input = Echo_EchoRequest
             internal typealias Output = Echo_EchoResponse
             internal static let descriptor = MethodDescriptor(
-                service: "echo.Echo",
+                service: Echo_Echo.serviceDescriptor.fullyQualifiedService,
                 method: "Collect"
             )
         }
@@ -54,7 +58,7 @@ internal enum Echo_Echo {
             internal typealias Input = Echo_EchoRequest
             internal typealias Output = Echo_EchoResponse
             internal static let descriptor = MethodDescriptor(
-                service: "echo.Echo",
+                service: Echo_Echo.serviceDescriptor.fullyQualifiedService,
                 method: "Update"
             )
         }
@@ -73,6 +77,10 @@ internal enum Echo_Echo {
     internal typealias ClientProtocol = Echo_EchoClientProtocol
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     internal typealias Client = Echo_EchoClient
+}
+
+extension ServiceDescriptor {
+    internal static let echo_Echo: ServiceDescriptor = Echo_Echo.serviceDescriptor
 }
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)

--- a/Sources/Examples/v2/Echo/Generated/echo.grpc.swift
+++ b/Sources/Examples/v2/Echo/Generated/echo.grpc.swift
@@ -25,10 +25,7 @@ import GRPCCore
 import GRPCProtobuf
 
 internal enum Echo_Echo {
-    internal static let descriptor = ServiceDescriptor(
-        package: "echo",
-        service: "Echo"
-    )
+    internal static let descriptor = ServiceDescriptor.echo_Echo
     internal enum Method {
         internal enum Get {
             internal typealias Input = Echo_EchoRequest
@@ -80,7 +77,10 @@ internal enum Echo_Echo {
 }
 
 extension ServiceDescriptor {
-    internal static let echo_Echo: ServiceDescriptor = Echo_Echo.descriptor
+    internal static let echo_Echo = Self(
+        package: "echo",
+        service: "Echo"
+    )
 }
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)

--- a/Sources/GRPCCodeGen/CodeGenerationRequest.swift
+++ b/Sources/GRPCCodeGen/CodeGenerationRequest.swift
@@ -321,3 +321,12 @@ public struct CodeGenerationRequest {
     }
   }
 }
+
+extension CodeGenerationRequest.Name {
+  /// The base name replacing occurrences of "." with "_".
+  ///
+  /// For example, if `base` is "Foo.Bar", then `normalizedBase` is "Foo_Bar".
+  public var normalizedBase: String {
+    return self.base.replacingOccurrences(of: ".", with: "_")
+  }
+}

--- a/Sources/GRPCCodeGen/Internal/Translator/TypealiasTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/TypealiasTranslator.swift
@@ -308,10 +308,10 @@ extension TypealiasTranslator {
     if service.namespace.normalizedBase.isEmpty {
       prefix = ""
     } else {
-      prefix = "\(service.namespace.normalizedBase)_"
+      prefix = service.namespace.normalizedBase + "_"
     }
 
-    return "\(prefix)\(service.name.normalizedBase)"
+    return prefix + service.name.normalizedBase
   }
 
   private func makeStaticServiceDescriptorProperty(

--- a/Sources/InteroperabilityTests/Generated/empty_service.grpc.swift
+++ b/Sources/InteroperabilityTests/Generated/empty_service.grpc.swift
@@ -25,7 +25,7 @@ import GRPCCore
 import GRPCProtobuf
 
 public enum Grpc_Testing_EmptyService {
-    public static let serviceDescriptor = ServiceDescriptor(
+    public static let descriptor = ServiceDescriptor(
         package: "grpc.testing",
         service: "EmptyService"
     )
@@ -43,7 +43,7 @@ public enum Grpc_Testing_EmptyService {
 }
 
 extension ServiceDescriptor {
-    public static let grpc_testing_EmptyService: ServiceDescriptor = Grpc_Testing_EmptyService.serviceDescriptor
+    public static let grpc_testing_EmptyService: ServiceDescriptor = Grpc_Testing_EmptyService.descriptor
 }
 
 /// A service that has zero methods.

--- a/Sources/InteroperabilityTests/Generated/empty_service.grpc.swift
+++ b/Sources/InteroperabilityTests/Generated/empty_service.grpc.swift
@@ -25,6 +25,10 @@ import GRPCCore
 import GRPCProtobuf
 
 public enum Grpc_Testing_EmptyService {
+    public static let serviceDescriptor = ServiceDescriptor(
+        package: "grpc.testing",
+        service: "EmptyService"
+    )
     public enum Method {
         public static let descriptors: [MethodDescriptor] = []
     }
@@ -36,6 +40,10 @@ public enum Grpc_Testing_EmptyService {
     public typealias ClientProtocol = Grpc_Testing_EmptyServiceClientProtocol
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     public typealias Client = Grpc_Testing_EmptyServiceClient
+}
+
+extension ServiceDescriptor {
+    public static let grpc_testing_EmptyService: ServiceDescriptor = Grpc_Testing_EmptyService.serviceDescriptor
 }
 
 /// A service that has zero methods.

--- a/Sources/InteroperabilityTests/Generated/empty_service.grpc.swift
+++ b/Sources/InteroperabilityTests/Generated/empty_service.grpc.swift
@@ -25,10 +25,7 @@ import GRPCCore
 import GRPCProtobuf
 
 public enum Grpc_Testing_EmptyService {
-    public static let descriptor = ServiceDescriptor(
-        package: "grpc.testing",
-        service: "EmptyService"
-    )
+    public static let descriptor = ServiceDescriptor.grpc_testing_EmptyService
     public enum Method {
         public static let descriptors: [MethodDescriptor] = []
     }
@@ -43,7 +40,10 @@ public enum Grpc_Testing_EmptyService {
 }
 
 extension ServiceDescriptor {
-    public static let grpc_testing_EmptyService: ServiceDescriptor = Grpc_Testing_EmptyService.descriptor
+    public static let grpc_testing_EmptyService = Self(
+        package: "grpc.testing",
+        service: "EmptyService"
+    )
 }
 
 /// A service that has zero methods.

--- a/Sources/InteroperabilityTests/Generated/test.grpc.swift
+++ b/Sources/InteroperabilityTests/Generated/test.grpc.swift
@@ -28,12 +28,16 @@ import GRPCCore
 import GRPCProtobuf
 
 public enum Grpc_Testing_ReconnectService {
+    public static let serviceDescriptor = ServiceDescriptor(
+        package: "grpc.testing",
+        service: "ReconnectService"
+    )
     public enum Method {
         public enum Start {
             public typealias Input = Grpc_Testing_ReconnectParams
             public typealias Output = Grpc_Testing_Empty
             public static let descriptor = MethodDescriptor(
-                service: "grpc.testing.ReconnectService",
+                service: Grpc_Testing_ReconnectService.serviceDescriptor.fullyQualifiedService,
                 method: "Start"
             )
         }
@@ -41,7 +45,7 @@ public enum Grpc_Testing_ReconnectService {
             public typealias Input = Grpc_Testing_Empty
             public typealias Output = Grpc_Testing_ReconnectInfo
             public static let descriptor = MethodDescriptor(
-                service: "grpc.testing.ReconnectService",
+                service: Grpc_Testing_ReconnectService.serviceDescriptor.fullyQualifiedService,
                 method: "Stop"
             )
         }
@@ -60,13 +64,21 @@ public enum Grpc_Testing_ReconnectService {
     public typealias Client = Grpc_Testing_ReconnectServiceClient
 }
 
+extension ServiceDescriptor {
+    public static let grpc_testing_ReconnectService: ServiceDescriptor = Grpc_Testing_ReconnectService.serviceDescriptor
+}
+
 public enum Grpc_Testing_TestService {
+    public static let serviceDescriptor = ServiceDescriptor(
+        package: "grpc.testing",
+        service: "TestService"
+    )
     public enum Method {
         public enum EmptyCall {
             public typealias Input = Grpc_Testing_Empty
             public typealias Output = Grpc_Testing_Empty
             public static let descriptor = MethodDescriptor(
-                service: "grpc.testing.TestService",
+                service: Grpc_Testing_TestService.serviceDescriptor.fullyQualifiedService,
                 method: "EmptyCall"
             )
         }
@@ -74,7 +86,7 @@ public enum Grpc_Testing_TestService {
             public typealias Input = Grpc_Testing_SimpleRequest
             public typealias Output = Grpc_Testing_SimpleResponse
             public static let descriptor = MethodDescriptor(
-                service: "grpc.testing.TestService",
+                service: Grpc_Testing_TestService.serviceDescriptor.fullyQualifiedService,
                 method: "UnaryCall"
             )
         }
@@ -82,7 +94,7 @@ public enum Grpc_Testing_TestService {
             public typealias Input = Grpc_Testing_SimpleRequest
             public typealias Output = Grpc_Testing_SimpleResponse
             public static let descriptor = MethodDescriptor(
-                service: "grpc.testing.TestService",
+                service: Grpc_Testing_TestService.serviceDescriptor.fullyQualifiedService,
                 method: "CacheableUnaryCall"
             )
         }
@@ -90,7 +102,7 @@ public enum Grpc_Testing_TestService {
             public typealias Input = Grpc_Testing_StreamingOutputCallRequest
             public typealias Output = Grpc_Testing_StreamingOutputCallResponse
             public static let descriptor = MethodDescriptor(
-                service: "grpc.testing.TestService",
+                service: Grpc_Testing_TestService.serviceDescriptor.fullyQualifiedService,
                 method: "StreamingOutputCall"
             )
         }
@@ -98,7 +110,7 @@ public enum Grpc_Testing_TestService {
             public typealias Input = Grpc_Testing_StreamingInputCallRequest
             public typealias Output = Grpc_Testing_StreamingInputCallResponse
             public static let descriptor = MethodDescriptor(
-                service: "grpc.testing.TestService",
+                service: Grpc_Testing_TestService.serviceDescriptor.fullyQualifiedService,
                 method: "StreamingInputCall"
             )
         }
@@ -106,7 +118,7 @@ public enum Grpc_Testing_TestService {
             public typealias Input = Grpc_Testing_StreamingOutputCallRequest
             public typealias Output = Grpc_Testing_StreamingOutputCallResponse
             public static let descriptor = MethodDescriptor(
-                service: "grpc.testing.TestService",
+                service: Grpc_Testing_TestService.serviceDescriptor.fullyQualifiedService,
                 method: "FullDuplexCall"
             )
         }
@@ -114,7 +126,7 @@ public enum Grpc_Testing_TestService {
             public typealias Input = Grpc_Testing_StreamingOutputCallRequest
             public typealias Output = Grpc_Testing_StreamingOutputCallResponse
             public static let descriptor = MethodDescriptor(
-                service: "grpc.testing.TestService",
+                service: Grpc_Testing_TestService.serviceDescriptor.fullyQualifiedService,
                 method: "HalfDuplexCall"
             )
         }
@@ -122,7 +134,7 @@ public enum Grpc_Testing_TestService {
             public typealias Input = Grpc_Testing_Empty
             public typealias Output = Grpc_Testing_Empty
             public static let descriptor = MethodDescriptor(
-                service: "grpc.testing.TestService",
+                service: Grpc_Testing_TestService.serviceDescriptor.fullyQualifiedService,
                 method: "UnimplementedCall"
             )
         }
@@ -147,13 +159,21 @@ public enum Grpc_Testing_TestService {
     public typealias Client = Grpc_Testing_TestServiceClient
 }
 
+extension ServiceDescriptor {
+    public static let grpc_testing_TestService: ServiceDescriptor = Grpc_Testing_TestService.serviceDescriptor
+}
+
 public enum Grpc_Testing_UnimplementedService {
+    public static let serviceDescriptor = ServiceDescriptor(
+        package: "grpc.testing",
+        service: "UnimplementedService"
+    )
     public enum Method {
         public enum UnimplementedCall {
             public typealias Input = Grpc_Testing_Empty
             public typealias Output = Grpc_Testing_Empty
             public static let descriptor = MethodDescriptor(
-                service: "grpc.testing.UnimplementedService",
+                service: Grpc_Testing_UnimplementedService.serviceDescriptor.fullyQualifiedService,
                 method: "UnimplementedCall"
             )
         }
@@ -169,6 +189,10 @@ public enum Grpc_Testing_UnimplementedService {
     public typealias ClientProtocol = Grpc_Testing_UnimplementedServiceClientProtocol
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     public typealias Client = Grpc_Testing_UnimplementedServiceClient
+}
+
+extension ServiceDescriptor {
+    public static let grpc_testing_UnimplementedService: ServiceDescriptor = Grpc_Testing_UnimplementedService.serviceDescriptor
 }
 
 /// A simple service to test the various types of RPCs and experiment with

--- a/Sources/InteroperabilityTests/Generated/test.grpc.swift
+++ b/Sources/InteroperabilityTests/Generated/test.grpc.swift
@@ -28,10 +28,7 @@ import GRPCCore
 import GRPCProtobuf
 
 public enum Grpc_Testing_ReconnectService {
-    public static let descriptor = ServiceDescriptor(
-        package: "grpc.testing",
-        service: "ReconnectService"
-    )
+    public static let descriptor = ServiceDescriptor.grpc_testing_ReconnectService
     public enum Method {
         public enum Start {
             public typealias Input = Grpc_Testing_ReconnectParams
@@ -65,14 +62,14 @@ public enum Grpc_Testing_ReconnectService {
 }
 
 extension ServiceDescriptor {
-    public static let grpc_testing_ReconnectService: ServiceDescriptor = Grpc_Testing_ReconnectService.descriptor
+    public static let grpc_testing_ReconnectService = Self(
+        package: "grpc.testing",
+        service: "ReconnectService"
+    )
 }
 
 public enum Grpc_Testing_TestService {
-    public static let descriptor = ServiceDescriptor(
-        package: "grpc.testing",
-        service: "TestService"
-    )
+    public static let descriptor = ServiceDescriptor.grpc_testing_TestService
     public enum Method {
         public enum EmptyCall {
             public typealias Input = Grpc_Testing_Empty
@@ -160,14 +157,14 @@ public enum Grpc_Testing_TestService {
 }
 
 extension ServiceDescriptor {
-    public static let grpc_testing_TestService: ServiceDescriptor = Grpc_Testing_TestService.descriptor
+    public static let grpc_testing_TestService = Self(
+        package: "grpc.testing",
+        service: "TestService"
+    )
 }
 
 public enum Grpc_Testing_UnimplementedService {
-    public static let descriptor = ServiceDescriptor(
-        package: "grpc.testing",
-        service: "UnimplementedService"
-    )
+    public static let descriptor = ServiceDescriptor.grpc_testing_UnimplementedService
     public enum Method {
         public enum UnimplementedCall {
             public typealias Input = Grpc_Testing_Empty
@@ -192,7 +189,10 @@ public enum Grpc_Testing_UnimplementedService {
 }
 
 extension ServiceDescriptor {
-    public static let grpc_testing_UnimplementedService: ServiceDescriptor = Grpc_Testing_UnimplementedService.descriptor
+    public static let grpc_testing_UnimplementedService = Self(
+        package: "grpc.testing",
+        service: "UnimplementedService"
+    )
 }
 
 /// A simple service to test the various types of RPCs and experiment with

--- a/Sources/InteroperabilityTests/Generated/test.grpc.swift
+++ b/Sources/InteroperabilityTests/Generated/test.grpc.swift
@@ -28,7 +28,7 @@ import GRPCCore
 import GRPCProtobuf
 
 public enum Grpc_Testing_ReconnectService {
-    public static let serviceDescriptor = ServiceDescriptor(
+    public static let descriptor = ServiceDescriptor(
         package: "grpc.testing",
         service: "ReconnectService"
     )
@@ -37,7 +37,7 @@ public enum Grpc_Testing_ReconnectService {
             public typealias Input = Grpc_Testing_ReconnectParams
             public typealias Output = Grpc_Testing_Empty
             public static let descriptor = MethodDescriptor(
-                service: Grpc_Testing_ReconnectService.serviceDescriptor.fullyQualifiedService,
+                service: Grpc_Testing_ReconnectService.descriptor.fullyQualifiedService,
                 method: "Start"
             )
         }
@@ -45,7 +45,7 @@ public enum Grpc_Testing_ReconnectService {
             public typealias Input = Grpc_Testing_Empty
             public typealias Output = Grpc_Testing_ReconnectInfo
             public static let descriptor = MethodDescriptor(
-                service: Grpc_Testing_ReconnectService.serviceDescriptor.fullyQualifiedService,
+                service: Grpc_Testing_ReconnectService.descriptor.fullyQualifiedService,
                 method: "Stop"
             )
         }
@@ -65,11 +65,11 @@ public enum Grpc_Testing_ReconnectService {
 }
 
 extension ServiceDescriptor {
-    public static let grpc_testing_ReconnectService: ServiceDescriptor = Grpc_Testing_ReconnectService.serviceDescriptor
+    public static let grpc_testing_ReconnectService: ServiceDescriptor = Grpc_Testing_ReconnectService.descriptor
 }
 
 public enum Grpc_Testing_TestService {
-    public static let serviceDescriptor = ServiceDescriptor(
+    public static let descriptor = ServiceDescriptor(
         package: "grpc.testing",
         service: "TestService"
     )
@@ -78,7 +78,7 @@ public enum Grpc_Testing_TestService {
             public typealias Input = Grpc_Testing_Empty
             public typealias Output = Grpc_Testing_Empty
             public static let descriptor = MethodDescriptor(
-                service: Grpc_Testing_TestService.serviceDescriptor.fullyQualifiedService,
+                service: Grpc_Testing_TestService.descriptor.fullyQualifiedService,
                 method: "EmptyCall"
             )
         }
@@ -86,7 +86,7 @@ public enum Grpc_Testing_TestService {
             public typealias Input = Grpc_Testing_SimpleRequest
             public typealias Output = Grpc_Testing_SimpleResponse
             public static let descriptor = MethodDescriptor(
-                service: Grpc_Testing_TestService.serviceDescriptor.fullyQualifiedService,
+                service: Grpc_Testing_TestService.descriptor.fullyQualifiedService,
                 method: "UnaryCall"
             )
         }
@@ -94,7 +94,7 @@ public enum Grpc_Testing_TestService {
             public typealias Input = Grpc_Testing_SimpleRequest
             public typealias Output = Grpc_Testing_SimpleResponse
             public static let descriptor = MethodDescriptor(
-                service: Grpc_Testing_TestService.serviceDescriptor.fullyQualifiedService,
+                service: Grpc_Testing_TestService.descriptor.fullyQualifiedService,
                 method: "CacheableUnaryCall"
             )
         }
@@ -102,7 +102,7 @@ public enum Grpc_Testing_TestService {
             public typealias Input = Grpc_Testing_StreamingOutputCallRequest
             public typealias Output = Grpc_Testing_StreamingOutputCallResponse
             public static let descriptor = MethodDescriptor(
-                service: Grpc_Testing_TestService.serviceDescriptor.fullyQualifiedService,
+                service: Grpc_Testing_TestService.descriptor.fullyQualifiedService,
                 method: "StreamingOutputCall"
             )
         }
@@ -110,7 +110,7 @@ public enum Grpc_Testing_TestService {
             public typealias Input = Grpc_Testing_StreamingInputCallRequest
             public typealias Output = Grpc_Testing_StreamingInputCallResponse
             public static let descriptor = MethodDescriptor(
-                service: Grpc_Testing_TestService.serviceDescriptor.fullyQualifiedService,
+                service: Grpc_Testing_TestService.descriptor.fullyQualifiedService,
                 method: "StreamingInputCall"
             )
         }
@@ -118,7 +118,7 @@ public enum Grpc_Testing_TestService {
             public typealias Input = Grpc_Testing_StreamingOutputCallRequest
             public typealias Output = Grpc_Testing_StreamingOutputCallResponse
             public static let descriptor = MethodDescriptor(
-                service: Grpc_Testing_TestService.serviceDescriptor.fullyQualifiedService,
+                service: Grpc_Testing_TestService.descriptor.fullyQualifiedService,
                 method: "FullDuplexCall"
             )
         }
@@ -126,7 +126,7 @@ public enum Grpc_Testing_TestService {
             public typealias Input = Grpc_Testing_StreamingOutputCallRequest
             public typealias Output = Grpc_Testing_StreamingOutputCallResponse
             public static let descriptor = MethodDescriptor(
-                service: Grpc_Testing_TestService.serviceDescriptor.fullyQualifiedService,
+                service: Grpc_Testing_TestService.descriptor.fullyQualifiedService,
                 method: "HalfDuplexCall"
             )
         }
@@ -134,7 +134,7 @@ public enum Grpc_Testing_TestService {
             public typealias Input = Grpc_Testing_Empty
             public typealias Output = Grpc_Testing_Empty
             public static let descriptor = MethodDescriptor(
-                service: Grpc_Testing_TestService.serviceDescriptor.fullyQualifiedService,
+                service: Grpc_Testing_TestService.descriptor.fullyQualifiedService,
                 method: "UnimplementedCall"
             )
         }
@@ -160,11 +160,11 @@ public enum Grpc_Testing_TestService {
 }
 
 extension ServiceDescriptor {
-    public static let grpc_testing_TestService: ServiceDescriptor = Grpc_Testing_TestService.serviceDescriptor
+    public static let grpc_testing_TestService: ServiceDescriptor = Grpc_Testing_TestService.descriptor
 }
 
 public enum Grpc_Testing_UnimplementedService {
-    public static let serviceDescriptor = ServiceDescriptor(
+    public static let descriptor = ServiceDescriptor(
         package: "grpc.testing",
         service: "UnimplementedService"
     )
@@ -173,7 +173,7 @@ public enum Grpc_Testing_UnimplementedService {
             public typealias Input = Grpc_Testing_Empty
             public typealias Output = Grpc_Testing_Empty
             public static let descriptor = MethodDescriptor(
-                service: Grpc_Testing_UnimplementedService.serviceDescriptor.fullyQualifiedService,
+                service: Grpc_Testing_UnimplementedService.descriptor.fullyQualifiedService,
                 method: "UnimplementedCall"
             )
         }
@@ -192,7 +192,7 @@ public enum Grpc_Testing_UnimplementedService {
 }
 
 extension ServiceDescriptor {
-    public static let grpc_testing_UnimplementedService: ServiceDescriptor = Grpc_Testing_UnimplementedService.serviceDescriptor
+    public static let grpc_testing_UnimplementedService: ServiceDescriptor = Grpc_Testing_UnimplementedService.descriptor
 }
 
 /// A simple service to test the various types of RPCs and experiment with

--- a/Sources/Services/Health/Generated/health.grpc.swift
+++ b/Sources/Services/Health/Generated/health.grpc.swift
@@ -28,7 +28,7 @@ import GRPCCore
 import GRPCProtobuf
 
 internal enum Grpc_Health_V1_Health {
-    internal static let serviceDescriptor = ServiceDescriptor(
+    internal static let descriptor = ServiceDescriptor(
         package: "grpc.health.v1",
         service: "Health"
     )
@@ -37,7 +37,7 @@ internal enum Grpc_Health_V1_Health {
             internal typealias Input = Grpc_Health_V1_HealthCheckRequest
             internal typealias Output = Grpc_Health_V1_HealthCheckResponse
             internal static let descriptor = MethodDescriptor(
-                service: Grpc_Health_V1_Health.serviceDescriptor.fullyQualifiedService,
+                service: Grpc_Health_V1_Health.descriptor.fullyQualifiedService,
                 method: "Check"
             )
         }
@@ -45,7 +45,7 @@ internal enum Grpc_Health_V1_Health {
             internal typealias Input = Grpc_Health_V1_HealthCheckRequest
             internal typealias Output = Grpc_Health_V1_HealthCheckResponse
             internal static let descriptor = MethodDescriptor(
-                service: Grpc_Health_V1_Health.serviceDescriptor.fullyQualifiedService,
+                service: Grpc_Health_V1_Health.descriptor.fullyQualifiedService,
                 method: "Watch"
             )
         }
@@ -61,7 +61,7 @@ internal enum Grpc_Health_V1_Health {
 }
 
 extension ServiceDescriptor {
-    internal static let grpc_health_v1_Health: ServiceDescriptor = Grpc_Health_V1_Health.serviceDescriptor
+    internal static let grpc_health_v1_Health: ServiceDescriptor = Grpc_Health_V1_Health.descriptor
 }
 
 /// Health is gRPC's mechanism for checking whether a server is able to handle

--- a/Sources/Services/Health/Generated/health.grpc.swift
+++ b/Sources/Services/Health/Generated/health.grpc.swift
@@ -28,10 +28,7 @@ import GRPCCore
 import GRPCProtobuf
 
 internal enum Grpc_Health_V1_Health {
-    internal static let descriptor = ServiceDescriptor(
-        package: "grpc.health.v1",
-        service: "Health"
-    )
+    internal static let descriptor = ServiceDescriptor.grpc_health_v1_Health
     internal enum Method {
         internal enum Check {
             internal typealias Input = Grpc_Health_V1_HealthCheckRequest
@@ -61,7 +58,10 @@ internal enum Grpc_Health_V1_Health {
 }
 
 extension ServiceDescriptor {
-    internal static let grpc_health_v1_Health: ServiceDescriptor = Grpc_Health_V1_Health.descriptor
+    internal static let grpc_health_v1_Health = Self(
+        package: "grpc.health.v1",
+        service: "Health"
+    )
 }
 
 /// Health is gRPC's mechanism for checking whether a server is able to handle

--- a/Sources/Services/Health/Generated/health.grpc.swift
+++ b/Sources/Services/Health/Generated/health.grpc.swift
@@ -28,12 +28,16 @@ import GRPCCore
 import GRPCProtobuf
 
 internal enum Grpc_Health_V1_Health {
+    internal static let serviceDescriptor = ServiceDescriptor(
+        package: "grpc.health.v1",
+        service: "Health"
+    )
     internal enum Method {
         internal enum Check {
             internal typealias Input = Grpc_Health_V1_HealthCheckRequest
             internal typealias Output = Grpc_Health_V1_HealthCheckResponse
             internal static let descriptor = MethodDescriptor(
-                service: "grpc.health.v1.Health",
+                service: Grpc_Health_V1_Health.serviceDescriptor.fullyQualifiedService,
                 method: "Check"
             )
         }
@@ -41,7 +45,7 @@ internal enum Grpc_Health_V1_Health {
             internal typealias Input = Grpc_Health_V1_HealthCheckRequest
             internal typealias Output = Grpc_Health_V1_HealthCheckResponse
             internal static let descriptor = MethodDescriptor(
-                service: "grpc.health.v1.Health",
+                service: Grpc_Health_V1_Health.serviceDescriptor.fullyQualifiedService,
                 method: "Watch"
             )
         }
@@ -54,6 +58,10 @@ internal enum Grpc_Health_V1_Health {
     internal typealias StreamingServiceProtocol = Grpc_Health_V1_HealthStreamingServiceProtocol
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     internal typealias ServiceProtocol = Grpc_Health_V1_HealthServiceProtocol
+}
+
+extension ServiceDescriptor {
+    internal static let grpc_health_v1_Health: ServiceDescriptor = Grpc_Health_V1_Health.serviceDescriptor
 }
 
 /// Health is gRPC's mechanism for checking whether a server is able to handle

--- a/Sources/performance-worker/Generated/grpc_testing_benchmark_service.grpc.swift
+++ b/Sources/performance-worker/Generated/grpc_testing_benchmark_service.grpc.swift
@@ -28,10 +28,7 @@ import GRPCCore
 import GRPCProtobuf
 
 internal enum Grpc_Testing_BenchmarkService {
-    internal static let descriptor = ServiceDescriptor(
-        package: "grpc.testing",
-        service: "BenchmarkService"
-    )
+    internal static let descriptor = ServiceDescriptor.grpc_testing_BenchmarkService
     internal enum Method {
         internal enum UnaryCall {
             internal typealias Input = Grpc_Testing_SimpleRequest
@@ -92,7 +89,10 @@ internal enum Grpc_Testing_BenchmarkService {
 }
 
 extension ServiceDescriptor {
-    internal static let grpc_testing_BenchmarkService: ServiceDescriptor = Grpc_Testing_BenchmarkService.descriptor
+    internal static let grpc_testing_BenchmarkService = Self(
+        package: "grpc.testing",
+        service: "BenchmarkService"
+    )
 }
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)

--- a/Sources/performance-worker/Generated/grpc_testing_benchmark_service.grpc.swift
+++ b/Sources/performance-worker/Generated/grpc_testing_benchmark_service.grpc.swift
@@ -28,7 +28,7 @@ import GRPCCore
 import GRPCProtobuf
 
 internal enum Grpc_Testing_BenchmarkService {
-    internal static let serviceDescriptor = ServiceDescriptor(
+    internal static let descriptor = ServiceDescriptor(
         package: "grpc.testing",
         service: "BenchmarkService"
     )
@@ -37,7 +37,7 @@ internal enum Grpc_Testing_BenchmarkService {
             internal typealias Input = Grpc_Testing_SimpleRequest
             internal typealias Output = Grpc_Testing_SimpleResponse
             internal static let descriptor = MethodDescriptor(
-                service: Grpc_Testing_BenchmarkService.serviceDescriptor.fullyQualifiedService,
+                service: Grpc_Testing_BenchmarkService.descriptor.fullyQualifiedService,
                 method: "UnaryCall"
             )
         }
@@ -45,7 +45,7 @@ internal enum Grpc_Testing_BenchmarkService {
             internal typealias Input = Grpc_Testing_SimpleRequest
             internal typealias Output = Grpc_Testing_SimpleResponse
             internal static let descriptor = MethodDescriptor(
-                service: Grpc_Testing_BenchmarkService.serviceDescriptor.fullyQualifiedService,
+                service: Grpc_Testing_BenchmarkService.descriptor.fullyQualifiedService,
                 method: "StreamingCall"
             )
         }
@@ -53,7 +53,7 @@ internal enum Grpc_Testing_BenchmarkService {
             internal typealias Input = Grpc_Testing_SimpleRequest
             internal typealias Output = Grpc_Testing_SimpleResponse
             internal static let descriptor = MethodDescriptor(
-                service: Grpc_Testing_BenchmarkService.serviceDescriptor.fullyQualifiedService,
+                service: Grpc_Testing_BenchmarkService.descriptor.fullyQualifiedService,
                 method: "StreamingFromClient"
             )
         }
@@ -61,7 +61,7 @@ internal enum Grpc_Testing_BenchmarkService {
             internal typealias Input = Grpc_Testing_SimpleRequest
             internal typealias Output = Grpc_Testing_SimpleResponse
             internal static let descriptor = MethodDescriptor(
-                service: Grpc_Testing_BenchmarkService.serviceDescriptor.fullyQualifiedService,
+                service: Grpc_Testing_BenchmarkService.descriptor.fullyQualifiedService,
                 method: "StreamingFromServer"
             )
         }
@@ -69,7 +69,7 @@ internal enum Grpc_Testing_BenchmarkService {
             internal typealias Input = Grpc_Testing_SimpleRequest
             internal typealias Output = Grpc_Testing_SimpleResponse
             internal static let descriptor = MethodDescriptor(
-                service: Grpc_Testing_BenchmarkService.serviceDescriptor.fullyQualifiedService,
+                service: Grpc_Testing_BenchmarkService.descriptor.fullyQualifiedService,
                 method: "StreamingBothWays"
             )
         }
@@ -92,7 +92,7 @@ internal enum Grpc_Testing_BenchmarkService {
 }
 
 extension ServiceDescriptor {
-    internal static let grpc_testing_BenchmarkService: ServiceDescriptor = Grpc_Testing_BenchmarkService.serviceDescriptor
+    internal static let grpc_testing_BenchmarkService: ServiceDescriptor = Grpc_Testing_BenchmarkService.descriptor
 }
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)

--- a/Sources/performance-worker/Generated/grpc_testing_benchmark_service.grpc.swift
+++ b/Sources/performance-worker/Generated/grpc_testing_benchmark_service.grpc.swift
@@ -28,12 +28,16 @@ import GRPCCore
 import GRPCProtobuf
 
 internal enum Grpc_Testing_BenchmarkService {
+    internal static let serviceDescriptor = ServiceDescriptor(
+        package: "grpc.testing",
+        service: "BenchmarkService"
+    )
     internal enum Method {
         internal enum UnaryCall {
             internal typealias Input = Grpc_Testing_SimpleRequest
             internal typealias Output = Grpc_Testing_SimpleResponse
             internal static let descriptor = MethodDescriptor(
-                service: "grpc.testing.BenchmarkService",
+                service: Grpc_Testing_BenchmarkService.serviceDescriptor.fullyQualifiedService,
                 method: "UnaryCall"
             )
         }
@@ -41,7 +45,7 @@ internal enum Grpc_Testing_BenchmarkService {
             internal typealias Input = Grpc_Testing_SimpleRequest
             internal typealias Output = Grpc_Testing_SimpleResponse
             internal static let descriptor = MethodDescriptor(
-                service: "grpc.testing.BenchmarkService",
+                service: Grpc_Testing_BenchmarkService.serviceDescriptor.fullyQualifiedService,
                 method: "StreamingCall"
             )
         }
@@ -49,7 +53,7 @@ internal enum Grpc_Testing_BenchmarkService {
             internal typealias Input = Grpc_Testing_SimpleRequest
             internal typealias Output = Grpc_Testing_SimpleResponse
             internal static let descriptor = MethodDescriptor(
-                service: "grpc.testing.BenchmarkService",
+                service: Grpc_Testing_BenchmarkService.serviceDescriptor.fullyQualifiedService,
                 method: "StreamingFromClient"
             )
         }
@@ -57,7 +61,7 @@ internal enum Grpc_Testing_BenchmarkService {
             internal typealias Input = Grpc_Testing_SimpleRequest
             internal typealias Output = Grpc_Testing_SimpleResponse
             internal static let descriptor = MethodDescriptor(
-                service: "grpc.testing.BenchmarkService",
+                service: Grpc_Testing_BenchmarkService.serviceDescriptor.fullyQualifiedService,
                 method: "StreamingFromServer"
             )
         }
@@ -65,7 +69,7 @@ internal enum Grpc_Testing_BenchmarkService {
             internal typealias Input = Grpc_Testing_SimpleRequest
             internal typealias Output = Grpc_Testing_SimpleResponse
             internal static let descriptor = MethodDescriptor(
-                service: "grpc.testing.BenchmarkService",
+                service: Grpc_Testing_BenchmarkService.serviceDescriptor.fullyQualifiedService,
                 method: "StreamingBothWays"
             )
         }
@@ -85,6 +89,10 @@ internal enum Grpc_Testing_BenchmarkService {
     internal typealias ClientProtocol = Grpc_Testing_BenchmarkServiceClientProtocol
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     internal typealias Client = Grpc_Testing_BenchmarkServiceClient
+}
+
+extension ServiceDescriptor {
+    internal static let grpc_testing_BenchmarkService: ServiceDescriptor = Grpc_Testing_BenchmarkService.serviceDescriptor
 }
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)

--- a/Sources/performance-worker/Generated/grpc_testing_worker_service.grpc.swift
+++ b/Sources/performance-worker/Generated/grpc_testing_worker_service.grpc.swift
@@ -28,12 +28,16 @@ import GRPCCore
 import GRPCProtobuf
 
 internal enum Grpc_Testing_WorkerService {
+    internal static let serviceDescriptor = ServiceDescriptor(
+        package: "grpc.testing",
+        service: "WorkerService"
+    )
     internal enum Method {
         internal enum RunServer {
             internal typealias Input = Grpc_Testing_ServerArgs
             internal typealias Output = Grpc_Testing_ServerStatus
             internal static let descriptor = MethodDescriptor(
-                service: "grpc.testing.WorkerService",
+                service: Grpc_Testing_WorkerService.serviceDescriptor.fullyQualifiedService,
                 method: "RunServer"
             )
         }
@@ -41,7 +45,7 @@ internal enum Grpc_Testing_WorkerService {
             internal typealias Input = Grpc_Testing_ClientArgs
             internal typealias Output = Grpc_Testing_ClientStatus
             internal static let descriptor = MethodDescriptor(
-                service: "grpc.testing.WorkerService",
+                service: Grpc_Testing_WorkerService.serviceDescriptor.fullyQualifiedService,
                 method: "RunClient"
             )
         }
@@ -49,7 +53,7 @@ internal enum Grpc_Testing_WorkerService {
             internal typealias Input = Grpc_Testing_CoreRequest
             internal typealias Output = Grpc_Testing_CoreResponse
             internal static let descriptor = MethodDescriptor(
-                service: "grpc.testing.WorkerService",
+                service: Grpc_Testing_WorkerService.serviceDescriptor.fullyQualifiedService,
                 method: "CoreCount"
             )
         }
@@ -57,7 +61,7 @@ internal enum Grpc_Testing_WorkerService {
             internal typealias Input = Grpc_Testing_Void
             internal typealias Output = Grpc_Testing_Void
             internal static let descriptor = MethodDescriptor(
-                service: "grpc.testing.WorkerService",
+                service: Grpc_Testing_WorkerService.serviceDescriptor.fullyQualifiedService,
                 method: "QuitWorker"
             )
         }
@@ -72,6 +76,10 @@ internal enum Grpc_Testing_WorkerService {
     internal typealias StreamingServiceProtocol = Grpc_Testing_WorkerServiceStreamingServiceProtocol
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     internal typealias ServiceProtocol = Grpc_Testing_WorkerServiceServiceProtocol
+}
+
+extension ServiceDescriptor {
+    internal static let grpc_testing_WorkerService: ServiceDescriptor = Grpc_Testing_WorkerService.serviceDescriptor
 }
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)

--- a/Sources/performance-worker/Generated/grpc_testing_worker_service.grpc.swift
+++ b/Sources/performance-worker/Generated/grpc_testing_worker_service.grpc.swift
@@ -28,10 +28,7 @@ import GRPCCore
 import GRPCProtobuf
 
 internal enum Grpc_Testing_WorkerService {
-    internal static let descriptor = ServiceDescriptor(
-        package: "grpc.testing",
-        service: "WorkerService"
-    )
+    internal static let descriptor = ServiceDescriptor.grpc_testing_WorkerService
     internal enum Method {
         internal enum RunServer {
             internal typealias Input = Grpc_Testing_ServerArgs
@@ -79,7 +76,10 @@ internal enum Grpc_Testing_WorkerService {
 }
 
 extension ServiceDescriptor {
-    internal static let grpc_testing_WorkerService: ServiceDescriptor = Grpc_Testing_WorkerService.descriptor
+    internal static let grpc_testing_WorkerService = Self(
+        package: "grpc.testing",
+        service: "WorkerService"
+    )
 }
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)

--- a/Sources/performance-worker/Generated/grpc_testing_worker_service.grpc.swift
+++ b/Sources/performance-worker/Generated/grpc_testing_worker_service.grpc.swift
@@ -28,7 +28,7 @@ import GRPCCore
 import GRPCProtobuf
 
 internal enum Grpc_Testing_WorkerService {
-    internal static let serviceDescriptor = ServiceDescriptor(
+    internal static let descriptor = ServiceDescriptor(
         package: "grpc.testing",
         service: "WorkerService"
     )
@@ -37,7 +37,7 @@ internal enum Grpc_Testing_WorkerService {
             internal typealias Input = Grpc_Testing_ServerArgs
             internal typealias Output = Grpc_Testing_ServerStatus
             internal static let descriptor = MethodDescriptor(
-                service: Grpc_Testing_WorkerService.serviceDescriptor.fullyQualifiedService,
+                service: Grpc_Testing_WorkerService.descriptor.fullyQualifiedService,
                 method: "RunServer"
             )
         }
@@ -45,7 +45,7 @@ internal enum Grpc_Testing_WorkerService {
             internal typealias Input = Grpc_Testing_ClientArgs
             internal typealias Output = Grpc_Testing_ClientStatus
             internal static let descriptor = MethodDescriptor(
-                service: Grpc_Testing_WorkerService.serviceDescriptor.fullyQualifiedService,
+                service: Grpc_Testing_WorkerService.descriptor.fullyQualifiedService,
                 method: "RunClient"
             )
         }
@@ -53,7 +53,7 @@ internal enum Grpc_Testing_WorkerService {
             internal typealias Input = Grpc_Testing_CoreRequest
             internal typealias Output = Grpc_Testing_CoreResponse
             internal static let descriptor = MethodDescriptor(
-                service: Grpc_Testing_WorkerService.serviceDescriptor.fullyQualifiedService,
+                service: Grpc_Testing_WorkerService.descriptor.fullyQualifiedService,
                 method: "CoreCount"
             )
         }
@@ -61,7 +61,7 @@ internal enum Grpc_Testing_WorkerService {
             internal typealias Input = Grpc_Testing_Void
             internal typealias Output = Grpc_Testing_Void
             internal static let descriptor = MethodDescriptor(
-                service: Grpc_Testing_WorkerService.serviceDescriptor.fullyQualifiedService,
+                service: Grpc_Testing_WorkerService.descriptor.fullyQualifiedService,
                 method: "QuitWorker"
             )
         }
@@ -79,7 +79,7 @@ internal enum Grpc_Testing_WorkerService {
 }
 
 extension ServiceDescriptor {
-    internal static let grpc_testing_WorkerService: ServiceDescriptor = Grpc_Testing_WorkerService.serviceDescriptor
+    internal static let grpc_testing_WorkerService: ServiceDescriptor = Grpc_Testing_WorkerService.descriptor
 }
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)

--- a/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
@@ -171,7 +171,7 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
       @_spi(Secret) import enum Foo.Bar
 
       public enum NamespaceA_ServiceA {
-          public static let serviceDescriptor = ServiceDescriptor(
+          public static let descriptor = ServiceDescriptor(
               package: "namespaceA",
               service: "ServiceA"
           )
@@ -185,7 +185,7 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
       }
 
       extension ServiceDescriptor {
-          public static let namespaceA_ServiceA: ServiceDescriptor = NamespaceA_ServiceA.serviceDescriptor
+          public static let namespaceA_ServiceA: ServiceDescriptor = NamespaceA_ServiceA.descriptor
       }
 
       /// Documentation for AService

--- a/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
@@ -171,10 +171,7 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
       @_spi(Secret) import enum Foo.Bar
 
       public enum NamespaceA_ServiceA {
-          public static let descriptor = ServiceDescriptor(
-              package: "namespaceA",
-              service: "ServiceA"
-          )
+          public static let descriptor = ServiceDescriptor.namespaceA_ServiceA
           public enum Method {
               public static let descriptors: [MethodDescriptor] = []
           }
@@ -185,7 +182,10 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
       }
 
       extension ServiceDescriptor {
-          public static let namespaceA_ServiceA: ServiceDescriptor = NamespaceA_ServiceA.descriptor
+          public static let namespaceA_ServiceA = Self(
+              package: "namespaceA",
+              service: "ServiceA"
+          )
       }
 
       /// Documentation for AService

--- a/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
@@ -171,6 +171,10 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
       @_spi(Secret) import enum Foo.Bar
 
       public enum NamespaceA_ServiceA {
+          public static let serviceDescriptor = ServiceDescriptor(
+              package: "namespaceA",
+              service: "ServiceA"
+          )
           public enum Method {
               public static let descriptors: [MethodDescriptor] = []
           }
@@ -178,6 +182,10 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
           public typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
+      }
+
+      extension ServiceDescriptor {
+          public static let namespaceA_ServiceA: ServiceDescriptor = NamespaceA_ServiceA.serviceDescriptor
       }
 
       /// Documentation for AService

--- a/Tests/GRPCCodeGenTests/Internal/Translator/TypealiasTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/TypealiasTranslatorSnippetBasedTests.swift
@@ -47,12 +47,16 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum NamespaceA_ServiceA {
+          public static let serviceDescriptor = ServiceDescriptor(
+              package: "namespaceA",
+              service: "ServiceA"
+          )
           public enum Method {
               public enum MethodA {
                   public typealias Input = NamespaceA_ServiceARequest
                   public typealias Output = NamespaceA_ServiceAResponse
                   public static let descriptor = MethodDescriptor(
-                      service: "namespaceA.ServiceA",
+                      service: NamespaceA_ServiceA.serviceDescriptor.fullyQualifiedService,
                       method: "MethodA"
                   )
               }
@@ -68,6 +72,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias Client = NamespaceA_ServiceAClient
+      }
+      extension ServiceDescriptor {
+          public static let namespaceA_ServiceA: ServiceDescriptor = NamespaceA_ServiceA.serviceDescriptor
       }
       """
 
@@ -94,6 +101,10 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum NamespaceA_ServiceA {
+          public static let serviceDescriptor = ServiceDescriptor(
+              package: "namespaceA",
+              service: "ServiceA"
+          )
           public enum Method {
               public static let descriptors: [MethodDescriptor] = []
           }
@@ -105,6 +116,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias Client = NamespaceA_ServiceAClient
+      }
+      extension ServiceDescriptor {
+          public static let namespaceA_ServiceA: ServiceDescriptor = NamespaceA_ServiceA.serviceDescriptor
       }
       """
 
@@ -131,6 +145,10 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum NamespaceA_ServiceA {
+          public static let serviceDescriptor = ServiceDescriptor(
+              package: "namespaceA",
+              service: "ServiceA"
+          )
           public enum Method {
               public static let descriptors: [MethodDescriptor] = []
           }
@@ -138,6 +156,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
+      }
+      extension ServiceDescriptor {
+          public static let namespaceA_ServiceA: ServiceDescriptor = NamespaceA_ServiceA.serviceDescriptor
       }
       """
 
@@ -164,6 +185,10 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum NamespaceA_ServiceA {
+          public static let serviceDescriptor = ServiceDescriptor(
+              package: "namespaceA",
+              service: "ServiceA"
+          )
           public enum Method {
               public static let descriptors: [MethodDescriptor] = []
           }
@@ -171,6 +196,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias Client = NamespaceA_ServiceAClient
+      }
+      extension ServiceDescriptor {
+          public static let namespaceA_ServiceA: ServiceDescriptor = NamespaceA_ServiceA.serviceDescriptor
       }
       """
 
@@ -197,9 +225,16 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum NamespaceA_ServiceA {
+          public static let serviceDescriptor = ServiceDescriptor(
+              package: "namespaceA",
+              service: "ServiceA"
+          )
           public enum Method {
               public static let descriptors: [MethodDescriptor] = []
           }
+      }
+      extension ServiceDescriptor {
+          public static let namespaceA_ServiceA: ServiceDescriptor = NamespaceA_ServiceA.serviceDescriptor
       }
       """
 
@@ -230,12 +265,16 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum ServiceA {
+          public static let serviceDescriptor = ServiceDescriptor(
+              package: "",
+              service: "ServiceA"
+          )
           public enum Method {
               public enum MethodA {
                   public typealias Input = ServiceARequest
                   public typealias Output = ServiceAResponse
                   public static let descriptor = MethodDescriptor(
-                      service: "ServiceA",
+                      service: ServiceA.serviceDescriptor.fullyQualifiedService,
                       method: "MethodA"
                   )
               }
@@ -251,6 +290,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public typealias ClientProtocol = ServiceAClientProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias Client = ServiceAClient
+      }
+      extension ServiceDescriptor {
+          public static let serviceA: ServiceDescriptor = ServiceA.serviceDescriptor
       }
       """
 
@@ -293,12 +335,16 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum NamespaceA_ServiceA {
+          public static let serviceDescriptor = ServiceDescriptor(
+              package: "namespaceA",
+              service: "ServiceA"
+          )
           public enum Method {
               public enum MethodA {
                   public typealias Input = NamespaceA_ServiceARequest
                   public typealias Output = NamespaceA_ServiceAResponse
                   public static let descriptor = MethodDescriptor(
-                      service: "namespaceA.ServiceA",
+                      service: NamespaceA_ServiceA.serviceDescriptor.fullyQualifiedService,
                       method: "MethodA"
                   )
               }
@@ -306,7 +352,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
                   public typealias Input = NamespaceA_ServiceARequest
                   public typealias Output = NamespaceA_ServiceAResponse
                   public static let descriptor = MethodDescriptor(
-                      service: "namespaceA.ServiceA",
+                      service: NamespaceA_ServiceA.serviceDescriptor.fullyQualifiedService,
                       method: "MethodB"
                   )
               }
@@ -323,6 +369,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias Client = NamespaceA_ServiceAClient
+      }
+      extension ServiceDescriptor {
+          public static let namespaceA_ServiceA: ServiceDescriptor = NamespaceA_ServiceA.serviceDescriptor
       }
       """
 
@@ -349,6 +398,10 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       package enum NamespaceA_ServiceA {
+          package static let serviceDescriptor = ServiceDescriptor(
+              package: "namespaceA",
+              service: "ServiceA"
+          )
           package enum Method {
               package static let descriptors: [MethodDescriptor] = []
           }
@@ -360,6 +413,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           package typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package typealias Client = NamespaceA_ServiceAClient
+      }
+      extension ServiceDescriptor {
+          package static let namespaceA_ServiceA: ServiceDescriptor = NamespaceA_ServiceA.serviceDescriptor
       }
       """
 
@@ -398,6 +454,10 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum NamespaceA_Aservice {
+          public static let serviceDescriptor = ServiceDescriptor(
+              package: "namespaceA",
+              service: "AService"
+          )
           public enum Method {
               public static let descriptors: [MethodDescriptor] = []
           }
@@ -410,7 +470,14 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias Client = NamespaceA_AserviceClient
       }
+      extension ServiceDescriptor {
+          public static let namespaceA_Aservice: ServiceDescriptor = NamespaceA_Aservice.serviceDescriptor
+      }
       public enum NamespaceA_Bservice {
+          public static let serviceDescriptor = ServiceDescriptor(
+              package: "namespaceA",
+              service: "BService"
+          )
           public enum Method {
               public static let descriptors: [MethodDescriptor] = []
           }
@@ -422,6 +489,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public typealias ClientProtocol = NamespaceA_BserviceClientProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias Client = NamespaceA_BserviceClient
+      }
+      extension ServiceDescriptor {
+          public static let namespaceA_Bservice: ServiceDescriptor = NamespaceA_Bservice.serviceDescriptor
       }
       """
 
@@ -452,6 +522,10 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       package enum AService {
+          package static let serviceDescriptor = ServiceDescriptor(
+              package: "",
+              service: "AService"
+          )
           package enum Method {
               package static let descriptors: [MethodDescriptor] = []
           }
@@ -464,7 +538,14 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package typealias Client = AServiceClient
       }
+      extension ServiceDescriptor {
+          package static let aservice: ServiceDescriptor = AService.serviceDescriptor
+      }
       package enum BService {
+          package static let serviceDescriptor = ServiceDescriptor(
+              package: "",
+              service: "BService"
+          )
           package enum Method {
               package static let descriptors: [MethodDescriptor] = []
           }
@@ -476,6 +557,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           package typealias ClientProtocol = BServiceClientProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package typealias Client = BServiceClient
+      }
+      extension ServiceDescriptor {
+          package static let bservice: ServiceDescriptor = BService.serviceDescriptor
       }
       """
 
@@ -514,6 +598,10 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       internal enum Anamespace_AService {
+          internal static let serviceDescriptor = ServiceDescriptor(
+              package: "anamespace",
+              service: "AService"
+          )
           internal enum Method {
               internal static let descriptors: [MethodDescriptor] = []
           }
@@ -526,7 +614,14 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           internal typealias Client = Anamespace_AServiceClient
       }
+      extension ServiceDescriptor {
+          internal static let anamespace_AService: ServiceDescriptor = Anamespace_AService.serviceDescriptor
+      }
       internal enum Bnamespace_BService {
+          internal static let serviceDescriptor = ServiceDescriptor(
+              package: "bnamespace",
+              service: "BService"
+          )
           internal enum Method {
               internal static let descriptors: [MethodDescriptor] = []
           }
@@ -538,6 +633,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           internal typealias ClientProtocol = Bnamespace_BServiceClientProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           internal typealias Client = Bnamespace_BServiceClient
+      }
+      extension ServiceDescriptor {
+          internal static let bnamespace_BService: ServiceDescriptor = Bnamespace_BService.serviceDescriptor
       }
       """
 
@@ -570,6 +668,10 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum Anamespace_AService {
+          public static let serviceDescriptor = ServiceDescriptor(
+              package: "anamespace",
+              service: "AService"
+          )
           public enum Method {
               public static let descriptors: [MethodDescriptor] = []
           }
@@ -582,7 +684,14 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias Client = Anamespace_AServiceClient
       }
+      extension ServiceDescriptor {
+          public static let anamespace_AService: ServiceDescriptor = Anamespace_AService.serviceDescriptor
+      }
       public enum BService {
+          public static let serviceDescriptor = ServiceDescriptor(
+              package: "",
+              service: "BService"
+          )
           public enum Method {
               public static let descriptors: [MethodDescriptor] = []
           }
@@ -594,6 +703,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public typealias ClientProtocol = BServiceClientProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias Client = BServiceClient
+      }
+      extension ServiceDescriptor {
+          public static let bService: ServiceDescriptor = BService.serviceDescriptor
       }
       """
 

--- a/Tests/GRPCCodeGenTests/Internal/Translator/TypealiasTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/TypealiasTranslatorSnippetBasedTests.swift
@@ -47,10 +47,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum NamespaceA_ServiceA {
-          public static let descriptor = ServiceDescriptor(
-              package: "namespaceA",
-              service: "ServiceA"
-          )
+          public static let descriptor = ServiceDescriptor.namespaceA_ServiceA
           public enum Method {
               public enum MethodA {
                   public typealias Input = NamespaceA_ServiceARequest
@@ -74,7 +71,10 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public typealias Client = NamespaceA_ServiceAClient
       }
       extension ServiceDescriptor {
-          public static let namespaceA_ServiceA: ServiceDescriptor = NamespaceA_ServiceA.descriptor
+          public static let namespaceA_ServiceA = Self(
+              package: "namespaceA",
+              service: "ServiceA"
+          )
       }
       """
 
@@ -101,10 +101,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum NamespaceA_ServiceA {
-          public static let descriptor = ServiceDescriptor(
-              package: "namespaceA",
-              service: "ServiceA"
-          )
+          public static let descriptor = ServiceDescriptor.namespaceA_ServiceA
           public enum Method {
               public static let descriptors: [MethodDescriptor] = []
           }
@@ -118,7 +115,10 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public typealias Client = NamespaceA_ServiceAClient
       }
       extension ServiceDescriptor {
-          public static let namespaceA_ServiceA: ServiceDescriptor = NamespaceA_ServiceA.descriptor
+          public static let namespaceA_ServiceA = Self(
+              package: "namespaceA",
+              service: "ServiceA"
+          )
       }
       """
 
@@ -145,10 +145,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum NamespaceA_ServiceA {
-          public static let descriptor = ServiceDescriptor(
-              package: "namespaceA",
-              service: "ServiceA"
-          )
+          public static let descriptor = ServiceDescriptor.namespaceA_ServiceA
           public enum Method {
               public static let descriptors: [MethodDescriptor] = []
           }
@@ -158,7 +155,10 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
       }
       extension ServiceDescriptor {
-          public static let namespaceA_ServiceA: ServiceDescriptor = NamespaceA_ServiceA.descriptor
+          public static let namespaceA_ServiceA = Self(
+              package: "namespaceA",
+              service: "ServiceA"
+          )
       }
       """
 
@@ -185,10 +185,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum NamespaceA_ServiceA {
-          public static let descriptor = ServiceDescriptor(
-              package: "namespaceA",
-              service: "ServiceA"
-          )
+          public static let descriptor = ServiceDescriptor.namespaceA_ServiceA
           public enum Method {
               public static let descriptors: [MethodDescriptor] = []
           }
@@ -198,7 +195,10 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public typealias Client = NamespaceA_ServiceAClient
       }
       extension ServiceDescriptor {
-          public static let namespaceA_ServiceA: ServiceDescriptor = NamespaceA_ServiceA.descriptor
+          public static let namespaceA_ServiceA = Self(
+              package: "namespaceA",
+              service: "ServiceA"
+          )
       }
       """
 
@@ -225,16 +225,16 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum NamespaceA_ServiceA {
-          public static let descriptor = ServiceDescriptor(
-              package: "namespaceA",
-              service: "ServiceA"
-          )
+          public static let descriptor = ServiceDescriptor.namespaceA_ServiceA
           public enum Method {
               public static let descriptors: [MethodDescriptor] = []
           }
       }
       extension ServiceDescriptor {
-          public static let namespaceA_ServiceA: ServiceDescriptor = NamespaceA_ServiceA.descriptor
+          public static let namespaceA_ServiceA = Self(
+              package: "namespaceA",
+              service: "ServiceA"
+          )
       }
       """
 
@@ -265,10 +265,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum ServiceA {
-          public static let descriptor = ServiceDescriptor(
-              package: "",
-              service: "ServiceA"
-          )
+          public static let descriptor = ServiceDescriptor.ServiceA
           public enum Method {
               public enum MethodA {
                   public typealias Input = ServiceARequest
@@ -292,7 +289,10 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public typealias Client = ServiceAClient
       }
       extension ServiceDescriptor {
-          public static let ServiceA: ServiceDescriptor = ServiceA.descriptor
+          public static let ServiceA = Self(
+              package: "",
+              service: "ServiceA"
+          )
       }
       """
 
@@ -335,10 +335,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum NamespaceA_ServiceA {
-          public static let descriptor = ServiceDescriptor(
-              package: "namespaceA",
-              service: "ServiceA"
-          )
+          public static let descriptor = ServiceDescriptor.namespaceA_ServiceA
           public enum Method {
               public enum MethodA {
                   public typealias Input = NamespaceA_ServiceARequest
@@ -371,7 +368,10 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public typealias Client = NamespaceA_ServiceAClient
       }
       extension ServiceDescriptor {
-          public static let namespaceA_ServiceA: ServiceDescriptor = NamespaceA_ServiceA.descriptor
+          public static let namespaceA_ServiceA = Self(
+              package: "namespaceA",
+              service: "ServiceA"
+          )
       }
       """
 
@@ -398,10 +398,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       package enum NamespaceA_ServiceA {
-          package static let descriptor = ServiceDescriptor(
-              package: "namespaceA",
-              service: "ServiceA"
-          )
+          package static let descriptor = ServiceDescriptor.namespaceA_ServiceA
           package enum Method {
               package static let descriptors: [MethodDescriptor] = []
           }
@@ -415,7 +412,10 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           package typealias Client = NamespaceA_ServiceAClient
       }
       extension ServiceDescriptor {
-          package static let namespaceA_ServiceA: ServiceDescriptor = NamespaceA_ServiceA.descriptor
+          package static let namespaceA_ServiceA = Self(
+              package: "namespaceA",
+              service: "ServiceA"
+          )
       }
       """
 
@@ -454,10 +454,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum NamespaceA_Aservice {
-          public static let descriptor = ServiceDescriptor(
-              package: "namespaceA",
-              service: "AService"
-          )
+          public static let descriptor = ServiceDescriptor.namespaceA_AService
           public enum Method {
               public static let descriptors: [MethodDescriptor] = []
           }
@@ -471,13 +468,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public typealias Client = NamespaceA_AserviceClient
       }
       extension ServiceDescriptor {
-          public static let namespaceA_AService: ServiceDescriptor = NamespaceA_Aservice.descriptor
+          public static let namespaceA_AService = Self(
+              package: "namespaceA",
+              service: "AService"
+          )
       }
       public enum NamespaceA_Bservice {
-          public static let descriptor = ServiceDescriptor(
-              package: "namespaceA",
-              service: "BService"
-          )
+          public static let descriptor = ServiceDescriptor.namespaceA_BService
           public enum Method {
               public static let descriptors: [MethodDescriptor] = []
           }
@@ -491,7 +488,10 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public typealias Client = NamespaceA_BserviceClient
       }
       extension ServiceDescriptor {
-          public static let namespaceA_BService: ServiceDescriptor = NamespaceA_Bservice.descriptor
+          public static let namespaceA_BService = Self(
+              package: "namespaceA",
+              service: "BService"
+          )
       }
       """
 
@@ -522,10 +522,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       package enum AService {
-          package static let descriptor = ServiceDescriptor(
-              package: "",
-              service: "AService"
-          )
+          package static let descriptor = ServiceDescriptor.AService
           package enum Method {
               package static let descriptors: [MethodDescriptor] = []
           }
@@ -539,13 +536,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           package typealias Client = AServiceClient
       }
       extension ServiceDescriptor {
-          package static let AService: ServiceDescriptor = AService.descriptor
+          package static let AService = Self(
+              package: "",
+              service: "AService"
+          )
       }
       package enum BService {
-          package static let descriptor = ServiceDescriptor(
-              package: "",
-              service: "BService"
-          )
+          package static let descriptor = ServiceDescriptor.BService
           package enum Method {
               package static let descriptors: [MethodDescriptor] = []
           }
@@ -559,7 +556,10 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           package typealias Client = BServiceClient
       }
       extension ServiceDescriptor {
-          package static let BService: ServiceDescriptor = BService.descriptor
+          package static let BService = Self(
+              package: "",
+              service: "BService"
+          )
       }
       """
 
@@ -598,10 +598,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       internal enum Anamespace_AService {
-          internal static let descriptor = ServiceDescriptor(
-              package: "anamespace",
-              service: "AService"
-          )
+          internal static let descriptor = ServiceDescriptor.anamespace_AService
           internal enum Method {
               internal static let descriptors: [MethodDescriptor] = []
           }
@@ -615,13 +612,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           internal typealias Client = Anamespace_AServiceClient
       }
       extension ServiceDescriptor {
-          internal static let anamespace_AService: ServiceDescriptor = Anamespace_AService.descriptor
+          internal static let anamespace_AService = Self(
+              package: "anamespace",
+              service: "AService"
+          )
       }
       internal enum Bnamespace_BService {
-          internal static let descriptor = ServiceDescriptor(
-              package: "bnamespace",
-              service: "BService"
-          )
+          internal static let descriptor = ServiceDescriptor.bnamespace_BService
           internal enum Method {
               internal static let descriptors: [MethodDescriptor] = []
           }
@@ -635,7 +632,10 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           internal typealias Client = Bnamespace_BServiceClient
       }
       extension ServiceDescriptor {
-          internal static let bnamespace_BService: ServiceDescriptor = Bnamespace_BService.descriptor
+          internal static let bnamespace_BService = Self(
+              package: "bnamespace",
+              service: "BService"
+          )
       }
       """
 
@@ -668,10 +668,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum Anamespace_AService {
-          public static let descriptor = ServiceDescriptor(
-              package: "anamespace",
-              service: "AService"
-          )
+          public static let descriptor = ServiceDescriptor.anamespace_AService
           public enum Method {
               public static let descriptors: [MethodDescriptor] = []
           }
@@ -685,13 +682,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public typealias Client = Anamespace_AServiceClient
       }
       extension ServiceDescriptor {
-          public static let anamespace_AService: ServiceDescriptor = Anamespace_AService.descriptor
+          public static let anamespace_AService = Self(
+              package: "anamespace",
+              service: "AService"
+          )
       }
       public enum BService {
-          public static let descriptor = ServiceDescriptor(
-              package: "",
-              service: "BService"
-          )
+          public static let descriptor = ServiceDescriptor.BService
           public enum Method {
               public static let descriptors: [MethodDescriptor] = []
           }
@@ -705,7 +702,10 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public typealias Client = BServiceClient
       }
       extension ServiceDescriptor {
-          public static let BService: ServiceDescriptor = BService.descriptor
+          public static let BService = Self(
+              package: "",
+              service: "BService"
+          )
       }
       """
 

--- a/Tests/GRPCCodeGenTests/Internal/Translator/TypealiasTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/TypealiasTranslatorSnippetBasedTests.swift
@@ -47,7 +47,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum NamespaceA_ServiceA {
-          public static let serviceDescriptor = ServiceDescriptor(
+          public static let descriptor = ServiceDescriptor(
               package: "namespaceA",
               service: "ServiceA"
           )
@@ -56,7 +56,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
                   public typealias Input = NamespaceA_ServiceARequest
                   public typealias Output = NamespaceA_ServiceAResponse
                   public static let descriptor = MethodDescriptor(
-                      service: NamespaceA_ServiceA.serviceDescriptor.fullyQualifiedService,
+                      service: NamespaceA_ServiceA.descriptor.fullyQualifiedService,
                       method: "MethodA"
                   )
               }
@@ -74,7 +74,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public typealias Client = NamespaceA_ServiceAClient
       }
       extension ServiceDescriptor {
-          public static let namespaceA_ServiceA: ServiceDescriptor = NamespaceA_ServiceA.serviceDescriptor
+          public static let namespaceA_ServiceA: ServiceDescriptor = NamespaceA_ServiceA.descriptor
       }
       """
 
@@ -101,7 +101,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum NamespaceA_ServiceA {
-          public static let serviceDescriptor = ServiceDescriptor(
+          public static let descriptor = ServiceDescriptor(
               package: "namespaceA",
               service: "ServiceA"
           )
@@ -118,7 +118,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public typealias Client = NamespaceA_ServiceAClient
       }
       extension ServiceDescriptor {
-          public static let namespaceA_ServiceA: ServiceDescriptor = NamespaceA_ServiceA.serviceDescriptor
+          public static let namespaceA_ServiceA: ServiceDescriptor = NamespaceA_ServiceA.descriptor
       }
       """
 
@@ -145,7 +145,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum NamespaceA_ServiceA {
-          public static let serviceDescriptor = ServiceDescriptor(
+          public static let descriptor = ServiceDescriptor(
               package: "namespaceA",
               service: "ServiceA"
           )
@@ -158,7 +158,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
       }
       extension ServiceDescriptor {
-          public static let namespaceA_ServiceA: ServiceDescriptor = NamespaceA_ServiceA.serviceDescriptor
+          public static let namespaceA_ServiceA: ServiceDescriptor = NamespaceA_ServiceA.descriptor
       }
       """
 
@@ -185,7 +185,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum NamespaceA_ServiceA {
-          public static let serviceDescriptor = ServiceDescriptor(
+          public static let descriptor = ServiceDescriptor(
               package: "namespaceA",
               service: "ServiceA"
           )
@@ -198,7 +198,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public typealias Client = NamespaceA_ServiceAClient
       }
       extension ServiceDescriptor {
-          public static let namespaceA_ServiceA: ServiceDescriptor = NamespaceA_ServiceA.serviceDescriptor
+          public static let namespaceA_ServiceA: ServiceDescriptor = NamespaceA_ServiceA.descriptor
       }
       """
 
@@ -225,7 +225,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum NamespaceA_ServiceA {
-          public static let serviceDescriptor = ServiceDescriptor(
+          public static let descriptor = ServiceDescriptor(
               package: "namespaceA",
               service: "ServiceA"
           )
@@ -234,7 +234,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           }
       }
       extension ServiceDescriptor {
-          public static let namespaceA_ServiceA: ServiceDescriptor = NamespaceA_ServiceA.serviceDescriptor
+          public static let namespaceA_ServiceA: ServiceDescriptor = NamespaceA_ServiceA.descriptor
       }
       """
 
@@ -265,7 +265,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum ServiceA {
-          public static let serviceDescriptor = ServiceDescriptor(
+          public static let descriptor = ServiceDescriptor(
               package: "",
               service: "ServiceA"
           )
@@ -274,7 +274,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
                   public typealias Input = ServiceARequest
                   public typealias Output = ServiceAResponse
                   public static let descriptor = MethodDescriptor(
-                      service: ServiceA.serviceDescriptor.fullyQualifiedService,
+                      service: ServiceA.descriptor.fullyQualifiedService,
                       method: "MethodA"
                   )
               }
@@ -292,7 +292,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public typealias Client = ServiceAClient
       }
       extension ServiceDescriptor {
-          public static let serviceA: ServiceDescriptor = ServiceA.serviceDescriptor
+          public static let ServiceA: ServiceDescriptor = ServiceA.descriptor
       }
       """
 
@@ -335,7 +335,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum NamespaceA_ServiceA {
-          public static let serviceDescriptor = ServiceDescriptor(
+          public static let descriptor = ServiceDescriptor(
               package: "namespaceA",
               service: "ServiceA"
           )
@@ -344,7 +344,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
                   public typealias Input = NamespaceA_ServiceARequest
                   public typealias Output = NamespaceA_ServiceAResponse
                   public static let descriptor = MethodDescriptor(
-                      service: NamespaceA_ServiceA.serviceDescriptor.fullyQualifiedService,
+                      service: NamespaceA_ServiceA.descriptor.fullyQualifiedService,
                       method: "MethodA"
                   )
               }
@@ -352,7 +352,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
                   public typealias Input = NamespaceA_ServiceARequest
                   public typealias Output = NamespaceA_ServiceAResponse
                   public static let descriptor = MethodDescriptor(
-                      service: NamespaceA_ServiceA.serviceDescriptor.fullyQualifiedService,
+                      service: NamespaceA_ServiceA.descriptor.fullyQualifiedService,
                       method: "MethodB"
                   )
               }
@@ -371,7 +371,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public typealias Client = NamespaceA_ServiceAClient
       }
       extension ServiceDescriptor {
-          public static let namespaceA_ServiceA: ServiceDescriptor = NamespaceA_ServiceA.serviceDescriptor
+          public static let namespaceA_ServiceA: ServiceDescriptor = NamespaceA_ServiceA.descriptor
       }
       """
 
@@ -398,7 +398,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       package enum NamespaceA_ServiceA {
-          package static let serviceDescriptor = ServiceDescriptor(
+          package static let descriptor = ServiceDescriptor(
               package: "namespaceA",
               service: "ServiceA"
           )
@@ -415,7 +415,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           package typealias Client = NamespaceA_ServiceAClient
       }
       extension ServiceDescriptor {
-          package static let namespaceA_ServiceA: ServiceDescriptor = NamespaceA_ServiceA.serviceDescriptor
+          package static let namespaceA_ServiceA: ServiceDescriptor = NamespaceA_ServiceA.descriptor
       }
       """
 
@@ -454,7 +454,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum NamespaceA_Aservice {
-          public static let serviceDescriptor = ServiceDescriptor(
+          public static let descriptor = ServiceDescriptor(
               package: "namespaceA",
               service: "AService"
           )
@@ -471,10 +471,10 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public typealias Client = NamespaceA_AserviceClient
       }
       extension ServiceDescriptor {
-          public static let namespaceA_Aservice: ServiceDescriptor = NamespaceA_Aservice.serviceDescriptor
+          public static let namespaceA_AService: ServiceDescriptor = NamespaceA_Aservice.descriptor
       }
       public enum NamespaceA_Bservice {
-          public static let serviceDescriptor = ServiceDescriptor(
+          public static let descriptor = ServiceDescriptor(
               package: "namespaceA",
               service: "BService"
           )
@@ -491,7 +491,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public typealias Client = NamespaceA_BserviceClient
       }
       extension ServiceDescriptor {
-          public static let namespaceA_Bservice: ServiceDescriptor = NamespaceA_Bservice.serviceDescriptor
+          public static let namespaceA_BService: ServiceDescriptor = NamespaceA_Bservice.descriptor
       }
       """
 
@@ -522,7 +522,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       package enum AService {
-          package static let serviceDescriptor = ServiceDescriptor(
+          package static let descriptor = ServiceDescriptor(
               package: "",
               service: "AService"
           )
@@ -539,10 +539,10 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           package typealias Client = AServiceClient
       }
       extension ServiceDescriptor {
-          package static let aservice: ServiceDescriptor = AService.serviceDescriptor
+          package static let AService: ServiceDescriptor = AService.descriptor
       }
       package enum BService {
-          package static let serviceDescriptor = ServiceDescriptor(
+          package static let descriptor = ServiceDescriptor(
               package: "",
               service: "BService"
           )
@@ -559,7 +559,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           package typealias Client = BServiceClient
       }
       extension ServiceDescriptor {
-          package static let bservice: ServiceDescriptor = BService.serviceDescriptor
+          package static let BService: ServiceDescriptor = BService.descriptor
       }
       """
 
@@ -598,7 +598,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       internal enum Anamespace_AService {
-          internal static let serviceDescriptor = ServiceDescriptor(
+          internal static let descriptor = ServiceDescriptor(
               package: "anamespace",
               service: "AService"
           )
@@ -615,10 +615,10 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           internal typealias Client = Anamespace_AServiceClient
       }
       extension ServiceDescriptor {
-          internal static let anamespace_AService: ServiceDescriptor = Anamespace_AService.serviceDescriptor
+          internal static let anamespace_AService: ServiceDescriptor = Anamespace_AService.descriptor
       }
       internal enum Bnamespace_BService {
-          internal static let serviceDescriptor = ServiceDescriptor(
+          internal static let descriptor = ServiceDescriptor(
               package: "bnamespace",
               service: "BService"
           )
@@ -635,7 +635,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           internal typealias Client = Bnamespace_BServiceClient
       }
       extension ServiceDescriptor {
-          internal static let bnamespace_BService: ServiceDescriptor = Bnamespace_BService.serviceDescriptor
+          internal static let bnamespace_BService: ServiceDescriptor = Bnamespace_BService.descriptor
       }
       """
 
@@ -668,7 +668,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum Anamespace_AService {
-          public static let serviceDescriptor = ServiceDescriptor(
+          public static let descriptor = ServiceDescriptor(
               package: "anamespace",
               service: "AService"
           )
@@ -685,10 +685,10 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public typealias Client = Anamespace_AServiceClient
       }
       extension ServiceDescriptor {
-          public static let anamespace_AService: ServiceDescriptor = Anamespace_AService.serviceDescriptor
+          public static let anamespace_AService: ServiceDescriptor = Anamespace_AService.descriptor
       }
       public enum BService {
-          public static let serviceDescriptor = ServiceDescriptor(
+          public static let descriptor = ServiceDescriptor(
               package: "",
               service: "BService"
           )
@@ -705,7 +705,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public typealias Client = BServiceClient
       }
       extension ServiceDescriptor {
-          public static let bService: ServiceDescriptor = BService.serviceDescriptor
+          public static let BService: ServiceDescriptor = BService.descriptor
       }
       """
 

--- a/Tests/GRPCHTTP2TransportTests/Generated/control.grpc.swift
+++ b/Tests/GRPCHTTP2TransportTests/Generated/control.grpc.swift
@@ -26,10 +26,7 @@ import GRPCCore
 import GRPCProtobuf
 
 internal enum Control {
-    internal static let descriptor = ServiceDescriptor(
-        package: "",
-        service: "Control"
-    )
+    internal static let descriptor = ServiceDescriptor.Control
     internal enum Method {
         internal enum Unary {
             internal typealias Input = ControlInput
@@ -81,7 +78,10 @@ internal enum Control {
 }
 
 extension ServiceDescriptor {
-    internal static let Control: ServiceDescriptor = Control.descriptor
+    internal static let Control = Self(
+        package: "",
+        service: "Control"
+    )
 }
 
 /// A controllable service for testing.

--- a/Tests/GRPCHTTP2TransportTests/Generated/control.grpc.swift
+++ b/Tests/GRPCHTTP2TransportTests/Generated/control.grpc.swift
@@ -26,12 +26,16 @@ import GRPCCore
 import GRPCProtobuf
 
 internal enum Control {
+    internal static let serviceDescriptor = ServiceDescriptor(
+        package: "",
+        service: "Control"
+    )
     internal enum Method {
         internal enum Unary {
             internal typealias Input = ControlInput
             internal typealias Output = ControlOutput
             internal static let descriptor = MethodDescriptor(
-                service: "Control",
+                service: Control.serviceDescriptor.fullyQualifiedService,
                 method: "Unary"
             )
         }
@@ -39,7 +43,7 @@ internal enum Control {
             internal typealias Input = ControlInput
             internal typealias Output = ControlOutput
             internal static let descriptor = MethodDescriptor(
-                service: "Control",
+                service: Control.serviceDescriptor.fullyQualifiedService,
                 method: "ServerStream"
             )
         }
@@ -47,7 +51,7 @@ internal enum Control {
             internal typealias Input = ControlInput
             internal typealias Output = ControlOutput
             internal static let descriptor = MethodDescriptor(
-                service: "Control",
+                service: Control.serviceDescriptor.fullyQualifiedService,
                 method: "ClientStream"
             )
         }
@@ -55,7 +59,7 @@ internal enum Control {
             internal typealias Input = ControlInput
             internal typealias Output = ControlOutput
             internal static let descriptor = MethodDescriptor(
-                service: "Control",
+                service: Control.serviceDescriptor.fullyQualifiedService,
                 method: "BidiStream"
             )
         }
@@ -74,6 +78,10 @@ internal enum Control {
     internal typealias ClientProtocol = ControlClientProtocol
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     internal typealias Client = ControlClient
+}
+
+extension ServiceDescriptor {
+    internal static let control: ServiceDescriptor = Control.serviceDescriptor
 }
 
 /// A controllable service for testing.

--- a/Tests/GRPCHTTP2TransportTests/Generated/control.grpc.swift
+++ b/Tests/GRPCHTTP2TransportTests/Generated/control.grpc.swift
@@ -26,7 +26,7 @@ import GRPCCore
 import GRPCProtobuf
 
 internal enum Control {
-    internal static let serviceDescriptor = ServiceDescriptor(
+    internal static let descriptor = ServiceDescriptor(
         package: "",
         service: "Control"
     )
@@ -35,7 +35,7 @@ internal enum Control {
             internal typealias Input = ControlInput
             internal typealias Output = ControlOutput
             internal static let descriptor = MethodDescriptor(
-                service: Control.serviceDescriptor.fullyQualifiedService,
+                service: Control.descriptor.fullyQualifiedService,
                 method: "Unary"
             )
         }
@@ -43,7 +43,7 @@ internal enum Control {
             internal typealias Input = ControlInput
             internal typealias Output = ControlOutput
             internal static let descriptor = MethodDescriptor(
-                service: Control.serviceDescriptor.fullyQualifiedService,
+                service: Control.descriptor.fullyQualifiedService,
                 method: "ServerStream"
             )
         }
@@ -51,7 +51,7 @@ internal enum Control {
             internal typealias Input = ControlInput
             internal typealias Output = ControlOutput
             internal static let descriptor = MethodDescriptor(
-                service: Control.serviceDescriptor.fullyQualifiedService,
+                service: Control.descriptor.fullyQualifiedService,
                 method: "ClientStream"
             )
         }
@@ -59,7 +59,7 @@ internal enum Control {
             internal typealias Input = ControlInput
             internal typealias Output = ControlOutput
             internal static let descriptor = MethodDescriptor(
-                service: Control.serviceDescriptor.fullyQualifiedService,
+                service: Control.descriptor.fullyQualifiedService,
                 method: "BidiStream"
             )
         }
@@ -81,7 +81,7 @@ internal enum Control {
 }
 
 extension ServiceDescriptor {
-    internal static let control: ServiceDescriptor = Control.serviceDescriptor
+    internal static let Control: ServiceDescriptor = Control.descriptor
 }
 
 /// A controllable service for testing.

--- a/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGeneratorTests.swift
+++ b/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGeneratorTests.swift
@@ -60,7 +60,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         import ExtraModule
 
         internal enum Hello_World_Greeter {
-            internal static let serviceDescriptor = ServiceDescriptor(
+            internal static let descriptor = ServiceDescriptor(
                 package: "hello.world",
                 service: "Greeter"
             )
@@ -69,7 +69,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
                     internal typealias Input = Hello_World_HelloRequest
                     internal typealias Output = Hello_World_HelloReply
                     internal static let descriptor = MethodDescriptor(
-                        service: Hello_World_Greeter.serviceDescriptor.fullyQualifiedService,
+                        service: Hello_World_Greeter.descriptor.fullyQualifiedService,
                         method: "SayHello"
                     )
                 }
@@ -84,7 +84,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         }
 
         extension ServiceDescriptor {
-            internal static let hello_world_Greeter: ServiceDescriptor = Hello_World_Greeter.serviceDescriptor
+            internal static let hello_world_Greeter: ServiceDescriptor = Hello_World_Greeter.descriptor
         }
 
         /// The greeting service definition.
@@ -183,7 +183,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         import ExtraModule
 
         public enum Helloworld_Greeter {
-          public static let serviceDescriptor = ServiceDescriptor(
+          public static let descriptor = ServiceDescriptor(
             package: "helloworld",
             service: "Greeter"
           )
@@ -192,7 +192,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
               public typealias Input = Helloworld_HelloRequest
               public typealias Output = Helloworld_HelloReply
               public static let descriptor = MethodDescriptor(
-                service: Helloworld_Greeter.serviceDescriptor.fullyQualifiedService,
+                service: Helloworld_Greeter.descriptor.fullyQualifiedService,
                 method: "SayHello"
               )
             }
@@ -207,7 +207,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         }
 
         extension ServiceDescriptor {
-          public static let helloworld_Greeter: ServiceDescriptor = Helloworld_Greeter.serviceDescriptor
+          public static let helloworld_Greeter: ServiceDescriptor = Helloworld_Greeter.descriptor
         }
 
         /// The greeting service definition.
@@ -286,7 +286,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         import ExtraModule
 
         package enum Greeter {
-          package static let serviceDescriptor = ServiceDescriptor(
+          package static let descriptor = ServiceDescriptor(
             package: "",
             service: "Greeter"
           )
@@ -295,7 +295,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
               package typealias Input = HelloRequest
               package typealias Output = HelloReply
               package static let descriptor = MethodDescriptor(
-                service: Greeter.serviceDescriptor.fullyQualifiedService,
+                service: Greeter.descriptor.fullyQualifiedService,
                 method: "SayHello"
               )
             }
@@ -314,7 +314,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         }
 
         extension ServiceDescriptor {
-          package static let greeter: ServiceDescriptor = Greeter.serviceDescriptor
+          package static let Greeter: ServiceDescriptor = Greeter.descriptor
         }
 
         /// The greeting service definition.

--- a/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGeneratorTests.swift
+++ b/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGeneratorTests.swift
@@ -60,10 +60,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         import ExtraModule
 
         internal enum Hello_World_Greeter {
-            internal static let descriptor = ServiceDescriptor(
-                package: "hello.world",
-                service: "Greeter"
-            )
+            internal static let descriptor = ServiceDescriptor.hello_world_Greeter
             internal enum Method {
                 internal enum SayHello {
                     internal typealias Input = Hello_World_HelloRequest
@@ -84,7 +81,10 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         }
 
         extension ServiceDescriptor {
-            internal static let hello_world_Greeter: ServiceDescriptor = Hello_World_Greeter.descriptor
+            internal static let hello_world_Greeter = Self(
+                package: "hello.world",
+                service: "Greeter"
+            )
         }
 
         /// The greeting service definition.
@@ -183,10 +183,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         import ExtraModule
 
         public enum Helloworld_Greeter {
-          public static let descriptor = ServiceDescriptor(
-            package: "helloworld",
-            service: "Greeter"
-          )
+          public static let descriptor = ServiceDescriptor.helloworld_Greeter
           public enum Method {
             public enum SayHello {
               public typealias Input = Helloworld_HelloRequest
@@ -207,7 +204,10 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         }
 
         extension ServiceDescriptor {
-          public static let helloworld_Greeter: ServiceDescriptor = Helloworld_Greeter.descriptor
+          public static let helloworld_Greeter = Self(
+            package: "helloworld",
+            service: "Greeter"
+          )
         }
 
         /// The greeting service definition.
@@ -286,10 +286,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         import ExtraModule
 
         package enum Greeter {
-          package static let descriptor = ServiceDescriptor(
-            package: "",
-            service: "Greeter"
-          )
+          package static let descriptor = ServiceDescriptor.Greeter
           package enum Method {
             package enum SayHello {
               package typealias Input = HelloRequest
@@ -314,7 +311,10 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         }
 
         extension ServiceDescriptor {
-          package static let Greeter: ServiceDescriptor = Greeter.descriptor
+          package static let Greeter = Self(
+            package: "",
+            service: "Greeter"
+          )
         }
 
         /// The greeting service definition.

--- a/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGeneratorTests.swift
+++ b/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGeneratorTests.swift
@@ -60,12 +60,16 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         import ExtraModule
 
         internal enum Hello_World_Greeter {
+            internal static let serviceDescriptor = ServiceDescriptor(
+                package: "hello.world",
+                service: "Greeter"
+            )
             internal enum Method {
                 internal enum SayHello {
                     internal typealias Input = Hello_World_HelloRequest
                     internal typealias Output = Hello_World_HelloReply
                     internal static let descriptor = MethodDescriptor(
-                        service: "hello.world.Greeter",
+                        service: Hello_World_Greeter.serviceDescriptor.fullyQualifiedService,
                         method: "SayHello"
                     )
                 }
@@ -77,6 +81,10 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
             internal typealias ClientProtocol = Hello_World_GreeterClientProtocol
             @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
             internal typealias Client = Hello_World_GreeterClient
+        }
+
+        extension ServiceDescriptor {
+            internal static let hello_world_Greeter: ServiceDescriptor = Hello_World_Greeter.serviceDescriptor
         }
 
         /// The greeting service definition.
@@ -175,12 +183,16 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         import ExtraModule
 
         public enum Helloworld_Greeter {
+          public static let serviceDescriptor = ServiceDescriptor(
+            package: "helloworld",
+            service: "Greeter"
+          )
           public enum Method {
             public enum SayHello {
               public typealias Input = Helloworld_HelloRequest
               public typealias Output = Helloworld_HelloReply
               public static let descriptor = MethodDescriptor(
-                service: "helloworld.Greeter",
+                service: Helloworld_Greeter.serviceDescriptor.fullyQualifiedService,
                 method: "SayHello"
               )
             }
@@ -192,6 +204,10 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
           public typealias StreamingServiceProtocol = Helloworld_GreeterStreamingServiceProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ServiceProtocol = Helloworld_GreeterServiceProtocol
+        }
+
+        extension ServiceDescriptor {
+          public static let helloworld_Greeter: ServiceDescriptor = Helloworld_Greeter.serviceDescriptor
         }
 
         /// The greeting service definition.
@@ -270,12 +286,16 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         import ExtraModule
 
         package enum Greeter {
+          package static let serviceDescriptor = ServiceDescriptor(
+            package: "",
+            service: "Greeter"
+          )
           package enum Method {
             package enum SayHello {
               package typealias Input = HelloRequest
               package typealias Output = HelloReply
               package static let descriptor = MethodDescriptor(
-                service: "Greeter",
+                service: Greeter.serviceDescriptor.fullyQualifiedService,
                 method: "SayHello"
               )
             }
@@ -291,6 +311,10 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
           package typealias ClientProtocol = GreeterClientProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package typealias Client = GreeterClient
+        }
+
+        extension ServiceDescriptor {
+          package static let greeter: ServiceDescriptor = Greeter.serviceDescriptor
         }
 
         /// The greeting service definition.


### PR DESCRIPTION
Motivation:

The generated code refers to services literally using strings. With the addition of service descriptors, the generated code can now utilize them to refer to services.

Modifications:

- Update the generated code to use service descriptors.
- For each service in the generated code, extend `ServiceDescriptor` to include a `static` property that holds the service descriptor for that service. (I.e. for a service `Foo` in the `bar` package, the service descriptor for `Foo` can be accessed using `ServiceDescriptor.bar_Foo`.)

Result:

The generated code will utilize and provide easy access to service descriptors.