### PR TITLE
Fix availability of health service

### DIFF
--- a/Sources/Services/Health/Health.swift
+++ b/Sources/Services/Health/Health.swift
@@ -40,7 +40,7 @@ public import GRPCCore
 ///   forService: .bar_Foo
 /// )
 /// ```
-@available(macOS 15.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 public struct Health: Sendable {
   /// An implementation of the `grpc.health.v1.Health` service.
   public let service: Health.Service
@@ -58,7 +58,7 @@ public struct Health: Sendable {
   }
 }
 
-@available(macOS 15.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Health {
   /// An implementation of the `grpc.health.v1.Health` service.
   public struct Service: RegistrableRPCService, Sendable {

--- a/Sources/Services/Health/HealthService.swift
+++ b/Sources/Services/Health/HealthService.swift
@@ -16,7 +16,7 @@
 
 internal import GRPCCore
 
-@available(macOS 15.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 internal struct HealthService: Grpc_Health_V1_HealthServiceProtocol {
   private let state = HealthService.State()
 
@@ -65,7 +65,7 @@ internal struct HealthService: Grpc_Health_V1_HealthServiceProtocol {
   }
 }
 
-@available(macOS 15.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension HealthService {
   private struct State: Sendable {
     // The state of each service keyed by the fully qualified service name.


### PR DESCRIPTION
Motivation:

A couple of availability annotations for the health service were incorrect for some platforms.

Modifications:

- Update availability

Result:

Builds on iOS etc.