### PR TITLE
Add support for TLS on H2 NIOTS server transport

### DIFF
--- a/Sources/GRPCHTTP2TransportNIOTransportServices/HTTP2ServerTransport+TransportServices.swift
+++ b/Sources/GRPCHTTP2TransportNIOTransportServices/HTTP2ServerTransport+TransportServices.swift
@@ -435,7 +435,7 @@ extension NWProtocolTLS.Options {
   convenience init(_ tlsConfig: HTTP2ServerTransport.TransportServices.Config.TLS) throws {
     self.init()
 
-    guard let sec_identity = sec_identity_create(tlsConfig.identity) else {
+    guard let sec_identity = sec_identity_create(tlsConfig.identityProvider()) else {
       throw RuntimeError(
         code: .transportError,
         message: """

--- a/Sources/GRPCHTTP2TransportNIOTransportServices/HTTP2ServerTransport+TransportServices.swift
+++ b/Sources/GRPCHTTP2TransportNIOTransportServices/HTTP2ServerTransport+TransportServices.swift
@@ -439,9 +439,9 @@ extension NWProtocolTLS.Options {
       throw RuntimeError(
         code: .transportError,
         message: """
-        There was an issue creating the SecIdentity required to set up TLS. \
-        Please check your TLS configuration.
-        """
+          There was an issue creating the SecIdentity required to set up TLS. \
+          Please check your TLS configuration.
+          """
       )
     }
 

--- a/Sources/GRPCHTTP2TransportNIOTransportServices/HTTP2ServerTransport+TransportServices.swift
+++ b/Sources/GRPCHTTP2TransportNIOTransportServices/HTTP2ServerTransport+TransportServices.swift
@@ -435,7 +435,7 @@ extension NWProtocolTLS.Options {
   convenience init(_ tlsConfig: HTTP2ServerTransport.TransportServices.Config.TLS) throws {
     self.init()
 
-    guard let sec_identity = sec_identity_create(tlsConfig.identityProvider()) else {
+    guard let sec_identity = sec_identity_create(try tlsConfig.identityProvider()) else {
       throw RuntimeError(
         code: .transportError,
         message: """

--- a/Sources/GRPCHTTP2TransportNIOTransportServices/HTTP2ServerTransport+TransportServices.swift
+++ b/Sources/GRPCHTTP2TransportNIOTransportServices/HTTP2ServerTransport+TransportServices.swift
@@ -455,13 +455,6 @@ extension NWProtocolTLS.Options {
       .TLSv12
     )
 
-    if let hostnameOverride = tlsConfig.hostnameOverride {
-      sec_protocol_options_set_tls_server_name(
-        self.securityProtocolOptions,
-        hostnameOverride
-      )
-    }
-
     for `protocol` in ["grpc-exp", "h2"] {
       sec_protocol_options_add_tls_application_protocol(
         self.securityProtocolOptions,

--- a/Sources/GRPCHTTP2TransportNIOTransportServices/TLSConfig.swift
+++ b/Sources/GRPCHTTP2TransportNIOTransportServices/TLSConfig.swift
@@ -41,9 +41,6 @@ extension HTTP2ServerTransport.TransportServices.Config {
     /// The `SecIdentity` to be used when setting up TLS.
     public var identity: SecIdentity
 
-    /// An optional hostname override to use during certificate verification.
-    public var hostnameOverride: String?
-
     /// Whether ALPN is required.
     ///
     /// If this is set to `true` but the client does not support ALPN, then the connection will be rejected.
@@ -51,7 +48,6 @@ extension HTTP2ServerTransport.TransportServices.Config {
 
     /// Create a new HTTP2 NIO Transport Services transport TLS config, with some values defaulted:
     /// - `requireALPN` equals `false`
-    /// - `hostnameOverride` equals `nil`
     ///
     /// - Returns: A new HTTP2 NIO Transport Services transport TLS config.
     public static func defaults(
@@ -59,23 +55,6 @@ extension HTTP2ServerTransport.TransportServices.Config {
     ) -> Self {
       Self(
         identity: identity,
-        hostnameOverride: nil,
-        requireALPN: false
-      )
-    }
-
-    /// Create a new HTTP2 NIO Transport Services transport TLS config, with some values defaulted to match
-    /// the requirements of mTLS:
-    /// - `requireALPN` equals `false`
-    /// - `hostnameOverride` equals `""`
-    ///
-    /// - Returns: A new HTTP2 NIO Transport Services transport TLS config.
-    public static func mTLS(
-      identity: SecIdentity
-    ) -> Self {
-      Self(
-        identity: identity,
-        hostnameOverride: "",
         requireALPN: false
       )
     }

--- a/Sources/GRPCHTTP2TransportNIOTransportServices/TLSConfig.swift
+++ b/Sources/GRPCHTTP2TransportNIOTransportServices/TLSConfig.swift
@@ -15,7 +15,7 @@
  */
 
 #if canImport(Network)
-@preconcurrency public import Network
+public import Network
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension HTTP2ServerTransport.TransportServices.Config {
@@ -39,7 +39,7 @@ extension HTTP2ServerTransport.TransportServices.Config {
 
   public struct TLS: Sendable {
     /// The `SecIdentity` to be used when setting up TLS.
-    public var identity: SecIdentity
+    public var identityProvider: @Sendable () -> SecIdentity
 
     /// Whether ALPN is required.
     ///
@@ -51,10 +51,10 @@ extension HTTP2ServerTransport.TransportServices.Config {
     ///
     /// - Returns: A new HTTP2 NIO Transport Services transport TLS config.
     public static func defaults(
-      identity: SecIdentity
+      identityProvider: @Sendable @escaping () -> SecIdentity
     ) -> Self {
       Self(
-        identity: identity,
+        identityProvider: identityProvider,
         requireALPN: false
       )
     }

--- a/Sources/GRPCHTTP2TransportNIOTransportServices/TLSConfig.swift
+++ b/Sources/GRPCHTTP2TransportNIOTransportServices/TLSConfig.swift
@@ -39,7 +39,7 @@ extension HTTP2ServerTransport.TransportServices.Config {
 
   public struct TLS: Sendable {
     /// The `SecIdentity` to be used when setting up TLS.
-    public var identityProvider: @Sendable () -> SecIdentity
+    public var identityProvider: @Sendable () throws -> SecIdentity
 
     /// Whether ALPN is required.
     ///
@@ -51,7 +51,7 @@ extension HTTP2ServerTransport.TransportServices.Config {
     ///
     /// - Returns: A new HTTP2 NIO Transport Services transport TLS config.
     public static func defaults(
-      identityProvider: @Sendable @escaping () -> SecIdentity
+      identityProvider: @Sendable @escaping () throws -> SecIdentity
     ) -> Self {
       Self(
         identityProvider: identityProvider,

--- a/Sources/GRPCHTTP2TransportNIOTransportServices/TLSConfig.swift
+++ b/Sources/GRPCHTTP2TransportNIOTransportServices/TLSConfig.swift
@@ -38,7 +38,7 @@ extension HTTP2ServerTransport.TransportServices.Config {
   }
 
   public struct TLS: Sendable {
-    /// The `SecIdentity` to be used when setting up TLS.
+    /// A provider for the `SecIdentity` to be used when setting up TLS.
     public var identityProvider: @Sendable () throws -> SecIdentity
 
     /// Whether ALPN is required.

--- a/Sources/GRPCHTTP2TransportNIOTransportServices/TLSConfig.swift
+++ b/Sources/GRPCHTTP2TransportNIOTransportServices/TLSConfig.swift
@@ -57,7 +57,7 @@ extension HTTP2ServerTransport.TransportServices.Config {
     public static func defaults(
       identity: SecIdentity
     ) -> Self {
-      Self.init(
+      Self(
         identity: identity,
         hostnameOverride: nil,
         requireALPN: false
@@ -73,7 +73,7 @@ extension HTTP2ServerTransport.TransportServices.Config {
     public static func mTLS(
       identity: SecIdentity
     ) -> Self {
-      Self.init(
+      Self(
         identity: identity,
         hostnameOverride: "",
         requireALPN: false

--- a/Sources/GRPCHTTP2TransportNIOTransportServices/TLSConfig.swift
+++ b/Sources/GRPCHTTP2TransportNIOTransportServices/TLSConfig.swift
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if canImport(Network)
+@preconcurrency public import Network
+
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+extension HTTP2ServerTransport.TransportServices.Config {
+  /// The security configuration for this connection.
+  public struct TransportSecurity: Sendable {
+    package enum Wrapped: Sendable {
+      case plaintext
+      case tls(TLS)
+    }
+
+    package let wrapped: Wrapped
+
+    /// This connection is plaintext: no encryption will take place.
+    public static let plaintext = Self(wrapped: .plaintext)
+
+    /// This connection will use TLS.
+    public static func tls(_ tls: TLS) -> Self {
+      Self(wrapped: .tls(tls))
+    }
+  }
+
+  public struct TLS: Sendable {
+    /// The `SecIdentity` to be used when setting up TLS.
+    public var identity: SecIdentity
+
+    /// An optional hostname override to use during certificate verification.
+    public var hostnameOverride: String?
+
+    /// Whether ALPN is required.
+    ///
+    /// If this is set to `true` but the client does not support ALPN, then the connection will be rejected.
+    public var requireALPN: Bool
+
+    /// Create a new HTTP2 NIO Transport Services transport TLS config, with some values defaulted:
+    /// - `requireALPN` equals `false`
+    /// - `hostnameOverride` equals `nil`
+    ///
+    /// - Returns: A new HTTP2 NIO Transport Services transport TLS config.
+    public static func defaults(
+      identity: SecIdentity
+    ) -> Self {
+      Self.init(
+        identity: identity,
+        hostnameOverride: nil,
+        requireALPN: false
+      )
+    }
+
+    /// Create a new HTTP2 NIO Transport Services transport TLS config, with some values defaulted to match
+    /// the requirements of mTLS:
+    /// - `requireALPN` equals `false`
+    /// - `hostnameOverride` equals `""`
+    ///
+    /// - Returns: A new HTTP2 NIO Transport Services transport TLS config.
+    public static func mTLS(
+      identity: SecIdentity
+    ) -> Self {
+      Self.init(
+        identity: identity,
+        hostnameOverride: "",
+        requireALPN: false
+      )
+    }
+  }
+}
+#endif

--- a/Tests/GRPCHTTP2TransportTests/HTTP2TransportNIOTransportServicesTests.swift
+++ b/Tests/GRPCHTTP2TransportTests/HTTP2TransportNIOTransportServicesTests.swift
@@ -208,16 +208,6 @@ final class HTTP2TransportNIOTransportServicesTests: XCTestCase {
       identity: self.identity
     )
     XCTAssertEqual(grpcTLSConfig.identity, self.identity)
-    XCTAssertEqual(grpcTLSConfig.hostnameOverride, nil)
-    XCTAssertEqual(grpcTLSConfig.requireALPN, false)
-  }
-
-  func testTLSConfig_mTLS() throws {
-    let grpcTLSConfig = HTTP2ServerTransport.TransportServices.Config.TLS.mTLS(
-      identity: self.identity
-    )
-    XCTAssertEqual(grpcTLSConfig.identity, self.identity)
-    XCTAssertEqual(grpcTLSConfig.hostnameOverride, "")
     XCTAssertEqual(grpcTLSConfig.requireALPN, false)
   }
 }

--- a/Tests/GRPCHTTP2TransportTests/HTTP2TransportNIOTransportServicesTests.swift
+++ b/Tests/GRPCHTTP2TransportTests/HTTP2TransportNIOTransportServicesTests.swift
@@ -22,10 +22,52 @@ import XCTest
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class HTTP2TransportNIOTransportServicesTests: XCTestCase {
+  private var identity: SecIdentity!
+
+  private static let p12bundleURL = URL(fileURLWithPath: #filePath)
+    .deletingLastPathComponent()  // (this file)
+    .deletingLastPathComponent()  // GRPCHTTP2TransportTests
+    .deletingLastPathComponent()  // Tests
+    .appendingPathComponent("Sources")
+    .appendingPathComponent("GRPCSampleData")
+    .appendingPathComponent("bundle")
+    .appendingPathExtension("p12")
+
+  override func setUp() async throws {
+    try await super.setUp()
+
+    self.identity = try self.loadIdentity()
+    XCTAssertNotNil(
+      self.identity,
+      "Unable to load identity from '\(Self.p12bundleURL)'"
+    )
+  }
+
+  private func loadIdentity() throws -> SecIdentity? {
+    let data = try Data(contentsOf: Self.p12bundleURL)
+    let options = [kSecImportExportPassphrase as String: "password"]
+
+    var rawItems: CFArray?
+    let status = SecPKCS12Import(data as CFData, options as CFDictionary, &rawItems)
+
+    switch status {
+    case errSecSuccess:
+      ()
+    case errSecInteractionNotAllowed:
+      throw XCTSkip("Unable to import PKCS12 bundle: no interaction allowed")
+    default:
+      XCTFail("SecPKCS12Import: failed with status \(status)")
+      return nil
+    }
+
+    let items = rawItems! as! [[String: Any]]
+    return items.first?[kSecImportItemIdentity as String] as! SecIdentity?
+  }
+
   func testGetListeningAddress_IPv4() async throws {
     let transport = GRPCHTTP2Core.HTTP2ServerTransport.TransportServices(
       address: .ipv4(host: "0.0.0.0", port: 0),
-      config: .defaults()
+      config: .defaults(transportSecurity: .plaintext)
     )
 
     try await withThrowingDiscardingTaskGroup { group in
@@ -45,7 +87,7 @@ final class HTTP2TransportNIOTransportServicesTests: XCTestCase {
   func testGetListeningAddress_IPv6() async throws {
     let transport = GRPCHTTP2Core.HTTP2ServerTransport.TransportServices(
       address: .ipv6(host: "::1", port: 0),
-      config: .defaults()
+      config: .defaults(transportSecurity: .plaintext)
     )
 
     try await withThrowingDiscardingTaskGroup { group in
@@ -65,7 +107,7 @@ final class HTTP2TransportNIOTransportServicesTests: XCTestCase {
   func testGetListeningAddress_UnixDomainSocket() async throws {
     let transport = GRPCHTTP2Core.HTTP2ServerTransport.TransportServices(
       address: .unixDomainSocket(path: "/tmp/niots-uds-test"),
-      config: .defaults()
+      config: .defaults(transportSecurity: .plaintext)
     )
     defer {
       // NIOTS does not unlink the UDS on close.
@@ -91,7 +133,7 @@ final class HTTP2TransportNIOTransportServicesTests: XCTestCase {
   func testGetListeningAddress_InvalidAddress() async {
     let transport = GRPCHTTP2Core.HTTP2ServerTransport.TransportServices(
       address: .unixDomainSocket(path: "/this/should/be/an/invalid/path"),
-      config: .defaults()
+      config: .defaults(transportSecurity: .plaintext)
     )
 
     try? await withThrowingDiscardingTaskGroup { group in
@@ -120,7 +162,7 @@ final class HTTP2TransportNIOTransportServicesTests: XCTestCase {
   func testGetListeningAddress_StoppedListening() async throws {
     let transport = GRPCHTTP2Core.HTTP2ServerTransport.TransportServices(
       address: .ipv4(host: "0.0.0.0", port: 0),
-      config: .defaults()
+      config: .defaults(transportSecurity: .plaintext)
     )
 
     try? await withThrowingDiscardingTaskGroup { group in
@@ -148,6 +190,24 @@ final class HTTP2TransportNIOTransportServicesTests: XCTestCase {
         transport.beginGracefulShutdown()
       }
     }
+  }
+
+  func testTLSConfig_Defaults() throws {
+    let grpcTLSConfig = HTTP2ServerTransport.TransportServices.Config.TLS.defaults(
+      identity: self.identity
+    )
+    XCTAssertEqual(grpcTLSConfig.identity, self.identity)
+    XCTAssertEqual(grpcTLSConfig.hostnameOverride, nil)
+    XCTAssertEqual(grpcTLSConfig.requireALPN, false)
+  }
+
+  func testTLSConfig_mTLS() throws {
+    let grpcTLSConfig = HTTP2ServerTransport.TransportServices.Config.TLS.mTLS(
+      identity: self.identity
+    )
+    XCTAssertEqual(grpcTLSConfig.identity, self.identity)
+    XCTAssertEqual(grpcTLSConfig.hostnameOverride, "")
+    XCTAssertEqual(grpcTLSConfig.requireALPN, false)
   }
 }
 #endif

--- a/Tests/GRPCHTTP2TransportTests/HTTP2TransportNIOTransportServicesTests.swift
+++ b/Tests/GRPCHTTP2TransportTests/HTTP2TransportNIOTransportServicesTests.swift
@@ -31,8 +31,8 @@ final class HTTP2TransportNIOTransportServicesTests: XCTestCase {
     .appendingPathComponent("bundle")
     .appendingPathExtension("p12")
 
-  @Sendable private static func loadIdentity() -> SecIdentity {
-    let data = try! Data(contentsOf: Self.p12bundleURL)
+  @Sendable private static func loadIdentity() throws -> SecIdentity {
+    let data = try Data(contentsOf: Self.p12bundleURL)
 
     var externalFormat = SecExternalFormat.formatUnknown
     var externalItemType = SecExternalItemType.itemTypeUnknown
@@ -204,7 +204,7 @@ final class HTTP2TransportNIOTransportServicesTests: XCTestCase {
     let grpcTLSConfig = HTTP2ServerTransport.TransportServices.Config.TLS.defaults(
       identityProvider: identityProvider
     )
-    XCTAssertEqual(grpcTLSConfig.identityProvider(), identityProvider())
+    XCTAssertEqual(try grpcTLSConfig.identityProvider(), try identityProvider())
     XCTAssertEqual(grpcTLSConfig.requireALPN, false)
   }
 }

--- a/Tests/GRPCHTTP2TransportTests/HTTP2TransportTests.swift
+++ b/Tests/GRPCHTTP2TransportTests/HTTP2TransportTests.swift
@@ -166,7 +166,7 @@ final class HTTP2TransportTests: XCTestCase {
       let server = GRPCServer(
         transport: .http2NIOTS(
           address: .ipv4(host: "127.0.0.1", port: 0),
-          config: .defaults {
+          config: .defaults(transportSecurity: .plaintext) {
             $0.compression.enabledAlgorithms = compression
           }
         ),


### PR DESCRIPTION
## Motivation
We currently have a NIOTS server transport implementation in gRPC v2, but it doesn't support TLS.

## Modifications
This PR adds support for TLS in the NIOTS-backed HTTP/2 implementation of the server transport for gRPC v2.
It also adds support for ALPN, to validate that the negotiated protocol, if required, is HTTP2 or `grpc-exp`. If it's not, an error will be fired/the channel will be closed, since we don't support H1.

## Result
We now support TLS/ALPN when using the NIOTS server transport in gRPC V2.