### PR TITLE
Update generated health tests

### DIFF
--- a/Sources/Services/Health/Generated/health.grpc.swift
+++ b/Sources/Services/Health/Generated/health.grpc.swift
@@ -258,7 +258,7 @@ extension Grpc_Health_V1_Health.ClientProtocol {
 package struct Grpc_Health_V1_HealthClient: Grpc_Health_V1_Health.ClientProtocol {
     private let client: GRPCCore.GRPCClient
 
-    package init(client: GRPCCore.GRPCClient) {
+    package init(wrapping client: GRPCCore.GRPCClient) {
         self.client = client
     }
 

--- a/Tests/Services/HealthTests/HealthTests.swift
+++ b/Tests/Services/HealthTests/HealthTests.swift
@@ -27,7 +27,7 @@ final class HealthTests: XCTestCase {
     let inProcess = InProcessTransport.makePair()
     let server = GRPCServer(transport: inProcess.server, services: [health.service])
     let client = GRPCClient(transport: inProcess.client)
-    let healthClient = Grpc_Health_V1_HealthClient(client: client)
+    let healthClient = Grpc_Health_V1_HealthClient(wrapping: client)
 
     try await withThrowingDiscardingTaskGroup { group in
       group.addTask {


### PR DESCRIPTION
Motivation:

The health tests didn't get updated in cc563a3d.

Modifications:

Regenerate and fix label

Result:

Generated code is up-to-date