### PR TITLE
Add explicit access-level modifier support for imports in code generator

### DIFF
--- a/Package@swift-6.swift
+++ b/Package@swift-6.swift
@@ -340,7 +340,11 @@ extension Target {
         .nioFileSystem,
         .argumentParser
       ],
-      swiftSettings: [.swiftLanguageMode(.v6), .enableUpcomingFeature("ExistentialAny")]
+      swiftSettings: [
+        .swiftLanguageMode(.v6),
+        .enableUpcomingFeature("ExistentialAny"),
+        .enableUpcomingFeature("InternalImportsByDefault")
+      ]
     )
   }
 
@@ -538,7 +542,10 @@ extension Target {
         .grpcCore,
         .grpcProtobuf
       ],
-      swiftSettings: [.swiftLanguageMode(.v6), .enableUpcomingFeature("ExistentialAny")]
+      swiftSettings: [
+        .swiftLanguageMode(.v6),
+        .enableUpcomingFeature("ExistentialAny")
+      ]
     )
   }
 
@@ -694,7 +701,11 @@ extension Target {
         .nioSSL, if: includeNIOSSL
       ),
       path: "Sources/Examples/v2/Echo",
-      swiftSettings: [.swiftLanguageMode(.v6), .enableUpcomingFeature("ExistentialAny")]
+      swiftSettings: [
+        .swiftLanguageMode(.v6),
+        .enableUpcomingFeature("ExistentialAny"),
+        .enableUpcomingFeature("InternalImportsByDefault")
+      ]
     )
   }
 

--- a/Package@swift-6.swift
+++ b/Package@swift-6.swift
@@ -544,7 +544,8 @@ extension Target {
       ],
       swiftSettings: [
         .swiftLanguageMode(.v6),
-        .enableUpcomingFeature("ExistentialAny")
+        .enableUpcomingFeature("ExistentialAny"),
+        .enableUpcomingFeature("InternalImportsByDefault")
       ]
     )
   }
@@ -904,7 +905,8 @@ extension Target {
       path: "Sources/Services/Health",
       swiftSettings: [
         .swiftLanguageMode(.v6),
-        .enableUpcomingFeature("ExistentialAny")
+        .enableUpcomingFeature("ExistentialAny"),
+        .enableUpcomingFeature("InternalImportsByDefault")
       ]
     )
   }

--- a/Package@swift-6.swift
+++ b/Package@swift-6.swift
@@ -544,8 +544,7 @@ extension Target {
       ],
       swiftSettings: [
         .swiftLanguageMode(.v6),
-        .enableUpcomingFeature("ExistentialAny"),
-        .enableUpcomingFeature("InternalImportsByDefault")
+        .enableUpcomingFeature("ExistentialAny")
       ]
     )
   }
@@ -905,8 +904,7 @@ extension Target {
       path: "Sources/Services/Health",
       swiftSettings: [
         .swiftLanguageMode(.v6),
-        .enableUpcomingFeature("ExistentialAny"),
-        .enableUpcomingFeature("InternalImportsByDefault")
+        .enableUpcomingFeature("ExistentialAny")
       ]
     )
   }

--- a/Sources/Examples/v2/Echo/Generated/echo.grpc.swift
+++ b/Sources/Examples/v2/Echo/Generated/echo.grpc.swift
@@ -21,8 +21,8 @@
 // For information on using the generated types, please see the documentation:
 //   https://github.com/grpc/grpc-swift
 
-import GRPCCore
-import GRPCProtobuf
+internal import GRPCCore
+internal import GRPCProtobuf
 
 internal enum Echo_Echo {
     internal static let descriptor = ServiceDescriptor.echo_Echo

--- a/Sources/Examples/v2/Echo/Subcommands/Collect.swift
+++ b/Sources/Examples/v2/Echo/Subcommands/Collect.swift
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import ArgumentParser
-import GRPCCore
-import GRPCHTTP2Core
-import GRPCHTTP2TransportNIOPosix
+internal import ArgumentParser
+private import GRPCCore
+private import GRPCHTTP2Core
+private import GRPCHTTP2TransportNIOPosix
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct Collect: AsyncParsableCommand {

--- a/Sources/GRPCCodeGen/CodeGenerationRequest.swift
+++ b/Sources/GRPCCodeGen/CodeGenerationRequest.swift
@@ -87,9 +87,6 @@ public struct CodeGenerationRequest {
     public var item: Item?
 
     /// The access level to be included in imports of this dependency.
-    ///
-    /// - Note: This defaults to `public`, which is the default access level for imports on compilers
-    /// up to and including Swift 6.0.
     public var accessLevel: SourceGenerator.Configuration.AccessLevel
 
     /// The name of the imported module or of the module an item is imported from.

--- a/Sources/GRPCCodeGen/CodeGenerationRequest.swift
+++ b/Sources/GRPCCodeGen/CodeGenerationRequest.swift
@@ -84,7 +84,13 @@ public struct CodeGenerationRequest {
   public struct Dependency: Equatable {
     /// If the dependency is an item, the property's value is the item representation.
     /// If the dependency is a module, this property is nil.
-    public var item: Item? = nil
+    public var item: Item?
+
+    /// The access level to be included in imports of this dependency.
+    ///
+    /// - Note: This defaults to `public`, which is the default access level for imports on compilers
+    /// up to and including Swift 6.0.
+    public var accessLevel: SourceGenerator.Configuration.AccessLevel
 
     /// The name of the imported module or of the module an item is imported from.
     public var module: String
@@ -102,12 +108,14 @@ public struct CodeGenerationRequest {
       item: Item? = nil,
       module: String,
       spi: String? = nil,
-      preconcurrency: PreconcurrencyRequirement = .notRequired
+      preconcurrency: PreconcurrencyRequirement = .notRequired,
+      accessLevel: SourceGenerator.Configuration.AccessLevel
     ) {
       self.item = item
       self.module = module
       self.spi = spi
       self.preconcurrency = preconcurrency
+      self.accessLevel = accessLevel
     }
 
     /// Represents an item imported from a module.

--- a/Sources/GRPCCodeGen/Internal/Renderer/TextBasedRenderer.swift
+++ b/Sources/GRPCCodeGen/Internal/Renderer/TextBasedRenderer.swift
@@ -198,17 +198,20 @@ struct TextBasedRenderer: RendererProtocol {
     func render(preconcurrency: Bool) {
       let spiPrefix = description.spi.map { "@_spi(\($0)) " } ?? ""
       let preconcurrencyPrefix = preconcurrency ? "@preconcurrency " : ""
+      let accessLevel = "\(description.accessLevel) "
 
       if let item = description.item {
         writer.writeLine(
-          "\(preconcurrencyPrefix)\(spiPrefix)import \(item.kind) \(description.moduleName).\(item.name)"
+          "\(preconcurrencyPrefix)\(spiPrefix)\(accessLevel)import \(item.kind) \(description.moduleName).\(item.name)"
         )
       } else if let moduleTypes = description.moduleTypes {
         for type in moduleTypes {
-          writer.writeLine("\(preconcurrencyPrefix)\(spiPrefix)import \(type)")
+          writer.writeLine("\(preconcurrencyPrefix)\(spiPrefix)\(accessLevel)import \(type)")
         }
       } else {
-        writer.writeLine("\(preconcurrencyPrefix)\(spiPrefix)import \(description.moduleName)")
+        writer.writeLine(
+          "\(preconcurrencyPrefix)\(spiPrefix)\(accessLevel)import \(description.moduleName)"
+        )
       }
     }
 

--- a/Sources/GRPCCodeGen/Internal/Renderer/TextBasedRenderer.swift
+++ b/Sources/GRPCCodeGen/Internal/Renderer/TextBasedRenderer.swift
@@ -198,7 +198,7 @@ struct TextBasedRenderer: RendererProtocol {
     func render(preconcurrency: Bool) {
       let spiPrefix = description.spi.map { "@_spi(\($0)) " } ?? ""
       let preconcurrencyPrefix = preconcurrency ? "@preconcurrency " : ""
-      let accessLevel = "\(description.accessLevel) "
+      let accessLevel = description.accessLevel.map { "\($0) " } ?? ""
 
       if let item = description.item {
         writer.writeLine(

--- a/Sources/GRPCCodeGen/Internal/StructuredSwiftRepresentation.swift
+++ b/Sources/GRPCCodeGen/Internal/StructuredSwiftRepresentation.swift
@@ -31,6 +31,11 @@
 ///
 /// For example: `import Foo`.
 struct ImportDescription: Equatable, Codable {
+  /// The access level of the imported module.
+  ///
+  /// For example, the `public` in `public import Foo`.
+  var accessLevel: AccessModifier
+
   /// The name of the imported module.
   ///
   /// For example, the `Foo` in `import Foo`.

--- a/Sources/GRPCCodeGen/Internal/StructuredSwiftRepresentation.swift
+++ b/Sources/GRPCCodeGen/Internal/StructuredSwiftRepresentation.swift
@@ -34,7 +34,9 @@ struct ImportDescription: Equatable, Codable {
   /// The access level of the imported module.
   ///
   /// For example, the `public` in `public import Foo`.
-  var accessLevel: AccessModifier
+  ///
+  /// - Note: This is optional, as explicit access-level modifiers are not required on `import` statements.
+  var accessLevel: AccessModifier? = nil
 
   /// The name of the imported module.
   ///

--- a/Sources/GRPCProtobufCodeGen/ProtobufCodeGenerator.swift
+++ b/Sources/GRPCProtobufCodeGen/ProtobufCodeGenerator.swift
@@ -34,7 +34,8 @@ public struct ProtobufCodeGenerator {
     let parser = ProtobufCodeGenParser(
       input: fileDescriptor,
       protoFileModuleMappings: protoFileModuleMappings,
-      extraModuleImports: extraModuleImports
+      extraModuleImports: extraModuleImports,
+      accessLevel: self.configuration.accessLevel
     )
     let sourceGenerator = SourceGenerator(configuration: self.configuration)
 

--- a/Sources/InteroperabilityTests/Generated/empty_service.grpc.swift
+++ b/Sources/InteroperabilityTests/Generated/empty_service.grpc.swift
@@ -21,8 +21,8 @@
 // For information on using the generated types, please see the documentation:
 //   https://github.com/grpc/grpc-swift
 
-import GRPCCore
-import GRPCProtobuf
+public import GRPCCore
+internal import GRPCProtobuf
 
 public enum Grpc_Testing_EmptyService {
     public static let descriptor = ServiceDescriptor.grpc_testing_EmptyService

--- a/Sources/InteroperabilityTests/Generated/test.grpc.swift
+++ b/Sources/InteroperabilityTests/Generated/test.grpc.swift
@@ -24,8 +24,8 @@
 // For information on using the generated types, please see the documentation:
 //   https://github.com/grpc/grpc-swift
 
-import GRPCCore
-import GRPCProtobuf
+public import GRPCCore
+internal import GRPCProtobuf
 
 public enum Grpc_Testing_ReconnectService {
     public static let descriptor = ServiceDescriptor.grpc_testing_ReconnectService

--- a/Sources/Services/Health/Generated/health.grpc.swift
+++ b/Sources/Services/Health/Generated/health.grpc.swift
@@ -24,8 +24,8 @@
 // For information on using the generated types, please see the documentation:
 //   https://github.com/grpc/grpc-swift
 
-import GRPCCore
-import GRPCProtobuf
+package import GRPCCore
+internal import GRPCProtobuf
 
 package enum Grpc_Health_V1_Health {
     package static let descriptor = ServiceDescriptor.grpc_health_v1_Health

--- a/Sources/Services/Health/Health.swift
+++ b/Sources/Services/Health/Health.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import GRPCCore
+public import GRPCCore
 
 /// ``Health`` is gRPC’s mechanism for checking whether a server is able to handle RPCs. Its semantics are documented in
 /// https://github.com/grpc/grpc/blob/master/doc/health-checking.md.

--- a/Sources/Services/Health/HealthService.swift
+++ b/Sources/Services/Health/HealthService.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import GRPCCore
+internal import GRPCCore
 
 @available(macOS 15.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 internal struct HealthService: Grpc_Health_V1_HealthServiceProtocol {

--- a/Sources/performance-worker/BenchmarkClient.swift
+++ b/Sources/performance-worker/BenchmarkClient.swift
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import Atomics
-import Foundation
-import GRPCCore
-import NIOConcurrencyHelpers
+private import Atomics
+private import Foundation
+internal import GRPCCore
+private import NIOConcurrencyHelpers
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct BenchmarkClient {

--- a/Sources/performance-worker/BenchmarkService.swift
+++ b/Sources/performance-worker/BenchmarkService.swift
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import Atomics
-import GRPCCore
+private import Atomics
+internal import GRPCCore
 
 import struct Foundation.Data
 

--- a/Sources/performance-worker/Generated/grpc_testing_benchmark_service.grpc.swift
+++ b/Sources/performance-worker/Generated/grpc_testing_benchmark_service.grpc.swift
@@ -24,8 +24,8 @@
 // For information on using the generated types, please see the documentation:
 //   https://github.com/grpc/grpc-swift
 
-import GRPCCore
-import GRPCProtobuf
+internal import GRPCCore
+internal import GRPCProtobuf
 
 internal enum Grpc_Testing_BenchmarkService {
     internal static let descriptor = ServiceDescriptor.grpc_testing_BenchmarkService

--- a/Sources/performance-worker/Generated/grpc_testing_worker_service.grpc.swift
+++ b/Sources/performance-worker/Generated/grpc_testing_worker_service.grpc.swift
@@ -24,8 +24,8 @@
 // For information on using the generated types, please see the documentation:
 //   https://github.com/grpc/grpc-swift
 
-import GRPCCore
-import GRPCProtobuf
+internal import GRPCCore
+internal import GRPCProtobuf
 
 internal enum Grpc_Testing_WorkerService {
     internal static let descriptor = ServiceDescriptor.grpc_testing_WorkerService

--- a/Sources/performance-worker/PerformanceWorker.swift
+++ b/Sources/performance-worker/PerformanceWorker.swift
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import ArgumentParser
-import GRPCCore
-import GRPCHTTP2Core
-import GRPCHTTP2TransportNIOPosix
-import NIOPosix
+internal import ArgumentParser
+private import GRPCCore
+private import GRPCHTTP2Core
+private import GRPCHTTP2TransportNIOPosix
+private import NIOPosix
 
 @main
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)

--- a/Sources/performance-worker/RPCStats.swift
+++ b/Sources/performance-worker/RPCStats.swift
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import Foundation
-import GRPCCore
-import NIOConcurrencyHelpers
+private import Foundation
+internal import GRPCCore
+internal import NIOConcurrencyHelpers
 
 /// Stores the real time latency histogram and error code count dictionary,
 /// for the RPCs made by a particular GRPCClient. It gets updated after

--- a/Tests/GRPCCodeGenTests/Internal/Renderer/TextBasedRendererTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Renderer/TextBasedRendererTests.swift
@@ -111,26 +111,25 @@ final class Test_TextBasedRenderer: XCTestCase {
     try _test(nil, renderedBy: { $0.renderImports(_:) }, rendersAs: "")
     try _test(
       [
-        ImportDescription(accessLevel: .internal, moduleName: "Foo"),
-        ImportDescription(accessLevel: .public, moduleName: "Bar"),
+        ImportDescription(moduleName: "Foo"),
+        ImportDescription(moduleName: "Bar"),
       ],
       renderedBy: { $0.renderImports(_:) },
       rendersAs: #"""
-        internal import Foo
-        public import Bar
+        import Foo
+        import Bar
         """#
     )
     try _test(
-      [ImportDescription(accessLevel: .internal, moduleName: "Foo", spi: "Secret")],
+      [ImportDescription(moduleName: "Foo", spi: "Secret")],
       renderedBy: { $0.renderImports(_:) },
       rendersAs: #"""
-        @_spi(Secret) internal import Foo
+        @_spi(Secret) import Foo
         """#
     )
     try _test(
       [
         ImportDescription(
-          accessLevel: .internal,
           moduleName: "Foo",
           preconcurrency: .onOS(["Bar", "Baz"])
         )
@@ -138,17 +137,16 @@ final class Test_TextBasedRenderer: XCTestCase {
       renderedBy: { $0.renderImports(_:) },
       rendersAs: #"""
         #if os(Bar) || os(Baz)
-        @preconcurrency internal import Foo
+        @preconcurrency import Foo
         #else
-        internal import Foo
+        import Foo
         #endif
         """#
     )
     try _test(
       [
-        ImportDescription(accessLevel: .internal, moduleName: "Foo", preconcurrency: .always),
+        ImportDescription(moduleName: "Foo", preconcurrency: .always),
         ImportDescription(
-          accessLevel: .internal,
           moduleName: "Bar",
           spi: "Secret",
           preconcurrency: .always
@@ -156,61 +154,51 @@ final class Test_TextBasedRenderer: XCTestCase {
       ],
       renderedBy: { $0.renderImports(_:) },
       rendersAs: #"""
-        @preconcurrency internal import Foo
-        @preconcurrency @_spi(Secret) internal import Bar
+        @preconcurrency import Foo
+        @preconcurrency @_spi(Secret) import Bar
         """#
     )
 
     try _test(
       [
         ImportDescription(
-          accessLevel: .package,
           moduleName: "Foo",
           item: ImportDescription.Item(kind: .typealias, name: "Bar")
         ),
         ImportDescription(
-          accessLevel: .package,
           moduleName: "Foo",
           item: ImportDescription.Item(kind: .struct, name: "Baz")
         ),
         ImportDescription(
-          accessLevel: .package,
           moduleName: "Foo",
           item: ImportDescription.Item(kind: .class, name: "Bac")
         ),
         ImportDescription(
-          accessLevel: .package,
           moduleName: "Foo",
           item: ImportDescription.Item(kind: .enum, name: "Bap")
         ),
         ImportDescription(
-          accessLevel: .package,
           moduleName: "Foo",
           item: ImportDescription.Item(kind: .protocol, name: "Bat")
         ),
         ImportDescription(
-          accessLevel: .package,
           moduleName: "Foo",
           item: ImportDescription.Item(kind: .let, name: "Bam")
         ),
         ImportDescription(
-          accessLevel: .package,
           moduleName: "Foo",
           item: ImportDescription.Item(kind: .var, name: "Bag")
         ),
         ImportDescription(
-          accessLevel: .package,
           moduleName: "Foo",
           item: ImportDescription.Item(kind: .func, name: "Bak")
         ),
         ImportDescription(
-          accessLevel: .package,
           moduleName: "Foo",
           spi: "Secret",
           item: ImportDescription.Item(kind: .func, name: "SecretBar")
         ),
         ImportDescription(
-          accessLevel: .package,
           moduleName: "Foo",
           preconcurrency: .always,
           item: ImportDescription.Item(kind: .func, name: "PreconcurrencyBar")
@@ -218,16 +206,16 @@ final class Test_TextBasedRenderer: XCTestCase {
       ],
       renderedBy: { $0.renderImports(_:) },
       rendersAs: #"""
-        package import typealias Foo.Bar
-        package import struct Foo.Baz
-        package import class Foo.Bac
-        package import enum Foo.Bap
-        package import protocol Foo.Bat
-        package import let Foo.Bam
-        package import var Foo.Bag
-        package import func Foo.Bak
-        @_spi(Secret) package import func Foo.SecretBar
-        @preconcurrency package import func Foo.PreconcurrencyBar
+        import typealias Foo.Bar
+        import struct Foo.Baz
+        import class Foo.Bac
+        import enum Foo.Bap
+        import protocol Foo.Bat
+        import let Foo.Bam
+        import var Foo.Bag
+        import func Foo.Bak
+        @_spi(Secret) import func Foo.SecretBar
+        @preconcurrency import func Foo.PreconcurrencyBar
         """#
     )
   }
@@ -880,14 +868,14 @@ final class Test_TextBasedRenderer: XCTestCase {
     try _test(
       .init(
         topComment: .inline("hi"),
-        imports: [.init(accessLevel: .internal, moduleName: "Foo")],
+        imports: [.init(moduleName: "Foo")],
         codeBlocks: [.init(comment: nil, item: .declaration(.struct(.init(name: "Bar"))))]
       ),
       renderedBy: { $0.renderFile(_:) },
       rendersAs: #"""
         // hi
 
-        internal import Foo
+        import Foo
 
         struct Bar {}
         """#
@@ -898,7 +886,7 @@ final class Test_TextBasedRenderer: XCTestCase {
     try _test(
       .init(
         topComment: .inline("hi"),
-        imports: [.init(accessLevel: .public, moduleName: "Foo")],
+        imports: [.init(moduleName: "Foo")],
         codeBlocks: [
           .init(
             comment: nil,
@@ -910,7 +898,7 @@ final class Test_TextBasedRenderer: XCTestCase {
       rendersAs: #"""
         // hi
 
-        public import Foo
+        import Foo
 
         struct Bar {
           struct Baz {}

--- a/Tests/GRPCCodeGenTests/Internal/Renderer/TextBasedRendererTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Renderer/TextBasedRendererTests.swift
@@ -110,77 +110,107 @@ final class Test_TextBasedRenderer: XCTestCase {
   func testImports() throws {
     try _test(nil, renderedBy: { $0.renderImports(_:) }, rendersAs: "")
     try _test(
-      [ImportDescription(moduleName: "Foo"), ImportDescription(moduleName: "Bar")],
+      [
+        ImportDescription(accessLevel: .internal, moduleName: "Foo"),
+        ImportDescription(accessLevel: .public, moduleName: "Bar"),
+      ],
       renderedBy: { $0.renderImports(_:) },
       rendersAs: #"""
-        import Foo
-        import Bar
+        internal import Foo
+        public import Bar
         """#
     )
     try _test(
-      [ImportDescription(moduleName: "Foo", spi: "Secret")],
+      [ImportDescription(accessLevel: .internal, moduleName: "Foo", spi: "Secret")],
       renderedBy: { $0.renderImports(_:) },
       rendersAs: #"""
-        @_spi(Secret) import Foo
+        @_spi(Secret) internal import Foo
         """#
     )
     try _test(
-      [ImportDescription(moduleName: "Foo", preconcurrency: .onOS(["Bar", "Baz"]))],
+      [
+        ImportDescription(
+          accessLevel: .internal,
+          moduleName: "Foo",
+          preconcurrency: .onOS(["Bar", "Baz"])
+        )
+      ],
       renderedBy: { $0.renderImports(_:) },
       rendersAs: #"""
         #if os(Bar) || os(Baz)
-        @preconcurrency import Foo
+        @preconcurrency internal import Foo
         #else
-        import Foo
+        internal import Foo
         #endif
         """#
     )
     try _test(
       [
-        ImportDescription(moduleName: "Foo", preconcurrency: .always),
-        ImportDescription(moduleName: "Bar", spi: "Secret", preconcurrency: .always),
+        ImportDescription(accessLevel: .internal, moduleName: "Foo", preconcurrency: .always),
+        ImportDescription(
+          accessLevel: .internal,
+          moduleName: "Bar",
+          spi: "Secret",
+          preconcurrency: .always
+        ),
       ],
       renderedBy: { $0.renderImports(_:) },
       rendersAs: #"""
-        @preconcurrency import Foo
-        @preconcurrency @_spi(Secret) import Bar
+        @preconcurrency internal import Foo
+        @preconcurrency @_spi(Secret) internal import Bar
         """#
     )
 
     try _test(
       [
         ImportDescription(
+          accessLevel: .package,
           moduleName: "Foo",
           item: ImportDescription.Item(kind: .typealias, name: "Bar")
         ),
         ImportDescription(
+          accessLevel: .package,
           moduleName: "Foo",
           item: ImportDescription.Item(kind: .struct, name: "Baz")
         ),
         ImportDescription(
+          accessLevel: .package,
           moduleName: "Foo",
           item: ImportDescription.Item(kind: .class, name: "Bac")
         ),
         ImportDescription(
+          accessLevel: .package,
           moduleName: "Foo",
           item: ImportDescription.Item(kind: .enum, name: "Bap")
         ),
         ImportDescription(
+          accessLevel: .package,
           moduleName: "Foo",
           item: ImportDescription.Item(kind: .protocol, name: "Bat")
         ),
-        ImportDescription(moduleName: "Foo", item: ImportDescription.Item(kind: .let, name: "Bam")),
-        ImportDescription(moduleName: "Foo", item: ImportDescription.Item(kind: .var, name: "Bag")),
         ImportDescription(
+          accessLevel: .package,
+          moduleName: "Foo",
+          item: ImportDescription.Item(kind: .let, name: "Bam")
+        ),
+        ImportDescription(
+          accessLevel: .package,
+          moduleName: "Foo",
+          item: ImportDescription.Item(kind: .var, name: "Bag")
+        ),
+        ImportDescription(
+          accessLevel: .package,
           moduleName: "Foo",
           item: ImportDescription.Item(kind: .func, name: "Bak")
         ),
         ImportDescription(
+          accessLevel: .package,
           moduleName: "Foo",
           spi: "Secret",
           item: ImportDescription.Item(kind: .func, name: "SecretBar")
         ),
         ImportDescription(
+          accessLevel: .package,
           moduleName: "Foo",
           preconcurrency: .always,
           item: ImportDescription.Item(kind: .func, name: "PreconcurrencyBar")
@@ -188,16 +218,16 @@ final class Test_TextBasedRenderer: XCTestCase {
       ],
       renderedBy: { $0.renderImports(_:) },
       rendersAs: #"""
-        import typealias Foo.Bar
-        import struct Foo.Baz
-        import class Foo.Bac
-        import enum Foo.Bap
-        import protocol Foo.Bat
-        import let Foo.Bam
-        import var Foo.Bag
-        import func Foo.Bak
-        @_spi(Secret) import func Foo.SecretBar
-        @preconcurrency import func Foo.PreconcurrencyBar
+        package import typealias Foo.Bar
+        package import struct Foo.Baz
+        package import class Foo.Bac
+        package import enum Foo.Bap
+        package import protocol Foo.Bat
+        package import let Foo.Bam
+        package import var Foo.Bag
+        package import func Foo.Bak
+        @_spi(Secret) package import func Foo.SecretBar
+        @preconcurrency package import func Foo.PreconcurrencyBar
         """#
     )
   }
@@ -850,14 +880,14 @@ final class Test_TextBasedRenderer: XCTestCase {
     try _test(
       .init(
         topComment: .inline("hi"),
-        imports: [.init(moduleName: "Foo")],
+        imports: [.init(accessLevel: .internal, moduleName: "Foo")],
         codeBlocks: [.init(comment: nil, item: .declaration(.struct(.init(name: "Bar"))))]
       ),
       renderedBy: { $0.renderFile(_:) },
       rendersAs: #"""
         // hi
 
-        import Foo
+        internal import Foo
 
         struct Bar {}
         """#
@@ -868,7 +898,7 @@ final class Test_TextBasedRenderer: XCTestCase {
     try _test(
       .init(
         topComment: .inline("hi"),
-        imports: [.init(moduleName: "Foo")],
+        imports: [.init(accessLevel: .public, moduleName: "Foo")],
         codeBlocks: [
           .init(
             comment: nil,
@@ -880,7 +910,7 @@ final class Test_TextBasedRenderer: XCTestCase {
       rendersAs: #"""
         // hi
 
-        import Foo
+        public import Foo
 
         struct Bar {
           struct Baz {}

--- a/Tests/GRPCCodeGenTests/Internal/Renderer/TextBasedRendererTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Renderer/TextBasedRendererTests.swift
@@ -113,11 +113,21 @@ final class Test_TextBasedRenderer: XCTestCase {
       [
         ImportDescription(moduleName: "Foo"),
         ImportDescription(moduleName: "Bar"),
+        ImportDescription(accessLevel: .fileprivate, moduleName: "BazFileprivate"),
+        ImportDescription(accessLevel: .private, moduleName: "BazPrivate"),
+        ImportDescription(accessLevel: .internal, moduleName: "BazInternal"),
+        ImportDescription(accessLevel: .package, moduleName: "BazPackage"),
+        ImportDescription(accessLevel: .public, moduleName: "BazPublic"),
       ],
       renderedBy: { $0.renderImports(_:) },
       rendersAs: #"""
         import Foo
         import Bar
+        fileprivate import BazFileprivate
+        private import BazPrivate
+        internal import BazInternal
+        package import BazPackage
+        public import BazPublic
         """#
     )
     try _test(
@@ -941,7 +951,6 @@ final class Test_TextBasedRenderer: XCTestCase {
 }
 
 extension Test_TextBasedRenderer {
-
   func _test<Input>(
     _ input: Input,
     renderedBy renderClosure: (TextBasedRenderer) -> ((Input) -> String),

--- a/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
@@ -27,46 +27,78 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
 
   func testImports() throws {
     var dependencies = [CodeGenerationRequest.Dependency]()
-    dependencies.append(CodeGenerationRequest.Dependency(module: "Foo"))
+    dependencies.append(CodeGenerationRequest.Dependency(module: "Foo", accessLevel: .public))
     dependencies.append(
-      CodeGenerationRequest.Dependency(item: .init(kind: .typealias, name: "Bar"), module: "Foo")
+      CodeGenerationRequest.Dependency(
+        item: .init(kind: .typealias, name: "Bar"),
+        module: "Foo",
+        accessLevel: .internal
+      )
     )
     dependencies.append(
-      CodeGenerationRequest.Dependency(item: .init(kind: .struct, name: "Baz"), module: "Foo")
+      CodeGenerationRequest.Dependency(
+        item: .init(kind: .struct, name: "Baz"),
+        module: "Foo",
+        accessLevel: .package
+      )
     )
     dependencies.append(
-      CodeGenerationRequest.Dependency(item: .init(kind: .class, name: "Bac"), module: "Foo")
+      CodeGenerationRequest.Dependency(
+        item: .init(kind: .class, name: "Bac"),
+        module: "Foo",
+        accessLevel: .package
+      )
     )
     dependencies.append(
-      CodeGenerationRequest.Dependency(item: .init(kind: .enum, name: "Bap"), module: "Foo")
+      CodeGenerationRequest.Dependency(
+        item: .init(kind: .enum, name: "Bap"),
+        module: "Foo",
+        accessLevel: .package
+      )
     )
     dependencies.append(
-      CodeGenerationRequest.Dependency(item: .init(kind: .protocol, name: "Bat"), module: "Foo")
+      CodeGenerationRequest.Dependency(
+        item: .init(kind: .protocol, name: "Bat"),
+        module: "Foo",
+        accessLevel: .package
+      )
     )
     dependencies.append(
-      CodeGenerationRequest.Dependency(item: .init(kind: .let, name: "Baq"), module: "Foo")
+      CodeGenerationRequest.Dependency(
+        item: .init(kind: .let, name: "Baq"),
+        module: "Foo",
+        accessLevel: .package
+      )
     )
     dependencies.append(
-      CodeGenerationRequest.Dependency(item: .init(kind: .var, name: "Bag"), module: "Foo")
+      CodeGenerationRequest.Dependency(
+        item: .init(kind: .var, name: "Bag"),
+        module: "Foo",
+        accessLevel: .package
+      )
     )
     dependencies.append(
-      CodeGenerationRequest.Dependency(item: .init(kind: .func, name: "Bak"), module: "Foo")
+      CodeGenerationRequest.Dependency(
+        item: .init(kind: .func, name: "Bak"),
+        module: "Foo",
+        accessLevel: .package
+      )
     )
 
     let expectedSwift =
       """
       /// Some really exciting license header 2023.
 
-      import GRPCCore
-      import Foo
-      import typealias Foo.Bar
-      import struct Foo.Baz
-      import class Foo.Bac
-      import enum Foo.Bap
-      import protocol Foo.Bat
-      import let Foo.Baq
-      import var Foo.Bag
-      import func Foo.Bak
+      public import GRPCCore
+      internal import Foo
+      package import typealias Foo.Bar
+      package import struct Foo.Baz
+      package import class Foo.Bac
+      package import enum Foo.Bap
+      package import protocol Foo.Bat
+      package import let Foo.Baq
+      package import var Foo.Bag
+      package import func Foo.Bak
 
       """
     try self.assertIDLToStructuredSwiftTranslation(
@@ -78,18 +110,26 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
 
   func testPreconcurrencyImports() throws {
     var dependencies = [CodeGenerationRequest.Dependency]()
-    dependencies.append(CodeGenerationRequest.Dependency(module: "Foo", preconcurrency: .required))
+    dependencies.append(
+      CodeGenerationRequest.Dependency(
+        module: "Foo",
+        preconcurrency: .required,
+        accessLevel: .internal
+      )
+    )
     dependencies.append(
       CodeGenerationRequest.Dependency(
         item: .init(kind: .enum, name: "Bar"),
         module: "Foo",
-        preconcurrency: .required
+        preconcurrency: .required,
+        accessLevel: .internal
       )
     )
     dependencies.append(
       CodeGenerationRequest.Dependency(
         module: "Baz",
-        preconcurrency: .requiredOnOS(["Deq", "Der"])
+        preconcurrency: .requiredOnOS(["Deq", "Der"]),
+        accessLevel: .internal
       )
     )
     let expectedSwift =
@@ -97,12 +137,12 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
       /// Some really exciting license header 2023.
 
       import GRPCCore
-      @preconcurrency import Foo
-      @preconcurrency import enum Foo.Bar
+      @preconcurrency internal import Foo
+      @preconcurrency internal import enum Foo.Bar
       #if os(Deq) || os(Der)
-      @preconcurrency import Baz
+      @preconcurrency internal import Baz
       #else
-      import Baz
+      internal import Baz
       #endif
 
       """
@@ -115,12 +155,15 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
 
   func testSPIImports() throws {
     var dependencies = [CodeGenerationRequest.Dependency]()
-    dependencies.append(CodeGenerationRequest.Dependency(module: "Foo", spi: "Secret"))
+    dependencies.append(
+      CodeGenerationRequest.Dependency(module: "Foo", spi: "Secret", accessLevel: .internal)
+    )
     dependencies.append(
       CodeGenerationRequest.Dependency(
         item: .init(kind: .enum, name: "Bar"),
         module: "Foo",
-        spi: "Secret"
+        spi: "Secret",
+        accessLevel: .internal
       )
     )
 
@@ -128,9 +171,9 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
       """
       /// Some really exciting license header 2023.
 
-      import GRPCCore
-      @_spi(Secret) import Foo
-      @_spi(Secret) import enum Foo.Bar
+      internal import GRPCCore
+      @_spi(Secret) internal import Foo
+      @_spi(Secret) internal import enum Foo.Bar
 
       """
     try self.assertIDLToStructuredSwiftTranslation(
@@ -142,12 +185,15 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
 
   func testGeneration() throws {
     var dependencies = [CodeGenerationRequest.Dependency]()
-    dependencies.append(CodeGenerationRequest.Dependency(module: "Foo", spi: "Secret"))
+    dependencies.append(
+      CodeGenerationRequest.Dependency(module: "Foo", spi: "Secret", accessLevel: .internal)
+    )
     dependencies.append(
       CodeGenerationRequest.Dependency(
         item: .init(kind: .enum, name: "Bar"),
         module: "Foo",
-        spi: "Secret"
+        spi: "Secret",
+        accessLevel: .internal
       )
     )
 

--- a/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
@@ -90,8 +90,8 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
       /// Some really exciting license header 2023.
 
       public import GRPCCore
-      internal import Foo
-      package import typealias Foo.Bar
+      public import Foo
+      internal import typealias Foo.Bar
       package import struct Foo.Baz
       package import class Foo.Bac
       package import enum Foo.Bap
@@ -136,7 +136,7 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
       """
       /// Some really exciting license header 2023.
 
-      import GRPCCore
+      public import GRPCCore
       @preconcurrency internal import Foo
       @preconcurrency internal import enum Foo.Bar
       #if os(Deq) || os(Der)
@@ -171,7 +171,7 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
       """
       /// Some really exciting license header 2023.
 
-      internal import GRPCCore
+      public import GRPCCore
       @_spi(Secret) internal import Foo
       @_spi(Secret) internal import enum Foo.Bar
 
@@ -212,9 +212,9 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
       """
       /// Some really exciting license header 2023.
 
-      import GRPCCore
-      @_spi(Secret) import Foo
-      @_spi(Secret) import enum Foo.Bar
+      public import GRPCCore
+      @_spi(Secret) internal import Foo
+      @_spi(Secret) internal import enum Foo.Bar
 
       public enum NamespaceA_ServiceA {
           public static let descriptor = ServiceDescriptor.namespaceA_ServiceA

--- a/Tests/GRPCHTTP2TransportTests/ControlService.swift
+++ b/Tests/GRPCHTTP2TransportTests/ControlService.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import GRPCCore
+internal import GRPCCore
 
 import struct Foundation.Data
 

--- a/Tests/GRPCHTTP2TransportTests/Generated/control.grpc.swift
+++ b/Tests/GRPCHTTP2TransportTests/Generated/control.grpc.swift
@@ -22,8 +22,8 @@
 // For information on using the generated types, please see the documentation:
 //   https://github.com/grpc/grpc-swift
 
-import GRPCCore
-import GRPCProtobuf
+internal import GRPCCore
+internal import GRPCProtobuf
 
 internal enum Control {
     internal static let descriptor = ServiceDescriptor.Control

--- a/Tests/GRPCHTTP2TransportTests/HTTP2TransportNIOPosixTests.swift
+++ b/Tests/GRPCHTTP2TransportTests/HTTP2TransportNIOPosixTests.swift
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import GRPCCore
-import GRPCHTTP2Core
-import GRPCHTTP2TransportNIOPosix
-import XCTest
+private import GRPCCore
+private import GRPCHTTP2Core
+private import GRPCHTTP2TransportNIOPosix
+internal import XCTest
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class HTTP2TransportNIOPosixTests: XCTestCase {

--- a/Tests/GRPCHTTP2TransportTests/HTTP2TransportNIOTransportServicesTests.swift
+++ b/Tests/GRPCHTTP2TransportTests/HTTP2TransportNIOTransportServicesTests.swift
@@ -15,10 +15,10 @@
  */
 
 #if canImport(Network)
-import GRPCCore
-import GRPCHTTP2Core
-import GRPCHTTP2TransportNIOTransportServices
-import XCTest
+private import GRPCCore
+private import GRPCHTTP2Core
+internal import GRPCHTTP2TransportNIOTransportServices
+internal import XCTest
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class HTTP2TransportNIOTransportServicesTests: XCTestCase {

--- a/Tests/GRPCHTTP2TransportTests/HTTP2TransportTests.swift
+++ b/Tests/GRPCHTTP2TransportTests/HTTP2TransportTests.swift
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import GRPCCore
-import GRPCHTTP2Core
-import GRPCHTTP2TransportNIOPosix
-import GRPCHTTP2TransportNIOTransportServices
-import GRPCProtobuf
-import XCTest
+internal import GRPCCore
+private import GRPCHTTP2Core
+private import GRPCHTTP2TransportNIOPosix
+private import GRPCHTTP2TransportNIOTransportServices
+private import GRPCProtobuf
+internal import XCTest
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class HTTP2TransportTests: XCTestCase {

--- a/Tests/GRPCHTTP2TransportTests/Test Utilities/HTTP2StatusCodeServer.swift
+++ b/Tests/GRPCHTTP2TransportTests/Test Utilities/HTTP2StatusCodeServer.swift
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import GRPCHTTP2Core
-import NIOCore
-import NIOHPACK
-import NIOHTTP2
-import NIOPosix
+internal import GRPCHTTP2Core
+private import NIOCore
+private import NIOHPACK
+private import NIOHTTP2
+private import NIOPosix
 
 /// An HTTP/2 test server which only responds to request headers by sending response headers and
 /// then closing. Each stream will be closed with the ":status" set to the value of the

--- a/Tests/GRPCHTTP2TransportTests/Test Utilities/XCTest+Utilities.swift
+++ b/Tests/GRPCHTTP2TransportTests/Test Utilities/XCTest+Utilities.swift
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import GRPCCore
-import XCTest
+
+private import XCTest
 
 func XCTAssertThrowsError<T, E: Error>(
   ofType: E.Type,

--- a/Tests/GRPCHTTP2TransportTests/XCTestCase+Vsock.swift
+++ b/Tests/GRPCHTTP2TransportTests/XCTestCase+Vsock.swift
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import NIOPosix
-import XCTest
+private import NIOPosix
+internal import XCTest
 
 extension XCTestCase {
   func vsockAvailable() -> Bool {

--- a/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGenParserTests.swift
+++ b/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGenParserTests.swift
@@ -55,7 +55,8 @@ final class ProtobufCodeGenParserTests: XCTestCase {
     let parsedCodeGenRequest = try ProtobufCodeGenParser(
       input: fileDescriptor,
       protoFileModuleMappings: ProtoFileToModuleMappings(moduleMappingsProto: moduleMappings),
-      extraModuleImports: ["ExtraModule"]
+      extraModuleImports: ["ExtraModule"],
+      accessLevel: .internal
     ).parse()
 
     self.testCommonHelloworldParsedRequestFields(for: parsedCodeGenRequest)
@@ -136,7 +137,8 @@ final class ProtobufCodeGenParserTests: XCTestCase {
     let parsedCodeGenRequest = try ProtobufCodeGenParser(
       input: fileDescriptor,
       protoFileModuleMappings: ProtoFileToModuleMappings(moduleMappingsProto: moduleMappings),
-      extraModuleImports: ["ExtraModule"]
+      extraModuleImports: ["ExtraModule"],
+      accessLevel: .internal
     ).parse()
 
     self.testCommonHelloworldParsedRequestFields(for: parsedCodeGenRequest)
@@ -217,7 +219,8 @@ final class ProtobufCodeGenParserTests: XCTestCase {
     let parsedCodeGenRequest = try ProtobufCodeGenParser(
       input: fileDescriptor,
       protoFileModuleMappings: ProtoFileToModuleMappings(moduleMappingsProto: moduleMappings),
-      extraModuleImports: ["ExtraModule"]
+      extraModuleImports: ["ExtraModule"],
+      accessLevel: .internal
     ).parse()
 
     self.testCommonHelloworldParsedRequestFields(for: parsedCodeGenRequest)

--- a/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGeneratorTests.swift
+++ b/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGeneratorTests.swift
@@ -54,10 +54,10 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         // For information on using the generated types, please see the documentation:
         //   https://github.com/grpc/grpc-swift
 
-        import GRPCCore
-        import GRPCProtobuf
-        import DifferentModule
-        import ExtraModule
+        internal import GRPCCore
+        internal import GRPCProtobuf
+        internal import DifferentModule
+        internal import ExtraModule
 
         internal enum Hello_World_Greeter {
             internal static let descriptor = ServiceDescriptor.hello_world_Greeter
@@ -181,10 +181,10 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         // For information on using the generated types, please see the documentation:
         //   https://github.com/grpc/grpc-swift
 
-        import GRPCCore
-        import GRPCProtobuf
-        import DifferentModule
-        import ExtraModule
+        public import GRPCCore
+        internal import GRPCProtobuf
+        public import DifferentModule
+        public import ExtraModule
 
         public enum Helloworld_Greeter {
           public static let descriptor = ServiceDescriptor.helloworld_Greeter
@@ -284,10 +284,10 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         // For information on using the generated types, please see the documentation:
         //   https://github.com/grpc/grpc-swift
 
-        import GRPCCore
-        import GRPCProtobuf
-        import DifferentModule
-        import ExtraModule
+        package import GRPCCore
+        internal import GRPCProtobuf
+        package import DifferentModule
+        package import ExtraModule
 
         package enum Greeter {
           package static let descriptor = ServiceDescriptor.Greeter


### PR DESCRIPTION
## Motivation
This is a follow-up of https://github.com/grpc/grpc-swift/pull/2003.
As of 5.9, Swift supports access-level modifiers on imports. In an upcoming Swift 6.x release, the default modifier will become `internal`.

## Modifications
This PR adds explicit access-level modifiers to the generated code and a few other modules that use this generated code.

## Result
Explicit access level imports present in more places.