### PR TITLE
Use Swift 6 to build docs on Swift Package Index

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -2,3 +2,4 @@ version: 1
 builder:
   configs:
     - documentation_targets: [GRPC, GRPCReflectionService, protoc-gen-grpc-swift, _GRPCCore]
+      swift_version: 6.0


### PR DESCRIPTION
Motivation:

We'd like v2 docs to be generated by the Swift Package Index. By default it uses the latest released Swift version, i.e. 5.10. As v2 requires Swift 6 we need to configure that.

Modifications:

- Set the swift version in .spi.yml

Result:

Docs for v2 should be built by Swift Package Index