### PR TITLE
Update .spi.yml

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -2,3 +2,4 @@ version: 1
 builder:
   configs:
     - documentation_targets: [GRPC, GRPCReflectionService, protoc-gen-grpc-swift, _GRPCCore]
+      swift_version: 6.0


### PR DESCRIPTION
Generate docs with Swift 6 instead of the default (latest release version, 5.10)

See https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/3292#issuecomment-2291140066 for details