### PR TITLE
Use fully qualified types in generated code

### DIFF
--- a/Sources/Examples/v2/Echo/Generated/echo.grpc.swift
+++ b/Sources/Examples/v2/Echo/Generated/echo.grpc.swift
@@ -25,12 +25,12 @@ import GRPCCore
 import GRPCProtobuf
 
 internal enum Echo_Echo {
-    internal static let descriptor = ServiceDescriptor.echo_Echo
+    internal static let descriptor = GRPCCore.ServiceDescriptor.echo_Echo
     internal enum Method {
         internal enum Get {
             internal typealias Input = Echo_EchoRequest
             internal typealias Output = Echo_EchoResponse
-            internal static let descriptor = MethodDescriptor(
+            internal static let descriptor = GRPCCore.MethodDescriptor(
                 service: Echo_Echo.descriptor.fullyQualifiedService,
                 method: "Get"
             )
@@ -38,7 +38,7 @@ internal enum Echo_Echo {
         internal enum Expand {
             internal typealias Input = Echo_EchoRequest
             internal typealias Output = Echo_EchoResponse
-            internal static let descriptor = MethodDescriptor(
+            internal static let descriptor = GRPCCore.MethodDescriptor(
                 service: Echo_Echo.descriptor.fullyQualifiedService,
                 method: "Expand"
             )
@@ -46,7 +46,7 @@ internal enum Echo_Echo {
         internal enum Collect {
             internal typealias Input = Echo_EchoRequest
             internal typealias Output = Echo_EchoResponse
-            internal static let descriptor = MethodDescriptor(
+            internal static let descriptor = GRPCCore.MethodDescriptor(
                 service: Echo_Echo.descriptor.fullyQualifiedService,
                 method: "Collect"
             )
@@ -54,12 +54,12 @@ internal enum Echo_Echo {
         internal enum Update {
             internal typealias Input = Echo_EchoRequest
             internal typealias Output = Echo_EchoResponse
-            internal static let descriptor = MethodDescriptor(
+            internal static let descriptor = GRPCCore.MethodDescriptor(
                 service: Echo_Echo.descriptor.fullyQualifiedService,
                 method: "Update"
             )
         }
-        internal static let descriptors: [MethodDescriptor] = [
+        internal static let descriptors: [GRPCCore.MethodDescriptor] = [
             Get.descriptor,
             Expand.descriptor,
             Collect.descriptor,
@@ -76,7 +76,7 @@ internal enum Echo_Echo {
     internal typealias Client = Echo_EchoClient
 }
 
-extension ServiceDescriptor {
+extension GRPCCore.ServiceDescriptor {
     internal static let echo_Echo = Self(
         package: "echo",
         service: "Echo"
@@ -86,16 +86,16 @@ extension ServiceDescriptor {
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 internal protocol Echo_EchoStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
     /// Immediately returns an echo of a request.
-    func get(request: ServerRequest.Stream<Echo_EchoRequest>) async throws -> ServerResponse.Stream<Echo_EchoResponse>
+    func get(request: GRPCCore.ServerRequest.Stream<Echo_EchoRequest>) async throws -> GRPCCore.ServerResponse.Stream<Echo_EchoResponse>
 
     /// Splits a request into words and returns each word in a stream of messages.
-    func expand(request: ServerRequest.Stream<Echo_EchoRequest>) async throws -> ServerResponse.Stream<Echo_EchoResponse>
+    func expand(request: GRPCCore.ServerRequest.Stream<Echo_EchoRequest>) async throws -> GRPCCore.ServerResponse.Stream<Echo_EchoResponse>
 
     /// Collects a stream of messages and returns them concatenated when the caller closes.
-    func collect(request: ServerRequest.Stream<Echo_EchoRequest>) async throws -> ServerResponse.Stream<Echo_EchoResponse>
+    func collect(request: GRPCCore.ServerRequest.Stream<Echo_EchoRequest>) async throws -> GRPCCore.ServerResponse.Stream<Echo_EchoResponse>
 
     /// Streams back messages as they are received in an input stream.
-    func update(request: ServerRequest.Stream<Echo_EchoRequest>) async throws -> ServerResponse.Stream<Echo_EchoResponse>
+    func update(request: GRPCCore.ServerRequest.Stream<Echo_EchoRequest>) async throws -> GRPCCore.ServerResponse.Stream<Echo_EchoResponse>
 }
 
 /// Conformance to `GRPCCore.RegistrableRPCService`.
@@ -105,32 +105,32 @@ extension Echo_Echo.StreamingServiceProtocol {
     internal func registerMethods(with router: inout GRPCCore.RPCRouter) {
         router.registerHandler(
             forMethod: Echo_Echo.Method.Get.descriptor,
-            deserializer: ProtobufDeserializer<Echo_EchoRequest>(),
-            serializer: ProtobufSerializer<Echo_EchoResponse>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Echo_EchoRequest>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Echo_EchoResponse>(),
             handler: { request in
                 try await self.get(request: request)
             }
         )
         router.registerHandler(
             forMethod: Echo_Echo.Method.Expand.descriptor,
-            deserializer: ProtobufDeserializer<Echo_EchoRequest>(),
-            serializer: ProtobufSerializer<Echo_EchoResponse>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Echo_EchoRequest>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Echo_EchoResponse>(),
             handler: { request in
                 try await self.expand(request: request)
             }
         )
         router.registerHandler(
             forMethod: Echo_Echo.Method.Collect.descriptor,
-            deserializer: ProtobufDeserializer<Echo_EchoRequest>(),
-            serializer: ProtobufSerializer<Echo_EchoResponse>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Echo_EchoRequest>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Echo_EchoResponse>(),
             handler: { request in
                 try await self.collect(request: request)
             }
         )
         router.registerHandler(
             forMethod: Echo_Echo.Method.Update.descriptor,
-            deserializer: ProtobufDeserializer<Echo_EchoRequest>(),
-            serializer: ProtobufSerializer<Echo_EchoResponse>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Echo_EchoRequest>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Echo_EchoResponse>(),
             handler: { request in
                 try await self.update(request: request)
             }
@@ -141,34 +141,34 @@ extension Echo_Echo.StreamingServiceProtocol {
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 internal protocol Echo_EchoServiceProtocol: Echo_Echo.StreamingServiceProtocol {
     /// Immediately returns an echo of a request.
-    func get(request: ServerRequest.Single<Echo_EchoRequest>) async throws -> ServerResponse.Single<Echo_EchoResponse>
+    func get(request: GRPCCore.ServerRequest.Single<Echo_EchoRequest>) async throws -> GRPCCore.ServerResponse.Single<Echo_EchoResponse>
 
     /// Splits a request into words and returns each word in a stream of messages.
-    func expand(request: ServerRequest.Single<Echo_EchoRequest>) async throws -> ServerResponse.Stream<Echo_EchoResponse>
+    func expand(request: GRPCCore.ServerRequest.Single<Echo_EchoRequest>) async throws -> GRPCCore.ServerResponse.Stream<Echo_EchoResponse>
 
     /// Collects a stream of messages and returns them concatenated when the caller closes.
-    func collect(request: ServerRequest.Stream<Echo_EchoRequest>) async throws -> ServerResponse.Single<Echo_EchoResponse>
+    func collect(request: GRPCCore.ServerRequest.Stream<Echo_EchoRequest>) async throws -> GRPCCore.ServerResponse.Single<Echo_EchoResponse>
 
     /// Streams back messages as they are received in an input stream.
-    func update(request: ServerRequest.Stream<Echo_EchoRequest>) async throws -> ServerResponse.Stream<Echo_EchoResponse>
+    func update(request: GRPCCore.ServerRequest.Stream<Echo_EchoRequest>) async throws -> GRPCCore.ServerResponse.Stream<Echo_EchoResponse>
 }
 
 /// Partial conformance to `Echo_EchoStreamingServiceProtocol`.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Echo_Echo.ServiceProtocol {
-    internal func get(request: ServerRequest.Stream<Echo_EchoRequest>) async throws -> ServerResponse.Stream<Echo_EchoResponse> {
-        let response = try await self.get(request: ServerRequest.Single(stream: request))
-        return ServerResponse.Stream(single: response)
+    internal func get(request: GRPCCore.ServerRequest.Stream<Echo_EchoRequest>) async throws -> GRPCCore.ServerResponse.Stream<Echo_EchoResponse> {
+        let response = try await self.get(request: GRPCCore.ServerRequest.Single(stream: request))
+        return GRPCCore.ServerResponse.Stream(single: response)
     }
 
-    internal func expand(request: ServerRequest.Stream<Echo_EchoRequest>) async throws -> ServerResponse.Stream<Echo_EchoResponse> {
-        let response = try await self.expand(request: ServerRequest.Single(stream: request))
+    internal func expand(request: GRPCCore.ServerRequest.Stream<Echo_EchoRequest>) async throws -> GRPCCore.ServerResponse.Stream<Echo_EchoResponse> {
+        let response = try await self.expand(request: GRPCCore.ServerRequest.Single(stream: request))
         return response
     }
 
-    internal func collect(request: ServerRequest.Stream<Echo_EchoRequest>) async throws -> ServerResponse.Stream<Echo_EchoResponse> {
+    internal func collect(request: GRPCCore.ServerRequest.Stream<Echo_EchoRequest>) async throws -> GRPCCore.ServerResponse.Stream<Echo_EchoResponse> {
         let response = try await self.collect(request: request)
-        return ServerResponse.Stream(single: response)
+        return GRPCCore.ServerResponse.Stream(single: response)
     }
 }
 
@@ -176,94 +176,94 @@ extension Echo_Echo.ServiceProtocol {
 internal protocol Echo_EchoClientProtocol: Sendable {
     /// Immediately returns an echo of a request.
     func get<R>(
-        request: ClientRequest.Single<Echo_EchoRequest>,
-        serializer: some MessageSerializer<Echo_EchoRequest>,
-        deserializer: some MessageDeserializer<Echo_EchoResponse>,
-        options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Single<Echo_EchoResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Echo_EchoRequest>,
+        serializer: some GRPCCore.MessageSerializer<Echo_EchoRequest>,
+        deserializer: some GRPCCore.MessageDeserializer<Echo_EchoResponse>,
+        options: GRPCCore.CallOptions,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Echo_EchoResponse>) async throws -> R
     ) async throws -> R where R: Sendable
 
     /// Splits a request into words and returns each word in a stream of messages.
     func expand<R>(
-        request: ClientRequest.Single<Echo_EchoRequest>,
-        serializer: some MessageSerializer<Echo_EchoRequest>,
-        deserializer: some MessageDeserializer<Echo_EchoResponse>,
-        options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Echo_EchoResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Echo_EchoRequest>,
+        serializer: some GRPCCore.MessageSerializer<Echo_EchoRequest>,
+        deserializer: some GRPCCore.MessageDeserializer<Echo_EchoResponse>,
+        options: GRPCCore.CallOptions,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Echo_EchoResponse>) async throws -> R
     ) async throws -> R where R: Sendable
 
     /// Collects a stream of messages and returns them concatenated when the caller closes.
     func collect<R>(
-        request: ClientRequest.Stream<Echo_EchoRequest>,
-        serializer: some MessageSerializer<Echo_EchoRequest>,
-        deserializer: some MessageDeserializer<Echo_EchoResponse>,
-        options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Single<Echo_EchoResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Stream<Echo_EchoRequest>,
+        serializer: some GRPCCore.MessageSerializer<Echo_EchoRequest>,
+        deserializer: some GRPCCore.MessageDeserializer<Echo_EchoResponse>,
+        options: GRPCCore.CallOptions,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Echo_EchoResponse>) async throws -> R
     ) async throws -> R where R: Sendable
 
     /// Streams back messages as they are received in an input stream.
     func update<R>(
-        request: ClientRequest.Stream<Echo_EchoRequest>,
-        serializer: some MessageSerializer<Echo_EchoRequest>,
-        deserializer: some MessageDeserializer<Echo_EchoResponse>,
-        options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Echo_EchoResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Stream<Echo_EchoRequest>,
+        serializer: some GRPCCore.MessageSerializer<Echo_EchoRequest>,
+        deserializer: some GRPCCore.MessageDeserializer<Echo_EchoResponse>,
+        options: GRPCCore.CallOptions,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Echo_EchoResponse>) async throws -> R
     ) async throws -> R where R: Sendable
 }
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Echo_Echo.ClientProtocol {
     internal func get<R>(
-        request: ClientRequest.Single<Echo_EchoRequest>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Echo_EchoResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Echo_EchoRequest>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Echo_EchoResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.get(
             request: request,
-            serializer: ProtobufSerializer<Echo_EchoRequest>(),
-            deserializer: ProtobufDeserializer<Echo_EchoResponse>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Echo_EchoRequest>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Echo_EchoResponse>(),
             options: options,
             body
         )
     }
 
     internal func expand<R>(
-        request: ClientRequest.Single<Echo_EchoRequest>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Echo_EchoResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Echo_EchoRequest>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Echo_EchoResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.expand(
             request: request,
-            serializer: ProtobufSerializer<Echo_EchoRequest>(),
-            deserializer: ProtobufDeserializer<Echo_EchoResponse>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Echo_EchoRequest>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Echo_EchoResponse>(),
             options: options,
             body
         )
     }
 
     internal func collect<R>(
-        request: ClientRequest.Stream<Echo_EchoRequest>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Echo_EchoResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Stream<Echo_EchoRequest>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Echo_EchoResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.collect(
             request: request,
-            serializer: ProtobufSerializer<Echo_EchoRequest>(),
-            deserializer: ProtobufDeserializer<Echo_EchoResponse>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Echo_EchoRequest>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Echo_EchoResponse>(),
             options: options,
             body
         )
     }
 
     internal func update<R>(
-        request: ClientRequest.Stream<Echo_EchoRequest>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Echo_EchoResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Stream<Echo_EchoRequest>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Echo_EchoResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.update(
             request: request,
-            serializer: ProtobufSerializer<Echo_EchoRequest>(),
-            deserializer: ProtobufDeserializer<Echo_EchoResponse>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Echo_EchoRequest>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Echo_EchoResponse>(),
             options: options,
             body
         )
@@ -280,11 +280,11 @@ internal struct Echo_EchoClient: Echo_Echo.ClientProtocol {
 
     /// Immediately returns an echo of a request.
     internal func get<R>(
-        request: ClientRequest.Single<Echo_EchoRequest>,
-        serializer: some MessageSerializer<Echo_EchoRequest>,
-        deserializer: some MessageDeserializer<Echo_EchoResponse>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Echo_EchoResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Echo_EchoRequest>,
+        serializer: some GRPCCore.MessageSerializer<Echo_EchoRequest>,
+        deserializer: some GRPCCore.MessageDeserializer<Echo_EchoResponse>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Echo_EchoResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.unary(
             request: request,
@@ -298,11 +298,11 @@ internal struct Echo_EchoClient: Echo_Echo.ClientProtocol {
 
     /// Splits a request into words and returns each word in a stream of messages.
     internal func expand<R>(
-        request: ClientRequest.Single<Echo_EchoRequest>,
-        serializer: some MessageSerializer<Echo_EchoRequest>,
-        deserializer: some MessageDeserializer<Echo_EchoResponse>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Echo_EchoResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Echo_EchoRequest>,
+        serializer: some GRPCCore.MessageSerializer<Echo_EchoRequest>,
+        deserializer: some GRPCCore.MessageDeserializer<Echo_EchoResponse>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Echo_EchoResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.serverStreaming(
             request: request,
@@ -316,11 +316,11 @@ internal struct Echo_EchoClient: Echo_Echo.ClientProtocol {
 
     /// Collects a stream of messages and returns them concatenated when the caller closes.
     internal func collect<R>(
-        request: ClientRequest.Stream<Echo_EchoRequest>,
-        serializer: some MessageSerializer<Echo_EchoRequest>,
-        deserializer: some MessageDeserializer<Echo_EchoResponse>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Echo_EchoResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Stream<Echo_EchoRequest>,
+        serializer: some GRPCCore.MessageSerializer<Echo_EchoRequest>,
+        deserializer: some GRPCCore.MessageDeserializer<Echo_EchoResponse>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Echo_EchoResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.clientStreaming(
             request: request,
@@ -334,11 +334,11 @@ internal struct Echo_EchoClient: Echo_Echo.ClientProtocol {
 
     /// Streams back messages as they are received in an input stream.
     internal func update<R>(
-        request: ClientRequest.Stream<Echo_EchoRequest>,
-        serializer: some MessageSerializer<Echo_EchoRequest>,
-        deserializer: some MessageDeserializer<Echo_EchoResponse>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Echo_EchoResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Stream<Echo_EchoRequest>,
+        serializer: some GRPCCore.MessageSerializer<Echo_EchoRequest>,
+        deserializer: some GRPCCore.MessageDeserializer<Echo_EchoResponse>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Echo_EchoResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.bidirectionalStreaming(
             request: request,

--- a/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
@@ -472,7 +472,7 @@ extension ClientCodeTranslator {
     parameters.append(
       ParameterDescription(
         label: "options",
-        type: .member("GRPCCore.CallOptions"),
+        type: .member(["GRPCCore", "CallOptions"]),
         defaultValue: includeDefaultCallOptions
           ? .memberAccess(MemberAccessDescription(right: "defaults")) : nil
       )
@@ -491,7 +491,9 @@ extension ClientCodeTranslator {
     in service: CodeGenerationRequest.ServiceDescriptor
   ) -> ParameterDescription {
     let requestType = method.isInputStreaming ? "Stream" : "Single"
-    let clientRequestType = ExistingTypeDescription.member(["GRPCCore.ClientRequest", requestType])
+    let clientRequestType = ExistingTypeDescription.member([
+      "GRPCCore", "ClientRequest", requestType,
+    ])
     return ParameterDescription(
       label: "request",
       type: .generic(
@@ -509,7 +511,7 @@ extension ClientCodeTranslator {
       label: "serializer",
       type: ExistingTypeDescription.some(
         .generic(
-          wrapper: .member("GRPCCore.MessageSerializer"),
+          wrapper: .member(["GRPCCore", "MessageSerializer"]),
           wrapped: .member(method.inputType)
         )
       )
@@ -524,7 +526,7 @@ extension ClientCodeTranslator {
       label: "deserializer",
       type: ExistingTypeDescription.some(
         .generic(
-          wrapper: .member("GRPCCore.MessageDeserializer"),
+          wrapper: .member(["GRPCCore", "MessageDeserializer"]),
           wrapped: .member(method.outputType)
         )
       )
@@ -538,7 +540,7 @@ extension ClientCodeTranslator {
   ) -> ParameterDescription {
     let clientStreaming = method.isOutputStreaming ? "Stream" : "Single"
     let closureParameterType = ExistingTypeDescription.generic(
-      wrapper: .member(["GRPCCore.ClientResponse", clientStreaming]),
+      wrapper: .member(["GRPCCore", "ClientResponse", clientStreaming]),
       wrapped: .member(method.outputType)
     )
 

--- a/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
@@ -25,24 +25,24 @@
 /// @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 /// public protocol Foo_BarClientProtocol: Sendable {
 ///   func baz<R>(
-///     request: ClientRequest.Single<Foo_Bar_Input>,
-///     serializer: some MessageSerializer<Foo_Bar_Input>,
-///     deserializer: some MessageDeserializer<Foo_Bar_Output>,
-///     options: CallOptions = .defaults,
-///     _ body: @Sendable @escaping (ClientResponse.Single<Foo_Bar_Output>) async throws -> R
+///     request: GRPCCore.ClientRequest.Single<Foo_Bar_Input>,
+///     serializer: some GRPCCore.MessageSerializer<Foo_Bar_Input>,
+///     deserializer: some GRPCCore.MessageDeserializer<Foo_Bar_Output>,
+///     options: GRPCCore.CallOptions = .defaults,
+///     _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Foo_Bar_Output>) async throws -> R
 ///   ) async throws -> R where R: Sendable
 /// }
 /// @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 /// extension Foo_Bar.ClientProtocol {
 ///   public func baz<R>(
-///     request: ClientRequest.Single<Foo_Bar_Input>,
-///     options: CallOptions = .defaults,
-///     _ body: @Sendable @escaping (ClientResponse.Single<Foo_Bar_Output>) async throws -> R
+///     request: GRPCCore.ClientRequest.Single<Foo_Bar_Input>,
+///     options: GRPCCore.CallOptions = .defaults,
+///     _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Foo_Bar_Output>) async throws -> R
 ///   ) async throws -> R where R: Sendable {
 ///     try await self.baz(
 ///       request: request,
-///       serializer: ProtobufSerializer<Foo_Bar_Input>(),
-///       deserializer: ProtobufDeserializer<Foo_Bar_Output>(),
+///       serializer: GRPCProtobuf.ProtobufSerializer<Foo_Bar_Input>(),
+///       deserializer: GRPCProtobuf.ProtobufDeserializer<Foo_Bar_Output>(),
 ///       options: options,
 ///       body
 ///     )
@@ -54,11 +54,11 @@
 ///     self.client = client
 ///   }
 ///   public func methodA<R>(
-///     request: ClientRequest.Stream<Foo_Bar_Input>,
-///     serializer: some MessageSerializer<Foo_Bar_Input>,
-///     deserializer: some MessageDeserializer<Foo_Bar_Output>,
-///     options: CallOptions = .defaults,
-///     _ body: @Sendable @escaping (ClientResponse.Single<Foo_Bar_Output>) async throws -> R
+///     request: GRPCCore.ClientRequest.Stream<Foo_Bar_Input>,
+///     serializer: some GRPCCore.MessageSerializer<Foo_Bar_Input>,
+///     deserializer: some GRPCCore.MessageDeserializer<Foo_Bar_Output>,
+///     options: GRPCCore.CallOptions = .defaults,
+///     _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Foo_Bar_Output>) async throws -> R
 ///   ) async throws -> R where R: Sendable {
 ///     try await self.client.unary(
 ///       request: request,
@@ -254,7 +254,7 @@ extension ClientCodeTranslator {
     parameters.append(
       ParameterDescription(
         label: "options",
-        type: .member("CallOptions"),
+        type: .member("GRPCCore.CallOptions"),
         defaultValue: includeDefaultCallOptions
           ? .memberAccess(MemberAccessDescription(right: "defaults")) : nil
       )
@@ -267,7 +267,7 @@ extension ClientCodeTranslator {
     in service: CodeGenerationRequest.ServiceDescriptor
   ) -> ParameterDescription {
     let requestType = method.isInputStreaming ? "Stream" : "Single"
-    let clientRequestType = ExistingTypeDescription.member(["ClientRequest", requestType])
+    let clientRequestType = ExistingTypeDescription.member(["GRPCCore.ClientRequest", requestType])
     return ParameterDescription(
       label: "request",
       type: .generic(
@@ -285,7 +285,7 @@ extension ClientCodeTranslator {
       label: "serializer",
       type: ExistingTypeDescription.some(
         .generic(
-          wrapper: .member("MessageSerializer"),
+          wrapper: .member("GRPCCore.MessageSerializer"),
           wrapped: .member(method.inputType)
         )
       )
@@ -300,7 +300,7 @@ extension ClientCodeTranslator {
       label: "deserializer",
       type: ExistingTypeDescription.some(
         .generic(
-          wrapper: .member("MessageDeserializer"),
+          wrapper: .member("GRPCCore.MessageDeserializer"),
           wrapped: .member(method.outputType)
         )
       )
@@ -313,7 +313,7 @@ extension ClientCodeTranslator {
   ) -> ParameterDescription {
     let clientStreaming = method.isOutputStreaming ? "Stream" : "Single"
     let closureParameterType = ExistingTypeDescription.generic(
-      wrapper: .member(["ClientResponse", clientStreaming]),
+      wrapper: .member(["GRPCCore.ClientResponse", clientStreaming]),
       wrapped: .member(method.outputType)
     )
 

--- a/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
@@ -25,8 +25,8 @@
 /// @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 /// public protocol Foo_BarStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
 ///   func baz(
-///     request: ServerRequest.Stream<Foo_Bar_Input>
-///   ) async throws -> ServerResponse.Stream<Foo_Bar_Output>
+///     request: GRPCCore.ServerRequest.Stream<Foo_Bar_Input>
+///   ) async throws -> GRPCCore.ServerResponse.Stream<Foo_Bar_Output>
 /// }
 /// // Conformance to `GRPCCore.RegistrableRPCService`.
 /// @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
@@ -34,8 +34,8 @@
 ///   public func registerMethods(with router: inout GRPCCore.RPCRouter) {
 ///     router.registerHandler(
 ///       forMethod: Foo_Bar.Method.baz.descriptor,
-///       deserializer: ProtobufDeserializer<Foo_Bar_Input>(),
-///       serializer: ProtobufSerializer<Foo_Bar_Output>(),
+///       deserializer: GRPCProtobuf.ProtobufDeserializer<Foo_Bar_Input>(),
+///       serializer: GRPCProtobuf.ProtobufSerializer<Foo_Bar_Output>(),
 ///       handler: { request in try await self.baz(request: request) }
 ///     )
 ///   }
@@ -43,17 +43,17 @@
 /// @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 /// public protocol Foo_BarServiceProtocol: Foo_Bar.StreamingServiceProtocol {
 ///   func baz(
-///     request: ServerRequest.Single<Foo_Bar_Input>
-///   ) async throws -> ServerResponse.Single<Foo_Bar_Output>
+///     request: GRPCCore.ServerRequest.Single<Foo_Bar_Input>
+///   ) async throws -> GRPCCore.ServerResponse.Single<Foo_Bar_Output>
 /// }
 /// // Partial conformance to `Foo_BarStreamingServiceProtocol`.
 /// @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 /// extension Foo_Bar.ServiceProtocol {
 ///   public func baz(
-///     request: ServerRequest.Stream<Foo_Bar_Input>
-///   ) async throws -> ServerResponse.Stream<Foo_Bar_Output> {
-///     let response = try await self.baz(request: ServerRequest.Single(stream: request))
-///     return ServerResponse.Stream(single: response)
+///     request: GRPCCore.ServerRequest.Stream<Foo_Bar_Input>
+///   ) async throws -> GRPCCore.ServerResponse.Stream<Foo_Bar_Output> {
+///     let response = try await self.baz(request: GRPCCore.ServerRequest.Single(stream: request))
+///     return GRPCCore.ServerResponse.Stream(single: response)
 ///   }
 /// }
 ///```
@@ -147,7 +147,7 @@ extension ServerCodeTranslator {
         .init(
           label: "request",
           type: .generic(
-            wrapper: .member(["ServerRequest", "Stream"]),
+            wrapper: .member(["GRPCCore.ServerRequest", "Stream"]),
             wrapped: .member(method.inputType)
           )
         )
@@ -155,7 +155,7 @@ extension ServerCodeTranslator {
       keywords: [.async, .throws],
       returnType: .identifierType(
         .generic(
-          wrapper: .member(["ServerResponse", "Stream"]),
+          wrapper: .member(["GRPCCore.ServerResponse", "Stream"]),
           wrapped: .member(method.outputType)
         )
       )
@@ -322,7 +322,7 @@ extension ServerCodeTranslator {
           label: "request",
           type:
             .generic(
-              wrapper: .member(["ServerRequest", inputStreaming]),
+              wrapper: .member(["GRPCCore.ServerRequest", inputStreaming]),
               wrapped: .member(method.inputType)
             )
         )
@@ -330,7 +330,7 @@ extension ServerCodeTranslator {
       keywords: [.async, .throws],
       returnType: .identifierType(
         .generic(
-          wrapper: .member(["ServerResponse", outputStreaming]),
+          wrapper: .member(["GRPCCore.ServerResponse", outputStreaming]),
           wrapped: .member(method.outputType)
         )
       )
@@ -390,7 +390,7 @@ extension ServerCodeTranslator {
       serverRequest = Expression.functionCall(
         calledExpression: .memberAccess(
           MemberAccessDescription(
-            left: .identifierPattern("ServerRequest"),
+            left: .identifierPattern("GRPCCore.ServerRequest"),
             right: "Single"
           )
         ),
@@ -429,7 +429,7 @@ extension ServerCodeTranslator {
       returnValue = .functionCall(
         calledExpression: .memberAccess(
           MemberAccessDescription(
-            left: .identifierType(.member(["ServerResponse"])),
+            left: .identifierType(.member(["GRPCCore.ServerResponse"])),
             right: "Stream"
           )
         ),

--- a/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
@@ -147,7 +147,7 @@ extension ServerCodeTranslator {
         .init(
           label: "request",
           type: .generic(
-            wrapper: .member(["GRPCCore.ServerRequest", "Stream"]),
+            wrapper: .member(["GRPCCore", "ServerRequest", "Stream"]),
             wrapped: .member(method.inputType)
           )
         )
@@ -155,7 +155,7 @@ extension ServerCodeTranslator {
       keywords: [.async, .throws],
       returnType: .identifierType(
         .generic(
-          wrapper: .member(["GRPCCore.ServerResponse", "Stream"]),
+          wrapper: .member(["GRPCCore", "ServerResponse", "Stream"]),
           wrapped: .member(method.outputType)
         )
       )
@@ -322,7 +322,7 @@ extension ServerCodeTranslator {
           label: "request",
           type:
             .generic(
-              wrapper: .member(["GRPCCore.ServerRequest", inputStreaming]),
+              wrapper: .member(["GRPCCore", "ServerRequest", inputStreaming]),
               wrapped: .member(method.inputType)
             )
         )
@@ -330,7 +330,7 @@ extension ServerCodeTranslator {
       keywords: [.async, .throws],
       returnType: .identifierType(
         .generic(
-          wrapper: .member(["GRPCCore.ServerResponse", outputStreaming]),
+          wrapper: .member(["GRPCCore", "ServerResponse", outputStreaming]),
           wrapped: .member(method.outputType)
         )
       )
@@ -429,7 +429,7 @@ extension ServerCodeTranslator {
       returnValue = .functionCall(
         calledExpression: .memberAccess(
           MemberAccessDescription(
-            left: .identifierType(.member(["GRPCCore.ServerResponse"])),
+            left: .identifierType(.member(["GRPCCore", "ServerResponse"])),
             right: "Stream"
           )
         ),

--- a/Sources/GRPCCodeGen/Internal/Translator/TypealiasTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/TypealiasTranslator.swift
@@ -199,7 +199,7 @@ extension TypealiasTranslator {
     let descriptorDeclarationLeft = Expression.identifier(.pattern("descriptor"))
     let descriptorDeclarationRight = Expression.functionCall(
       FunctionCallDescription(
-        calledExpression: .identifierType(.member("GRPCCore.MethodDescriptor")),
+        calledExpression: .identifierType(.member(["GRPCCore", "MethodDescriptor"])),
         arguments: [
           FunctionArgumentDescription(
             label: "service",
@@ -245,7 +245,7 @@ extension TypealiasTranslator {
       isStatic: true,
       kind: .let,
       left: .identifier(.pattern("descriptors")),
-      type: .array(.member("GRPCCore.MethodDescriptor")),
+      type: .array(.member(["GRPCCore", "MethodDescriptor"])),
       right: .literal(.array(methodDescriptors))
     )
   }

--- a/Sources/GRPCCodeGen/Internal/Translator/TypealiasTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/TypealiasTranslator.swift
@@ -22,13 +22,13 @@
 /// a representation for the following generated code:
 /// ```swift
 /// public enum Echo_Echo {
-///   public static let descriptor = ServiceDescriptor.echo_Echo
+///   public static let descriptor = GRPCCore.ServiceDescriptor.echo_Echo
 ///
 ///   public enum Method {
 ///     public enum Get {
 ///       public typealias Input = Echo_EchoRequest
 ///       public typealias Output = Echo_EchoResponse
-///       public static let descriptor = MethodDescriptor(
+///       public static let descriptor = GRPCCore.MethodDescriptor(
 ///         service: Echo_Echo.descriptor.fullyQualifiedService,
 ///         method: "Get"
 ///       )
@@ -37,14 +37,14 @@
 ///     public enum Collect {
 ///       public typealias Input = Echo_EchoRequest
 ///       public typealias Output = Echo_EchoResponse
-///       public static let descriptor = MethodDescriptor(
+///       public static let descriptor = GRPCCore.MethodDescriptor(
 ///         service: Echo_Echo.descriptor.fullyQualifiedService,
 ///         method: "Collect"
 ///       )
 ///     }
 ///     // ...
 ///
-///     public static let descriptors: [MethodDescriptor] = [
+///     public static let descriptors: [GRPCCore.MethodDescriptor] = [
 ///       Get.descriptor,
 ///       Collect.descriptor,
 ///       // ...
@@ -58,7 +58,7 @@
 ///
 /// }
 ///
-/// extension ServiceDescriptor {
+/// extension GRPCCore.ServiceDescriptor {
 ///   public static let echo_Echo = Self(
 ///     package: "echo",
 ///     service: "Echo"
@@ -199,7 +199,7 @@ extension TypealiasTranslator {
     let descriptorDeclarationLeft = Expression.identifier(.pattern("descriptor"))
     let descriptorDeclarationRight = Expression.functionCall(
       FunctionCallDescription(
-        calledExpression: .identifierType(.member("MethodDescriptor")),
+        calledExpression: .identifierType(.member("GRPCCore.MethodDescriptor")),
         arguments: [
           FunctionArgumentDescription(
             label: "service",
@@ -245,7 +245,7 @@ extension TypealiasTranslator {
       isStatic: true,
       kind: .let,
       left: .identifier(.pattern("descriptors")),
-      type: .array(.member("MethodDescriptor")),
+      type: .array(.member("GRPCCore.MethodDescriptor")),
       right: .literal(.array(methodDescriptors))
     )
   }
@@ -326,7 +326,7 @@ extension TypealiasTranslator {
       left: .identifierPattern("descriptor"),
       right: .memberAccess(
         MemberAccessDescription(
-          left: .identifierPattern("ServiceDescriptor"),
+          left: .identifierPattern("GRPCCore.ServiceDescriptor"),
           right: serviceIdentifier
         )
       )
@@ -356,7 +356,7 @@ extension TypealiasTranslator {
 
     return .extension(
       ExtensionDescription(
-        onType: "ServiceDescriptor",
+        onType: "GRPCCore.ServiceDescriptor",
         declarations: [
           .variable(
             VariableDescription(

--- a/Sources/GRPCProtobufCodeGen/ProtobufCodeGenParser.swift
+++ b/Sources/GRPCProtobufCodeGen/ProtobufCodeGenParser.swift
@@ -59,10 +59,10 @@ internal struct ProtobufCodeGenParser {
 
       """
     let lookupSerializer: (String) -> String = { messageType in
-      "ProtobufSerializer<\(messageType)>()"
+      "GRPCProtobuf.ProtobufSerializer<\(messageType)>()"
     }
     let lookupDeserializer: (String) -> String = { messageType in
-      "ProtobufDeserializer<\(messageType)>()"
+      "GRPCProtobuf.ProtobufDeserializer<\(messageType)>()"
     }
     let services = self.input.services.map {
       CodeGenerationRequest.ServiceDescriptor(

--- a/Sources/InteroperabilityTests/Generated/empty_service.grpc.swift
+++ b/Sources/InteroperabilityTests/Generated/empty_service.grpc.swift
@@ -25,9 +25,9 @@ import GRPCCore
 import GRPCProtobuf
 
 public enum Grpc_Testing_EmptyService {
-    public static let descriptor = ServiceDescriptor.grpc_testing_EmptyService
+    public static let descriptor = GRPCCore.ServiceDescriptor.grpc_testing_EmptyService
     public enum Method {
-        public static let descriptors: [MethodDescriptor] = []
+        public static let descriptors: [GRPCCore.MethodDescriptor] = []
     }
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     public typealias StreamingServiceProtocol = Grpc_Testing_EmptyServiceStreamingServiceProtocol
@@ -39,7 +39,7 @@ public enum Grpc_Testing_EmptyService {
     public typealias Client = Grpc_Testing_EmptyServiceClient
 }
 
-extension ServiceDescriptor {
+extension GRPCCore.ServiceDescriptor {
     public static let grpc_testing_EmptyService = Self(
         package: "grpc.testing",
         service: "EmptyService"

--- a/Sources/InteroperabilityTests/Generated/test.grpc.swift
+++ b/Sources/InteroperabilityTests/Generated/test.grpc.swift
@@ -28,12 +28,12 @@ import GRPCCore
 import GRPCProtobuf
 
 public enum Grpc_Testing_ReconnectService {
-    public static let descriptor = ServiceDescriptor.grpc_testing_ReconnectService
+    public static let descriptor = GRPCCore.ServiceDescriptor.grpc_testing_ReconnectService
     public enum Method {
         public enum Start {
             public typealias Input = Grpc_Testing_ReconnectParams
             public typealias Output = Grpc_Testing_Empty
-            public static let descriptor = MethodDescriptor(
+            public static let descriptor = GRPCCore.MethodDescriptor(
                 service: Grpc_Testing_ReconnectService.descriptor.fullyQualifiedService,
                 method: "Start"
             )
@@ -41,12 +41,12 @@ public enum Grpc_Testing_ReconnectService {
         public enum Stop {
             public typealias Input = Grpc_Testing_Empty
             public typealias Output = Grpc_Testing_ReconnectInfo
-            public static let descriptor = MethodDescriptor(
+            public static let descriptor = GRPCCore.MethodDescriptor(
                 service: Grpc_Testing_ReconnectService.descriptor.fullyQualifiedService,
                 method: "Stop"
             )
         }
-        public static let descriptors: [MethodDescriptor] = [
+        public static let descriptors: [GRPCCore.MethodDescriptor] = [
             Start.descriptor,
             Stop.descriptor
         ]
@@ -61,7 +61,7 @@ public enum Grpc_Testing_ReconnectService {
     public typealias Client = Grpc_Testing_ReconnectServiceClient
 }
 
-extension ServiceDescriptor {
+extension GRPCCore.ServiceDescriptor {
     public static let grpc_testing_ReconnectService = Self(
         package: "grpc.testing",
         service: "ReconnectService"
@@ -69,12 +69,12 @@ extension ServiceDescriptor {
 }
 
 public enum Grpc_Testing_TestService {
-    public static let descriptor = ServiceDescriptor.grpc_testing_TestService
+    public static let descriptor = GRPCCore.ServiceDescriptor.grpc_testing_TestService
     public enum Method {
         public enum EmptyCall {
             public typealias Input = Grpc_Testing_Empty
             public typealias Output = Grpc_Testing_Empty
-            public static let descriptor = MethodDescriptor(
+            public static let descriptor = GRPCCore.MethodDescriptor(
                 service: Grpc_Testing_TestService.descriptor.fullyQualifiedService,
                 method: "EmptyCall"
             )
@@ -82,7 +82,7 @@ public enum Grpc_Testing_TestService {
         public enum UnaryCall {
             public typealias Input = Grpc_Testing_SimpleRequest
             public typealias Output = Grpc_Testing_SimpleResponse
-            public static let descriptor = MethodDescriptor(
+            public static let descriptor = GRPCCore.MethodDescriptor(
                 service: Grpc_Testing_TestService.descriptor.fullyQualifiedService,
                 method: "UnaryCall"
             )
@@ -90,7 +90,7 @@ public enum Grpc_Testing_TestService {
         public enum CacheableUnaryCall {
             public typealias Input = Grpc_Testing_SimpleRequest
             public typealias Output = Grpc_Testing_SimpleResponse
-            public static let descriptor = MethodDescriptor(
+            public static let descriptor = GRPCCore.MethodDescriptor(
                 service: Grpc_Testing_TestService.descriptor.fullyQualifiedService,
                 method: "CacheableUnaryCall"
             )
@@ -98,7 +98,7 @@ public enum Grpc_Testing_TestService {
         public enum StreamingOutputCall {
             public typealias Input = Grpc_Testing_StreamingOutputCallRequest
             public typealias Output = Grpc_Testing_StreamingOutputCallResponse
-            public static let descriptor = MethodDescriptor(
+            public static let descriptor = GRPCCore.MethodDescriptor(
                 service: Grpc_Testing_TestService.descriptor.fullyQualifiedService,
                 method: "StreamingOutputCall"
             )
@@ -106,7 +106,7 @@ public enum Grpc_Testing_TestService {
         public enum StreamingInputCall {
             public typealias Input = Grpc_Testing_StreamingInputCallRequest
             public typealias Output = Grpc_Testing_StreamingInputCallResponse
-            public static let descriptor = MethodDescriptor(
+            public static let descriptor = GRPCCore.MethodDescriptor(
                 service: Grpc_Testing_TestService.descriptor.fullyQualifiedService,
                 method: "StreamingInputCall"
             )
@@ -114,7 +114,7 @@ public enum Grpc_Testing_TestService {
         public enum FullDuplexCall {
             public typealias Input = Grpc_Testing_StreamingOutputCallRequest
             public typealias Output = Grpc_Testing_StreamingOutputCallResponse
-            public static let descriptor = MethodDescriptor(
+            public static let descriptor = GRPCCore.MethodDescriptor(
                 service: Grpc_Testing_TestService.descriptor.fullyQualifiedService,
                 method: "FullDuplexCall"
             )
@@ -122,7 +122,7 @@ public enum Grpc_Testing_TestService {
         public enum HalfDuplexCall {
             public typealias Input = Grpc_Testing_StreamingOutputCallRequest
             public typealias Output = Grpc_Testing_StreamingOutputCallResponse
-            public static let descriptor = MethodDescriptor(
+            public static let descriptor = GRPCCore.MethodDescriptor(
                 service: Grpc_Testing_TestService.descriptor.fullyQualifiedService,
                 method: "HalfDuplexCall"
             )
@@ -130,12 +130,12 @@ public enum Grpc_Testing_TestService {
         public enum UnimplementedCall {
             public typealias Input = Grpc_Testing_Empty
             public typealias Output = Grpc_Testing_Empty
-            public static let descriptor = MethodDescriptor(
+            public static let descriptor = GRPCCore.MethodDescriptor(
                 service: Grpc_Testing_TestService.descriptor.fullyQualifiedService,
                 method: "UnimplementedCall"
             )
         }
-        public static let descriptors: [MethodDescriptor] = [
+        public static let descriptors: [GRPCCore.MethodDescriptor] = [
             EmptyCall.descriptor,
             UnaryCall.descriptor,
             CacheableUnaryCall.descriptor,
@@ -156,7 +156,7 @@ public enum Grpc_Testing_TestService {
     public typealias Client = Grpc_Testing_TestServiceClient
 }
 
-extension ServiceDescriptor {
+extension GRPCCore.ServiceDescriptor {
     public static let grpc_testing_TestService = Self(
         package: "grpc.testing",
         service: "TestService"
@@ -164,17 +164,17 @@ extension ServiceDescriptor {
 }
 
 public enum Grpc_Testing_UnimplementedService {
-    public static let descriptor = ServiceDescriptor.grpc_testing_UnimplementedService
+    public static let descriptor = GRPCCore.ServiceDescriptor.grpc_testing_UnimplementedService
     public enum Method {
         public enum UnimplementedCall {
             public typealias Input = Grpc_Testing_Empty
             public typealias Output = Grpc_Testing_Empty
-            public static let descriptor = MethodDescriptor(
+            public static let descriptor = GRPCCore.MethodDescriptor(
                 service: Grpc_Testing_UnimplementedService.descriptor.fullyQualifiedService,
                 method: "UnimplementedCall"
             )
         }
-        public static let descriptors: [MethodDescriptor] = [
+        public static let descriptors: [GRPCCore.MethodDescriptor] = [
             UnimplementedCall.descriptor
         ]
     }
@@ -188,7 +188,7 @@ public enum Grpc_Testing_UnimplementedService {
     public typealias Client = Grpc_Testing_UnimplementedServiceClient
 }
 
-extension ServiceDescriptor {
+extension GRPCCore.ServiceDescriptor {
     public static let grpc_testing_UnimplementedService = Self(
         package: "grpc.testing",
         service: "UnimplementedService"
@@ -200,38 +200,38 @@ extension ServiceDescriptor {
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 public protocol Grpc_Testing_TestServiceStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
     /// One empty request followed by one empty response.
-    func emptyCall(request: ServerRequest.Stream<Grpc_Testing_Empty>) async throws -> ServerResponse.Stream<Grpc_Testing_Empty>
+    func emptyCall(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_Empty>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_Empty>
 
     /// One request followed by one response.
-    func unaryCall(request: ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_SimpleResponse>
+    func unaryCall(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_SimpleResponse>
 
     /// One request followed by one response. Response has cache control
     /// headers set such that a caching HTTP proxy (such as GFE) can
     /// satisfy subsequent requests.
-    func cacheableUnaryCall(request: ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_SimpleResponse>
+    func cacheableUnaryCall(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_SimpleResponse>
 
     /// One request followed by a sequence of responses (streamed download).
     /// The server returns the payload with client desired type and sizes.
-    func streamingOutputCall(request: ServerRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>
+    func streamingOutputCall(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>
 
     /// A sequence of requests followed by one response (streamed upload).
     /// The server returns the aggregated size of client payload as the result.
-    func streamingInputCall(request: ServerRequest.Stream<Grpc_Testing_StreamingInputCallRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_StreamingInputCallResponse>
+    func streamingInputCall(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_StreamingInputCallRequest>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_StreamingInputCallResponse>
 
     /// A sequence of requests with each request served by the server immediately.
     /// As one request could lead to multiple responses, this interface
     /// demonstrates the idea of full duplexing.
-    func fullDuplexCall(request: ServerRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>
+    func fullDuplexCall(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>
 
     /// A sequence of requests followed by a sequence of responses.
     /// The server buffers all the client requests and then serves them in order. A
     /// stream of responses are returned to the client when the server starts with
     /// first request.
-    func halfDuplexCall(request: ServerRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>
+    func halfDuplexCall(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>
 
     /// The test server will not implement this method. It will be used
     /// to test the behavior when clients call unimplemented methods.
-    func unimplementedCall(request: ServerRequest.Stream<Grpc_Testing_Empty>) async throws -> ServerResponse.Stream<Grpc_Testing_Empty>
+    func unimplementedCall(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_Empty>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_Empty>
 }
 
 /// Conformance to `GRPCCore.RegistrableRPCService`.
@@ -241,64 +241,64 @@ extension Grpc_Testing_TestService.StreamingServiceProtocol {
     public func registerMethods(with router: inout GRPCCore.RPCRouter) {
         router.registerHandler(
             forMethod: Grpc_Testing_TestService.Method.EmptyCall.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_Empty>(),
-            serializer: ProtobufSerializer<Grpc_Testing_Empty>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Testing_Empty>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Testing_Empty>(),
             handler: { request in
                 try await self.emptyCall(request: request)
             }
         )
         router.registerHandler(
             forMethod: Grpc_Testing_TestService.Method.UnaryCall.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_SimpleRequest>(),
-            serializer: ProtobufSerializer<Grpc_Testing_SimpleResponse>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Testing_SimpleRequest>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Testing_SimpleResponse>(),
             handler: { request in
                 try await self.unaryCall(request: request)
             }
         )
         router.registerHandler(
             forMethod: Grpc_Testing_TestService.Method.CacheableUnaryCall.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_SimpleRequest>(),
-            serializer: ProtobufSerializer<Grpc_Testing_SimpleResponse>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Testing_SimpleRequest>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Testing_SimpleResponse>(),
             handler: { request in
                 try await self.cacheableUnaryCall(request: request)
             }
         )
         router.registerHandler(
             forMethod: Grpc_Testing_TestService.Method.StreamingOutputCall.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_StreamingOutputCallRequest>(),
-            serializer: ProtobufSerializer<Grpc_Testing_StreamingOutputCallResponse>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Testing_StreamingOutputCallRequest>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Testing_StreamingOutputCallResponse>(),
             handler: { request in
                 try await self.streamingOutputCall(request: request)
             }
         )
         router.registerHandler(
             forMethod: Grpc_Testing_TestService.Method.StreamingInputCall.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_StreamingInputCallRequest>(),
-            serializer: ProtobufSerializer<Grpc_Testing_StreamingInputCallResponse>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Testing_StreamingInputCallRequest>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Testing_StreamingInputCallResponse>(),
             handler: { request in
                 try await self.streamingInputCall(request: request)
             }
         )
         router.registerHandler(
             forMethod: Grpc_Testing_TestService.Method.FullDuplexCall.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_StreamingOutputCallRequest>(),
-            serializer: ProtobufSerializer<Grpc_Testing_StreamingOutputCallResponse>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Testing_StreamingOutputCallRequest>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Testing_StreamingOutputCallResponse>(),
             handler: { request in
                 try await self.fullDuplexCall(request: request)
             }
         )
         router.registerHandler(
             forMethod: Grpc_Testing_TestService.Method.HalfDuplexCall.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_StreamingOutputCallRequest>(),
-            serializer: ProtobufSerializer<Grpc_Testing_StreamingOutputCallResponse>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Testing_StreamingOutputCallRequest>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Testing_StreamingOutputCallResponse>(),
             handler: { request in
                 try await self.halfDuplexCall(request: request)
             }
         )
         router.registerHandler(
             forMethod: Grpc_Testing_TestService.Method.UnimplementedCall.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_Empty>(),
-            serializer: ProtobufSerializer<Grpc_Testing_Empty>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Testing_Empty>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Testing_Empty>(),
             handler: { request in
                 try await self.unimplementedCall(request: request)
             }
@@ -311,71 +311,71 @@ extension Grpc_Testing_TestService.StreamingServiceProtocol {
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 public protocol Grpc_Testing_TestServiceServiceProtocol: Grpc_Testing_TestService.StreamingServiceProtocol {
     /// One empty request followed by one empty response.
-    func emptyCall(request: ServerRequest.Single<Grpc_Testing_Empty>) async throws -> ServerResponse.Single<Grpc_Testing_Empty>
+    func emptyCall(request: GRPCCore.ServerRequest.Single<Grpc_Testing_Empty>) async throws -> GRPCCore.ServerResponse.Single<Grpc_Testing_Empty>
 
     /// One request followed by one response.
-    func unaryCall(request: ServerRequest.Single<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Single<Grpc_Testing_SimpleResponse>
+    func unaryCall(request: GRPCCore.ServerRequest.Single<Grpc_Testing_SimpleRequest>) async throws -> GRPCCore.ServerResponse.Single<Grpc_Testing_SimpleResponse>
 
     /// One request followed by one response. Response has cache control
     /// headers set such that a caching HTTP proxy (such as GFE) can
     /// satisfy subsequent requests.
-    func cacheableUnaryCall(request: ServerRequest.Single<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Single<Grpc_Testing_SimpleResponse>
+    func cacheableUnaryCall(request: GRPCCore.ServerRequest.Single<Grpc_Testing_SimpleRequest>) async throws -> GRPCCore.ServerResponse.Single<Grpc_Testing_SimpleResponse>
 
     /// One request followed by a sequence of responses (streamed download).
     /// The server returns the payload with client desired type and sizes.
-    func streamingOutputCall(request: ServerRequest.Single<Grpc_Testing_StreamingOutputCallRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>
+    func streamingOutputCall(request: GRPCCore.ServerRequest.Single<Grpc_Testing_StreamingOutputCallRequest>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>
 
     /// A sequence of requests followed by one response (streamed upload).
     /// The server returns the aggregated size of client payload as the result.
-    func streamingInputCall(request: ServerRequest.Stream<Grpc_Testing_StreamingInputCallRequest>) async throws -> ServerResponse.Single<Grpc_Testing_StreamingInputCallResponse>
+    func streamingInputCall(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_StreamingInputCallRequest>) async throws -> GRPCCore.ServerResponse.Single<Grpc_Testing_StreamingInputCallResponse>
 
     /// A sequence of requests with each request served by the server immediately.
     /// As one request could lead to multiple responses, this interface
     /// demonstrates the idea of full duplexing.
-    func fullDuplexCall(request: ServerRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>
+    func fullDuplexCall(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>
 
     /// A sequence of requests followed by a sequence of responses.
     /// The server buffers all the client requests and then serves them in order. A
     /// stream of responses are returned to the client when the server starts with
     /// first request.
-    func halfDuplexCall(request: ServerRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>
+    func halfDuplexCall(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>
 
     /// The test server will not implement this method. It will be used
     /// to test the behavior when clients call unimplemented methods.
-    func unimplementedCall(request: ServerRequest.Single<Grpc_Testing_Empty>) async throws -> ServerResponse.Single<Grpc_Testing_Empty>
+    func unimplementedCall(request: GRPCCore.ServerRequest.Single<Grpc_Testing_Empty>) async throws -> GRPCCore.ServerResponse.Single<Grpc_Testing_Empty>
 }
 
 /// Partial conformance to `Grpc_Testing_TestServiceStreamingServiceProtocol`.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_TestService.ServiceProtocol {
-    public func emptyCall(request: ServerRequest.Stream<Grpc_Testing_Empty>) async throws -> ServerResponse.Stream<Grpc_Testing_Empty> {
-        let response = try await self.emptyCall(request: ServerRequest.Single(stream: request))
-        return ServerResponse.Stream(single: response)
+    public func emptyCall(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_Empty>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_Empty> {
+        let response = try await self.emptyCall(request: GRPCCore.ServerRequest.Single(stream: request))
+        return GRPCCore.ServerResponse.Stream(single: response)
     }
 
-    public func unaryCall(request: ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_SimpleResponse> {
-        let response = try await self.unaryCall(request: ServerRequest.Single(stream: request))
-        return ServerResponse.Stream(single: response)
+    public func unaryCall(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_SimpleResponse> {
+        let response = try await self.unaryCall(request: GRPCCore.ServerRequest.Single(stream: request))
+        return GRPCCore.ServerResponse.Stream(single: response)
     }
 
-    public func cacheableUnaryCall(request: ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_SimpleResponse> {
-        let response = try await self.cacheableUnaryCall(request: ServerRequest.Single(stream: request))
-        return ServerResponse.Stream(single: response)
+    public func cacheableUnaryCall(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_SimpleResponse> {
+        let response = try await self.cacheableUnaryCall(request: GRPCCore.ServerRequest.Single(stream: request))
+        return GRPCCore.ServerResponse.Stream(single: response)
     }
 
-    public func streamingOutputCall(request: ServerRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_StreamingOutputCallResponse> {
-        let response = try await self.streamingOutputCall(request: ServerRequest.Single(stream: request))
+    public func streamingOutputCall(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_StreamingOutputCallResponse> {
+        let response = try await self.streamingOutputCall(request: GRPCCore.ServerRequest.Single(stream: request))
         return response
     }
 
-    public func streamingInputCall(request: ServerRequest.Stream<Grpc_Testing_StreamingInputCallRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_StreamingInputCallResponse> {
+    public func streamingInputCall(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_StreamingInputCallRequest>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_StreamingInputCallResponse> {
         let response = try await self.streamingInputCall(request: request)
-        return ServerResponse.Stream(single: response)
+        return GRPCCore.ServerResponse.Stream(single: response)
     }
 
-    public func unimplementedCall(request: ServerRequest.Stream<Grpc_Testing_Empty>) async throws -> ServerResponse.Stream<Grpc_Testing_Empty> {
-        let response = try await self.unimplementedCall(request: ServerRequest.Single(stream: request))
-        return ServerResponse.Stream(single: response)
+    public func unimplementedCall(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_Empty>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_Empty> {
+        let response = try await self.unimplementedCall(request: GRPCCore.ServerRequest.Single(stream: request))
+        return GRPCCore.ServerResponse.Stream(single: response)
     }
 }
 
@@ -384,7 +384,7 @@ extension Grpc_Testing_TestService.ServiceProtocol {
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 public protocol Grpc_Testing_UnimplementedServiceStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
     /// A call that no server should implement
-    func unimplementedCall(request: ServerRequest.Stream<Grpc_Testing_Empty>) async throws -> ServerResponse.Stream<Grpc_Testing_Empty>
+    func unimplementedCall(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_Empty>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_Empty>
 }
 
 /// Conformance to `GRPCCore.RegistrableRPCService`.
@@ -394,8 +394,8 @@ extension Grpc_Testing_UnimplementedService.StreamingServiceProtocol {
     public func registerMethods(with router: inout GRPCCore.RPCRouter) {
         router.registerHandler(
             forMethod: Grpc_Testing_UnimplementedService.Method.UnimplementedCall.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_Empty>(),
-            serializer: ProtobufSerializer<Grpc_Testing_Empty>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Testing_Empty>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Testing_Empty>(),
             handler: { request in
                 try await self.unimplementedCall(request: request)
             }
@@ -408,24 +408,24 @@ extension Grpc_Testing_UnimplementedService.StreamingServiceProtocol {
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 public protocol Grpc_Testing_UnimplementedServiceServiceProtocol: Grpc_Testing_UnimplementedService.StreamingServiceProtocol {
     /// A call that no server should implement
-    func unimplementedCall(request: ServerRequest.Single<Grpc_Testing_Empty>) async throws -> ServerResponse.Single<Grpc_Testing_Empty>
+    func unimplementedCall(request: GRPCCore.ServerRequest.Single<Grpc_Testing_Empty>) async throws -> GRPCCore.ServerResponse.Single<Grpc_Testing_Empty>
 }
 
 /// Partial conformance to `Grpc_Testing_UnimplementedServiceStreamingServiceProtocol`.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_UnimplementedService.ServiceProtocol {
-    public func unimplementedCall(request: ServerRequest.Stream<Grpc_Testing_Empty>) async throws -> ServerResponse.Stream<Grpc_Testing_Empty> {
-        let response = try await self.unimplementedCall(request: ServerRequest.Single(stream: request))
-        return ServerResponse.Stream(single: response)
+    public func unimplementedCall(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_Empty>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_Empty> {
+        let response = try await self.unimplementedCall(request: GRPCCore.ServerRequest.Single(stream: request))
+        return GRPCCore.ServerResponse.Stream(single: response)
     }
 }
 
 /// A service used to control reconnect server.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 public protocol Grpc_Testing_ReconnectServiceStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
-    func start(request: ServerRequest.Stream<Grpc_Testing_ReconnectParams>) async throws -> ServerResponse.Stream<Grpc_Testing_Empty>
+    func start(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_ReconnectParams>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_Empty>
 
-    func stop(request: ServerRequest.Stream<Grpc_Testing_Empty>) async throws -> ServerResponse.Stream<Grpc_Testing_ReconnectInfo>
+    func stop(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_Empty>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_ReconnectInfo>
 }
 
 /// Conformance to `GRPCCore.RegistrableRPCService`.
@@ -435,16 +435,16 @@ extension Grpc_Testing_ReconnectService.StreamingServiceProtocol {
     public func registerMethods(with router: inout GRPCCore.RPCRouter) {
         router.registerHandler(
             forMethod: Grpc_Testing_ReconnectService.Method.Start.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_ReconnectParams>(),
-            serializer: ProtobufSerializer<Grpc_Testing_Empty>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Testing_ReconnectParams>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Testing_Empty>(),
             handler: { request in
                 try await self.start(request: request)
             }
         )
         router.registerHandler(
             forMethod: Grpc_Testing_ReconnectService.Method.Stop.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_Empty>(),
-            serializer: ProtobufSerializer<Grpc_Testing_ReconnectInfo>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Testing_Empty>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Testing_ReconnectInfo>(),
             handler: { request in
                 try await self.stop(request: request)
             }
@@ -455,22 +455,22 @@ extension Grpc_Testing_ReconnectService.StreamingServiceProtocol {
 /// A service used to control reconnect server.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 public protocol Grpc_Testing_ReconnectServiceServiceProtocol: Grpc_Testing_ReconnectService.StreamingServiceProtocol {
-    func start(request: ServerRequest.Single<Grpc_Testing_ReconnectParams>) async throws -> ServerResponse.Single<Grpc_Testing_Empty>
+    func start(request: GRPCCore.ServerRequest.Single<Grpc_Testing_ReconnectParams>) async throws -> GRPCCore.ServerResponse.Single<Grpc_Testing_Empty>
 
-    func stop(request: ServerRequest.Single<Grpc_Testing_Empty>) async throws -> ServerResponse.Single<Grpc_Testing_ReconnectInfo>
+    func stop(request: GRPCCore.ServerRequest.Single<Grpc_Testing_Empty>) async throws -> GRPCCore.ServerResponse.Single<Grpc_Testing_ReconnectInfo>
 }
 
 /// Partial conformance to `Grpc_Testing_ReconnectServiceStreamingServiceProtocol`.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_ReconnectService.ServiceProtocol {
-    public func start(request: ServerRequest.Stream<Grpc_Testing_ReconnectParams>) async throws -> ServerResponse.Stream<Grpc_Testing_Empty> {
-        let response = try await self.start(request: ServerRequest.Single(stream: request))
-        return ServerResponse.Stream(single: response)
+    public func start(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_ReconnectParams>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_Empty> {
+        let response = try await self.start(request: GRPCCore.ServerRequest.Single(stream: request))
+        return GRPCCore.ServerResponse.Stream(single: response)
     }
 
-    public func stop(request: ServerRequest.Stream<Grpc_Testing_Empty>) async throws -> ServerResponse.Stream<Grpc_Testing_ReconnectInfo> {
-        let response = try await self.stop(request: ServerRequest.Single(stream: request))
-        return ServerResponse.Stream(single: response)
+    public func stop(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_Empty>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_ReconnectInfo> {
+        let response = try await self.stop(request: GRPCCore.ServerRequest.Single(stream: request))
+        return GRPCCore.ServerResponse.Stream(single: response)
     }
 }
 
@@ -480,62 +480,62 @@ extension Grpc_Testing_ReconnectService.ServiceProtocol {
 public protocol Grpc_Testing_TestServiceClientProtocol: Sendable {
     /// One empty request followed by one empty response.
     func emptyCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_Empty>,
-        serializer: some MessageSerializer<Grpc_Testing_Empty>,
-        deserializer: some MessageDeserializer<Grpc_Testing_Empty>,
-        options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Grpc_Testing_Empty>,
+        serializer: some GRPCCore.MessageSerializer<Grpc_Testing_Empty>,
+        deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_Empty>,
+        options: GRPCCore.CallOptions,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
     ) async throws -> R where R: Sendable
 
     /// One request followed by one response.
     func unaryCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_SimpleRequest>,
-        serializer: some MessageSerializer<Grpc_Testing_SimpleRequest>,
-        deserializer: some MessageDeserializer<Grpc_Testing_SimpleResponse>,
-        options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Grpc_Testing_SimpleRequest>,
+        serializer: some GRPCCore.MessageSerializer<Grpc_Testing_SimpleRequest>,
+        deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_SimpleResponse>,
+        options: GRPCCore.CallOptions,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable
 
     /// One request followed by one response. Response has cache control
     /// headers set such that a caching HTTP proxy (such as GFE) can
     /// satisfy subsequent requests.
     func cacheableUnaryCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_SimpleRequest>,
-        serializer: some MessageSerializer<Grpc_Testing_SimpleRequest>,
-        deserializer: some MessageDeserializer<Grpc_Testing_SimpleResponse>,
-        options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Grpc_Testing_SimpleRequest>,
+        serializer: some GRPCCore.MessageSerializer<Grpc_Testing_SimpleRequest>,
+        deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_SimpleResponse>,
+        options: GRPCCore.CallOptions,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable
 
     /// One request followed by a sequence of responses (streamed download).
     /// The server returns the payload with client desired type and sizes.
     func streamingOutputCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_StreamingOutputCallRequest>,
-        serializer: some MessageSerializer<Grpc_Testing_StreamingOutputCallRequest>,
-        deserializer: some MessageDeserializer<Grpc_Testing_StreamingOutputCallResponse>,
-        options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Grpc_Testing_StreamingOutputCallRequest>,
+        serializer: some GRPCCore.MessageSerializer<Grpc_Testing_StreamingOutputCallRequest>,
+        deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_StreamingOutputCallResponse>,
+        options: GRPCCore.CallOptions,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
     ) async throws -> R where R: Sendable
 
     /// A sequence of requests followed by one response (streamed upload).
     /// The server returns the aggregated size of client payload as the result.
     func streamingInputCall<R>(
-        request: ClientRequest.Stream<Grpc_Testing_StreamingInputCallRequest>,
-        serializer: some MessageSerializer<Grpc_Testing_StreamingInputCallRequest>,
-        deserializer: some MessageDeserializer<Grpc_Testing_StreamingInputCallResponse>,
-        options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_StreamingInputCallResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Stream<Grpc_Testing_StreamingInputCallRequest>,
+        serializer: some GRPCCore.MessageSerializer<Grpc_Testing_StreamingInputCallRequest>,
+        deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_StreamingInputCallResponse>,
+        options: GRPCCore.CallOptions,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_StreamingInputCallResponse>) async throws -> R
     ) async throws -> R where R: Sendable
 
     /// A sequence of requests with each request served by the server immediately.
     /// As one request could lead to multiple responses, this interface
     /// demonstrates the idea of full duplexing.
     func fullDuplexCall<R>(
-        request: ClientRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>,
-        serializer: some MessageSerializer<Grpc_Testing_StreamingOutputCallRequest>,
-        deserializer: some MessageDeserializer<Grpc_Testing_StreamingOutputCallResponse>,
-        options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>,
+        serializer: some GRPCCore.MessageSerializer<Grpc_Testing_StreamingOutputCallRequest>,
+        deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_StreamingOutputCallResponse>,
+        options: GRPCCore.CallOptions,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
     ) async throws -> R where R: Sendable
 
     /// A sequence of requests followed by a sequence of responses.
@@ -543,133 +543,133 @@ public protocol Grpc_Testing_TestServiceClientProtocol: Sendable {
     /// stream of responses are returned to the client when the server starts with
     /// first request.
     func halfDuplexCall<R>(
-        request: ClientRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>,
-        serializer: some MessageSerializer<Grpc_Testing_StreamingOutputCallRequest>,
-        deserializer: some MessageDeserializer<Grpc_Testing_StreamingOutputCallResponse>,
-        options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>,
+        serializer: some GRPCCore.MessageSerializer<Grpc_Testing_StreamingOutputCallRequest>,
+        deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_StreamingOutputCallResponse>,
+        options: GRPCCore.CallOptions,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
     ) async throws -> R where R: Sendable
 
     /// The test server will not implement this method. It will be used
     /// to test the behavior when clients call unimplemented methods.
     func unimplementedCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_Empty>,
-        serializer: some MessageSerializer<Grpc_Testing_Empty>,
-        deserializer: some MessageDeserializer<Grpc_Testing_Empty>,
-        options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Grpc_Testing_Empty>,
+        serializer: some GRPCCore.MessageSerializer<Grpc_Testing_Empty>,
+        deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_Empty>,
+        options: GRPCCore.CallOptions,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
     ) async throws -> R where R: Sendable
 }
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_TestService.ClientProtocol {
     public func emptyCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_Empty>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Grpc_Testing_Empty>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.emptyCall(
             request: request,
-            serializer: ProtobufSerializer<Grpc_Testing_Empty>(),
-            deserializer: ProtobufDeserializer<Grpc_Testing_Empty>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Testing_Empty>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Testing_Empty>(),
             options: options,
             body
         )
     }
 
     public func unaryCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_SimpleRequest>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Grpc_Testing_SimpleRequest>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.unaryCall(
             request: request,
-            serializer: ProtobufSerializer<Grpc_Testing_SimpleRequest>(),
-            deserializer: ProtobufDeserializer<Grpc_Testing_SimpleResponse>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Testing_SimpleRequest>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Testing_SimpleResponse>(),
             options: options,
             body
         )
     }
 
     public func cacheableUnaryCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_SimpleRequest>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Grpc_Testing_SimpleRequest>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.cacheableUnaryCall(
             request: request,
-            serializer: ProtobufSerializer<Grpc_Testing_SimpleRequest>(),
-            deserializer: ProtobufDeserializer<Grpc_Testing_SimpleResponse>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Testing_SimpleRequest>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Testing_SimpleResponse>(),
             options: options,
             body
         )
     }
 
     public func streamingOutputCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_StreamingOutputCallRequest>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Grpc_Testing_StreamingOutputCallRequest>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.streamingOutputCall(
             request: request,
-            serializer: ProtobufSerializer<Grpc_Testing_StreamingOutputCallRequest>(),
-            deserializer: ProtobufDeserializer<Grpc_Testing_StreamingOutputCallResponse>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Testing_StreamingOutputCallRequest>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Testing_StreamingOutputCallResponse>(),
             options: options,
             body
         )
     }
 
     public func streamingInputCall<R>(
-        request: ClientRequest.Stream<Grpc_Testing_StreamingInputCallRequest>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_StreamingInputCallResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Stream<Grpc_Testing_StreamingInputCallRequest>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_StreamingInputCallResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.streamingInputCall(
             request: request,
-            serializer: ProtobufSerializer<Grpc_Testing_StreamingInputCallRequest>(),
-            deserializer: ProtobufDeserializer<Grpc_Testing_StreamingInputCallResponse>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Testing_StreamingInputCallRequest>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Testing_StreamingInputCallResponse>(),
             options: options,
             body
         )
     }
 
     public func fullDuplexCall<R>(
-        request: ClientRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.fullDuplexCall(
             request: request,
-            serializer: ProtobufSerializer<Grpc_Testing_StreamingOutputCallRequest>(),
-            deserializer: ProtobufDeserializer<Grpc_Testing_StreamingOutputCallResponse>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Testing_StreamingOutputCallRequest>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Testing_StreamingOutputCallResponse>(),
             options: options,
             body
         )
     }
 
     public func halfDuplexCall<R>(
-        request: ClientRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.halfDuplexCall(
             request: request,
-            serializer: ProtobufSerializer<Grpc_Testing_StreamingOutputCallRequest>(),
-            deserializer: ProtobufDeserializer<Grpc_Testing_StreamingOutputCallResponse>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Testing_StreamingOutputCallRequest>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Testing_StreamingOutputCallResponse>(),
             options: options,
             body
         )
     }
 
     public func unimplementedCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_Empty>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Grpc_Testing_Empty>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.unimplementedCall(
             request: request,
-            serializer: ProtobufSerializer<Grpc_Testing_Empty>(),
-            deserializer: ProtobufDeserializer<Grpc_Testing_Empty>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Testing_Empty>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Testing_Empty>(),
             options: options,
             body
         )
@@ -688,11 +688,11 @@ public struct Grpc_Testing_TestServiceClient: Grpc_Testing_TestService.ClientPro
 
     /// One empty request followed by one empty response.
     public func emptyCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_Empty>,
-        serializer: some MessageSerializer<Grpc_Testing_Empty>,
-        deserializer: some MessageDeserializer<Grpc_Testing_Empty>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Grpc_Testing_Empty>,
+        serializer: some GRPCCore.MessageSerializer<Grpc_Testing_Empty>,
+        deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_Empty>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.unary(
             request: request,
@@ -706,11 +706,11 @@ public struct Grpc_Testing_TestServiceClient: Grpc_Testing_TestService.ClientPro
 
     /// One request followed by one response.
     public func unaryCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_SimpleRequest>,
-        serializer: some MessageSerializer<Grpc_Testing_SimpleRequest>,
-        deserializer: some MessageDeserializer<Grpc_Testing_SimpleResponse>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Grpc_Testing_SimpleRequest>,
+        serializer: some GRPCCore.MessageSerializer<Grpc_Testing_SimpleRequest>,
+        deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_SimpleResponse>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.unary(
             request: request,
@@ -726,11 +726,11 @@ public struct Grpc_Testing_TestServiceClient: Grpc_Testing_TestService.ClientPro
     /// headers set such that a caching HTTP proxy (such as GFE) can
     /// satisfy subsequent requests.
     public func cacheableUnaryCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_SimpleRequest>,
-        serializer: some MessageSerializer<Grpc_Testing_SimpleRequest>,
-        deserializer: some MessageDeserializer<Grpc_Testing_SimpleResponse>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Grpc_Testing_SimpleRequest>,
+        serializer: some GRPCCore.MessageSerializer<Grpc_Testing_SimpleRequest>,
+        deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_SimpleResponse>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.unary(
             request: request,
@@ -745,11 +745,11 @@ public struct Grpc_Testing_TestServiceClient: Grpc_Testing_TestService.ClientPro
     /// One request followed by a sequence of responses (streamed download).
     /// The server returns the payload with client desired type and sizes.
     public func streamingOutputCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_StreamingOutputCallRequest>,
-        serializer: some MessageSerializer<Grpc_Testing_StreamingOutputCallRequest>,
-        deserializer: some MessageDeserializer<Grpc_Testing_StreamingOutputCallResponse>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Grpc_Testing_StreamingOutputCallRequest>,
+        serializer: some GRPCCore.MessageSerializer<Grpc_Testing_StreamingOutputCallRequest>,
+        deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_StreamingOutputCallResponse>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.serverStreaming(
             request: request,
@@ -764,11 +764,11 @@ public struct Grpc_Testing_TestServiceClient: Grpc_Testing_TestService.ClientPro
     /// A sequence of requests followed by one response (streamed upload).
     /// The server returns the aggregated size of client payload as the result.
     public func streamingInputCall<R>(
-        request: ClientRequest.Stream<Grpc_Testing_StreamingInputCallRequest>,
-        serializer: some MessageSerializer<Grpc_Testing_StreamingInputCallRequest>,
-        deserializer: some MessageDeserializer<Grpc_Testing_StreamingInputCallResponse>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_StreamingInputCallResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Stream<Grpc_Testing_StreamingInputCallRequest>,
+        serializer: some GRPCCore.MessageSerializer<Grpc_Testing_StreamingInputCallRequest>,
+        deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_StreamingInputCallResponse>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_StreamingInputCallResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.clientStreaming(
             request: request,
@@ -784,11 +784,11 @@ public struct Grpc_Testing_TestServiceClient: Grpc_Testing_TestService.ClientPro
     /// As one request could lead to multiple responses, this interface
     /// demonstrates the idea of full duplexing.
     public func fullDuplexCall<R>(
-        request: ClientRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>,
-        serializer: some MessageSerializer<Grpc_Testing_StreamingOutputCallRequest>,
-        deserializer: some MessageDeserializer<Grpc_Testing_StreamingOutputCallResponse>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>,
+        serializer: some GRPCCore.MessageSerializer<Grpc_Testing_StreamingOutputCallRequest>,
+        deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_StreamingOutputCallResponse>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.bidirectionalStreaming(
             request: request,
@@ -805,11 +805,11 @@ public struct Grpc_Testing_TestServiceClient: Grpc_Testing_TestService.ClientPro
     /// stream of responses are returned to the client when the server starts with
     /// first request.
     public func halfDuplexCall<R>(
-        request: ClientRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>,
-        serializer: some MessageSerializer<Grpc_Testing_StreamingOutputCallRequest>,
-        deserializer: some MessageDeserializer<Grpc_Testing_StreamingOutputCallResponse>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>,
+        serializer: some GRPCCore.MessageSerializer<Grpc_Testing_StreamingOutputCallRequest>,
+        deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_StreamingOutputCallResponse>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.bidirectionalStreaming(
             request: request,
@@ -824,11 +824,11 @@ public struct Grpc_Testing_TestServiceClient: Grpc_Testing_TestService.ClientPro
     /// The test server will not implement this method. It will be used
     /// to test the behavior when clients call unimplemented methods.
     public func unimplementedCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_Empty>,
-        serializer: some MessageSerializer<Grpc_Testing_Empty>,
-        deserializer: some MessageDeserializer<Grpc_Testing_Empty>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Grpc_Testing_Empty>,
+        serializer: some GRPCCore.MessageSerializer<Grpc_Testing_Empty>,
+        deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_Empty>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.unary(
             request: request,
@@ -847,25 +847,25 @@ public struct Grpc_Testing_TestServiceClient: Grpc_Testing_TestService.ClientPro
 public protocol Grpc_Testing_UnimplementedServiceClientProtocol: Sendable {
     /// A call that no server should implement
     func unimplementedCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_Empty>,
-        serializer: some MessageSerializer<Grpc_Testing_Empty>,
-        deserializer: some MessageDeserializer<Grpc_Testing_Empty>,
-        options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Grpc_Testing_Empty>,
+        serializer: some GRPCCore.MessageSerializer<Grpc_Testing_Empty>,
+        deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_Empty>,
+        options: GRPCCore.CallOptions,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
     ) async throws -> R where R: Sendable
 }
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_UnimplementedService.ClientProtocol {
     public func unimplementedCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_Empty>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Grpc_Testing_Empty>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.unimplementedCall(
             request: request,
-            serializer: ProtobufSerializer<Grpc_Testing_Empty>(),
-            deserializer: ProtobufDeserializer<Grpc_Testing_Empty>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Testing_Empty>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Testing_Empty>(),
             options: options,
             body
         )
@@ -884,11 +884,11 @@ public struct Grpc_Testing_UnimplementedServiceClient: Grpc_Testing_Unimplemente
 
     /// A call that no server should implement
     public func unimplementedCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_Empty>,
-        serializer: some MessageSerializer<Grpc_Testing_Empty>,
-        deserializer: some MessageDeserializer<Grpc_Testing_Empty>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Grpc_Testing_Empty>,
+        serializer: some GRPCCore.MessageSerializer<Grpc_Testing_Empty>,
+        deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_Empty>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.unary(
             request: request,
@@ -905,47 +905,47 @@ public struct Grpc_Testing_UnimplementedServiceClient: Grpc_Testing_Unimplemente
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 public protocol Grpc_Testing_ReconnectServiceClientProtocol: Sendable {
     func start<R>(
-        request: ClientRequest.Single<Grpc_Testing_ReconnectParams>,
-        serializer: some MessageSerializer<Grpc_Testing_ReconnectParams>,
-        deserializer: some MessageDeserializer<Grpc_Testing_Empty>,
-        options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Grpc_Testing_ReconnectParams>,
+        serializer: some GRPCCore.MessageSerializer<Grpc_Testing_ReconnectParams>,
+        deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_Empty>,
+        options: GRPCCore.CallOptions,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
     ) async throws -> R where R: Sendable
 
     func stop<R>(
-        request: ClientRequest.Single<Grpc_Testing_Empty>,
-        serializer: some MessageSerializer<Grpc_Testing_Empty>,
-        deserializer: some MessageDeserializer<Grpc_Testing_ReconnectInfo>,
-        options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_ReconnectInfo>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Grpc_Testing_Empty>,
+        serializer: some GRPCCore.MessageSerializer<Grpc_Testing_Empty>,
+        deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_ReconnectInfo>,
+        options: GRPCCore.CallOptions,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_ReconnectInfo>) async throws -> R
     ) async throws -> R where R: Sendable
 }
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_ReconnectService.ClientProtocol {
     public func start<R>(
-        request: ClientRequest.Single<Grpc_Testing_ReconnectParams>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Grpc_Testing_ReconnectParams>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.start(
             request: request,
-            serializer: ProtobufSerializer<Grpc_Testing_ReconnectParams>(),
-            deserializer: ProtobufDeserializer<Grpc_Testing_Empty>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Testing_ReconnectParams>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Testing_Empty>(),
             options: options,
             body
         )
     }
 
     public func stop<R>(
-        request: ClientRequest.Single<Grpc_Testing_Empty>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_ReconnectInfo>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Grpc_Testing_Empty>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_ReconnectInfo>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.stop(
             request: request,
-            serializer: ProtobufSerializer<Grpc_Testing_Empty>(),
-            deserializer: ProtobufDeserializer<Grpc_Testing_ReconnectInfo>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Testing_Empty>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Testing_ReconnectInfo>(),
             options: options,
             body
         )
@@ -962,11 +962,11 @@ public struct Grpc_Testing_ReconnectServiceClient: Grpc_Testing_ReconnectService
     }
 
     public func start<R>(
-        request: ClientRequest.Single<Grpc_Testing_ReconnectParams>,
-        serializer: some MessageSerializer<Grpc_Testing_ReconnectParams>,
-        deserializer: some MessageDeserializer<Grpc_Testing_Empty>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Grpc_Testing_ReconnectParams>,
+        serializer: some GRPCCore.MessageSerializer<Grpc_Testing_ReconnectParams>,
+        deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_Empty>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.unary(
             request: request,
@@ -979,11 +979,11 @@ public struct Grpc_Testing_ReconnectServiceClient: Grpc_Testing_ReconnectService
     }
 
     public func stop<R>(
-        request: ClientRequest.Single<Grpc_Testing_Empty>,
-        serializer: some MessageSerializer<Grpc_Testing_Empty>,
-        deserializer: some MessageDeserializer<Grpc_Testing_ReconnectInfo>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_ReconnectInfo>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Grpc_Testing_Empty>,
+        serializer: some GRPCCore.MessageSerializer<Grpc_Testing_Empty>,
+        deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_ReconnectInfo>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_ReconnectInfo>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.unary(
             request: request,

--- a/Sources/Services/Health/Generated/health.grpc.swift
+++ b/Sources/Services/Health/Generated/health.grpc.swift
@@ -28,12 +28,12 @@ import GRPCCore
 import GRPCProtobuf
 
 package enum Grpc_Health_V1_Health {
-    package static let descriptor = ServiceDescriptor.grpc_health_v1_Health
+    package static let descriptor = GRPCCore.ServiceDescriptor.grpc_health_v1_Health
     package enum Method {
         package enum Check {
             package typealias Input = Grpc_Health_V1_HealthCheckRequest
             package typealias Output = Grpc_Health_V1_HealthCheckResponse
-            package static let descriptor = MethodDescriptor(
+            package static let descriptor = GRPCCore.MethodDescriptor(
                 service: Grpc_Health_V1_Health.descriptor.fullyQualifiedService,
                 method: "Check"
             )
@@ -41,12 +41,12 @@ package enum Grpc_Health_V1_Health {
         package enum Watch {
             package typealias Input = Grpc_Health_V1_HealthCheckRequest
             package typealias Output = Grpc_Health_V1_HealthCheckResponse
-            package static let descriptor = MethodDescriptor(
+            package static let descriptor = GRPCCore.MethodDescriptor(
                 service: Grpc_Health_V1_Health.descriptor.fullyQualifiedService,
                 method: "Watch"
             )
         }
-        package static let descriptors: [MethodDescriptor] = [
+        package static let descriptors: [GRPCCore.MethodDescriptor] = [
             Check.descriptor,
             Watch.descriptor
         ]
@@ -61,7 +61,7 @@ package enum Grpc_Health_V1_Health {
     package typealias Client = Grpc_Health_V1_HealthClient
 }
 
-extension ServiceDescriptor {
+extension GRPCCore.ServiceDescriptor {
     package static let grpc_health_v1_Health = Self(
         package: "grpc.health.v1",
         service: "Health"
@@ -82,7 +82,7 @@ package protocol Grpc_Health_V1_HealthStreamingServiceProtocol: GRPCCore.Registr
     /// server unhealthy if they do not receive a timely response.
     ///
     /// Check implementations should be idempotent and side effect free.
-    func check(request: ServerRequest.Stream<Grpc_Health_V1_HealthCheckRequest>) async throws -> ServerResponse.Stream<Grpc_Health_V1_HealthCheckResponse>
+    func check(request: GRPCCore.ServerRequest.Stream<Grpc_Health_V1_HealthCheckRequest>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Health_V1_HealthCheckResponse>
 
     /// Performs a watch for the serving status of the requested service.
     /// The server will immediately send back a message indicating the current
@@ -99,7 +99,7 @@ package protocol Grpc_Health_V1_HealthStreamingServiceProtocol: GRPCCore.Registr
     /// should assume this method is not supported and should not retry the
     /// call.  If the call terminates with any other status (including OK),
     /// clients should retry the call with appropriate exponential backoff.
-    func watch(request: ServerRequest.Stream<Grpc_Health_V1_HealthCheckRequest>) async throws -> ServerResponse.Stream<Grpc_Health_V1_HealthCheckResponse>
+    func watch(request: GRPCCore.ServerRequest.Stream<Grpc_Health_V1_HealthCheckRequest>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Health_V1_HealthCheckResponse>
 }
 
 /// Conformance to `GRPCCore.RegistrableRPCService`.
@@ -109,16 +109,16 @@ extension Grpc_Health_V1_Health.StreamingServiceProtocol {
     package func registerMethods(with router: inout GRPCCore.RPCRouter) {
         router.registerHandler(
             forMethod: Grpc_Health_V1_Health.Method.Check.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Health_V1_HealthCheckRequest>(),
-            serializer: ProtobufSerializer<Grpc_Health_V1_HealthCheckResponse>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Health_V1_HealthCheckRequest>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Health_V1_HealthCheckResponse>(),
             handler: { request in
                 try await self.check(request: request)
             }
         )
         router.registerHandler(
             forMethod: Grpc_Health_V1_Health.Method.Watch.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Health_V1_HealthCheckRequest>(),
-            serializer: ProtobufSerializer<Grpc_Health_V1_HealthCheckResponse>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Health_V1_HealthCheckRequest>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Health_V1_HealthCheckResponse>(),
             handler: { request in
                 try await self.watch(request: request)
             }
@@ -140,7 +140,7 @@ package protocol Grpc_Health_V1_HealthServiceProtocol: Grpc_Health_V1_Health.Str
     /// server unhealthy if they do not receive a timely response.
     ///
     /// Check implementations should be idempotent and side effect free.
-    func check(request: ServerRequest.Single<Grpc_Health_V1_HealthCheckRequest>) async throws -> ServerResponse.Single<Grpc_Health_V1_HealthCheckResponse>
+    func check(request: GRPCCore.ServerRequest.Single<Grpc_Health_V1_HealthCheckRequest>) async throws -> GRPCCore.ServerResponse.Single<Grpc_Health_V1_HealthCheckResponse>
 
     /// Performs a watch for the serving status of the requested service.
     /// The server will immediately send back a message indicating the current
@@ -157,19 +157,19 @@ package protocol Grpc_Health_V1_HealthServiceProtocol: Grpc_Health_V1_Health.Str
     /// should assume this method is not supported and should not retry the
     /// call.  If the call terminates with any other status (including OK),
     /// clients should retry the call with appropriate exponential backoff.
-    func watch(request: ServerRequest.Single<Grpc_Health_V1_HealthCheckRequest>) async throws -> ServerResponse.Stream<Grpc_Health_V1_HealthCheckResponse>
+    func watch(request: GRPCCore.ServerRequest.Single<Grpc_Health_V1_HealthCheckRequest>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Health_V1_HealthCheckResponse>
 }
 
 /// Partial conformance to `Grpc_Health_V1_HealthStreamingServiceProtocol`.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Health_V1_Health.ServiceProtocol {
-    package func check(request: ServerRequest.Stream<Grpc_Health_V1_HealthCheckRequest>) async throws -> ServerResponse.Stream<Grpc_Health_V1_HealthCheckResponse> {
-        let response = try await self.check(request: ServerRequest.Single(stream: request))
-        return ServerResponse.Stream(single: response)
+    package func check(request: GRPCCore.ServerRequest.Stream<Grpc_Health_V1_HealthCheckRequest>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Health_V1_HealthCheckResponse> {
+        let response = try await self.check(request: GRPCCore.ServerRequest.Single(stream: request))
+        return GRPCCore.ServerResponse.Stream(single: response)
     }
 
-    package func watch(request: ServerRequest.Stream<Grpc_Health_V1_HealthCheckRequest>) async throws -> ServerResponse.Stream<Grpc_Health_V1_HealthCheckResponse> {
-        let response = try await self.watch(request: ServerRequest.Single(stream: request))
+    package func watch(request: GRPCCore.ServerRequest.Stream<Grpc_Health_V1_HealthCheckRequest>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Health_V1_HealthCheckResponse> {
+        let response = try await self.watch(request: GRPCCore.ServerRequest.Single(stream: request))
         return response
     }
 }
@@ -189,11 +189,11 @@ package protocol Grpc_Health_V1_HealthClientProtocol: Sendable {
     ///
     /// Check implementations should be idempotent and side effect free.
     func check<R>(
-        request: ClientRequest.Single<Grpc_Health_V1_HealthCheckRequest>,
-        serializer: some MessageSerializer<Grpc_Health_V1_HealthCheckRequest>,
-        deserializer: some MessageDeserializer<Grpc_Health_V1_HealthCheckResponse>,
-        options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Health_V1_HealthCheckResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Grpc_Health_V1_HealthCheckRequest>,
+        serializer: some GRPCCore.MessageSerializer<Grpc_Health_V1_HealthCheckRequest>,
+        deserializer: some GRPCCore.MessageDeserializer<Grpc_Health_V1_HealthCheckResponse>,
+        options: GRPCCore.CallOptions,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Health_V1_HealthCheckResponse>) async throws -> R
     ) async throws -> R where R: Sendable
 
     /// Performs a watch for the serving status of the requested service.
@@ -212,39 +212,39 @@ package protocol Grpc_Health_V1_HealthClientProtocol: Sendable {
     /// call.  If the call terminates with any other status (including OK),
     /// clients should retry the call with appropriate exponential backoff.
     func watch<R>(
-        request: ClientRequest.Single<Grpc_Health_V1_HealthCheckRequest>,
-        serializer: some MessageSerializer<Grpc_Health_V1_HealthCheckRequest>,
-        deserializer: some MessageDeserializer<Grpc_Health_V1_HealthCheckResponse>,
-        options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Health_V1_HealthCheckResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Grpc_Health_V1_HealthCheckRequest>,
+        serializer: some GRPCCore.MessageSerializer<Grpc_Health_V1_HealthCheckRequest>,
+        deserializer: some GRPCCore.MessageDeserializer<Grpc_Health_V1_HealthCheckResponse>,
+        options: GRPCCore.CallOptions,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Grpc_Health_V1_HealthCheckResponse>) async throws -> R
     ) async throws -> R where R: Sendable
 }
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Health_V1_Health.ClientProtocol {
     package func check<R>(
-        request: ClientRequest.Single<Grpc_Health_V1_HealthCheckRequest>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Health_V1_HealthCheckResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Grpc_Health_V1_HealthCheckRequest>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Health_V1_HealthCheckResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.check(
             request: request,
-            serializer: ProtobufSerializer<Grpc_Health_V1_HealthCheckRequest>(),
-            deserializer: ProtobufDeserializer<Grpc_Health_V1_HealthCheckResponse>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Health_V1_HealthCheckRequest>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Health_V1_HealthCheckResponse>(),
             options: options,
             body
         )
     }
 
     package func watch<R>(
-        request: ClientRequest.Single<Grpc_Health_V1_HealthCheckRequest>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Health_V1_HealthCheckResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Grpc_Health_V1_HealthCheckRequest>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Grpc_Health_V1_HealthCheckResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.watch(
             request: request,
-            serializer: ProtobufSerializer<Grpc_Health_V1_HealthCheckRequest>(),
-            deserializer: ProtobufDeserializer<Grpc_Health_V1_HealthCheckResponse>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Health_V1_HealthCheckRequest>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Health_V1_HealthCheckResponse>(),
             options: options,
             body
         )
@@ -272,11 +272,11 @@ package struct Grpc_Health_V1_HealthClient: Grpc_Health_V1_Health.ClientProtocol
     ///
     /// Check implementations should be idempotent and side effect free.
     package func check<R>(
-        request: ClientRequest.Single<Grpc_Health_V1_HealthCheckRequest>,
-        serializer: some MessageSerializer<Grpc_Health_V1_HealthCheckRequest>,
-        deserializer: some MessageDeserializer<Grpc_Health_V1_HealthCheckResponse>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Health_V1_HealthCheckResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Grpc_Health_V1_HealthCheckRequest>,
+        serializer: some GRPCCore.MessageSerializer<Grpc_Health_V1_HealthCheckRequest>,
+        deserializer: some GRPCCore.MessageDeserializer<Grpc_Health_V1_HealthCheckResponse>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Health_V1_HealthCheckResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.unary(
             request: request,
@@ -304,11 +304,11 @@ package struct Grpc_Health_V1_HealthClient: Grpc_Health_V1_Health.ClientProtocol
     /// call.  If the call terminates with any other status (including OK),
     /// clients should retry the call with appropriate exponential backoff.
     package func watch<R>(
-        request: ClientRequest.Single<Grpc_Health_V1_HealthCheckRequest>,
-        serializer: some MessageSerializer<Grpc_Health_V1_HealthCheckRequest>,
-        deserializer: some MessageDeserializer<Grpc_Health_V1_HealthCheckResponse>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Health_V1_HealthCheckResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Grpc_Health_V1_HealthCheckRequest>,
+        serializer: some GRPCCore.MessageSerializer<Grpc_Health_V1_HealthCheckRequest>,
+        deserializer: some GRPCCore.MessageDeserializer<Grpc_Health_V1_HealthCheckResponse>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Grpc_Health_V1_HealthCheckResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.serverStreaming(
             request: request,

--- a/Sources/performance-worker/Generated/grpc_testing_benchmark_service.grpc.swift
+++ b/Sources/performance-worker/Generated/grpc_testing_benchmark_service.grpc.swift
@@ -28,12 +28,12 @@ import GRPCCore
 import GRPCProtobuf
 
 internal enum Grpc_Testing_BenchmarkService {
-    internal static let descriptor = ServiceDescriptor.grpc_testing_BenchmarkService
+    internal static let descriptor = GRPCCore.ServiceDescriptor.grpc_testing_BenchmarkService
     internal enum Method {
         internal enum UnaryCall {
             internal typealias Input = Grpc_Testing_SimpleRequest
             internal typealias Output = Grpc_Testing_SimpleResponse
-            internal static let descriptor = MethodDescriptor(
+            internal static let descriptor = GRPCCore.MethodDescriptor(
                 service: Grpc_Testing_BenchmarkService.descriptor.fullyQualifiedService,
                 method: "UnaryCall"
             )
@@ -41,7 +41,7 @@ internal enum Grpc_Testing_BenchmarkService {
         internal enum StreamingCall {
             internal typealias Input = Grpc_Testing_SimpleRequest
             internal typealias Output = Grpc_Testing_SimpleResponse
-            internal static let descriptor = MethodDescriptor(
+            internal static let descriptor = GRPCCore.MethodDescriptor(
                 service: Grpc_Testing_BenchmarkService.descriptor.fullyQualifiedService,
                 method: "StreamingCall"
             )
@@ -49,7 +49,7 @@ internal enum Grpc_Testing_BenchmarkService {
         internal enum StreamingFromClient {
             internal typealias Input = Grpc_Testing_SimpleRequest
             internal typealias Output = Grpc_Testing_SimpleResponse
-            internal static let descriptor = MethodDescriptor(
+            internal static let descriptor = GRPCCore.MethodDescriptor(
                 service: Grpc_Testing_BenchmarkService.descriptor.fullyQualifiedService,
                 method: "StreamingFromClient"
             )
@@ -57,7 +57,7 @@ internal enum Grpc_Testing_BenchmarkService {
         internal enum StreamingFromServer {
             internal typealias Input = Grpc_Testing_SimpleRequest
             internal typealias Output = Grpc_Testing_SimpleResponse
-            internal static let descriptor = MethodDescriptor(
+            internal static let descriptor = GRPCCore.MethodDescriptor(
                 service: Grpc_Testing_BenchmarkService.descriptor.fullyQualifiedService,
                 method: "StreamingFromServer"
             )
@@ -65,12 +65,12 @@ internal enum Grpc_Testing_BenchmarkService {
         internal enum StreamingBothWays {
             internal typealias Input = Grpc_Testing_SimpleRequest
             internal typealias Output = Grpc_Testing_SimpleResponse
-            internal static let descriptor = MethodDescriptor(
+            internal static let descriptor = GRPCCore.MethodDescriptor(
                 service: Grpc_Testing_BenchmarkService.descriptor.fullyQualifiedService,
                 method: "StreamingBothWays"
             )
         }
-        internal static let descriptors: [MethodDescriptor] = [
+        internal static let descriptors: [GRPCCore.MethodDescriptor] = [
             UnaryCall.descriptor,
             StreamingCall.descriptor,
             StreamingFromClient.descriptor,
@@ -88,7 +88,7 @@ internal enum Grpc_Testing_BenchmarkService {
     internal typealias Client = Grpc_Testing_BenchmarkServiceClient
 }
 
-extension ServiceDescriptor {
+extension GRPCCore.ServiceDescriptor {
     internal static let grpc_testing_BenchmarkService = Self(
         package: "grpc.testing",
         service: "BenchmarkService"
@@ -99,24 +99,24 @@ extension ServiceDescriptor {
 internal protocol Grpc_Testing_BenchmarkServiceStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
     /// One request followed by one response.
     /// The server returns the client payload as-is.
-    func unaryCall(request: ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_SimpleResponse>
+    func unaryCall(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_SimpleResponse>
 
     /// Repeated sequence of one request followed by one response.
     /// Should be called streaming ping-pong
     /// The server returns the client payload as-is on each response
-    func streamingCall(request: ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_SimpleResponse>
+    func streamingCall(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_SimpleResponse>
 
     /// Single-sided unbounded streaming from client to server
     /// The server returns the client payload as-is once the client does WritesDone
-    func streamingFromClient(request: ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_SimpleResponse>
+    func streamingFromClient(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_SimpleResponse>
 
     /// Single-sided unbounded streaming from server to client
     /// The server repeatedly returns the client payload as-is
-    func streamingFromServer(request: ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_SimpleResponse>
+    func streamingFromServer(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_SimpleResponse>
 
     /// Two-sided unbounded streaming between server to client
     /// Both sides send the content of their own choice to the other
-    func streamingBothWays(request: ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_SimpleResponse>
+    func streamingBothWays(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_SimpleResponse>
 }
 
 /// Conformance to `GRPCCore.RegistrableRPCService`.
@@ -126,40 +126,40 @@ extension Grpc_Testing_BenchmarkService.StreamingServiceProtocol {
     internal func registerMethods(with router: inout GRPCCore.RPCRouter) {
         router.registerHandler(
             forMethod: Grpc_Testing_BenchmarkService.Method.UnaryCall.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_SimpleRequest>(),
-            serializer: ProtobufSerializer<Grpc_Testing_SimpleResponse>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Testing_SimpleRequest>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Testing_SimpleResponse>(),
             handler: { request in
                 try await self.unaryCall(request: request)
             }
         )
         router.registerHandler(
             forMethod: Grpc_Testing_BenchmarkService.Method.StreamingCall.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_SimpleRequest>(),
-            serializer: ProtobufSerializer<Grpc_Testing_SimpleResponse>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Testing_SimpleRequest>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Testing_SimpleResponse>(),
             handler: { request in
                 try await self.streamingCall(request: request)
             }
         )
         router.registerHandler(
             forMethod: Grpc_Testing_BenchmarkService.Method.StreamingFromClient.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_SimpleRequest>(),
-            serializer: ProtobufSerializer<Grpc_Testing_SimpleResponse>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Testing_SimpleRequest>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Testing_SimpleResponse>(),
             handler: { request in
                 try await self.streamingFromClient(request: request)
             }
         )
         router.registerHandler(
             forMethod: Grpc_Testing_BenchmarkService.Method.StreamingFromServer.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_SimpleRequest>(),
-            serializer: ProtobufSerializer<Grpc_Testing_SimpleResponse>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Testing_SimpleRequest>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Testing_SimpleResponse>(),
             handler: { request in
                 try await self.streamingFromServer(request: request)
             }
         )
         router.registerHandler(
             forMethod: Grpc_Testing_BenchmarkService.Method.StreamingBothWays.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_SimpleRequest>(),
-            serializer: ProtobufSerializer<Grpc_Testing_SimpleResponse>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Testing_SimpleRequest>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Testing_SimpleResponse>(),
             handler: { request in
                 try await self.streamingBothWays(request: request)
             }
@@ -171,41 +171,41 @@ extension Grpc_Testing_BenchmarkService.StreamingServiceProtocol {
 internal protocol Grpc_Testing_BenchmarkServiceServiceProtocol: Grpc_Testing_BenchmarkService.StreamingServiceProtocol {
     /// One request followed by one response.
     /// The server returns the client payload as-is.
-    func unaryCall(request: ServerRequest.Single<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Single<Grpc_Testing_SimpleResponse>
+    func unaryCall(request: GRPCCore.ServerRequest.Single<Grpc_Testing_SimpleRequest>) async throws -> GRPCCore.ServerResponse.Single<Grpc_Testing_SimpleResponse>
 
     /// Repeated sequence of one request followed by one response.
     /// Should be called streaming ping-pong
     /// The server returns the client payload as-is on each response
-    func streamingCall(request: ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_SimpleResponse>
+    func streamingCall(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_SimpleResponse>
 
     /// Single-sided unbounded streaming from client to server
     /// The server returns the client payload as-is once the client does WritesDone
-    func streamingFromClient(request: ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Single<Grpc_Testing_SimpleResponse>
+    func streamingFromClient(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> GRPCCore.ServerResponse.Single<Grpc_Testing_SimpleResponse>
 
     /// Single-sided unbounded streaming from server to client
     /// The server repeatedly returns the client payload as-is
-    func streamingFromServer(request: ServerRequest.Single<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_SimpleResponse>
+    func streamingFromServer(request: GRPCCore.ServerRequest.Single<Grpc_Testing_SimpleRequest>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_SimpleResponse>
 
     /// Two-sided unbounded streaming between server to client
     /// Both sides send the content of their own choice to the other
-    func streamingBothWays(request: ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_SimpleResponse>
+    func streamingBothWays(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_SimpleResponse>
 }
 
 /// Partial conformance to `Grpc_Testing_BenchmarkServiceStreamingServiceProtocol`.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_BenchmarkService.ServiceProtocol {
-    internal func unaryCall(request: ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_SimpleResponse> {
-        let response = try await self.unaryCall(request: ServerRequest.Single(stream: request))
-        return ServerResponse.Stream(single: response)
+    internal func unaryCall(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_SimpleResponse> {
+        let response = try await self.unaryCall(request: GRPCCore.ServerRequest.Single(stream: request))
+        return GRPCCore.ServerResponse.Stream(single: response)
     }
 
-    internal func streamingFromClient(request: ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_SimpleResponse> {
+    internal func streamingFromClient(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_SimpleResponse> {
         let response = try await self.streamingFromClient(request: request)
-        return ServerResponse.Stream(single: response)
+        return GRPCCore.ServerResponse.Stream(single: response)
     }
 
-    internal func streamingFromServer(request: ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_SimpleResponse> {
-        let response = try await self.streamingFromServer(request: ServerRequest.Single(stream: request))
+    internal func streamingFromServer(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_SimpleRequest>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_SimpleResponse> {
+        let response = try await self.streamingFromServer(request: GRPCCore.ServerRequest.Single(stream: request))
         return response
     }
 }
@@ -215,122 +215,122 @@ internal protocol Grpc_Testing_BenchmarkServiceClientProtocol: Sendable {
     /// One request followed by one response.
     /// The server returns the client payload as-is.
     func unaryCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_SimpleRequest>,
-        serializer: some MessageSerializer<Grpc_Testing_SimpleRequest>,
-        deserializer: some MessageDeserializer<Grpc_Testing_SimpleResponse>,
-        options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Grpc_Testing_SimpleRequest>,
+        serializer: some GRPCCore.MessageSerializer<Grpc_Testing_SimpleRequest>,
+        deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_SimpleResponse>,
+        options: GRPCCore.CallOptions,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable
 
     /// Repeated sequence of one request followed by one response.
     /// Should be called streaming ping-pong
     /// The server returns the client payload as-is on each response
     func streamingCall<R>(
-        request: ClientRequest.Stream<Grpc_Testing_SimpleRequest>,
-        serializer: some MessageSerializer<Grpc_Testing_SimpleRequest>,
-        deserializer: some MessageDeserializer<Grpc_Testing_SimpleResponse>,
-        options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_SimpleResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Stream<Grpc_Testing_SimpleRequest>,
+        serializer: some GRPCCore.MessageSerializer<Grpc_Testing_SimpleRequest>,
+        deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_SimpleResponse>,
+        options: GRPCCore.CallOptions,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable
 
     /// Single-sided unbounded streaming from client to server
     /// The server returns the client payload as-is once the client does WritesDone
     func streamingFromClient<R>(
-        request: ClientRequest.Stream<Grpc_Testing_SimpleRequest>,
-        serializer: some MessageSerializer<Grpc_Testing_SimpleRequest>,
-        deserializer: some MessageDeserializer<Grpc_Testing_SimpleResponse>,
-        options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Stream<Grpc_Testing_SimpleRequest>,
+        serializer: some GRPCCore.MessageSerializer<Grpc_Testing_SimpleRequest>,
+        deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_SimpleResponse>,
+        options: GRPCCore.CallOptions,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable
 
     /// Single-sided unbounded streaming from server to client
     /// The server repeatedly returns the client payload as-is
     func streamingFromServer<R>(
-        request: ClientRequest.Single<Grpc_Testing_SimpleRequest>,
-        serializer: some MessageSerializer<Grpc_Testing_SimpleRequest>,
-        deserializer: some MessageDeserializer<Grpc_Testing_SimpleResponse>,
-        options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_SimpleResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Grpc_Testing_SimpleRequest>,
+        serializer: some GRPCCore.MessageSerializer<Grpc_Testing_SimpleRequest>,
+        deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_SimpleResponse>,
+        options: GRPCCore.CallOptions,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable
 
     /// Two-sided unbounded streaming between server to client
     /// Both sides send the content of their own choice to the other
     func streamingBothWays<R>(
-        request: ClientRequest.Stream<Grpc_Testing_SimpleRequest>,
-        serializer: some MessageSerializer<Grpc_Testing_SimpleRequest>,
-        deserializer: some MessageDeserializer<Grpc_Testing_SimpleResponse>,
-        options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_SimpleResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Stream<Grpc_Testing_SimpleRequest>,
+        serializer: some GRPCCore.MessageSerializer<Grpc_Testing_SimpleRequest>,
+        deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_SimpleResponse>,
+        options: GRPCCore.CallOptions,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable
 }
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_BenchmarkService.ClientProtocol {
     internal func unaryCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_SimpleRequest>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Grpc_Testing_SimpleRequest>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.unaryCall(
             request: request,
-            serializer: ProtobufSerializer<Grpc_Testing_SimpleRequest>(),
-            deserializer: ProtobufDeserializer<Grpc_Testing_SimpleResponse>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Testing_SimpleRequest>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Testing_SimpleResponse>(),
             options: options,
             body
         )
     }
 
     internal func streamingCall<R>(
-        request: ClientRequest.Stream<Grpc_Testing_SimpleRequest>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_SimpleResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Stream<Grpc_Testing_SimpleRequest>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.streamingCall(
             request: request,
-            serializer: ProtobufSerializer<Grpc_Testing_SimpleRequest>(),
-            deserializer: ProtobufDeserializer<Grpc_Testing_SimpleResponse>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Testing_SimpleRequest>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Testing_SimpleResponse>(),
             options: options,
             body
         )
     }
 
     internal func streamingFromClient<R>(
-        request: ClientRequest.Stream<Grpc_Testing_SimpleRequest>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Stream<Grpc_Testing_SimpleRequest>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.streamingFromClient(
             request: request,
-            serializer: ProtobufSerializer<Grpc_Testing_SimpleRequest>(),
-            deserializer: ProtobufDeserializer<Grpc_Testing_SimpleResponse>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Testing_SimpleRequest>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Testing_SimpleResponse>(),
             options: options,
             body
         )
     }
 
     internal func streamingFromServer<R>(
-        request: ClientRequest.Single<Grpc_Testing_SimpleRequest>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_SimpleResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Grpc_Testing_SimpleRequest>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.streamingFromServer(
             request: request,
-            serializer: ProtobufSerializer<Grpc_Testing_SimpleRequest>(),
-            deserializer: ProtobufDeserializer<Grpc_Testing_SimpleResponse>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Testing_SimpleRequest>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Testing_SimpleResponse>(),
             options: options,
             body
         )
     }
 
     internal func streamingBothWays<R>(
-        request: ClientRequest.Stream<Grpc_Testing_SimpleRequest>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_SimpleResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Stream<Grpc_Testing_SimpleRequest>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.streamingBothWays(
             request: request,
-            serializer: ProtobufSerializer<Grpc_Testing_SimpleRequest>(),
-            deserializer: ProtobufDeserializer<Grpc_Testing_SimpleResponse>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Testing_SimpleRequest>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Testing_SimpleResponse>(),
             options: options,
             body
         )
@@ -348,11 +348,11 @@ internal struct Grpc_Testing_BenchmarkServiceClient: Grpc_Testing_BenchmarkServi
     /// One request followed by one response.
     /// The server returns the client payload as-is.
     internal func unaryCall<R>(
-        request: ClientRequest.Single<Grpc_Testing_SimpleRequest>,
-        serializer: some MessageSerializer<Grpc_Testing_SimpleRequest>,
-        deserializer: some MessageDeserializer<Grpc_Testing_SimpleResponse>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Grpc_Testing_SimpleRequest>,
+        serializer: some GRPCCore.MessageSerializer<Grpc_Testing_SimpleRequest>,
+        deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_SimpleResponse>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.unary(
             request: request,
@@ -368,11 +368,11 @@ internal struct Grpc_Testing_BenchmarkServiceClient: Grpc_Testing_BenchmarkServi
     /// Should be called streaming ping-pong
     /// The server returns the client payload as-is on each response
     internal func streamingCall<R>(
-        request: ClientRequest.Stream<Grpc_Testing_SimpleRequest>,
-        serializer: some MessageSerializer<Grpc_Testing_SimpleRequest>,
-        deserializer: some MessageDeserializer<Grpc_Testing_SimpleResponse>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_SimpleResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Stream<Grpc_Testing_SimpleRequest>,
+        serializer: some GRPCCore.MessageSerializer<Grpc_Testing_SimpleRequest>,
+        deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_SimpleResponse>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.bidirectionalStreaming(
             request: request,
@@ -387,11 +387,11 @@ internal struct Grpc_Testing_BenchmarkServiceClient: Grpc_Testing_BenchmarkServi
     /// Single-sided unbounded streaming from client to server
     /// The server returns the client payload as-is once the client does WritesDone
     internal func streamingFromClient<R>(
-        request: ClientRequest.Stream<Grpc_Testing_SimpleRequest>,
-        serializer: some MessageSerializer<Grpc_Testing_SimpleRequest>,
-        deserializer: some MessageDeserializer<Grpc_Testing_SimpleResponse>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Stream<Grpc_Testing_SimpleRequest>,
+        serializer: some GRPCCore.MessageSerializer<Grpc_Testing_SimpleRequest>,
+        deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_SimpleResponse>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.clientStreaming(
             request: request,
@@ -406,11 +406,11 @@ internal struct Grpc_Testing_BenchmarkServiceClient: Grpc_Testing_BenchmarkServi
     /// Single-sided unbounded streaming from server to client
     /// The server repeatedly returns the client payload as-is
     internal func streamingFromServer<R>(
-        request: ClientRequest.Single<Grpc_Testing_SimpleRequest>,
-        serializer: some MessageSerializer<Grpc_Testing_SimpleRequest>,
-        deserializer: some MessageDeserializer<Grpc_Testing_SimpleResponse>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_SimpleResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<Grpc_Testing_SimpleRequest>,
+        serializer: some GRPCCore.MessageSerializer<Grpc_Testing_SimpleRequest>,
+        deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_SimpleResponse>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.serverStreaming(
             request: request,
@@ -425,11 +425,11 @@ internal struct Grpc_Testing_BenchmarkServiceClient: Grpc_Testing_BenchmarkServi
     /// Two-sided unbounded streaming between server to client
     /// Both sides send the content of their own choice to the other
     internal func streamingBothWays<R>(
-        request: ClientRequest.Stream<Grpc_Testing_SimpleRequest>,
-        serializer: some MessageSerializer<Grpc_Testing_SimpleRequest>,
-        deserializer: some MessageDeserializer<Grpc_Testing_SimpleResponse>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Stream<Grpc_Testing_SimpleResponse>) async throws -> R
+        request: GRPCCore.ClientRequest.Stream<Grpc_Testing_SimpleRequest>,
+        serializer: some GRPCCore.MessageSerializer<Grpc_Testing_SimpleRequest>,
+        deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_SimpleResponse>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.bidirectionalStreaming(
             request: request,

--- a/Sources/performance-worker/Generated/grpc_testing_worker_service.grpc.swift
+++ b/Sources/performance-worker/Generated/grpc_testing_worker_service.grpc.swift
@@ -28,12 +28,12 @@ import GRPCCore
 import GRPCProtobuf
 
 internal enum Grpc_Testing_WorkerService {
-    internal static let descriptor = ServiceDescriptor.grpc_testing_WorkerService
+    internal static let descriptor = GRPCCore.ServiceDescriptor.grpc_testing_WorkerService
     internal enum Method {
         internal enum RunServer {
             internal typealias Input = Grpc_Testing_ServerArgs
             internal typealias Output = Grpc_Testing_ServerStatus
-            internal static let descriptor = MethodDescriptor(
+            internal static let descriptor = GRPCCore.MethodDescriptor(
                 service: Grpc_Testing_WorkerService.descriptor.fullyQualifiedService,
                 method: "RunServer"
             )
@@ -41,7 +41,7 @@ internal enum Grpc_Testing_WorkerService {
         internal enum RunClient {
             internal typealias Input = Grpc_Testing_ClientArgs
             internal typealias Output = Grpc_Testing_ClientStatus
-            internal static let descriptor = MethodDescriptor(
+            internal static let descriptor = GRPCCore.MethodDescriptor(
                 service: Grpc_Testing_WorkerService.descriptor.fullyQualifiedService,
                 method: "RunClient"
             )
@@ -49,7 +49,7 @@ internal enum Grpc_Testing_WorkerService {
         internal enum CoreCount {
             internal typealias Input = Grpc_Testing_CoreRequest
             internal typealias Output = Grpc_Testing_CoreResponse
-            internal static let descriptor = MethodDescriptor(
+            internal static let descriptor = GRPCCore.MethodDescriptor(
                 service: Grpc_Testing_WorkerService.descriptor.fullyQualifiedService,
                 method: "CoreCount"
             )
@@ -57,12 +57,12 @@ internal enum Grpc_Testing_WorkerService {
         internal enum QuitWorker {
             internal typealias Input = Grpc_Testing_Void
             internal typealias Output = Grpc_Testing_Void
-            internal static let descriptor = MethodDescriptor(
+            internal static let descriptor = GRPCCore.MethodDescriptor(
                 service: Grpc_Testing_WorkerService.descriptor.fullyQualifiedService,
                 method: "QuitWorker"
             )
         }
-        internal static let descriptors: [MethodDescriptor] = [
+        internal static let descriptors: [GRPCCore.MethodDescriptor] = [
             RunServer.descriptor,
             RunClient.descriptor,
             CoreCount.descriptor,
@@ -75,7 +75,7 @@ internal enum Grpc_Testing_WorkerService {
     internal typealias ServiceProtocol = Grpc_Testing_WorkerServiceServiceProtocol
 }
 
-extension ServiceDescriptor {
+extension GRPCCore.ServiceDescriptor {
     internal static let grpc_testing_WorkerService = Self(
         package: "grpc.testing",
         service: "WorkerService"
@@ -90,7 +90,7 @@ internal protocol Grpc_Testing_WorkerServiceStreamingServiceProtocol: GRPCCore.R
     /// stats. Closing the stream will initiate shutdown of the test server
     /// and once the shutdown has finished, the OK status is sent to terminate
     /// this RPC.
-    func runServer(request: ServerRequest.Stream<Grpc_Testing_ServerArgs>) async throws -> ServerResponse.Stream<Grpc_Testing_ServerStatus>
+    func runServer(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_ServerArgs>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_ServerStatus>
 
     /// Start client with specified workload.
     /// First request sent specifies the ClientConfig followed by ClientStatus
@@ -98,13 +98,13 @@ internal protocol Grpc_Testing_WorkerServiceStreamingServiceProtocol: GRPCCore.R
     /// stats. Closing the stream will initiate shutdown of the test client
     /// and once the shutdown has finished, the OK status is sent to terminate
     /// this RPC.
-    func runClient(request: ServerRequest.Stream<Grpc_Testing_ClientArgs>) async throws -> ServerResponse.Stream<Grpc_Testing_ClientStatus>
+    func runClient(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_ClientArgs>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_ClientStatus>
 
     /// Just return the core count - unary call
-    func coreCount(request: ServerRequest.Stream<Grpc_Testing_CoreRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_CoreResponse>
+    func coreCount(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_CoreRequest>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_CoreResponse>
 
     /// Quit this worker
-    func quitWorker(request: ServerRequest.Stream<Grpc_Testing_Void>) async throws -> ServerResponse.Stream<Grpc_Testing_Void>
+    func quitWorker(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_Void>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_Void>
 }
 
 /// Conformance to `GRPCCore.RegistrableRPCService`.
@@ -114,32 +114,32 @@ extension Grpc_Testing_WorkerService.StreamingServiceProtocol {
     internal func registerMethods(with router: inout GRPCCore.RPCRouter) {
         router.registerHandler(
             forMethod: Grpc_Testing_WorkerService.Method.RunServer.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_ServerArgs>(),
-            serializer: ProtobufSerializer<Grpc_Testing_ServerStatus>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Testing_ServerArgs>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Testing_ServerStatus>(),
             handler: { request in
                 try await self.runServer(request: request)
             }
         )
         router.registerHandler(
             forMethod: Grpc_Testing_WorkerService.Method.RunClient.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_ClientArgs>(),
-            serializer: ProtobufSerializer<Grpc_Testing_ClientStatus>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Testing_ClientArgs>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Testing_ClientStatus>(),
             handler: { request in
                 try await self.runClient(request: request)
             }
         )
         router.registerHandler(
             forMethod: Grpc_Testing_WorkerService.Method.CoreCount.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_CoreRequest>(),
-            serializer: ProtobufSerializer<Grpc_Testing_CoreResponse>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Testing_CoreRequest>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Testing_CoreResponse>(),
             handler: { request in
                 try await self.coreCount(request: request)
             }
         )
         router.registerHandler(
             forMethod: Grpc_Testing_WorkerService.Method.QuitWorker.descriptor,
-            deserializer: ProtobufDeserializer<Grpc_Testing_Void>(),
-            serializer: ProtobufSerializer<Grpc_Testing_Void>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<Grpc_Testing_Void>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<Grpc_Testing_Void>(),
             handler: { request in
                 try await self.quitWorker(request: request)
             }
@@ -155,7 +155,7 @@ internal protocol Grpc_Testing_WorkerServiceServiceProtocol: Grpc_Testing_Worker
     /// stats. Closing the stream will initiate shutdown of the test server
     /// and once the shutdown has finished, the OK status is sent to terminate
     /// this RPC.
-    func runServer(request: ServerRequest.Stream<Grpc_Testing_ServerArgs>) async throws -> ServerResponse.Stream<Grpc_Testing_ServerStatus>
+    func runServer(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_ServerArgs>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_ServerStatus>
 
     /// Start client with specified workload.
     /// First request sent specifies the ClientConfig followed by ClientStatus
@@ -163,25 +163,25 @@ internal protocol Grpc_Testing_WorkerServiceServiceProtocol: Grpc_Testing_Worker
     /// stats. Closing the stream will initiate shutdown of the test client
     /// and once the shutdown has finished, the OK status is sent to terminate
     /// this RPC.
-    func runClient(request: ServerRequest.Stream<Grpc_Testing_ClientArgs>) async throws -> ServerResponse.Stream<Grpc_Testing_ClientStatus>
+    func runClient(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_ClientArgs>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_ClientStatus>
 
     /// Just return the core count - unary call
-    func coreCount(request: ServerRequest.Single<Grpc_Testing_CoreRequest>) async throws -> ServerResponse.Single<Grpc_Testing_CoreResponse>
+    func coreCount(request: GRPCCore.ServerRequest.Single<Grpc_Testing_CoreRequest>) async throws -> GRPCCore.ServerResponse.Single<Grpc_Testing_CoreResponse>
 
     /// Quit this worker
-    func quitWorker(request: ServerRequest.Single<Grpc_Testing_Void>) async throws -> ServerResponse.Single<Grpc_Testing_Void>
+    func quitWorker(request: GRPCCore.ServerRequest.Single<Grpc_Testing_Void>) async throws -> GRPCCore.ServerResponse.Single<Grpc_Testing_Void>
 }
 
 /// Partial conformance to `Grpc_Testing_WorkerServiceStreamingServiceProtocol`.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_WorkerService.ServiceProtocol {
-    internal func coreCount(request: ServerRequest.Stream<Grpc_Testing_CoreRequest>) async throws -> ServerResponse.Stream<Grpc_Testing_CoreResponse> {
-        let response = try await self.coreCount(request: ServerRequest.Single(stream: request))
-        return ServerResponse.Stream(single: response)
+    internal func coreCount(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_CoreRequest>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_CoreResponse> {
+        let response = try await self.coreCount(request: GRPCCore.ServerRequest.Single(stream: request))
+        return GRPCCore.ServerResponse.Stream(single: response)
     }
 
-    internal func quitWorker(request: ServerRequest.Stream<Grpc_Testing_Void>) async throws -> ServerResponse.Stream<Grpc_Testing_Void> {
-        let response = try await self.quitWorker(request: ServerRequest.Single(stream: request))
-        return ServerResponse.Stream(single: response)
+    internal func quitWorker(request: GRPCCore.ServerRequest.Stream<Grpc_Testing_Void>) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_Void> {
+        let response = try await self.quitWorker(request: GRPCCore.ServerRequest.Single(stream: request))
+        return GRPCCore.ServerResponse.Stream(single: response)
     }
 }

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
@@ -47,24 +47,24 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       public protocol NamespaceA_ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
-              request: ClientRequest.Single<NamespaceA_ServiceARequest>,
-              serializer: some MessageSerializer<NamespaceA_ServiceARequest>,
-              deserializer: some MessageDeserializer<NamespaceA_ServiceAResponse>,
-              options: CallOptions,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R
+              request: GRPCCore.ClientRequest.Single<NamespaceA_ServiceARequest>,
+              serializer: some GRPCCore.MessageSerializer<NamespaceA_ServiceARequest>,
+              deserializer: some GRPCCore.MessageDeserializer<NamespaceA_ServiceAResponse>,
+              options: GRPCCore.CallOptions,
+              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable
       }
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
           public func methodA<R>(
-              request: ClientRequest.Single<NamespaceA_ServiceARequest>,
-              options: CallOptions = .defaults,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R
+              request: GRPCCore.ClientRequest.Single<NamespaceA_ServiceARequest>,
+              options: GRPCCore.CallOptions = .defaults,
+              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.methodA(
                   request: request,
-                  serializer: ProtobufSerializer<NamespaceA_ServiceARequest>(),
-                  deserializer: ProtobufDeserializer<NamespaceA_ServiceAResponse>(),
+                  serializer: GRPCProtobuf.ProtobufSerializer<NamespaceA_ServiceARequest>(),
+                  deserializer: GRPCProtobuf.ProtobufDeserializer<NamespaceA_ServiceAResponse>(),
                   options: options,
                   body
               )
@@ -81,11 +81,11 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           
           /// Documentation for MethodA
           public func methodA<R>(
-              request: ClientRequest.Single<NamespaceA_ServiceARequest>,
-              serializer: some MessageSerializer<NamespaceA_ServiceARequest>,
-              deserializer: some MessageDeserializer<NamespaceA_ServiceAResponse>,
-              options: CallOptions = .defaults,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R
+              request: GRPCCore.ClientRequest.Single<NamespaceA_ServiceARequest>,
+              serializer: some GRPCCore.MessageSerializer<NamespaceA_ServiceARequest>,
+              deserializer: some GRPCCore.MessageDeserializer<NamespaceA_ServiceAResponse>,
+              options: GRPCCore.CallOptions = .defaults,
+              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.client.unary(
                   request: request,
@@ -128,24 +128,24 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       public protocol NamespaceA_ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
-              request: ClientRequest.Stream<NamespaceA_ServiceARequest>,
-              serializer: some MessageSerializer<NamespaceA_ServiceARequest>,
-              deserializer: some MessageDeserializer<NamespaceA_ServiceAResponse>,
-              options: CallOptions,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R
+              request: GRPCCore.ClientRequest.Stream<NamespaceA_ServiceARequest>,
+              serializer: some GRPCCore.MessageSerializer<NamespaceA_ServiceARequest>,
+              deserializer: some GRPCCore.MessageDeserializer<NamespaceA_ServiceAResponse>,
+              options: GRPCCore.CallOptions,
+              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable
       }
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
           public func methodA<R>(
-              request: ClientRequest.Stream<NamespaceA_ServiceARequest>,
-              options: CallOptions = .defaults,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R
+              request: GRPCCore.ClientRequest.Stream<NamespaceA_ServiceARequest>,
+              options: GRPCCore.CallOptions = .defaults,
+              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.methodA(
                   request: request,
-                  serializer: ProtobufSerializer<NamespaceA_ServiceARequest>(),
-                  deserializer: ProtobufDeserializer<NamespaceA_ServiceAResponse>(),
+                  serializer: GRPCProtobuf.ProtobufSerializer<NamespaceA_ServiceARequest>(),
+                  deserializer: GRPCProtobuf.ProtobufDeserializer<NamespaceA_ServiceAResponse>(),
                   options: options,
                   body
               )
@@ -162,11 +162,11 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           
           /// Documentation for MethodA
           public func methodA<R>(
-              request: ClientRequest.Stream<NamespaceA_ServiceARequest>,
-              serializer: some MessageSerializer<NamespaceA_ServiceARequest>,
-              deserializer: some MessageDeserializer<NamespaceA_ServiceAResponse>,
-              options: CallOptions = .defaults,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R
+              request: GRPCCore.ClientRequest.Stream<NamespaceA_ServiceARequest>,
+              serializer: some GRPCCore.MessageSerializer<NamespaceA_ServiceARequest>,
+              deserializer: some GRPCCore.MessageDeserializer<NamespaceA_ServiceAResponse>,
+              options: GRPCCore.CallOptions = .defaults,
+              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.client.clientStreaming(
                   request: request,
@@ -209,24 +209,24 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       public protocol NamespaceA_ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
-              request: ClientRequest.Single<NamespaceA_ServiceARequest>,
-              serializer: some MessageSerializer<NamespaceA_ServiceARequest>,
-              deserializer: some MessageDeserializer<NamespaceA_ServiceAResponse>,
-              options: CallOptions,
-              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> R
+              request: GRPCCore.ClientRequest.Single<NamespaceA_ServiceARequest>,
+              serializer: some GRPCCore.MessageSerializer<NamespaceA_ServiceARequest>,
+              deserializer: some GRPCCore.MessageDeserializer<NamespaceA_ServiceAResponse>,
+              options: GRPCCore.CallOptions,
+              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable
       }
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
           public func methodA<R>(
-              request: ClientRequest.Single<NamespaceA_ServiceARequest>,
-              options: CallOptions = .defaults,
-              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> R
+              request: GRPCCore.ClientRequest.Single<NamespaceA_ServiceARequest>,
+              options: GRPCCore.CallOptions = .defaults,
+              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.methodA(
                   request: request,
-                  serializer: ProtobufSerializer<NamespaceA_ServiceARequest>(),
-                  deserializer: ProtobufDeserializer<NamespaceA_ServiceAResponse>(),
+                  serializer: GRPCProtobuf.ProtobufSerializer<NamespaceA_ServiceARequest>(),
+                  deserializer: GRPCProtobuf.ProtobufDeserializer<NamespaceA_ServiceAResponse>(),
                   options: options,
                   body
               )
@@ -243,11 +243,11 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           
           /// Documentation for MethodA
           public func methodA<R>(
-              request: ClientRequest.Single<NamespaceA_ServiceARequest>,
-              serializer: some MessageSerializer<NamespaceA_ServiceARequest>,
-              deserializer: some MessageDeserializer<NamespaceA_ServiceAResponse>,
-              options: CallOptions = .defaults,
-              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> R
+              request: GRPCCore.ClientRequest.Single<NamespaceA_ServiceARequest>,
+              serializer: some GRPCCore.MessageSerializer<NamespaceA_ServiceARequest>,
+              deserializer: some GRPCCore.MessageDeserializer<NamespaceA_ServiceAResponse>,
+              options: GRPCCore.CallOptions = .defaults,
+              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.client.serverStreaming(
                   request: request,
@@ -290,24 +290,24 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       public protocol NamespaceA_ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
-              request: ClientRequest.Stream<NamespaceA_ServiceARequest>,
-              serializer: some MessageSerializer<NamespaceA_ServiceARequest>,
-              deserializer: some MessageDeserializer<NamespaceA_ServiceAResponse>,
-              options: CallOptions,
-              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> R
+              request: GRPCCore.ClientRequest.Stream<NamespaceA_ServiceARequest>,
+              serializer: some GRPCCore.MessageSerializer<NamespaceA_ServiceARequest>,
+              deserializer: some GRPCCore.MessageDeserializer<NamespaceA_ServiceAResponse>,
+              options: GRPCCore.CallOptions,
+              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable
       }
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
           public func methodA<R>(
-              request: ClientRequest.Stream<NamespaceA_ServiceARequest>,
-              options: CallOptions = .defaults,
-              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> R
+              request: GRPCCore.ClientRequest.Stream<NamespaceA_ServiceARequest>,
+              options: GRPCCore.CallOptions = .defaults,
+              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.methodA(
                   request: request,
-                  serializer: ProtobufSerializer<NamespaceA_ServiceARequest>(),
-                  deserializer: ProtobufDeserializer<NamespaceA_ServiceAResponse>(),
+                  serializer: GRPCProtobuf.ProtobufSerializer<NamespaceA_ServiceARequest>(),
+                  deserializer: GRPCProtobuf.ProtobufDeserializer<NamespaceA_ServiceAResponse>(),
                   options: options,
                   body
               )
@@ -324,11 +324,11 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           
           /// Documentation for MethodA
           public func methodA<R>(
-              request: ClientRequest.Stream<NamespaceA_ServiceARequest>,
-              serializer: some MessageSerializer<NamespaceA_ServiceARequest>,
-              deserializer: some MessageDeserializer<NamespaceA_ServiceAResponse>,
-              options: CallOptions = .defaults,
-              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> R
+              request: GRPCCore.ClientRequest.Stream<NamespaceA_ServiceARequest>,
+              serializer: some GRPCCore.MessageSerializer<NamespaceA_ServiceARequest>,
+              deserializer: some GRPCCore.MessageDeserializer<NamespaceA_ServiceAResponse>,
+              options: GRPCCore.CallOptions = .defaults,
+              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.client.bidirectionalStreaming(
                   request: request,
@@ -379,47 +379,47 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       package protocol NamespaceA_ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
-              request: ClientRequest.Stream<NamespaceA_ServiceARequest>,
-              serializer: some MessageSerializer<NamespaceA_ServiceARequest>,
-              deserializer: some MessageDeserializer<NamespaceA_ServiceAResponse>,
-              options: CallOptions,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R
+              request: GRPCCore.ClientRequest.Stream<NamespaceA_ServiceARequest>,
+              serializer: some GRPCCore.MessageSerializer<NamespaceA_ServiceARequest>,
+              deserializer: some GRPCCore.MessageDeserializer<NamespaceA_ServiceAResponse>,
+              options: GRPCCore.CallOptions,
+              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable
           
           /// Documentation for MethodB
           func methodB<R>(
-              request: ClientRequest.Single<NamespaceA_ServiceARequest>,
-              serializer: some MessageSerializer<NamespaceA_ServiceARequest>,
-              deserializer: some MessageDeserializer<NamespaceA_ServiceAResponse>,
-              options: CallOptions,
-              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> R
+              request: GRPCCore.ClientRequest.Single<NamespaceA_ServiceARequest>,
+              serializer: some GRPCCore.MessageSerializer<NamespaceA_ServiceARequest>,
+              deserializer: some GRPCCore.MessageDeserializer<NamespaceA_ServiceAResponse>,
+              options: GRPCCore.CallOptions,
+              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable
       }
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
           package func methodA<R>(
-              request: ClientRequest.Stream<NamespaceA_ServiceARequest>,
-              options: CallOptions = .defaults,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R
+              request: GRPCCore.ClientRequest.Stream<NamespaceA_ServiceARequest>,
+              options: GRPCCore.CallOptions = .defaults,
+              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.methodA(
                   request: request,
-                  serializer: ProtobufSerializer<NamespaceA_ServiceARequest>(),
-                  deserializer: ProtobufDeserializer<NamespaceA_ServiceAResponse>(),
+                  serializer: GRPCProtobuf.ProtobufSerializer<NamespaceA_ServiceARequest>(),
+                  deserializer: GRPCProtobuf.ProtobufDeserializer<NamespaceA_ServiceAResponse>(),
                   options: options,
                   body
               )
           }
           
           package func methodB<R>(
-              request: ClientRequest.Single<NamespaceA_ServiceARequest>,
-              options: CallOptions = .defaults,
-              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> R
+              request: GRPCCore.ClientRequest.Single<NamespaceA_ServiceARequest>,
+              options: GRPCCore.CallOptions = .defaults,
+              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.methodB(
                   request: request,
-                  serializer: ProtobufSerializer<NamespaceA_ServiceARequest>(),
-                  deserializer: ProtobufDeserializer<NamespaceA_ServiceAResponse>(),
+                  serializer: GRPCProtobuf.ProtobufSerializer<NamespaceA_ServiceARequest>(),
+                  deserializer: GRPCProtobuf.ProtobufDeserializer<NamespaceA_ServiceAResponse>(),
                   options: options,
                   body
               )
@@ -436,11 +436,11 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           
           /// Documentation for MethodA
           package func methodA<R>(
-              request: ClientRequest.Stream<NamespaceA_ServiceARequest>,
-              serializer: some MessageSerializer<NamespaceA_ServiceARequest>,
-              deserializer: some MessageDeserializer<NamespaceA_ServiceAResponse>,
-              options: CallOptions = .defaults,
-              _ body: @Sendable @escaping (ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R
+              request: GRPCCore.ClientRequest.Stream<NamespaceA_ServiceARequest>,
+              serializer: some GRPCCore.MessageSerializer<NamespaceA_ServiceARequest>,
+              deserializer: some GRPCCore.MessageDeserializer<NamespaceA_ServiceAResponse>,
+              options: GRPCCore.CallOptions = .defaults,
+              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.client.clientStreaming(
                   request: request,
@@ -454,11 +454,11 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           
           /// Documentation for MethodB
           package func methodB<R>(
-              request: ClientRequest.Single<NamespaceA_ServiceARequest>,
-              serializer: some MessageSerializer<NamespaceA_ServiceARequest>,
-              deserializer: some MessageDeserializer<NamespaceA_ServiceAResponse>,
-              options: CallOptions = .defaults,
-              _ body: @Sendable @escaping (ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> R
+              request: GRPCCore.ClientRequest.Single<NamespaceA_ServiceARequest>,
+              serializer: some GRPCCore.MessageSerializer<NamespaceA_ServiceARequest>,
+              deserializer: some GRPCCore.MessageDeserializer<NamespaceA_ServiceAResponse>,
+              options: GRPCCore.CallOptions = .defaults,
+              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.client.serverStreaming(
                   request: request,
@@ -501,24 +501,24 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       internal protocol ServiceAClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
-              request: ClientRequest.Single<ServiceARequest>,
-              serializer: some MessageSerializer<ServiceARequest>,
-              deserializer: some MessageDeserializer<ServiceAResponse>,
-              options: CallOptions,
-              _ body: @Sendable @escaping (ClientResponse.Single<ServiceAResponse>) async throws -> R
+              request: GRPCCore.ClientRequest.Single<ServiceARequest>,
+              serializer: some GRPCCore.MessageSerializer<ServiceARequest>,
+              deserializer: some GRPCCore.MessageDeserializer<ServiceAResponse>,
+              options: GRPCCore.CallOptions,
+              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable
       }
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension ServiceA.ClientProtocol {
           internal func methodA<R>(
-              request: ClientRequest.Single<ServiceARequest>,
-              options: CallOptions = .defaults,
-              _ body: @Sendable @escaping (ClientResponse.Single<ServiceAResponse>) async throws -> R
+              request: GRPCCore.ClientRequest.Single<ServiceARequest>,
+              options: GRPCCore.CallOptions = .defaults,
+              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.methodA(
                   request: request,
-                  serializer: ProtobufSerializer<ServiceARequest>(),
-                  deserializer: ProtobufDeserializer<ServiceAResponse>(),
+                  serializer: GRPCProtobuf.ProtobufSerializer<ServiceARequest>(),
+                  deserializer: GRPCProtobuf.ProtobufDeserializer<ServiceAResponse>(),
                   options: options,
                   body
               )
@@ -535,11 +535,11 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           
           /// Documentation for MethodA
           internal func methodA<R>(
-              request: ClientRequest.Single<ServiceARequest>,
-              serializer: some MessageSerializer<ServiceARequest>,
-              deserializer: some MessageDeserializer<ServiceAResponse>,
-              options: CallOptions = .defaults,
-              _ body: @Sendable @escaping (ClientResponse.Single<ServiceAResponse>) async throws -> R
+              request: GRPCCore.ClientRequest.Single<ServiceARequest>,
+              serializer: some GRPCCore.MessageSerializer<ServiceARequest>,
+              deserializer: some GRPCCore.MessageDeserializer<ServiceAResponse>,
+              options: GRPCCore.CallOptions = .defaults,
+              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.client.unary(
                   request: request,

--- a/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
@@ -171,9 +171,9 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
       @_spi(Secret) import enum Foo.Bar
 
       public enum NamespaceA_ServiceA {
-          public static let descriptor = ServiceDescriptor.namespaceA_ServiceA
+          public static let descriptor = GRPCCore.ServiceDescriptor.namespaceA_ServiceA
           public enum Method {
-              public static let descriptors: [MethodDescriptor] = []
+              public static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
@@ -181,7 +181,7 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
           public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
       }
 
-      extension ServiceDescriptor {
+      extension GRPCCore.ServiceDescriptor {
           public static let namespaceA_ServiceA = Self(
               package: "namespaceA",
               service: "ServiceA"

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
@@ -54,7 +54,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for unaryMethod
-          func unary(request: ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Stream<NamespaceA_ServiceAResponse>
+          func unary(request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> GRPCCore.ServerResponse.Stream<NamespaceA_ServiceAResponse>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
@@ -63,8 +63,8 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
                   forMethod: NamespaceA_ServiceA.Method.Unary.descriptor,
-                  deserializer: ProtobufDeserializer<NamespaceA_ServiceARequest>(),
-                  serializer: ProtobufSerializer<NamespaceA_ServiceAResponse>(),
+                  deserializer: GRPCProtobuf.ProtobufDeserializer<NamespaceA_ServiceARequest>(),
+                  serializer: GRPCProtobuf.ProtobufSerializer<NamespaceA_ServiceAResponse>(),
                   handler: { request in
                       try await self.unary(request: request)
                   }
@@ -75,14 +75,14 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public protocol NamespaceA_ServiceAServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
           /// Documentation for unaryMethod
-          func unary(request: ServerRequest.Single<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Single<NamespaceA_ServiceAResponse>
+          func unary(request: GRPCCore.ServerRequest.Single<NamespaceA_ServiceARequest>) async throws -> GRPCCore.ServerResponse.Single<NamespaceA_ServiceAResponse>
       }
       /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ServiceProtocol {
-          public func unary(request: ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Stream<NamespaceA_ServiceAResponse> {
-              let response = try await self.unary(request: ServerRequest.Single(stream: request))
-              return ServerResponse.Stream(single: response)
+          public func unary(request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> GRPCCore.ServerResponse.Stream<NamespaceA_ServiceAResponse> {
+              let response = try await self.unary(request: GRPCCore.ServerRequest.Single(stream: request))
+              return GRPCCore.ServerResponse.Stream(single: response)
           }
       }
       """
@@ -123,7 +123,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       package protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for inputStreamingMethod
-          func inputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Stream<NamespaceA_ServiceAResponse>
+          func inputStreaming(request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> GRPCCore.ServerResponse.Stream<NamespaceA_ServiceAResponse>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
@@ -132,8 +132,8 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           package func registerMethods(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
                   forMethod: NamespaceA_ServiceA.Method.InputStreaming.descriptor,
-                  deserializer: ProtobufDeserializer<NamespaceA_ServiceARequest>(),
-                  serializer: ProtobufSerializer<NamespaceA_ServiceAResponse>(),
+                  deserializer: GRPCProtobuf.ProtobufDeserializer<NamespaceA_ServiceARequest>(),
+                  serializer: GRPCProtobuf.ProtobufSerializer<NamespaceA_ServiceAResponse>(),
                   handler: { request in
                       try await self.inputStreaming(request: request)
                   }
@@ -144,14 +144,14 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       package protocol NamespaceA_ServiceAServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
           /// Documentation for inputStreamingMethod
-          func inputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Single<NamespaceA_ServiceAResponse>
+          func inputStreaming(request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> GRPCCore.ServerResponse.Single<NamespaceA_ServiceAResponse>
       }
       /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ServiceProtocol {
-          package func inputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Stream<NamespaceA_ServiceAResponse> {
+          package func inputStreaming(request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> GRPCCore.ServerResponse.Stream<NamespaceA_ServiceAResponse> {
               let response = try await self.inputStreaming(request: request)
-              return ServerResponse.Stream(single: response)
+              return GRPCCore.ServerResponse.Stream(single: response)
           }
       }
       """
@@ -196,7 +196,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for outputStreamingMethod
-          func outputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Stream<NamespaceA_ServiceAResponse>
+          func outputStreaming(request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> GRPCCore.ServerResponse.Stream<NamespaceA_ServiceAResponse>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
@@ -205,8 +205,8 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
                   forMethod: NamespaceA_ServiceA.Method.OutputStreaming.descriptor,
-                  deserializer: ProtobufDeserializer<NamespaceA_ServiceARequest>(),
-                  serializer: ProtobufSerializer<NamespaceA_ServiceAResponse>(),
+                  deserializer: GRPCProtobuf.ProtobufDeserializer<NamespaceA_ServiceARequest>(),
+                  serializer: GRPCProtobuf.ProtobufSerializer<NamespaceA_ServiceAResponse>(),
                   handler: { request in
                       try await self.outputStreaming(request: request)
                   }
@@ -217,13 +217,13 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public protocol NamespaceA_ServiceAServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
           /// Documentation for outputStreamingMethod
-          func outputStreaming(request: ServerRequest.Single<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Stream<NamespaceA_ServiceAResponse>
+          func outputStreaming(request: GRPCCore.ServerRequest.Single<NamespaceA_ServiceARequest>) async throws -> GRPCCore.ServerResponse.Stream<NamespaceA_ServiceAResponse>
       }
       /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ServiceProtocol {
-          public func outputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Stream<NamespaceA_ServiceAResponse> {
-              let response = try await self.outputStreaming(request: ServerRequest.Single(stream: request))
+          public func outputStreaming(request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> GRPCCore.ServerResponse.Stream<NamespaceA_ServiceAResponse> {
+              let response = try await self.outputStreaming(request: GRPCCore.ServerRequest.Single(stream: request))
               return response
           }
       }
@@ -269,7 +269,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       package protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for bidirectionalStreamingMethod
-          func bidirectionalStreaming(request: ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Stream<NamespaceA_ServiceAResponse>
+          func bidirectionalStreaming(request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> GRPCCore.ServerResponse.Stream<NamespaceA_ServiceAResponse>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
@@ -278,8 +278,8 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           package func registerMethods(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
                   forMethod: NamespaceA_ServiceA.Method.BidirectionalStreaming.descriptor,
-                  deserializer: ProtobufDeserializer<NamespaceA_ServiceARequest>(),
-                  serializer: ProtobufSerializer<NamespaceA_ServiceAResponse>(),
+                  deserializer: GRPCProtobuf.ProtobufDeserializer<NamespaceA_ServiceARequest>(),
+                  serializer: GRPCProtobuf.ProtobufSerializer<NamespaceA_ServiceAResponse>(),
                   handler: { request in
                       try await self.bidirectionalStreaming(request: request)
                   }
@@ -290,7 +290,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       package protocol NamespaceA_ServiceAServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
           /// Documentation for bidirectionalStreamingMethod
-          func bidirectionalStreaming(request: ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Stream<NamespaceA_ServiceAResponse>
+          func bidirectionalStreaming(request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> GRPCCore.ServerResponse.Stream<NamespaceA_ServiceAResponse>
       }
       /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
@@ -350,10 +350,10 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       internal protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for inputStreamingMethod
-          func inputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Stream<NamespaceA_ServiceAResponse>
+          func inputStreaming(request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> GRPCCore.ServerResponse.Stream<NamespaceA_ServiceAResponse>
           
           /// Documentation for outputStreamingMethod
-          func outputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Stream<NamespaceA_ServiceAResponse>
+          func outputStreaming(request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> GRPCCore.ServerResponse.Stream<NamespaceA_ServiceAResponse>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
@@ -362,16 +362,16 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           internal func registerMethods(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
                   forMethod: NamespaceA_ServiceA.Method.InputStreaming.descriptor,
-                  deserializer: ProtobufDeserializer<NamespaceA_ServiceARequest>(),
-                  serializer: ProtobufSerializer<NamespaceA_ServiceAResponse>(),
+                  deserializer: GRPCProtobuf.ProtobufDeserializer<NamespaceA_ServiceARequest>(),
+                  serializer: GRPCProtobuf.ProtobufSerializer<NamespaceA_ServiceAResponse>(),
                   handler: { request in
                       try await self.inputStreaming(request: request)
                   }
               )
               router.registerHandler(
                   forMethod: NamespaceA_ServiceA.Method.OutputStreaming.descriptor,
-                  deserializer: ProtobufDeserializer<NamespaceA_ServiceARequest>(),
-                  serializer: ProtobufSerializer<NamespaceA_ServiceAResponse>(),
+                  deserializer: GRPCProtobuf.ProtobufDeserializer<NamespaceA_ServiceARequest>(),
+                  serializer: GRPCProtobuf.ProtobufSerializer<NamespaceA_ServiceAResponse>(),
                   handler: { request in
                       try await self.outputStreaming(request: request)
                   }
@@ -382,21 +382,21 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       internal protocol NamespaceA_ServiceAServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
           /// Documentation for inputStreamingMethod
-          func inputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Single<NamespaceA_ServiceAResponse>
+          func inputStreaming(request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> GRPCCore.ServerResponse.Single<NamespaceA_ServiceAResponse>
           
           /// Documentation for outputStreamingMethod
-          func outputStreaming(request: ServerRequest.Single<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Stream<NamespaceA_ServiceAResponse>
+          func outputStreaming(request: GRPCCore.ServerRequest.Single<NamespaceA_ServiceARequest>) async throws -> GRPCCore.ServerResponse.Stream<NamespaceA_ServiceAResponse>
       }
       /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ServiceProtocol {
-          internal func inputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Stream<NamespaceA_ServiceAResponse> {
+          internal func inputStreaming(request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> GRPCCore.ServerResponse.Stream<NamespaceA_ServiceAResponse> {
               let response = try await self.inputStreaming(request: request)
-              return ServerResponse.Stream(single: response)
+              return GRPCCore.ServerResponse.Stream(single: response)
           }
           
-          internal func outputStreaming(request: ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Stream<NamespaceA_ServiceAResponse> {
-              let response = try await self.outputStreaming(request: ServerRequest.Single(stream: request))
+          internal func outputStreaming(request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> GRPCCore.ServerResponse.Stream<NamespaceA_ServiceAResponse> {
+              let response = try await self.outputStreaming(request: GRPCCore.ServerRequest.Single(stream: request))
               return response
           }
       }
@@ -434,7 +434,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       internal protocol ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for MethodA
-          func methodA(request: ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Stream<NamespaceA_ServiceAResponse>
+          func methodA(request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> GRPCCore.ServerResponse.Stream<NamespaceA_ServiceAResponse>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
@@ -443,8 +443,8 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           internal func registerMethods(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
                   forMethod: ServiceA.Method.MethodA.descriptor,
-                  deserializer: ProtobufDeserializer<NamespaceA_ServiceARequest>(),
-                  serializer: ProtobufSerializer<NamespaceA_ServiceAResponse>(),
+                  deserializer: GRPCProtobuf.ProtobufDeserializer<NamespaceA_ServiceARequest>(),
+                  serializer: GRPCProtobuf.ProtobufSerializer<NamespaceA_ServiceAResponse>(),
                   handler: { request in
                       try await self.methodA(request: request)
                   }
@@ -455,14 +455,14 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       internal protocol ServiceAServiceProtocol: ServiceA.StreamingServiceProtocol {
           /// Documentation for MethodA
-          func methodA(request: ServerRequest.Single<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Single<NamespaceA_ServiceAResponse>
+          func methodA(request: GRPCCore.ServerRequest.Single<NamespaceA_ServiceARequest>) async throws -> GRPCCore.ServerResponse.Single<NamespaceA_ServiceAResponse>
       }
       /// Partial conformance to `ServiceAStreamingServiceProtocol`.
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension ServiceA.ServiceProtocol {
-          internal func methodA(request: ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> ServerResponse.Stream<NamespaceA_ServiceAResponse> {
-              let response = try await self.methodA(request: ServerRequest.Single(stream: request))
-              return ServerResponse.Stream(single: response)
+          internal func methodA(request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>) async throws -> GRPCCore.ServerResponse.Stream<NamespaceA_ServiceAResponse> {
+              let response = try await self.methodA(request: GRPCCore.ServerRequest.Single(stream: request))
+              return GRPCCore.ServerResponse.Stream(single: response)
           }
       }
       """

--- a/Tests/GRPCCodeGenTests/Internal/Translator/TestFunctions.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/TestFunctions.swift
@@ -81,10 +81,10 @@ internal func makeCodeGenerationRequest(
     dependencies: dependencies,
     services: services,
     lookupSerializer: {
-      "ProtobufSerializer<\($0)>()"
+      "GRPCProtobuf.ProtobufSerializer<\($0)>()"
     },
     lookupDeserializer: {
-      "ProtobufDeserializer<\($0)>()"
+      "GRPCProtobuf.ProtobufDeserializer<\($0)>()"
     }
   )
 }

--- a/Tests/GRPCCodeGenTests/Internal/Translator/TypealiasTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/TypealiasTranslatorSnippetBasedTests.swift
@@ -47,17 +47,17 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum NamespaceA_ServiceA {
-          public static let descriptor = ServiceDescriptor.namespaceA_ServiceA
+          public static let descriptor = GRPCCore.ServiceDescriptor.namespaceA_ServiceA
           public enum Method {
               public enum MethodA {
                   public typealias Input = NamespaceA_ServiceARequest
                   public typealias Output = NamespaceA_ServiceAResponse
-                  public static let descriptor = MethodDescriptor(
+                  public static let descriptor = GRPCCore.MethodDescriptor(
                       service: NamespaceA_ServiceA.descriptor.fullyQualifiedService,
                       method: "MethodA"
                   )
               }
-              public static let descriptors: [MethodDescriptor] = [
+              public static let descriptors: [GRPCCore.MethodDescriptor] = [
                   MethodA.descriptor
               ]
           }
@@ -70,7 +70,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias Client = NamespaceA_ServiceAClient
       }
-      extension ServiceDescriptor {
+      extension GRPCCore.ServiceDescriptor {
           public static let namespaceA_ServiceA = Self(
               package: "namespaceA",
               service: "ServiceA"
@@ -101,9 +101,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum NamespaceA_ServiceA {
-          public static let descriptor = ServiceDescriptor.namespaceA_ServiceA
+          public static let descriptor = GRPCCore.ServiceDescriptor.namespaceA_ServiceA
           public enum Method {
-              public static let descriptors: [MethodDescriptor] = []
+              public static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
@@ -114,7 +114,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias Client = NamespaceA_ServiceAClient
       }
-      extension ServiceDescriptor {
+      extension GRPCCore.ServiceDescriptor {
           public static let namespaceA_ServiceA = Self(
               package: "namespaceA",
               service: "ServiceA"
@@ -145,16 +145,16 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum NamespaceA_ServiceA {
-          public static let descriptor = ServiceDescriptor.namespaceA_ServiceA
+          public static let descriptor = GRPCCore.ServiceDescriptor.namespaceA_ServiceA
           public enum Method {
-              public static let descriptors: [MethodDescriptor] = []
+              public static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
       }
-      extension ServiceDescriptor {
+      extension GRPCCore.ServiceDescriptor {
           public static let namespaceA_ServiceA = Self(
               package: "namespaceA",
               service: "ServiceA"
@@ -185,16 +185,16 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum NamespaceA_ServiceA {
-          public static let descriptor = ServiceDescriptor.namespaceA_ServiceA
+          public static let descriptor = GRPCCore.ServiceDescriptor.namespaceA_ServiceA
           public enum Method {
-              public static let descriptors: [MethodDescriptor] = []
+              public static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias Client = NamespaceA_ServiceAClient
       }
-      extension ServiceDescriptor {
+      extension GRPCCore.ServiceDescriptor {
           public static let namespaceA_ServiceA = Self(
               package: "namespaceA",
               service: "ServiceA"
@@ -225,12 +225,12 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum NamespaceA_ServiceA {
-          public static let descriptor = ServiceDescriptor.namespaceA_ServiceA
+          public static let descriptor = GRPCCore.ServiceDescriptor.namespaceA_ServiceA
           public enum Method {
-              public static let descriptors: [MethodDescriptor] = []
+              public static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
       }
-      extension ServiceDescriptor {
+      extension GRPCCore.ServiceDescriptor {
           public static let namespaceA_ServiceA = Self(
               package: "namespaceA",
               service: "ServiceA"
@@ -265,17 +265,17 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum ServiceA {
-          public static let descriptor = ServiceDescriptor.ServiceA
+          public static let descriptor = GRPCCore.ServiceDescriptor.ServiceA
           public enum Method {
               public enum MethodA {
                   public typealias Input = ServiceARequest
                   public typealias Output = ServiceAResponse
-                  public static let descriptor = MethodDescriptor(
+                  public static let descriptor = GRPCCore.MethodDescriptor(
                       service: ServiceA.descriptor.fullyQualifiedService,
                       method: "MethodA"
                   )
               }
-              public static let descriptors: [MethodDescriptor] = [
+              public static let descriptors: [GRPCCore.MethodDescriptor] = [
                   MethodA.descriptor
               ]
           }
@@ -288,7 +288,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias Client = ServiceAClient
       }
-      extension ServiceDescriptor {
+      extension GRPCCore.ServiceDescriptor {
           public static let ServiceA = Self(
               package: "",
               service: "ServiceA"
@@ -335,12 +335,12 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum NamespaceA_ServiceA {
-          public static let descriptor = ServiceDescriptor.namespaceA_ServiceA
+          public static let descriptor = GRPCCore.ServiceDescriptor.namespaceA_ServiceA
           public enum Method {
               public enum MethodA {
                   public typealias Input = NamespaceA_ServiceARequest
                   public typealias Output = NamespaceA_ServiceAResponse
-                  public static let descriptor = MethodDescriptor(
+                  public static let descriptor = GRPCCore.MethodDescriptor(
                       service: NamespaceA_ServiceA.descriptor.fullyQualifiedService,
                       method: "MethodA"
                   )
@@ -348,12 +348,12 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               public enum MethodB {
                   public typealias Input = NamespaceA_ServiceARequest
                   public typealias Output = NamespaceA_ServiceAResponse
-                  public static let descriptor = MethodDescriptor(
+                  public static let descriptor = GRPCCore.MethodDescriptor(
                       service: NamespaceA_ServiceA.descriptor.fullyQualifiedService,
                       method: "MethodB"
                   )
               }
-              public static let descriptors: [MethodDescriptor] = [
+              public static let descriptors: [GRPCCore.MethodDescriptor] = [
                   MethodA.descriptor,
                   MethodB.descriptor
               ]
@@ -367,7 +367,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias Client = NamespaceA_ServiceAClient
       }
-      extension ServiceDescriptor {
+      extension GRPCCore.ServiceDescriptor {
           public static let namespaceA_ServiceA = Self(
               package: "namespaceA",
               service: "ServiceA"
@@ -398,9 +398,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       package enum NamespaceA_ServiceA {
-          package static let descriptor = ServiceDescriptor.namespaceA_ServiceA
+          package static let descriptor = GRPCCore.ServiceDescriptor.namespaceA_ServiceA
           package enum Method {
-              package static let descriptors: [MethodDescriptor] = []
+              package static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
@@ -411,7 +411,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package typealias Client = NamespaceA_ServiceAClient
       }
-      extension ServiceDescriptor {
+      extension GRPCCore.ServiceDescriptor {
           package static let namespaceA_ServiceA = Self(
               package: "namespaceA",
               service: "ServiceA"
@@ -454,9 +454,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum NamespaceA_Aservice {
-          public static let descriptor = ServiceDescriptor.namespaceA_AService
+          public static let descriptor = GRPCCore.ServiceDescriptor.namespaceA_AService
           public enum Method {
-              public static let descriptors: [MethodDescriptor] = []
+              public static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias StreamingServiceProtocol = NamespaceA_AserviceStreamingServiceProtocol
@@ -467,16 +467,16 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias Client = NamespaceA_AserviceClient
       }
-      extension ServiceDescriptor {
+      extension GRPCCore.ServiceDescriptor {
           public static let namespaceA_AService = Self(
               package: "namespaceA",
               service: "AService"
           )
       }
       public enum NamespaceA_Bservice {
-          public static let descriptor = ServiceDescriptor.namespaceA_BService
+          public static let descriptor = GRPCCore.ServiceDescriptor.namespaceA_BService
           public enum Method {
-              public static let descriptors: [MethodDescriptor] = []
+              public static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias StreamingServiceProtocol = NamespaceA_BserviceStreamingServiceProtocol
@@ -487,7 +487,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias Client = NamespaceA_BserviceClient
       }
-      extension ServiceDescriptor {
+      extension GRPCCore.ServiceDescriptor {
           public static let namespaceA_BService = Self(
               package: "namespaceA",
               service: "BService"
@@ -522,9 +522,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       package enum AService {
-          package static let descriptor = ServiceDescriptor.AService
+          package static let descriptor = GRPCCore.ServiceDescriptor.AService
           package enum Method {
-              package static let descriptors: [MethodDescriptor] = []
+              package static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package typealias StreamingServiceProtocol = AServiceStreamingServiceProtocol
@@ -535,16 +535,16 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package typealias Client = AServiceClient
       }
-      extension ServiceDescriptor {
+      extension GRPCCore.ServiceDescriptor {
           package static let AService = Self(
               package: "",
               service: "AService"
           )
       }
       package enum BService {
-          package static let descriptor = ServiceDescriptor.BService
+          package static let descriptor = GRPCCore.ServiceDescriptor.BService
           package enum Method {
-              package static let descriptors: [MethodDescriptor] = []
+              package static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package typealias StreamingServiceProtocol = BServiceStreamingServiceProtocol
@@ -555,7 +555,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package typealias Client = BServiceClient
       }
-      extension ServiceDescriptor {
+      extension GRPCCore.ServiceDescriptor {
           package static let BService = Self(
               package: "",
               service: "BService"
@@ -598,9 +598,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       internal enum Anamespace_AService {
-          internal static let descriptor = ServiceDescriptor.anamespace_AService
+          internal static let descriptor = GRPCCore.ServiceDescriptor.anamespace_AService
           internal enum Method {
-              internal static let descriptors: [MethodDescriptor] = []
+              internal static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           internal typealias StreamingServiceProtocol = Anamespace_AServiceStreamingServiceProtocol
@@ -611,16 +611,16 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           internal typealias Client = Anamespace_AServiceClient
       }
-      extension ServiceDescriptor {
+      extension GRPCCore.ServiceDescriptor {
           internal static let anamespace_AService = Self(
               package: "anamespace",
               service: "AService"
           )
       }
       internal enum Bnamespace_BService {
-          internal static let descriptor = ServiceDescriptor.bnamespace_BService
+          internal static let descriptor = GRPCCore.ServiceDescriptor.bnamespace_BService
           internal enum Method {
-              internal static let descriptors: [MethodDescriptor] = []
+              internal static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           internal typealias StreamingServiceProtocol = Bnamespace_BServiceStreamingServiceProtocol
@@ -631,7 +631,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           internal typealias Client = Bnamespace_BServiceClient
       }
-      extension ServiceDescriptor {
+      extension GRPCCore.ServiceDescriptor {
           internal static let bnamespace_BService = Self(
               package: "bnamespace",
               service: "BService"
@@ -668,9 +668,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       public enum Anamespace_AService {
-          public static let descriptor = ServiceDescriptor.anamespace_AService
+          public static let descriptor = GRPCCore.ServiceDescriptor.anamespace_AService
           public enum Method {
-              public static let descriptors: [MethodDescriptor] = []
+              public static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias StreamingServiceProtocol = Anamespace_AServiceStreamingServiceProtocol
@@ -681,16 +681,16 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias Client = Anamespace_AServiceClient
       }
-      extension ServiceDescriptor {
+      extension GRPCCore.ServiceDescriptor {
           public static let anamespace_AService = Self(
               package: "anamespace",
               service: "AService"
           )
       }
       public enum BService {
-          public static let descriptor = ServiceDescriptor.BService
+          public static let descriptor = GRPCCore.ServiceDescriptor.BService
           public enum Method {
-              public static let descriptors: [MethodDescriptor] = []
+              public static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias StreamingServiceProtocol = BServiceStreamingServiceProtocol
@@ -701,7 +701,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias Client = BServiceClient
       }
-      extension ServiceDescriptor {
+      extension GRPCCore.ServiceDescriptor {
           public static let BService = Self(
               package: "",
               service: "BService"

--- a/Tests/GRPCHTTP2TransportTests/Generated/control.grpc.swift
+++ b/Tests/GRPCHTTP2TransportTests/Generated/control.grpc.swift
@@ -26,12 +26,12 @@ import GRPCCore
 import GRPCProtobuf
 
 internal enum Control {
-    internal static let descriptor = ServiceDescriptor.Control
+    internal static let descriptor = GRPCCore.ServiceDescriptor.Control
     internal enum Method {
         internal enum Unary {
             internal typealias Input = ControlInput
             internal typealias Output = ControlOutput
-            internal static let descriptor = MethodDescriptor(
+            internal static let descriptor = GRPCCore.MethodDescriptor(
                 service: Control.descriptor.fullyQualifiedService,
                 method: "Unary"
             )
@@ -39,7 +39,7 @@ internal enum Control {
         internal enum ServerStream {
             internal typealias Input = ControlInput
             internal typealias Output = ControlOutput
-            internal static let descriptor = MethodDescriptor(
+            internal static let descriptor = GRPCCore.MethodDescriptor(
                 service: Control.descriptor.fullyQualifiedService,
                 method: "ServerStream"
             )
@@ -47,7 +47,7 @@ internal enum Control {
         internal enum ClientStream {
             internal typealias Input = ControlInput
             internal typealias Output = ControlOutput
-            internal static let descriptor = MethodDescriptor(
+            internal static let descriptor = GRPCCore.MethodDescriptor(
                 service: Control.descriptor.fullyQualifiedService,
                 method: "ClientStream"
             )
@@ -55,12 +55,12 @@ internal enum Control {
         internal enum BidiStream {
             internal typealias Input = ControlInput
             internal typealias Output = ControlOutput
-            internal static let descriptor = MethodDescriptor(
+            internal static let descriptor = GRPCCore.MethodDescriptor(
                 service: Control.descriptor.fullyQualifiedService,
                 method: "BidiStream"
             )
         }
-        internal static let descriptors: [MethodDescriptor] = [
+        internal static let descriptors: [GRPCCore.MethodDescriptor] = [
             Unary.descriptor,
             ServerStream.descriptor,
             ClientStream.descriptor,
@@ -77,7 +77,7 @@ internal enum Control {
     internal typealias Client = ControlClient
 }
 
-extension ServiceDescriptor {
+extension GRPCCore.ServiceDescriptor {
     internal static let Control = Self(
         package: "",
         service: "Control"
@@ -90,13 +90,13 @@ extension ServiceDescriptor {
 /// the output.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 internal protocol ControlStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
-    func unary(request: ServerRequest.Stream<ControlInput>) async throws -> ServerResponse.Stream<ControlOutput>
+    func unary(request: GRPCCore.ServerRequest.Stream<ControlInput>) async throws -> GRPCCore.ServerResponse.Stream<ControlOutput>
 
-    func serverStream(request: ServerRequest.Stream<ControlInput>) async throws -> ServerResponse.Stream<ControlOutput>
+    func serverStream(request: GRPCCore.ServerRequest.Stream<ControlInput>) async throws -> GRPCCore.ServerResponse.Stream<ControlOutput>
 
-    func clientStream(request: ServerRequest.Stream<ControlInput>) async throws -> ServerResponse.Stream<ControlOutput>
+    func clientStream(request: GRPCCore.ServerRequest.Stream<ControlInput>) async throws -> GRPCCore.ServerResponse.Stream<ControlOutput>
 
-    func bidiStream(request: ServerRequest.Stream<ControlInput>) async throws -> ServerResponse.Stream<ControlOutput>
+    func bidiStream(request: GRPCCore.ServerRequest.Stream<ControlInput>) async throws -> GRPCCore.ServerResponse.Stream<ControlOutput>
 }
 
 /// Conformance to `GRPCCore.RegistrableRPCService`.
@@ -106,32 +106,32 @@ extension Control.StreamingServiceProtocol {
     internal func registerMethods(with router: inout GRPCCore.RPCRouter) {
         router.registerHandler(
             forMethod: Control.Method.Unary.descriptor,
-            deserializer: ProtobufDeserializer<ControlInput>(),
-            serializer: ProtobufSerializer<ControlOutput>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<ControlInput>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<ControlOutput>(),
             handler: { request in
                 try await self.unary(request: request)
             }
         )
         router.registerHandler(
             forMethod: Control.Method.ServerStream.descriptor,
-            deserializer: ProtobufDeserializer<ControlInput>(),
-            serializer: ProtobufSerializer<ControlOutput>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<ControlInput>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<ControlOutput>(),
             handler: { request in
                 try await self.serverStream(request: request)
             }
         )
         router.registerHandler(
             forMethod: Control.Method.ClientStream.descriptor,
-            deserializer: ProtobufDeserializer<ControlInput>(),
-            serializer: ProtobufSerializer<ControlOutput>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<ControlInput>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<ControlOutput>(),
             handler: { request in
                 try await self.clientStream(request: request)
             }
         )
         router.registerHandler(
             forMethod: Control.Method.BidiStream.descriptor,
-            deserializer: ProtobufDeserializer<ControlInput>(),
-            serializer: ProtobufSerializer<ControlOutput>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<ControlInput>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<ControlOutput>(),
             handler: { request in
                 try await self.bidiStream(request: request)
             }
@@ -145,31 +145,31 @@ extension Control.StreamingServiceProtocol {
 /// the output.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 internal protocol ControlServiceProtocol: Control.StreamingServiceProtocol {
-    func unary(request: ServerRequest.Single<ControlInput>) async throws -> ServerResponse.Single<ControlOutput>
+    func unary(request: GRPCCore.ServerRequest.Single<ControlInput>) async throws -> GRPCCore.ServerResponse.Single<ControlOutput>
 
-    func serverStream(request: ServerRequest.Single<ControlInput>) async throws -> ServerResponse.Stream<ControlOutput>
+    func serverStream(request: GRPCCore.ServerRequest.Single<ControlInput>) async throws -> GRPCCore.ServerResponse.Stream<ControlOutput>
 
-    func clientStream(request: ServerRequest.Stream<ControlInput>) async throws -> ServerResponse.Single<ControlOutput>
+    func clientStream(request: GRPCCore.ServerRequest.Stream<ControlInput>) async throws -> GRPCCore.ServerResponse.Single<ControlOutput>
 
-    func bidiStream(request: ServerRequest.Stream<ControlInput>) async throws -> ServerResponse.Stream<ControlOutput>
+    func bidiStream(request: GRPCCore.ServerRequest.Stream<ControlInput>) async throws -> GRPCCore.ServerResponse.Stream<ControlOutput>
 }
 
 /// Partial conformance to `ControlStreamingServiceProtocol`.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Control.ServiceProtocol {
-    internal func unary(request: ServerRequest.Stream<ControlInput>) async throws -> ServerResponse.Stream<ControlOutput> {
-        let response = try await self.unary(request: ServerRequest.Single(stream: request))
-        return ServerResponse.Stream(single: response)
+    internal func unary(request: GRPCCore.ServerRequest.Stream<ControlInput>) async throws -> GRPCCore.ServerResponse.Stream<ControlOutput> {
+        let response = try await self.unary(request: GRPCCore.ServerRequest.Single(stream: request))
+        return GRPCCore.ServerResponse.Stream(single: response)
     }
 
-    internal func serverStream(request: ServerRequest.Stream<ControlInput>) async throws -> ServerResponse.Stream<ControlOutput> {
-        let response = try await self.serverStream(request: ServerRequest.Single(stream: request))
+    internal func serverStream(request: GRPCCore.ServerRequest.Stream<ControlInput>) async throws -> GRPCCore.ServerResponse.Stream<ControlOutput> {
+        let response = try await self.serverStream(request: GRPCCore.ServerRequest.Single(stream: request))
         return response
     }
 
-    internal func clientStream(request: ServerRequest.Stream<ControlInput>) async throws -> ServerResponse.Stream<ControlOutput> {
+    internal func clientStream(request: GRPCCore.ServerRequest.Stream<ControlInput>) async throws -> GRPCCore.ServerResponse.Stream<ControlOutput> {
         let response = try await self.clientStream(request: request)
-        return ServerResponse.Stream(single: response)
+        return GRPCCore.ServerResponse.Stream(single: response)
     }
 }
 
@@ -180,91 +180,91 @@ extension Control.ServiceProtocol {
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 internal protocol ControlClientProtocol: Sendable {
     func unary<R>(
-        request: ClientRequest.Single<ControlInput>,
-        serializer: some MessageSerializer<ControlInput>,
-        deserializer: some MessageDeserializer<ControlOutput>,
-        options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Single<ControlOutput>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<ControlInput>,
+        serializer: some GRPCCore.MessageSerializer<ControlInput>,
+        deserializer: some GRPCCore.MessageDeserializer<ControlOutput>,
+        options: GRPCCore.CallOptions,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<ControlOutput>) async throws -> R
     ) async throws -> R where R: Sendable
 
     func serverStream<R>(
-        request: ClientRequest.Single<ControlInput>,
-        serializer: some MessageSerializer<ControlInput>,
-        deserializer: some MessageDeserializer<ControlOutput>,
-        options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Stream<ControlOutput>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<ControlInput>,
+        serializer: some GRPCCore.MessageSerializer<ControlInput>,
+        deserializer: some GRPCCore.MessageDeserializer<ControlOutput>,
+        options: GRPCCore.CallOptions,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<ControlOutput>) async throws -> R
     ) async throws -> R where R: Sendable
 
     func clientStream<R>(
-        request: ClientRequest.Stream<ControlInput>,
-        serializer: some MessageSerializer<ControlInput>,
-        deserializer: some MessageDeserializer<ControlOutput>,
-        options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Single<ControlOutput>) async throws -> R
+        request: GRPCCore.ClientRequest.Stream<ControlInput>,
+        serializer: some GRPCCore.MessageSerializer<ControlInput>,
+        deserializer: some GRPCCore.MessageDeserializer<ControlOutput>,
+        options: GRPCCore.CallOptions,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<ControlOutput>) async throws -> R
     ) async throws -> R where R: Sendable
 
     func bidiStream<R>(
-        request: ClientRequest.Stream<ControlInput>,
-        serializer: some MessageSerializer<ControlInput>,
-        deserializer: some MessageDeserializer<ControlOutput>,
-        options: CallOptions,
-        _ body: @Sendable @escaping (ClientResponse.Stream<ControlOutput>) async throws -> R
+        request: GRPCCore.ClientRequest.Stream<ControlInput>,
+        serializer: some GRPCCore.MessageSerializer<ControlInput>,
+        deserializer: some GRPCCore.MessageDeserializer<ControlOutput>,
+        options: GRPCCore.CallOptions,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<ControlOutput>) async throws -> R
     ) async throws -> R where R: Sendable
 }
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Control.ClientProtocol {
     internal func unary<R>(
-        request: ClientRequest.Single<ControlInput>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<ControlOutput>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<ControlInput>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<ControlOutput>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.unary(
             request: request,
-            serializer: ProtobufSerializer<ControlInput>(),
-            deserializer: ProtobufDeserializer<ControlOutput>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<ControlInput>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<ControlOutput>(),
             options: options,
             body
         )
     }
 
     internal func serverStream<R>(
-        request: ClientRequest.Single<ControlInput>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Stream<ControlOutput>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<ControlInput>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<ControlOutput>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.serverStream(
             request: request,
-            serializer: ProtobufSerializer<ControlInput>(),
-            deserializer: ProtobufDeserializer<ControlOutput>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<ControlInput>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<ControlOutput>(),
             options: options,
             body
         )
     }
 
     internal func clientStream<R>(
-        request: ClientRequest.Stream<ControlInput>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<ControlOutput>) async throws -> R
+        request: GRPCCore.ClientRequest.Stream<ControlInput>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<ControlOutput>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.clientStream(
             request: request,
-            serializer: ProtobufSerializer<ControlInput>(),
-            deserializer: ProtobufDeserializer<ControlOutput>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<ControlInput>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<ControlOutput>(),
             options: options,
             body
         )
     }
 
     internal func bidiStream<R>(
-        request: ClientRequest.Stream<ControlInput>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Stream<ControlOutput>) async throws -> R
+        request: GRPCCore.ClientRequest.Stream<ControlInput>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<ControlOutput>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.bidiStream(
             request: request,
-            serializer: ProtobufSerializer<ControlInput>(),
-            deserializer: ProtobufDeserializer<ControlOutput>(),
+            serializer: GRPCProtobuf.ProtobufSerializer<ControlInput>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<ControlOutput>(),
             options: options,
             body
         )
@@ -284,11 +284,11 @@ internal struct ControlClient: Control.ClientProtocol {
     }
 
     internal func unary<R>(
-        request: ClientRequest.Single<ControlInput>,
-        serializer: some MessageSerializer<ControlInput>,
-        deserializer: some MessageDeserializer<ControlOutput>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<ControlOutput>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<ControlInput>,
+        serializer: some GRPCCore.MessageSerializer<ControlInput>,
+        deserializer: some GRPCCore.MessageDeserializer<ControlOutput>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<ControlOutput>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.unary(
             request: request,
@@ -301,11 +301,11 @@ internal struct ControlClient: Control.ClientProtocol {
     }
 
     internal func serverStream<R>(
-        request: ClientRequest.Single<ControlInput>,
-        serializer: some MessageSerializer<ControlInput>,
-        deserializer: some MessageDeserializer<ControlOutput>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Stream<ControlOutput>) async throws -> R
+        request: GRPCCore.ClientRequest.Single<ControlInput>,
+        serializer: some GRPCCore.MessageSerializer<ControlInput>,
+        deserializer: some GRPCCore.MessageDeserializer<ControlOutput>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<ControlOutput>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.serverStreaming(
             request: request,
@@ -318,11 +318,11 @@ internal struct ControlClient: Control.ClientProtocol {
     }
 
     internal func clientStream<R>(
-        request: ClientRequest.Stream<ControlInput>,
-        serializer: some MessageSerializer<ControlInput>,
-        deserializer: some MessageDeserializer<ControlOutput>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Single<ControlOutput>) async throws -> R
+        request: GRPCCore.ClientRequest.Stream<ControlInput>,
+        serializer: some GRPCCore.MessageSerializer<ControlInput>,
+        deserializer: some GRPCCore.MessageDeserializer<ControlOutput>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<ControlOutput>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.clientStreaming(
             request: request,
@@ -335,11 +335,11 @@ internal struct ControlClient: Control.ClientProtocol {
     }
 
     internal func bidiStream<R>(
-        request: ClientRequest.Stream<ControlInput>,
-        serializer: some MessageSerializer<ControlInput>,
-        deserializer: some MessageDeserializer<ControlOutput>,
-        options: CallOptions = .defaults,
-        _ body: @Sendable @escaping (ClientResponse.Stream<ControlOutput>) async throws -> R
+        request: GRPCCore.ClientRequest.Stream<ControlInput>,
+        serializer: some GRPCCore.MessageSerializer<ControlInput>,
+        deserializer: some GRPCCore.MessageDeserializer<ControlOutput>,
+        options: GRPCCore.CallOptions = .defaults,
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<ControlOutput>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.bidirectionalStreaming(
             request: request,

--- a/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGenParserTests.swift
+++ b/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGenParserTests.swift
@@ -95,11 +95,11 @@ final class ProtobufCodeGenParserTests: XCTestCase {
 
     XCTAssertEqual(
       parsedCodeGenRequest.lookupSerializer("Helloworld_HelloRequest"),
-      "ProtobufSerializer<Helloworld_HelloRequest>()"
+      "GRPCProtobuf.ProtobufSerializer<Helloworld_HelloRequest>()"
     )
     XCTAssertEqual(
       parsedCodeGenRequest.lookupDeserializer("Helloworld_HelloRequest"),
-      "ProtobufDeserializer<Helloworld_HelloRequest>()"
+      "GRPCProtobuf.ProtobufDeserializer<Helloworld_HelloRequest>()"
     )
   }
 
@@ -176,11 +176,11 @@ final class ProtobufCodeGenParserTests: XCTestCase {
 
     XCTAssertEqual(
       parsedCodeGenRequest.lookupSerializer("Hello_World_HelloRequest"),
-      "ProtobufSerializer<Hello_World_HelloRequest>()"
+      "GRPCProtobuf.ProtobufSerializer<Hello_World_HelloRequest>()"
     )
     XCTAssertEqual(
       parsedCodeGenRequest.lookupDeserializer("Hello_World_HelloRequest"),
-      "ProtobufDeserializer<Hello_World_HelloRequest>()"
+      "GRPCProtobuf.ProtobufDeserializer<Hello_World_HelloRequest>()"
     )
   }
 
@@ -257,11 +257,11 @@ final class ProtobufCodeGenParserTests: XCTestCase {
 
     XCTAssertEqual(
       parsedCodeGenRequest.lookupSerializer("HelloRequest"),
-      "ProtobufSerializer<HelloRequest>()"
+      "GRPCProtobuf.ProtobufSerializer<HelloRequest>()"
     )
     XCTAssertEqual(
       parsedCodeGenRequest.lookupDeserializer("HelloRequest"),
-      "ProtobufDeserializer<HelloRequest>()"
+      "GRPCProtobuf.ProtobufDeserializer<HelloRequest>()"
     )
   }
 }

--- a/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGeneratorTests.swift
+++ b/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGeneratorTests.swift
@@ -60,17 +60,17 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         import ExtraModule
 
         internal enum Hello_World_Greeter {
-            internal static let descriptor = ServiceDescriptor.hello_world_Greeter
+            internal static let descriptor = GRPCCore.ServiceDescriptor.hello_world_Greeter
             internal enum Method {
                 internal enum SayHello {
                     internal typealias Input = Hello_World_HelloRequest
                     internal typealias Output = Hello_World_HelloReply
-                    internal static let descriptor = MethodDescriptor(
+                    internal static let descriptor = GRPCCore.MethodDescriptor(
                         service: Hello_World_Greeter.descriptor.fullyQualifiedService,
                         method: "SayHello"
                     )
                 }
-                internal static let descriptors: [MethodDescriptor] = [
+                internal static let descriptors: [GRPCCore.MethodDescriptor] = [
                     SayHello.descriptor
                 ]
             }
@@ -80,7 +80,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
             internal typealias Client = Hello_World_GreeterClient
         }
 
-        extension ServiceDescriptor {
+        extension GRPCCore.ServiceDescriptor {
             internal static let hello_world_Greeter = Self(
                 package: "hello.world",
                 service: "Greeter"
@@ -92,25 +92,25 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         internal protocol Hello_World_GreeterClientProtocol: Sendable {
             /// Sends a greeting.
             func sayHello<R>(
-                request: ClientRequest.Single<Hello_World_HelloRequest>,
-                serializer: some MessageSerializer<Hello_World_HelloRequest>,
-                deserializer: some MessageDeserializer<Hello_World_HelloReply>,
-                options: CallOptions,
-                _ body: @Sendable @escaping (ClientResponse.Single<Hello_World_HelloReply>) async throws -> R
+                request: GRPCCore.ClientRequest.Single<Hello_World_HelloRequest>,
+                serializer: some GRPCCore.MessageSerializer<Hello_World_HelloRequest>,
+                deserializer: some GRPCCore.MessageDeserializer<Hello_World_HelloReply>,
+                options: GRPCCore.CallOptions,
+                _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Hello_World_HelloReply>) async throws -> R
             ) async throws -> R where R: Sendable
         }
 
         @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
         extension Hello_World_Greeter.ClientProtocol {
             internal func sayHello<R>(
-                request: ClientRequest.Single<Hello_World_HelloRequest>,
-                options: CallOptions = .defaults,
-                _ body: @Sendable @escaping (ClientResponse.Single<Hello_World_HelloReply>) async throws -> R
+                request: GRPCCore.ClientRequest.Single<Hello_World_HelloRequest>,
+                options: GRPCCore.CallOptions = .defaults,
+                _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Hello_World_HelloReply>) async throws -> R
             ) async throws -> R where R: Sendable {
                 try await self.sayHello(
                     request: request,
-                    serializer: ProtobufSerializer<Hello_World_HelloRequest>(),
-                    deserializer: ProtobufDeserializer<Hello_World_HelloReply>(),
+                    serializer: GRPCProtobuf.ProtobufSerializer<Hello_World_HelloRequest>(),
+                    deserializer: GRPCProtobuf.ProtobufDeserializer<Hello_World_HelloReply>(),
                     options: options,
                     body
                 )
@@ -128,11 +128,11 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
             
             /// Sends a greeting.
             internal func sayHello<R>(
-                request: ClientRequest.Single<Hello_World_HelloRequest>,
-                serializer: some MessageSerializer<Hello_World_HelloRequest>,
-                deserializer: some MessageDeserializer<Hello_World_HelloReply>,
-                options: CallOptions = .defaults,
-                _ body: @Sendable @escaping (ClientResponse.Single<Hello_World_HelloReply>) async throws -> R
+                request: GRPCCore.ClientRequest.Single<Hello_World_HelloRequest>,
+                serializer: some GRPCCore.MessageSerializer<Hello_World_HelloRequest>,
+                deserializer: some GRPCCore.MessageDeserializer<Hello_World_HelloReply>,
+                options: GRPCCore.CallOptions = .defaults,
+                _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Hello_World_HelloReply>) async throws -> R
             ) async throws -> R where R: Sendable {
                 try await self.client.unary(
                     request: request,
@@ -183,17 +183,17 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         import ExtraModule
 
         public enum Helloworld_Greeter {
-          public static let descriptor = ServiceDescriptor.helloworld_Greeter
+          public static let descriptor = GRPCCore.ServiceDescriptor.helloworld_Greeter
           public enum Method {
             public enum SayHello {
               public typealias Input = Helloworld_HelloRequest
               public typealias Output = Helloworld_HelloReply
-              public static let descriptor = MethodDescriptor(
+              public static let descriptor = GRPCCore.MethodDescriptor(
                 service: Helloworld_Greeter.descriptor.fullyQualifiedService,
                 method: "SayHello"
               )
             }
-            public static let descriptors: [MethodDescriptor] = [
+            public static let descriptors: [GRPCCore.MethodDescriptor] = [
               SayHello.descriptor
             ]
           }
@@ -203,7 +203,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
           public typealias ServiceProtocol = Helloworld_GreeterServiceProtocol
         }
 
-        extension ServiceDescriptor {
+        extension GRPCCore.ServiceDescriptor {
           public static let helloworld_Greeter = Self(
             package: "helloworld",
             service: "Greeter"
@@ -214,7 +214,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
         public protocol Helloworld_GreeterStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Sends a greeting.
-          func sayHello(request: ServerRequest.Stream<Helloworld_HelloRequest>) async throws -> ServerResponse.Stream<Helloworld_HelloReply>
+          func sayHello(request: GRPCCore.ServerRequest.Stream<Helloworld_HelloRequest>) async throws -> GRPCCore.ServerResponse.Stream<Helloworld_HelloReply>
         }
 
         /// Conformance to `GRPCCore.RegistrableRPCService`.
@@ -224,8 +224,8 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {
             router.registerHandler(
               forMethod: Helloworld_Greeter.Method.SayHello.descriptor,
-              deserializer: ProtobufDeserializer<Helloworld_HelloRequest>(),
-              serializer: ProtobufSerializer<Helloworld_HelloReply>(),
+              deserializer: GRPCProtobuf.ProtobufDeserializer<Helloworld_HelloRequest>(),
+              serializer: GRPCProtobuf.ProtobufSerializer<Helloworld_HelloReply>(),
               handler: { request in
                 try await self.sayHello(request: request)
               }
@@ -237,15 +237,15 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
         public protocol Helloworld_GreeterServiceProtocol: Helloworld_Greeter.StreamingServiceProtocol {
           /// Sends a greeting.
-          func sayHello(request: ServerRequest.Single<Helloworld_HelloRequest>) async throws -> ServerResponse.Single<Helloworld_HelloReply>
+          func sayHello(request: GRPCCore.ServerRequest.Single<Helloworld_HelloRequest>) async throws -> GRPCCore.ServerResponse.Single<Helloworld_HelloReply>
         }
 
         /// Partial conformance to `Helloworld_GreeterStreamingServiceProtocol`.
         @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
         extension Helloworld_Greeter.ServiceProtocol {
-          public func sayHello(request: ServerRequest.Stream<Helloworld_HelloRequest>) async throws -> ServerResponse.Stream<Helloworld_HelloReply> {
-            let response = try await self.sayHello(request: ServerRequest.Single(stream: request))
-            return ServerResponse.Stream(single: response)
+          public func sayHello(request: GRPCCore.ServerRequest.Stream<Helloworld_HelloRequest>) async throws -> GRPCCore.ServerResponse.Stream<Helloworld_HelloReply> {
+            let response = try await self.sayHello(request: GRPCCore.ServerRequest.Single(stream: request))
+            return GRPCCore.ServerResponse.Stream(single: response)
           }
         }
         """
@@ -286,17 +286,17 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         import ExtraModule
 
         package enum Greeter {
-          package static let descriptor = ServiceDescriptor.Greeter
+          package static let descriptor = GRPCCore.ServiceDescriptor.Greeter
           package enum Method {
             package enum SayHello {
               package typealias Input = HelloRequest
               package typealias Output = HelloReply
-              package static let descriptor = MethodDescriptor(
+              package static let descriptor = GRPCCore.MethodDescriptor(
                 service: Greeter.descriptor.fullyQualifiedService,
                 method: "SayHello"
               )
             }
-            package static let descriptors: [MethodDescriptor] = [
+            package static let descriptors: [GRPCCore.MethodDescriptor] = [
               SayHello.descriptor
             ]
           }
@@ -310,7 +310,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
           package typealias Client = GreeterClient
         }
 
-        extension ServiceDescriptor {
+        extension GRPCCore.ServiceDescriptor {
           package static let Greeter = Self(
             package: "",
             service: "Greeter"
@@ -321,7 +321,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
         package protocol GreeterStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Sends a greeting.
-          func sayHello(request: ServerRequest.Stream<HelloRequest>) async throws -> ServerResponse.Stream<HelloReply>
+          func sayHello(request: GRPCCore.ServerRequest.Stream<HelloRequest>) async throws -> GRPCCore.ServerResponse.Stream<HelloReply>
         }
 
         /// Conformance to `GRPCCore.RegistrableRPCService`.
@@ -331,8 +331,8 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
           package func registerMethods(with router: inout GRPCCore.RPCRouter) {
             router.registerHandler(
               forMethod: Greeter.Method.SayHello.descriptor,
-              deserializer: ProtobufDeserializer<HelloRequest>(),
-              serializer: ProtobufSerializer<HelloReply>(),
+              deserializer: GRPCProtobuf.ProtobufDeserializer<HelloRequest>(),
+              serializer: GRPCProtobuf.ProtobufSerializer<HelloReply>(),
               handler: { request in
                 try await self.sayHello(request: request)
               }
@@ -344,15 +344,15 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
         package protocol GreeterServiceProtocol: Greeter.StreamingServiceProtocol {
           /// Sends a greeting.
-          func sayHello(request: ServerRequest.Single<HelloRequest>) async throws -> ServerResponse.Single<HelloReply>
+          func sayHello(request: GRPCCore.ServerRequest.Single<HelloRequest>) async throws -> GRPCCore.ServerResponse.Single<HelloReply>
         }
 
         /// Partial conformance to `GreeterStreamingServiceProtocol`.
         @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
         extension Greeter.ServiceProtocol {
-          package func sayHello(request: ServerRequest.Stream<HelloRequest>) async throws -> ServerResponse.Stream<HelloReply> {
-            let response = try await self.sayHello(request: ServerRequest.Single(stream: request))
-            return ServerResponse.Stream(single: response)
+          package func sayHello(request: GRPCCore.ServerRequest.Stream<HelloRequest>) async throws -> GRPCCore.ServerResponse.Stream<HelloReply> {
+            let response = try await self.sayHello(request: GRPCCore.ServerRequest.Single(stream: request))
+            return GRPCCore.ServerResponse.Stream(single: response)
           }
         }
 
@@ -361,25 +361,25 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
         package protocol GreeterClientProtocol: Sendable {
           /// Sends a greeting.
           func sayHello<R>(
-            request: ClientRequest.Single<HelloRequest>,
-            serializer: some MessageSerializer<HelloRequest>,
-            deserializer: some MessageDeserializer<HelloReply>,
-            options: CallOptions,
-            _ body: @Sendable @escaping (ClientResponse.Single<HelloReply>) async throws -> R
+            request: GRPCCore.ClientRequest.Single<HelloRequest>,
+            serializer: some GRPCCore.MessageSerializer<HelloRequest>,
+            deserializer: some GRPCCore.MessageDeserializer<HelloReply>,
+            options: GRPCCore.CallOptions,
+            _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<HelloReply>) async throws -> R
           ) async throws -> R where R: Sendable
         }
 
         @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
         extension Greeter.ClientProtocol {
           package func sayHello<R>(
-            request: ClientRequest.Single<HelloRequest>,
-            options: CallOptions = .defaults,
-            _ body: @Sendable @escaping (ClientResponse.Single<HelloReply>) async throws -> R
+            request: GRPCCore.ClientRequest.Single<HelloRequest>,
+            options: GRPCCore.CallOptions = .defaults,
+            _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<HelloReply>) async throws -> R
           ) async throws -> R where R: Sendable {
             try await self.sayHello(
               request: request,
-              serializer: ProtobufSerializer<HelloRequest>(),
-              deserializer: ProtobufDeserializer<HelloReply>(),
+              serializer: GRPCProtobuf.ProtobufSerializer<HelloRequest>(),
+              deserializer: GRPCProtobuf.ProtobufDeserializer<HelloReply>(),
               options: options,
               body
             )
@@ -397,11 +397,11 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
           
           /// Sends a greeting.
           package func sayHello<R>(
-            request: ClientRequest.Single<HelloRequest>,
-            serializer: some MessageSerializer<HelloRequest>,
-            deserializer: some MessageDeserializer<HelloReply>,
-            options: CallOptions = .defaults,
-            _ body: @Sendable @escaping (ClientResponse.Single<HelloReply>) async throws -> R
+            request: GRPCCore.ClientRequest.Single<HelloRequest>,
+            serializer: some GRPCCore.MessageSerializer<HelloRequest>,
+            deserializer: some GRPCCore.MessageDeserializer<HelloReply>,
+            options: GRPCCore.CallOptions = .defaults,
+            _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<HelloReply>) async throws -> R
           ) async throws -> R where R: Sendable {
             try await self.client.unary(
               request: request,


### PR DESCRIPTION
Motivation:

The generated code has possible namespace collisions between user-defined types and gRPC types.

Modifications:

- Adjust `GRPCCodeGen` and `GRPCProtobufCodeGen` to use the fully qualified names of gRPC types when generating code.

Result:

This will help avoid namespace collision between user-defined types and gRPC types.