### PR TITLE
Change label in init of generated client 

### DIFF
--- a/Sources/Examples/v2/Echo/Generated/echo.grpc.swift
+++ b/Sources/Examples/v2/Echo/Generated/echo.grpc.swift
@@ -266,7 +266,7 @@ extension Echo_Echo.ClientProtocol {
 internal struct Echo_EchoClient: Echo_Echo.ClientProtocol {
     private let client: GRPCCore.GRPCClient
 
-    internal init(client: GRPCCore.GRPCClient) {
+    internal init(wrapping client: GRPCCore.GRPCClient) {
         self.client = client
     }
 

--- a/Sources/Examples/v2/Echo/Subcommands/Collect.swift
+++ b/Sources/Examples/v2/Echo/Subcommands/Collect.swift
@@ -37,7 +37,7 @@ struct Collect: AsyncParsableCommand {
         try await client.run()
       }
 
-      let echo = Echo_EchoClient(client: client)
+      let echo = Echo_EchoClient(wrapping: client)
 
       for _ in 0 ..< self.arguments.repetitions {
         let request = ClientRequest.Stream(of: Echo_EchoRequest.self) { writer in

--- a/Sources/Examples/v2/Echo/Subcommands/Expand.swift
+++ b/Sources/Examples/v2/Echo/Subcommands/Expand.swift
@@ -37,7 +37,7 @@ struct Expand: AsyncParsableCommand {
         try await client.run()
       }
 
-      let echo = Echo_EchoClient(client: client)
+      let echo = Echo_EchoClient(wrapping: client)
 
       for _ in 0 ..< self.arguments.repetitions {
         let message = Echo_EchoRequest.with { $0.text = self.arguments.message }

--- a/Sources/Examples/v2/Echo/Subcommands/Get.swift
+++ b/Sources/Examples/v2/Echo/Subcommands/Get.swift
@@ -35,7 +35,7 @@ struct Get: AsyncParsableCommand {
         try await client.run()
       }
 
-      let echo = Echo_EchoClient(client: client)
+      let echo = Echo_EchoClient(wrapping: client)
 
       for _ in 0 ..< self.arguments.repetitions {
         let message = Echo_EchoRequest.with { $0.text = self.arguments.message }

--- a/Sources/Examples/v2/Echo/Subcommands/Update.swift
+++ b/Sources/Examples/v2/Echo/Subcommands/Update.swift
@@ -37,7 +37,7 @@ struct Update: AsyncParsableCommand {
         try await client.run()
       }
 
-      let echo = Echo_EchoClient(client: client)
+      let echo = Echo_EchoClient(wrapping: client)
 
       for _ in 0 ..< self.arguments.repetitions {
         let request = ClientRequest.Stream(of: Echo_EchoRequest.self) { writer in

--- a/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
@@ -50,7 +50,7 @@
 /// @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 /// public struct Foo_BarClient: Foo_Bar.ClientProtocol {
 ///   private let client: GRPCCore.GRPCClient
-///   public init(client: GRPCCore.GRPCClient) {
+///   public init(wrapping client: GRPCCore.GRPCClient) {
 ///     self.client = client
 ///   }
 ///   public func methodA<R>(
@@ -369,7 +369,9 @@ extension ClientCodeTranslator {
       signature: .init(
         accessModifier: self.accessModifier,
         kind: .initializer,
-        parameters: [.init(label: "client", type: .member(["GRPCCore", "GRPCClient"]))]
+        parameters: [
+          .init(label: "wrapping", name: "client", type: .member(["GRPCCore", "GRPCClient"]))
+        ]
       ),
       body: [CodeBlock(item: .expression(initializerBody))]
     )

--- a/Sources/InteroperabilityTests/Generated/empty_service.grpc.swift
+++ b/Sources/InteroperabilityTests/Generated/empty_service.grpc.swift
@@ -75,7 +75,7 @@ extension Grpc_Testing_EmptyService.ClientProtocol {
 public struct Grpc_Testing_EmptyServiceClient: Grpc_Testing_EmptyService.ClientProtocol {
     private let client: GRPCCore.GRPCClient
 
-    public init(client: GRPCCore.GRPCClient) {
+    public init(wrapping client: GRPCCore.GRPCClient) {
         self.client = client
     }
 }

--- a/Sources/InteroperabilityTests/Generated/test.grpc.swift
+++ b/Sources/InteroperabilityTests/Generated/test.grpc.swift
@@ -658,7 +658,7 @@ extension Grpc_Testing_TestService.ClientProtocol {
 public struct Grpc_Testing_TestServiceClient: Grpc_Testing_TestService.ClientProtocol {
     private let client: GRPCCore.GRPCClient
 
-    public init(client: GRPCCore.GRPCClient) {
+    public init(wrapping client: GRPCCore.GRPCClient) {
         self.client = client
     }
 
@@ -854,7 +854,7 @@ extension Grpc_Testing_UnimplementedService.ClientProtocol {
 public struct Grpc_Testing_UnimplementedServiceClient: Grpc_Testing_UnimplementedService.ClientProtocol {
     private let client: GRPCCore.GRPCClient
 
-    public init(client: GRPCCore.GRPCClient) {
+    public init(wrapping client: GRPCCore.GRPCClient) {
         self.client = client
     }
 
@@ -933,7 +933,7 @@ extension Grpc_Testing_ReconnectService.ClientProtocol {
 public struct Grpc_Testing_ReconnectServiceClient: Grpc_Testing_ReconnectService.ClientProtocol {
     private let client: GRPCCore.GRPCClient
 
-    public init(client: GRPCCore.GRPCClient) {
+    public init(wrapping client: GRPCCore.GRPCClient) {
         self.client = client
     }
 

--- a/Sources/InteroperabilityTests/InteroperabilityTestCases.swift
+++ b/Sources/InteroperabilityTests/InteroperabilityTestCases.swift
@@ -34,7 +34,7 @@ import struct Foundation.Data
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct EmptyUnary: InteroperabilityTest {
   func run(client: GRPCClient) async throws {
-    let testServiceClient = Grpc_Testing_TestService.Client(client: client)
+    let testServiceClient = Grpc_Testing_TestService.Client(wrapping: client)
     try await testServiceClient.emptyCall(
       request: ClientRequest.Single(message: Grpc_Testing_Empty())
     ) { response in
@@ -68,7 +68,7 @@ struct EmptyUnary: InteroperabilityTest {
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct LargeUnary: InteroperabilityTest {
   func run(client: GRPCClient) async throws {
-    let testServiceClient = Grpc_Testing_TestService.Client(client: client)
+    let testServiceClient = Grpc_Testing_TestService.Client(wrapping: client)
     let request = Grpc_Testing_SimpleRequest.with { request in
       request.responseSize = 314_159
       request.payload = Grpc_Testing_Payload.with {
@@ -144,7 +144,7 @@ struct LargeUnary: InteroperabilityTest {
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 class ClientCompressedUnary: InteroperabilityTest {
   func run(client: GRPCClient) async throws {
-    let testServiceClient = Grpc_Testing_TestService.Client(client: client)
+    let testServiceClient = Grpc_Testing_TestService.Client(wrapping: client)
     let compressedRequest = Grpc_Testing_SimpleRequest.with { request in
       request.expectCompressed = .with { $0.value = true }
       request.responseSize = 314_159
@@ -253,7 +253,7 @@ class ClientCompressedUnary: InteroperabilityTest {
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 class ServerCompressedUnary: InteroperabilityTest {
   func run(client: GRPCClient) async throws {
-    let testServiceClient = Grpc_Testing_TestService.Client(client: client)
+    let testServiceClient = Grpc_Testing_TestService.Client(wrapping: client)
 
     let compressedRequest = Grpc_Testing_SimpleRequest.with { request in
       request.responseCompressed = .with { $0.value = true }
@@ -343,7 +343,7 @@ class ServerCompressedUnary: InteroperabilityTest {
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct ClientStreaming: InteroperabilityTest {
   func run(client: GRPCClient) async throws {
-    let testServiceClient = Grpc_Testing_TestService.Client(client: client)
+    let testServiceClient = Grpc_Testing_TestService.Client(wrapping: client)
     let request = ClientRequest.Stream { writer in
       for bytes in [27182, 8, 1828, 45904] {
         let message = Grpc_Testing_StreamingInputCallRequest.with {
@@ -394,7 +394,7 @@ struct ClientStreaming: InteroperabilityTest {
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct ServerStreaming: InteroperabilityTest {
   func run(client: GRPCClient) async throws {
-    let testServiceClient = Grpc_Testing_TestService.Client(client: client)
+    let testServiceClient = Grpc_Testing_TestService.Client(wrapping: client)
     let responseSizes = [31415, 9, 2653, 58979]
     let request = Grpc_Testing_StreamingOutputCallRequest.with { request in
       request.responseParameters = responseSizes.map {
@@ -470,7 +470,7 @@ struct ServerStreaming: InteroperabilityTest {
 class ServerCompressedStreaming: InteroperabilityTest {
   @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
   func run(client: GRPCClient) async throws {
-    let testServiceClient = Grpc_Testing_TestService.Client(client: client)
+    let testServiceClient = Grpc_Testing_TestService.Client(wrapping: client)
     let request: Grpc_Testing_StreamingOutputCallRequest = .with { request in
       request.responseParameters = [
         .with {
@@ -583,7 +583,7 @@ class ServerCompressedStreaming: InteroperabilityTest {
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct PingPong: InteroperabilityTest {
   func run(client: GRPCClient) async throws {
-    let testServiceClient = Grpc_Testing_TestService.Client(client: client)
+    let testServiceClient = Grpc_Testing_TestService.Client(wrapping: client)
     let ids = AsyncStream.makeStream(of: Int.self)
 
     let request = ClientRequest.Stream { writer in
@@ -650,7 +650,7 @@ struct PingPong: InteroperabilityTest {
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct EmptyStream: InteroperabilityTest {
   func run(client: GRPCClient) async throws {
-    let testServiceClient = Grpc_Testing_TestService.Client(client: client)
+    let testServiceClient = Grpc_Testing_TestService.Client(wrapping: client)
     let request = ClientRequest.Stream<Grpc_Testing_StreamingOutputCallRequest> { _ in }
 
     try await testServiceClient.fullDuplexCall(request: request) { response in
@@ -722,7 +722,7 @@ struct CustomMetadata: InteroperabilityTest {
   }
 
   func run(client: GRPCClient) async throws {
-    let testServiceClient = Grpc_Testing_TestService.Client(client: client)
+    let testServiceClient = Grpc_Testing_TestService.Client(wrapping: client)
 
     let unaryRequest = Grpc_Testing_SimpleRequest.with { request in
       request.responseSize = 314_159
@@ -830,7 +830,7 @@ struct StatusCodeAndMessage: InteroperabilityTest {
   let expectedMessage = "test status message"
 
   func run(client: GRPCClient) async throws {
-    let testServiceClient = Grpc_Testing_TestService.Client(client: client)
+    let testServiceClient = Grpc_Testing_TestService.Client(wrapping: client)
 
     let message = Grpc_Testing_SimpleRequest.with {
       $0.responseStatus = Grpc_Testing_EchoStatus.with {
@@ -905,7 +905,7 @@ struct StatusCodeAndMessage: InteroperabilityTest {
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct SpecialStatusMessage: InteroperabilityTest {
   func run(client: GRPCClient) async throws {
-    let testServiceClient = Grpc_Testing_TestService.Client(client: client)
+    let testServiceClient = Grpc_Testing_TestService.Client(wrapping: client)
 
     let responseMessage = "\t\ntest with whitespace\r\nand Unicode BMP ☺ and non-BMP 😈\t\n"
     let message = Grpc_Testing_SimpleRequest.with {
@@ -948,7 +948,7 @@ struct SpecialStatusMessage: InteroperabilityTest {
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct UnimplementedMethod: InteroperabilityTest {
   func run(client: GRPCClient) async throws {
-    let testServiceClient = Grpc_Testing_TestService.Client(client: client)
+    let testServiceClient = Grpc_Testing_TestService.Client(wrapping: client)
     try await testServiceClient.unimplementedCall(
       request: ClientRequest.Single(message: Grpc_Testing_Empty())
     ) { response in
@@ -981,7 +981,7 @@ struct UnimplementedMethod: InteroperabilityTest {
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct UnimplementedService: InteroperabilityTest {
   func run(client: GRPCClient) async throws {
-    let unimplementedServiceClient = Grpc_Testing_UnimplementedService.Client(client: client)
+    let unimplementedServiceClient = Grpc_Testing_UnimplementedService.Client(wrapping: client)
     try await unimplementedServiceClient.unimplementedCall(
       request: ClientRequest.Single(message: Grpc_Testing_Empty())
     ) { response in

--- a/Sources/performance-worker/BenchmarkClient.swift
+++ b/Sources/performance-worker/BenchmarkClient.swift
@@ -93,7 +93,7 @@ struct BenchmarkClient {
   }
 
   internal func run() async throws {
-    let benchmarkClient = Grpc_Testing_BenchmarkServiceClient(client: self.client)
+    let benchmarkClient = Grpc_Testing_BenchmarkServiceClient(wrapping: self.client)
     return try await withThrowingTaskGroup(of: Void.self) { clientGroup in
       // Start the client.
       clientGroup.addTask {

--- a/Sources/performance-worker/Generated/grpc_testing_benchmark_service.grpc.swift
+++ b/Sources/performance-worker/Generated/grpc_testing_benchmark_service.grpc.swift
@@ -333,7 +333,7 @@ extension Grpc_Testing_BenchmarkService.ClientProtocol {
 internal struct Grpc_Testing_BenchmarkServiceClient: Grpc_Testing_BenchmarkService.ClientProtocol {
     private let client: GRPCCore.GRPCClient
 
-    internal init(client: GRPCCore.GRPCClient) {
+    internal init(wrapping client: GRPCCore.GRPCClient) {
         self.client = client
     }
 

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
@@ -75,7 +75,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       public struct NamespaceA_ServiceAClient: NamespaceA_ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
-          public init(client: GRPCCore.GRPCClient) {
+          public init(wrapping client: GRPCCore.GRPCClient) {
               self.client = client
           }
           
@@ -156,7 +156,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       public struct NamespaceA_ServiceAClient: NamespaceA_ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
-          public init(client: GRPCCore.GRPCClient) {
+          public init(wrapping client: GRPCCore.GRPCClient) {
               self.client = client
           }
           
@@ -237,7 +237,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       public struct NamespaceA_ServiceAClient: NamespaceA_ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
-          public init(client: GRPCCore.GRPCClient) {
+          public init(wrapping client: GRPCCore.GRPCClient) {
               self.client = client
           }
           
@@ -318,7 +318,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       public struct NamespaceA_ServiceAClient: NamespaceA_ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
-          public init(client: GRPCCore.GRPCClient) {
+          public init(wrapping client: GRPCCore.GRPCClient) {
               self.client = client
           }
           
@@ -430,7 +430,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       package struct NamespaceA_ServiceAClient: NamespaceA_ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
-          package init(client: GRPCCore.GRPCClient) {
+          package init(wrapping client: GRPCCore.GRPCClient) {
               self.client = client
           }
           
@@ -529,7 +529,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       internal struct ServiceAClient: ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
-          internal init(client: GRPCCore.GRPCClient) {
+          internal init(wrapping client: GRPCCore.GRPCClient) {
               self.client = client
           }
           
@@ -594,7 +594,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       public struct NamespaceA_ServiceAClient: NamespaceA_ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
-          public init(client: GRPCCore.GRPCClient) {
+          public init(wrapping client: GRPCCore.GRPCClient) {
               self.client = client
           }
       }
@@ -613,7 +613,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       public struct ServiceBClient: ServiceB.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
-          public init(client: GRPCCore.GRPCClient) {
+          public init(wrapping client: GRPCCore.GRPCClient) {
               self.client = client
           }
       }

--- a/Tests/GRPCHTTP2TransportTests/Generated/control.grpc.swift
+++ b/Tests/GRPCHTTP2TransportTests/Generated/control.grpc.swift
@@ -271,7 +271,7 @@ extension Control.ClientProtocol {
 internal struct ControlClient: Control.ClientProtocol {
     private let client: GRPCCore.GRPCClient
 
-    internal init(client: GRPCCore.GRPCClient) {
+    internal init(wrapping client: GRPCCore.GRPCClient) {
         self.client = client
     }
 

--- a/Tests/GRPCHTTP2TransportTests/HTTP2TransportTests.swift
+++ b/Tests/GRPCHTTP2TransportTests/HTTP2TransportTests.swift
@@ -88,7 +88,7 @@ final class HTTP2TransportTests: XCTestCase {
         }
 
         do {
-          let control = ControlClient(client: client)
+          let control = ControlClient(wrapping: client)
           try await execute(control, pair)
         } catch {
           XCTFail("Unexpected error: '\(error)' (\(pair))")
@@ -123,7 +123,7 @@ final class HTTP2TransportTests: XCTestCase {
         }
 
         do {
-          let control = ControlClient(client: client)
+          let control = ControlClient(wrapping: client)
           try await execute(control, clientKind)
         } catch {
           XCTFail("Unexpected error: '\(error)' (\(clientKind))")

--- a/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGeneratorTests.swift
+++ b/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGeneratorTests.swift
@@ -114,7 +114,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         internal struct Hello_World_GreeterClient: Hello_World_Greeter.ClientProtocol {
             private let client: GRPCCore.GRPCClient
             
-            internal init(client: GRPCCore.GRPCClient) {
+            internal init(wrapping client: GRPCCore.GRPCClient) {
                 self.client = client
             }
             
@@ -367,7 +367,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         package struct GreeterClient: Greeter.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
-          package init(client: GRPCCore.GRPCClient) {
+          package init(wrapping client: GRPCCore.GRPCClient) {
             self.client = client
           }
           


### PR DESCRIPTION
Motivation:

In v2 a generated client stub for the echo service will have the following init:
```swift
init(client: GRPCClient)
```

As client stubs are named `<Package>_<Service>Client`, the call site for the echo service looks like:
```swift
let client: GRPCClient = …
let echo = Echo_EchoClient(client: client)
```
This reads badly.

Modifications:

- Change the label from `client:` to `wrapping client:` (since the generated stub wraps the underlying `GRPCClient` to provide the type-safe APIs).

Result:

The call site will look like:
```swift
let client: GRPCClient = …
let echo = Echo_EchoClient(wrapping: client)
```