### PR TITLE
Generate default response handlers

### DIFF
--- a/Sources/Examples/v2/Echo/Generated/echo.grpc.swift
+++ b/Sources/Examples/v2/Echo/Generated/echo.grpc.swift
@@ -208,7 +208,9 @@ extension Echo_Echo.ClientProtocol {
     internal func get<R>(
         request: ClientRequest.Single<Echo_EchoRequest>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Echo_EchoResponse>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Echo_EchoResponse>) async throws -> R = {
+            try $0.message
+        }
     ) async throws -> R where R: Sendable {
         try await self.get(
             request: request,
@@ -236,7 +238,9 @@ extension Echo_Echo.ClientProtocol {
     internal func collect<R>(
         request: ClientRequest.Stream<Echo_EchoRequest>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Echo_EchoResponse>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Echo_EchoResponse>) async throws -> R = {
+            try $0.message
+        }
     ) async throws -> R where R: Sendable {
         try await self.collect(
             request: request,
@@ -276,7 +280,9 @@ internal struct Echo_EchoClient: Echo_Echo.ClientProtocol {
         serializer: some MessageSerializer<Echo_EchoRequest>,
         deserializer: some MessageDeserializer<Echo_EchoResponse>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Echo_EchoResponse>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Echo_EchoResponse>) async throws -> R = {
+            try $0.message
+        }
     ) async throws -> R where R: Sendable {
         try await self.client.unary(
             request: request,
@@ -312,7 +318,9 @@ internal struct Echo_EchoClient: Echo_Echo.ClientProtocol {
         serializer: some MessageSerializer<Echo_EchoRequest>,
         deserializer: some MessageDeserializer<Echo_EchoResponse>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Echo_EchoResponse>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Echo_EchoResponse>) async throws -> R = {
+            try $0.message
+        }
     ) async throws -> R where R: Sendable {
         try await self.client.clientStreaming(
             request: request,

--- a/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
@@ -37,7 +37,9 @@
 ///   public func baz<R>(
 ///     request: ClientRequest.Single<Foo_Bar_Input>,
 ///     options: CallOptions = .defaults,
-///     _ body: @Sendable @escaping (ClientResponse.Single<Foo_Bar_Output>) async throws -> R
+///     _ body: @Sendable @escaping (ClientResponse.Single<Foo_Bar_Output>) async throws -> R = {
+///       try $0.message
+///     }
 ///   ) async throws -> R where R: Sendable {
 ///     try await self.baz(
 ///       request: request,
@@ -58,7 +60,9 @@
 ///     serializer: some MessageSerializer<Foo_Bar_Input>,
 ///     deserializer: some MessageDeserializer<Foo_Bar_Output>,
 ///     options: CallOptions = .defaults,
-///     _ body: @Sendable @escaping (ClientResponse.Single<Foo_Bar_Output>) async throws -> R
+///     _ body: @Sendable @escaping (ClientResponse.Single<Foo_Bar_Output>) async throws -> R = {
+///       try $0.message
+///     }
 ///   ) async throws -> R where R: Sendable {
 ///     try await self.client.unary(
 ///       request: request,
@@ -173,7 +177,8 @@ extension ClientCodeTranslator {
       from: codeGenerationRequest,
       // The serializer/deserializer for the protocol extension method will be auto-generated.
       includeSerializationParameters: !isProtocolExtension,
-      includeDefaultCallOptions: includeDefaultCallOptions
+      includeDefaultCallOptions: includeDefaultCallOptions,
+      includeDefaultResponseHandler: isProtocolExtension && !method.isOutputStreaming
     )
     let functionSignature = FunctionSignatureDescription(
       accessModifier: accessModifier,
@@ -242,7 +247,8 @@ extension ClientCodeTranslator {
     in service: CodeGenerationRequest.ServiceDescriptor,
     from codeGenerationRequest: CodeGenerationRequest,
     includeSerializationParameters: Bool,
-    includeDefaultCallOptions: Bool
+    includeDefaultCallOptions: Bool,
+    includeDefaultResponseHandler: Bool
   ) -> [ParameterDescription] {
     var parameters = [ParameterDescription]()
 
@@ -259,7 +265,13 @@ extension ClientCodeTranslator {
           ? .memberAccess(MemberAccessDescription(right: "defaults")) : nil
       )
     )
-    parameters.append(self.bodyParameter(for: method, in: service))
+    parameters.append(
+      self.bodyParameter(
+        for: method,
+        in: service,
+        includeDefaultResponseHandler: includeDefaultResponseHandler
+      )
+    )
     return parameters
   }
   private func clientRequestParameter(
@@ -309,7 +321,8 @@ extension ClientCodeTranslator {
 
   private func bodyParameter(
     for method: CodeGenerationRequest.ServiceDescriptor.MethodDescriptor,
-    in service: CodeGenerationRequest.ServiceDescriptor
+    in service: CodeGenerationRequest.ServiceDescriptor,
+    includeDefaultResponseHandler: Bool
   ) -> ParameterDescription {
     let clientStreaming = method.isOutputStreaming ? "Stream" : "Single"
     let closureParameterType = ExistingTypeDescription.generic(
@@ -324,7 +337,30 @@ extension ClientCodeTranslator {
       sendable: true,
       escaping: true
     )
-    return ParameterDescription(name: "body", type: .closure(bodyClosure))
+
+    var defaultResponseHandler: Expression? = nil
+
+    if includeDefaultResponseHandler {
+      defaultResponseHandler = .closureInvocation(
+        body: [
+          CodeBlock(
+            item: .expression(
+              .try(
+                .memberAccess(
+                  MemberAccessDescription(left: .identifierPattern("$0"), right: "message")
+                )
+              )
+            )
+          )
+        ]
+      )
+    }
+
+    return ParameterDescription(
+      name: "body",
+      type: .closure(bodyClosure),
+      defaultValue: defaultResponseHandler
+    )
   }
 
   private func makeClientStruct(
@@ -401,7 +437,8 @@ extension ClientCodeTranslator {
       in: service,
       from: codeGenerationRequest,
       includeSerializationParameters: true,
-      includeDefaultCallOptions: true
+      includeDefaultCallOptions: true,
+      includeDefaultResponseHandler: !method.isOutputStreaming
     )
     let grpcMethodName = self.clientMethod(
       isInputStreaming: method.isInputStreaming,

--- a/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
@@ -342,17 +342,9 @@ extension ClientCodeTranslator {
 
     if includeDefaultResponseHandler {
       defaultResponseHandler = .closureInvocation(
-        body: [
-          CodeBlock(
-            item: .expression(
-              .try(
-                .memberAccess(
-                  MemberAccessDescription(left: .identifierPattern("$0"), right: "message")
-                )
-              )
-            )
-          )
-        ]
+        ClosureInvocationDescription(
+          body: [.expression(.try(.identifierPattern("$0").dot("message")))]
+        )
       )
     }
 

--- a/Sources/InteroperabilityTests/Generated/test.grpc.swift
+++ b/Sources/InteroperabilityTests/Generated/test.grpc.swift
@@ -542,7 +542,9 @@ extension Grpc_Testing_TestService.ClientProtocol {
     public func emptyCall<R>(
         request: ClientRequest.Single<Grpc_Testing_Empty>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R = {
+            try $0.message
+        }
     ) async throws -> R where R: Sendable {
         try await self.emptyCall(
             request: request,
@@ -556,7 +558,9 @@ extension Grpc_Testing_TestService.ClientProtocol {
     public func unaryCall<R>(
         request: ClientRequest.Single<Grpc_Testing_SimpleRequest>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R = {
+            try $0.message
+        }
     ) async throws -> R where R: Sendable {
         try await self.unaryCall(
             request: request,
@@ -570,7 +574,9 @@ extension Grpc_Testing_TestService.ClientProtocol {
     public func cacheableUnaryCall<R>(
         request: ClientRequest.Single<Grpc_Testing_SimpleRequest>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R = {
+            try $0.message
+        }
     ) async throws -> R where R: Sendable {
         try await self.cacheableUnaryCall(
             request: request,
@@ -598,7 +604,9 @@ extension Grpc_Testing_TestService.ClientProtocol {
     public func streamingInputCall<R>(
         request: ClientRequest.Stream<Grpc_Testing_StreamingInputCallRequest>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_StreamingInputCallResponse>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_StreamingInputCallResponse>) async throws -> R = {
+            try $0.message
+        }
     ) async throws -> R where R: Sendable {
         try await self.streamingInputCall(
             request: request,
@@ -640,7 +648,9 @@ extension Grpc_Testing_TestService.ClientProtocol {
     public func unimplementedCall<R>(
         request: ClientRequest.Single<Grpc_Testing_Empty>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R = {
+            try $0.message
+        }
     ) async throws -> R where R: Sendable {
         try await self.unimplementedCall(
             request: request,
@@ -668,7 +678,9 @@ public struct Grpc_Testing_TestServiceClient: Grpc_Testing_TestService.ClientPro
         serializer: some MessageSerializer<Grpc_Testing_Empty>,
         deserializer: some MessageDeserializer<Grpc_Testing_Empty>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R = {
+            try $0.message
+        }
     ) async throws -> R where R: Sendable {
         try await self.client.unary(
             request: request,
@@ -686,7 +698,9 @@ public struct Grpc_Testing_TestServiceClient: Grpc_Testing_TestService.ClientPro
         serializer: some MessageSerializer<Grpc_Testing_SimpleRequest>,
         deserializer: some MessageDeserializer<Grpc_Testing_SimpleResponse>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R = {
+            try $0.message
+        }
     ) async throws -> R where R: Sendable {
         try await self.client.unary(
             request: request,
@@ -706,7 +720,9 @@ public struct Grpc_Testing_TestServiceClient: Grpc_Testing_TestService.ClientPro
         serializer: some MessageSerializer<Grpc_Testing_SimpleRequest>,
         deserializer: some MessageDeserializer<Grpc_Testing_SimpleResponse>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R = {
+            try $0.message
+        }
     ) async throws -> R where R: Sendable {
         try await self.client.unary(
             request: request,
@@ -744,7 +760,9 @@ public struct Grpc_Testing_TestServiceClient: Grpc_Testing_TestService.ClientPro
         serializer: some MessageSerializer<Grpc_Testing_StreamingInputCallRequest>,
         deserializer: some MessageDeserializer<Grpc_Testing_StreamingInputCallResponse>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_StreamingInputCallResponse>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_StreamingInputCallResponse>) async throws -> R = {
+            try $0.message
+        }
     ) async throws -> R where R: Sendable {
         try await self.client.clientStreaming(
             request: request,
@@ -804,7 +822,9 @@ public struct Grpc_Testing_TestServiceClient: Grpc_Testing_TestService.ClientPro
         serializer: some MessageSerializer<Grpc_Testing_Empty>,
         deserializer: some MessageDeserializer<Grpc_Testing_Empty>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R = {
+            try $0.message
+        }
     ) async throws -> R where R: Sendable {
         try await self.client.unary(
             request: request,
@@ -836,7 +856,9 @@ extension Grpc_Testing_UnimplementedService.ClientProtocol {
     public func unimplementedCall<R>(
         request: ClientRequest.Single<Grpc_Testing_Empty>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R = {
+            try $0.message
+        }
     ) async throws -> R where R: Sendable {
         try await self.unimplementedCall(
             request: request,
@@ -864,7 +886,9 @@ public struct Grpc_Testing_UnimplementedServiceClient: Grpc_Testing_Unimplemente
         serializer: some MessageSerializer<Grpc_Testing_Empty>,
         deserializer: some MessageDeserializer<Grpc_Testing_Empty>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R = {
+            try $0.message
+        }
     ) async throws -> R where R: Sendable {
         try await self.client.unary(
             request: request,
@@ -902,7 +926,9 @@ extension Grpc_Testing_ReconnectService.ClientProtocol {
     public func start<R>(
         request: ClientRequest.Single<Grpc_Testing_ReconnectParams>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R = {
+            try $0.message
+        }
     ) async throws -> R where R: Sendable {
         try await self.start(
             request: request,
@@ -916,7 +942,9 @@ extension Grpc_Testing_ReconnectService.ClientProtocol {
     public func stop<R>(
         request: ClientRequest.Single<Grpc_Testing_Empty>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_ReconnectInfo>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_ReconnectInfo>) async throws -> R = {
+            try $0.message
+        }
     ) async throws -> R where R: Sendable {
         try await self.stop(
             request: request,
@@ -942,7 +970,9 @@ public struct Grpc_Testing_ReconnectServiceClient: Grpc_Testing_ReconnectService
         serializer: some MessageSerializer<Grpc_Testing_ReconnectParams>,
         deserializer: some MessageDeserializer<Grpc_Testing_Empty>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R = {
+            try $0.message
+        }
     ) async throws -> R where R: Sendable {
         try await self.client.unary(
             request: request,
@@ -959,7 +989,9 @@ public struct Grpc_Testing_ReconnectServiceClient: Grpc_Testing_ReconnectService
         serializer: some MessageSerializer<Grpc_Testing_Empty>,
         deserializer: some MessageDeserializer<Grpc_Testing_ReconnectInfo>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_ReconnectInfo>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_ReconnectInfo>) async throws -> R = {
+            try $0.message
+        }
     ) async throws -> R where R: Sendable {
         try await self.client.unary(
             request: request,

--- a/Sources/Services/Health/Generated/health.grpc.swift
+++ b/Sources/Services/Health/Generated/health.grpc.swift
@@ -217,7 +217,9 @@ extension Grpc_Health_V1_Health.ClientProtocol {
     package func check<R>(
         request: ClientRequest.Single<Grpc_Health_V1_HealthCheckRequest>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Health_V1_HealthCheckResponse>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Health_V1_HealthCheckResponse>) async throws -> R = {
+            try $0.message
+        }
     ) async throws -> R where R: Sendable {
         try await self.check(
             request: request,
@@ -268,7 +270,9 @@ package struct Grpc_Health_V1_HealthClient: Grpc_Health_V1_Health.ClientProtocol
         serializer: some MessageSerializer<Grpc_Health_V1_HealthCheckRequest>,
         deserializer: some MessageDeserializer<Grpc_Health_V1_HealthCheckResponse>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Health_V1_HealthCheckResponse>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Health_V1_HealthCheckResponse>) async throws -> R = {
+            try $0.message
+        }
     ) async throws -> R where R: Sendable {
         try await self.client.unary(
             request: request,

--- a/Sources/performance-worker/Generated/grpc_testing_benchmark_service.grpc.swift
+++ b/Sources/performance-worker/Generated/grpc_testing_benchmark_service.grpc.swift
@@ -261,7 +261,9 @@ extension Grpc_Testing_BenchmarkService.ClientProtocol {
     internal func unaryCall<R>(
         request: ClientRequest.Single<Grpc_Testing_SimpleRequest>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R = {
+            try $0.message
+        }
     ) async throws -> R where R: Sendable {
         try await self.unaryCall(
             request: request,
@@ -289,7 +291,9 @@ extension Grpc_Testing_BenchmarkService.ClientProtocol {
     internal func streamingFromClient<R>(
         request: ClientRequest.Stream<Grpc_Testing_SimpleRequest>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R = {
+            try $0.message
+        }
     ) async throws -> R where R: Sendable {
         try await self.streamingFromClient(
             request: request,
@@ -344,7 +348,9 @@ internal struct Grpc_Testing_BenchmarkServiceClient: Grpc_Testing_BenchmarkServi
         serializer: some MessageSerializer<Grpc_Testing_SimpleRequest>,
         deserializer: some MessageDeserializer<Grpc_Testing_SimpleResponse>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R = {
+            try $0.message
+        }
     ) async throws -> R where R: Sendable {
         try await self.client.unary(
             request: request,
@@ -383,7 +389,9 @@ internal struct Grpc_Testing_BenchmarkServiceClient: Grpc_Testing_BenchmarkServi
         serializer: some MessageSerializer<Grpc_Testing_SimpleRequest>,
         deserializer: some MessageDeserializer<Grpc_Testing_SimpleResponse>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R = {
+            try $0.message
+        }
     ) async throws -> R where R: Sendable {
         try await self.client.clientStreaming(
             request: request,

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
@@ -59,7 +59,9 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           public func methodA<R>(
               request: ClientRequest.Single<NamespaceA_ServiceARequest>,
               options: CallOptions = .defaults,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R = {
+                  try $0.message
+              }
           ) async throws -> R where R: Sendable {
               try await self.methodA(
                   request: request,
@@ -85,7 +87,9 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               serializer: some MessageSerializer<NamespaceA_ServiceARequest>,
               deserializer: some MessageDeserializer<NamespaceA_ServiceAResponse>,
               options: CallOptions = .defaults,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R = {
+                  try $0.message
+              }
           ) async throws -> R where R: Sendable {
               try await self.client.unary(
                   request: request,
@@ -140,7 +144,9 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           public func methodA<R>(
               request: ClientRequest.Stream<NamespaceA_ServiceARequest>,
               options: CallOptions = .defaults,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R = {
+                  try $0.message
+              }
           ) async throws -> R where R: Sendable {
               try await self.methodA(
                   request: request,
@@ -166,7 +172,9 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               serializer: some MessageSerializer<NamespaceA_ServiceARequest>,
               deserializer: some MessageDeserializer<NamespaceA_ServiceAResponse>,
               options: CallOptions = .defaults,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R = {
+                  try $0.message
+              }
           ) async throws -> R where R: Sendable {
               try await self.client.clientStreaming(
                   request: request,
@@ -400,7 +408,9 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           package func methodA<R>(
               request: ClientRequest.Stream<NamespaceA_ServiceARequest>,
               options: CallOptions = .defaults,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R = {
+                  try $0.message
+              }
           ) async throws -> R where R: Sendable {
               try await self.methodA(
                   request: request,
@@ -440,7 +450,9 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               serializer: some MessageSerializer<NamespaceA_ServiceARequest>,
               deserializer: some MessageDeserializer<NamespaceA_ServiceAResponse>,
               options: CallOptions = .defaults,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R
+              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R = {
+                  try $0.message
+              }
           ) async throws -> R where R: Sendable {
               try await self.client.clientStreaming(
                   request: request,
@@ -513,7 +525,9 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           internal func methodA<R>(
               request: ClientRequest.Single<ServiceARequest>,
               options: CallOptions = .defaults,
-              _ body: @Sendable @escaping (ClientResponse.Single<ServiceAResponse>) async throws -> R
+              _ body: @Sendable @escaping (ClientResponse.Single<ServiceAResponse>) async throws -> R = {
+                  try $0.message
+              }
           ) async throws -> R where R: Sendable {
               try await self.methodA(
                   request: request,
@@ -539,7 +553,9 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               serializer: some MessageSerializer<ServiceARequest>,
               deserializer: some MessageDeserializer<ServiceAResponse>,
               options: CallOptions = .defaults,
-              _ body: @Sendable @escaping (ClientResponse.Single<ServiceAResponse>) async throws -> R
+              _ body: @Sendable @escaping (ClientResponse.Single<ServiceAResponse>) async throws -> R = {
+                  try $0.message
+              }
           ) async throws -> R where R: Sendable {
               try await self.client.unary(
                   request: request,

--- a/Tests/GRPCHTTP2TransportTests/Generated/control.grpc.swift
+++ b/Tests/GRPCHTTP2TransportTests/Generated/control.grpc.swift
@@ -209,7 +209,9 @@ extension Control.ClientProtocol {
     internal func unary<R>(
         request: ClientRequest.Single<ControlInput>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<ControlOutput>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<ControlOutput>) async throws -> R = {
+            try $0.message
+        }
     ) async throws -> R where R: Sendable {
         try await self.unary(
             request: request,
@@ -237,7 +239,9 @@ extension Control.ClientProtocol {
     internal func clientStream<R>(
         request: ClientRequest.Stream<ControlInput>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<ControlOutput>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<ControlOutput>) async throws -> R = {
+            try $0.message
+        }
     ) async throws -> R where R: Sendable {
         try await self.clientStream(
             request: request,
@@ -280,7 +284,9 @@ internal struct ControlClient: Control.ClientProtocol {
         serializer: some MessageSerializer<ControlInput>,
         deserializer: some MessageDeserializer<ControlOutput>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<ControlOutput>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<ControlOutput>) async throws -> R = {
+            try $0.message
+        }
     ) async throws -> R where R: Sendable {
         try await self.client.unary(
             request: request,
@@ -314,7 +320,9 @@ internal struct ControlClient: Control.ClientProtocol {
         serializer: some MessageSerializer<ControlInput>,
         deserializer: some MessageDeserializer<ControlOutput>,
         options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<ControlOutput>) async throws -> R
+        _ body: @Sendable @escaping (ClientResponse.Single<ControlOutput>) async throws -> R = {
+            try $0.message
+        }
     ) async throws -> R where R: Sendable {
         try await self.client.clientStreaming(
             request: request,

--- a/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGeneratorTests.swift
+++ b/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGeneratorTests.swift
@@ -97,7 +97,9 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
             internal func sayHello<R>(
                 request: ClientRequest.Single<Hello_World_HelloRequest>,
                 options: CallOptions = .defaults,
-                _ body: @Sendable @escaping (ClientResponse.Single<Hello_World_HelloReply>) async throws -> R
+                _ body: @Sendable @escaping (ClientResponse.Single<Hello_World_HelloReply>) async throws -> R = {
+                    try $0.message
+                }
             ) async throws -> R where R: Sendable {
                 try await self.sayHello(
                     request: request,
@@ -124,7 +126,9 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
                 serializer: some MessageSerializer<Hello_World_HelloRequest>,
                 deserializer: some MessageDeserializer<Hello_World_HelloReply>,
                 options: CallOptions = .defaults,
-                _ body: @Sendable @escaping (ClientResponse.Single<Hello_World_HelloReply>) async throws -> R
+                _ body: @Sendable @escaping (ClientResponse.Single<Hello_World_HelloReply>) async throws -> R = {
+                    try $0.message
+                }
             ) async throws -> R where R: Sendable {
                 try await self.client.unary(
                     request: request,
@@ -350,7 +354,9 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
           package func sayHello<R>(
             request: ClientRequest.Single<HelloRequest>,
             options: CallOptions = .defaults,
-            _ body: @Sendable @escaping (ClientResponse.Single<HelloReply>) async throws -> R
+            _ body: @Sendable @escaping (ClientResponse.Single<HelloReply>) async throws -> R = {
+              try $0.message
+            }
           ) async throws -> R where R: Sendable {
             try await self.sayHello(
               request: request,
@@ -377,7 +383,9 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
             serializer: some MessageSerializer<HelloRequest>,
             deserializer: some MessageDeserializer<HelloReply>,
             options: CallOptions = .defaults,
-            _ body: @Sendable @escaping (ClientResponse.Single<HelloReply>) async throws -> R
+            _ body: @Sendable @escaping (ClientResponse.Single<HelloReply>) async throws -> R = {
+              try $0.message
+            }
           ) async throws -> R where R: Sendable {
             try await self.client.unary(
               request: request,


### PR DESCRIPTION
Motivation:

The client stub for all RPCs accepts a response handler and can return the result of that response. For unary and client-streaming RPCs, the most common handler will just return the response message. This handler should be generated as the default for those RPC types.

Modifications:

- Default the response handler parameter (`body`) to `{ try $0.message }`.

Result:

As an example, part of the generated code for the Echo service which looks like:

```swift
extension Echo_Echo.ClientProtocol {
    internal func get<R>(
        request: ClientRequest.Single<Echo_EchoRequest>,
        options: CallOptions = .defaults,
        _ body: @Sendable @escaping (ClientResponse.Single<Echo_EchoResponse>) async throws -> R
    ) async throws -> R where R: Sendable {
        try await self.get(...)
    }
```

Becomes:

```swift
extension Echo_Echo.ClientProtocol {
    internal func get<R>(
        request: ClientRequest.Single<Echo_EchoRequest>,
        options: CallOptions = .defaults,
        _ body: @Sendable @escaping (ClientResponse.Single<Echo_EchoResponse>) async throws -> R = {
	    try $0.message
        }
    ) async throws -> R where R: Sendable {
        try await self.get(...)
    }
```