### PR TITLE
Remove swift-atomics from v2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -123,6 +123,7 @@ extension Target.Dependency {
     name: "SwiftProtobufPluginLibrary",
     package: "swift-protobuf"
   )
+  static let atomics: Self = .product(name: "Atomics", package: "swift-atomics")
   static let dequeModule: Self = .product(name: "DequeModule", package: "swift-collections")
 }
 

--- a/Package.swift
+++ b/Package.swift
@@ -146,6 +146,7 @@ extension Target {
       .logging,
       .protobuf,
       .dequeModule,
+      .atomics
     ].appending(
       .nioSSL, if: includeNIOSSL
     ),
@@ -198,7 +199,8 @@ extension Target {
       .nioEmbedded,
       .nioTransportServices,
       .logging,
-      .reflectionService
+      .reflectionService,
+      .atomics
     ].appending(
       .nioSSL, if: includeNIOSSL
     ),

--- a/Package.swift
+++ b/Package.swift
@@ -51,6 +51,10 @@ let packageDependencies: [Package.Dependency] = [
     from: "1.0.5"
   ),
   .package(
+    url: "https://github.com/apple/swift-atomics.git",
+    from: "1.2.0"
+  ),
+  .package(
     url: "https://github.com/apple/swift-protobuf.git",
     from: "1.27.0"
   ),

--- a/Package@swift-6.swift
+++ b/Package@swift-6.swift
@@ -179,6 +179,7 @@ extension Target {
         .logging,
         .protobuf,
         .dequeModule,
+        .atomics
       ].appending(
         .nioSSL, if: includeNIOSSL
       ),
@@ -381,7 +382,8 @@ extension Target {
         .nioEmbedded,
         .nioTransportServices,
         .logging,
-        .reflectionService
+        .reflectionService,
+        .atomics
       ].appending(
         .nioSSL, if: includeNIOSSL
       ),

--- a/Package@swift-6.swift
+++ b/Package@swift-6.swift
@@ -192,7 +192,6 @@ extension Target {
       name: "GRPCCore",
       dependencies: [
         .dequeModule,
-        .atomics
       ],
       path: "Sources/GRPCCore",
       swiftSettings: [
@@ -242,7 +241,6 @@ extension Target {
         .nioTLS,
         .cgrpcZlib,
         .dequeModule,
-        .atomics
       ],
       swiftSettings: [
         .swiftLanguageMode(.v6),
@@ -401,7 +399,6 @@ extension Target {
         .grpcCore,
         .grpcInProcessTransport,
         .dequeModule,
-        .atomics,
         .protobuf,
       ],
       swiftSettings: [.swiftLanguageMode(.v6), .enableUpcomingFeature("ExistentialAny")]

--- a/Sources/GRPCCore/Streaming/Internal/AsyncIteratorSequence.swift
+++ b/Sources/GRPCCore/Streaming/Internal/AsyncIteratorSequence.swift
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-public import Atomics  // should be @usableFromInline
+public import Synchronization  // should be @usableFromInline
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 @usableFromInline
 /// An `AsyncSequence` which wraps an existing async iterator.
-struct AsyncIteratorSequence<Base: AsyncIteratorProtocol>: AsyncSequence {
+final class AsyncIteratorSequence<Base: AsyncIteratorProtocol>: AsyncSequence {
   @usableFromInline
   typealias Element = Base.Element
 
@@ -29,7 +29,7 @@ struct AsyncIteratorSequence<Base: AsyncIteratorProtocol>: AsyncSequence {
 
   /// Set to `true` when an iterator has been made.
   @usableFromInline
-  let _hasMadeIterator = ManagedAtomic(false)
+  let _hasMadeIterator = Atomic(false)
 
   @inlinable
   init(_ base: Base) {

--- a/Sources/GRPCHTTP2Core/Client/Connection/GRPCChannel.swift
+++ b/Sources/GRPCHTTP2Core/Client/Connection/GRPCChannel.swift
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-internal import Atomics
-internal import DequeModule
+private import DequeModule
 package import GRPCCore
 private import Synchronization
 

--- a/Sources/GRPCHTTP2Core/Internal/ProcessUniqueID.swift
+++ b/Sources/GRPCHTTP2Core/Internal/ProcessUniqueID.swift
@@ -14,15 +14,17 @@
  * limitations under the License.
  */
 
-internal import Atomics
+private import Synchronization
 
 /// An ID which is unique within this process.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct ProcessUniqueID: Hashable, Sendable, CustomStringConvertible {
-  private static let source = ManagedAtomic(UInt64(0))
+  private static let source = Atomic(UInt64(0))
   private let rawValue: UInt64
 
   init() {
-    self.rawValue = Self.source.loadThenWrappingIncrement(ordering: .relaxed)
+    let (_, newValue) = Self.source.add(1, ordering: .relaxed)
+    self.rawValue = newValue
   }
 
   var description: String {
@@ -31,6 +33,7 @@ struct ProcessUniqueID: Hashable, Sendable, CustomStringConvertible {
 }
 
 /// A process-unique ID for a subchannel.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 package struct SubchannelID: Hashable, Sendable, CustomStringConvertible {
   private let id = ProcessUniqueID()
   package init() {}
@@ -40,6 +43,7 @@ package struct SubchannelID: Hashable, Sendable, CustomStringConvertible {
 }
 
 /// A process-unique ID for a load-balancer.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct LoadBalancerID: Hashable, Sendable, CustomStringConvertible {
   private let id = ProcessUniqueID()
   var description: String {
@@ -48,6 +52,7 @@ struct LoadBalancerID: Hashable, Sendable, CustomStringConvertible {
 }
 
 /// A process-unique ID for an entry in a queue.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct QueueEntryID: Hashable, Sendable, CustomStringConvertible {
   private let id = ProcessUniqueID()
   var description: String {

--- a/Sources/performance-worker/BenchmarkClient.swift
+++ b/Sources/performance-worker/BenchmarkClient.swift
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-private import Atomics
 private import Foundation
 internal import GRPCCore
 private import NIOConcurrencyHelpers
+private import Synchronization
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-struct BenchmarkClient {
-  private let _isShuttingDown = ManagedAtomic(false)
+final class BenchmarkClient: Sendable {
+  private let _isShuttingDown = Atomic(false)
 
   /// Whether the benchmark client is shutting down. Used to control when to stop sending messages
   /// or creating new RPCs.
@@ -30,17 +30,17 @@ struct BenchmarkClient {
   }
 
   /// The underlying client.
-  private var client: GRPCClient
+  private let client: GRPCClient
 
   /// The number of concurrent RPCs to run.
-  private var concurrentRPCs: Int
+  private let concurrentRPCs: Int
 
   /// The type of RPC to make against the server.
-  private var rpcType: RPCType
+  private let rpcType: RPCType
 
   /// The max number of messages to send on a stream before replacing the RPC with a new one. A
   /// value of zero means there is no limit.
-  private var messagesPerStream: Int
+  private let messagesPerStream: Int
   private var noMessageLimit: Bool { self.messagesPerStream == 0 }
 
   /// The message to send for all RPC types to the server.
@@ -206,7 +206,7 @@ struct BenchmarkClient {
             let nanos = now.uptimeNanoseconds - lastMessageSendTime.uptimeNanoseconds
             lastMessageSendTime = now
             self.record(latencyNanos: Double(nanos), errorCode: nil)
-            try await writer.write(message)
+            try await writer.write(self.message)
           } else {
             break
           }

--- a/Sources/performance-worker/BenchmarkService.swift
+++ b/Sources/performance-worker/BenchmarkService.swift
@@ -22,7 +22,7 @@ import struct Foundation.Data
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class BenchmarkService: Grpc_Testing_BenchmarkService.ServiceProtocol {
   /// Used to check if the server can be streaming responses.
-  private let working = Atomic<Bool>(true)
+  private let working = Atomic(true)
 
   /// One request followed by one response.
   /// The server returns a client payload with the size requested by the client.

--- a/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTestSupport/ClientRPCExecutorTestHarness+ServerBehavior.swift
+++ b/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTestSupport/ClientRPCExecutorTestHarness+ServerBehavior.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Atomics
+
 import XCTest
 
 @testable import GRPCCore
@@ -104,10 +104,10 @@ extension ClientRPCExecutorTestHarness.ServerStreamHandler {
   }
 
   static func attemptBased(_ onAttempt: @Sendable @escaping (_ attempt: Int) -> Self) -> Self {
-    let attempts = ManagedAtomic(1)
+    let attempts = AtomicCounter(1)
     return Self { stream in
-      let attempt = attempts.loadThenWrappingIncrement(ordering: .sequentiallyConsistent)
-      let handler = onAttempt(attempt)
+      let (oldAttemptCount, _) = attempts.increment()
+      let handler = onAttempt(oldAttemptCount)
       try await handler.handle(stream: stream)
     }
   }

--- a/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTestSupport/ClientRPCExecutorTestHarness.swift
+++ b/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTestSupport/ClientRPCExecutorTestHarness.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Atomics
+
 import GRPCInProcessTransport
 import XCTest
 

--- a/Tests/GRPCCoreTests/Call/Server/Internal/ServerRPCExecutorTests.swift
+++ b/Tests/GRPCCoreTests/Call/Server/Internal/ServerRPCExecutorTests.swift
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import Atomics
 import XCTest
 
 @testable import GRPCCore
@@ -290,8 +289,8 @@ final class ServerRPCExecutorTests: XCTestCase {
   }
 
   func testMultipleInterceptorsAreCalled() async throws {
-    let counter1 = ManagedAtomic(0)
-    let counter2 = ManagedAtomic(0)
+    let counter1 = AtomicCounter()
+    let counter2 = AtomicCounter()
 
     // The interceptor skips the handler altogether.
     let harness = ServerRPCExecutorTestHarness(
@@ -309,13 +308,13 @@ final class ServerRPCExecutorTests: XCTestCase {
       XCTAssertEqual(parts, [.metadata([:]), .status(.ok, [:])])
     }
 
-    XCTAssertEqual(counter1.load(ordering: .sequentiallyConsistent), 1)
-    XCTAssertEqual(counter2.load(ordering: .sequentiallyConsistent), 1)
+    XCTAssertEqual(counter1.value, 1)
+    XCTAssertEqual(counter2.value, 1)
   }
 
   func testInterceptorsAreCalledInOrder() async throws {
-    let counter1 = ManagedAtomic(0)
-    let counter2 = ManagedAtomic(0)
+    let counter1 = AtomicCounter()
+    let counter2 = AtomicCounter()
 
     // The interceptor skips the handler altogether.
     let harness = ServerRPCExecutorTestHarness(
@@ -334,9 +333,9 @@ final class ServerRPCExecutorTests: XCTestCase {
       XCTAssertEqual(parts, [.status(Status(code: .unavailable, message: ""), [:])])
     }
 
-    XCTAssertEqual(counter1.load(ordering: .sequentiallyConsistent), 1)
+    XCTAssertEqual(counter1.value, 1)
     // Zero because the RPC should've been rejected by the second interceptor.
-    XCTAssertEqual(counter2.load(ordering: .sequentiallyConsistent), 0)
+    XCTAssertEqual(counter2.value, 0)
   }
 
   func testThrowingInterceptor() async throws {

--- a/Tests/GRPCCoreTests/GRPCClientTests.swift
+++ b/Tests/GRPCCoreTests/GRPCClientTests.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Atomics
+
 import GRPCCore
 import GRPCInProcessTransport
 import XCTest
@@ -230,8 +230,8 @@ final class GRPCClientTests: XCTestCase {
   }
 
   func testInterceptorsAreAppliedInOrder() async throws {
-    let counter1 = ManagedAtomic(0)
-    let counter2 = ManagedAtomic(0)
+    let counter1 = AtomicCounter()
+    let counter2 = AtomicCounter()
 
     try await self.withInProcessConnectedClient(
       services: [BinaryEcho()],
@@ -254,8 +254,8 @@ final class GRPCClientTests: XCTestCase {
       }
     }
 
-    XCTAssertEqual(counter1.load(ordering: .sequentiallyConsistent), 1)
-    XCTAssertEqual(counter2.load(ordering: .sequentiallyConsistent), 0)
+    XCTAssertEqual(counter1.value, 1)
+    XCTAssertEqual(counter2.value, 0)
   }
 
   func testNoNewRPCsAfterClientClose() async throws {

--- a/Tests/GRPCCoreTests/GRPCServerTests.swift
+++ b/Tests/GRPCCoreTests/GRPCServerTests.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Atomics
+
 import GRPCCore
 import GRPCInProcessTransport
 import XCTest
@@ -215,8 +215,8 @@ final class GRPCServerTests: XCTestCase {
   }
 
   func testInterceptorsAreAppliedInOrder() async throws {
-    let counter1 = ManagedAtomic(0)
-    let counter2 = ManagedAtomic(0)
+    let counter1 = AtomicCounter()
+    let counter2 = AtomicCounter()
 
     try await self.withInProcessClientConnectedToServer(
       services: [BinaryEcho()],
@@ -240,12 +240,12 @@ final class GRPCServerTests: XCTestCase {
       }
     }
 
-    XCTAssertEqual(counter1.load(ordering: .sequentiallyConsistent), 1)
-    XCTAssertEqual(counter2.load(ordering: .sequentiallyConsistent), 0)
+    XCTAssertEqual(counter1.value, 1)
+    XCTAssertEqual(counter2.value, 0)
   }
 
   func testInterceptorsAreNotAppliedToUnimplementedMethods() async throws {
-    let counter = ManagedAtomic(0)
+    let counter = AtomicCounter()
 
     try await self.withInProcessClientConnectedToServer(
       services: [BinaryEcho()],
@@ -265,7 +265,7 @@ final class GRPCServerTests: XCTestCase {
       }
     }
 
-    XCTAssertEqual(counter.load(ordering: .sequentiallyConsistent), 0)
+    XCTAssertEqual(counter.value, 0)
   }
 
   func testNoNewRPCsAfterServerStopListening() async throws {

--- a/Tests/GRPCCoreTests/Test Utilities/AtomicCounter.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/AtomicCounter.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-private import Synchronization
+import Synchronization
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class AtomicCounter: Sendable {

--- a/Tests/GRPCCoreTests/Test Utilities/Call/Client/ClientInterceptors.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/Call/Client/ClientInterceptors.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Atomics
+
 import GRPCCore
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
@@ -30,7 +30,7 @@ extension ClientInterceptor where Self == RejectAllClientInterceptor {
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension ClientInterceptor where Self == RequestCountingClientInterceptor {
-  static func requestCounter(_ counter: ManagedAtomic<Int>) -> Self {
+  static func requestCounter(_ counter: AtomicCounter) -> Self {
     return RequestCountingClientInterceptor(counter: counter)
   }
 }
@@ -68,9 +68,9 @@ struct RejectAllClientInterceptor: ClientInterceptor {
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct RequestCountingClientInterceptor: ClientInterceptor {
   /// The number of requests made.
-  let counter: ManagedAtomic<Int>
+  let counter: AtomicCounter
 
-  init(counter: ManagedAtomic<Int>) {
+  init(counter: AtomicCounter) {
     self.counter = counter
   }
 
@@ -82,7 +82,7 @@ struct RequestCountingClientInterceptor: ClientInterceptor {
       ClientInterceptorContext
     ) async throws -> ClientResponse.Stream<Output>
   ) async throws -> ClientResponse.Stream<Output> {
-    self.counter.wrappingIncrement(ordering: .sequentiallyConsistent)
+    self.counter.increment()
     return try await next(request, context)
   }
 }

--- a/Tests/GRPCCoreTests/Test Utilities/Call/Server/ServerInterceptors.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/Call/Server/ServerInterceptors.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Atomics
+
 import GRPCCore
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
@@ -29,7 +29,7 @@ extension ServerInterceptor where Self == RejectAllServerInterceptor {
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension ServerInterceptor where Self == RequestCountingServerInterceptor {
-  static func requestCounter(_ counter: ManagedAtomic<Int>) -> Self {
+  static func requestCounter(_ counter: AtomicCounter) -> Self {
     return RequestCountingServerInterceptor(counter: counter)
   }
 }
@@ -67,9 +67,9 @@ struct RejectAllServerInterceptor: ServerInterceptor {
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct RequestCountingServerInterceptor: ServerInterceptor {
   /// The number of requests made.
-  let counter: ManagedAtomic<Int>
+  let counter: AtomicCounter
 
-  init(counter: ManagedAtomic<Int>) {
+  init(counter: AtomicCounter) {
     self.counter = counter
   }
 
@@ -81,7 +81,7 @@ struct RequestCountingServerInterceptor: ServerInterceptor {
       ServerInterceptorContext
     ) async throws -> ServerResponse.Stream<Output>
   ) async throws -> ServerResponse.Stream<Output> {
-    self.counter.wrappingIncrement(ordering: .sequentiallyConsistent)
+    self.counter.increment()
     return try await next(request, context)
   }
 }

--- a/Tests/GRPCHTTP2CoreTests/Client/Connection/RequestQueueTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Client/Connection/RequestQueueTests.swift
@@ -15,7 +15,7 @@
  */
 
 import GRPCCore
-private import Synchronization
+import Synchronization
 import XCTest
 
 @testable import GRPCHTTP2Core

--- a/Tests/GRPCHTTP2CoreTests/Client/Connection/RequestQueueTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Client/Connection/RequestQueueTests.swift
@@ -15,7 +15,7 @@
  */
 
 import GRPCCore
-import Synchronization
+private import Synchronization
 import XCTest
 
 @testable import GRPCHTTP2Core

--- a/Tests/GRPCHTTP2CoreTests/Client/Connection/Utilities/TestServer.swift
+++ b/Tests/GRPCHTTP2CoreTests/Client/Connection/Utilities/TestServer.swift
@@ -18,7 +18,7 @@ import GRPCCore
 import NIOCore
 import NIOHTTP2
 import NIOPosix
-import Synchronization
+private import Synchronization
 import XCTest
 
 @testable import GRPCHTTP2Core

--- a/Tests/GRPCHTTP2CoreTests/Client/Connection/Utilities/TestServer.swift
+++ b/Tests/GRPCHTTP2CoreTests/Client/Connection/Utilities/TestServer.swift
@@ -18,7 +18,7 @@ import GRPCCore
 import NIOCore
 import NIOHTTP2
 import NIOPosix
-private import Synchronization
+import Synchronization
 import XCTest
 
 @testable import GRPCHTTP2Core

--- a/Tests/GRPCHTTP2CoreTests/Internal/ProcessUniqueIDTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Internal/ProcessUniqueIDTests.swift
@@ -18,6 +18,7 @@ import XCTest
 
 @testable import GRPCHTTP2Core
 
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class ProcessUniqueIDTests: XCTestCase {
   func testProcessUniqueIDIsUnique() {
     var ids: Set<ProcessUniqueID> = []

--- a/Tests/GRPCHTTP2CoreTests/Internal/TimerTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Internal/TimerTests.swift
@@ -17,7 +17,7 @@
 import GRPCCore
 import GRPCHTTP2Core
 import NIOEmbedded
-private import Synchronization
+import Synchronization
 import XCTest
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)

--- a/Tests/GRPCHTTP2CoreTests/Internal/TimerTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Internal/TimerTests.swift
@@ -61,7 +61,7 @@ internal final class TimerTests: XCTestCase {
     let loop = EmbeddedEventLoop()
     defer { try! loop.close() }
 
-    let counter = AtomicCounter(0)
+    let counter = AtomicCounter()
     var timer = Timer(delay: .seconds(1), repeat: true)
     timer.schedule(on: loop) {
       counter.increment()

--- a/Tests/GRPCHTTP2CoreTests/Internal/TimerTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Internal/TimerTests.swift
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-import Atomics
 import GRPCCore
 import GRPCHTTP2Core
 import NIOEmbedded
-import Synchronization
+private import Synchronization
 import XCTest
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
@@ -62,25 +61,25 @@ internal final class TimerTests: XCTestCase {
     let loop = EmbeddedEventLoop()
     defer { try! loop.close() }
 
-    let value = Atomic(0)
+    let counter = AtomicCounter(0)
     var timer = Timer(delay: .seconds(1), repeat: true)
     timer.schedule(on: loop) {
-      value.add(1, ordering: .releasing)
+      counter.increment()
     }
 
     loop.advanceTime(by: .milliseconds(999))
-    XCTAssertEqual(value.load(ordering: .acquiring), 0)
+    XCTAssertEqual(counter.value, 0)
     loop.advanceTime(by: .milliseconds(1))
-    XCTAssertEqual(value.load(ordering: .acquiring), 1)
+    XCTAssertEqual(counter.value, 1)
 
     loop.advanceTime(by: .seconds(1))
-    XCTAssertEqual(value.load(ordering: .acquiring), 2)
+    XCTAssertEqual(counter.value, 2)
     loop.advanceTime(by: .seconds(1))
-    XCTAssertEqual(value.load(ordering: .acquiring), 3)
+    XCTAssertEqual(counter.value, 3)
 
     timer.cancel()
     loop.advanceTime(by: .seconds(1))
-    XCTAssertEqual(value.load(ordering: .acquiring), 3)
+    XCTAssertEqual(counter.value, 3)
   }
 
   func testCancelRepeatedTimer() {

--- a/Tests/GRPCHTTP2CoreTests/Test Utilities/AtomicCounter.swift
+++ b/Tests/GRPCHTTP2CoreTests/Test Utilities/AtomicCounter.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-private import Synchronization
+import Synchronization
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class AtomicCounter: Sendable {


### PR DESCRIPTION
Motivation:

Swift 6 includes built-in support for atomics in the Synchronization module. Currently we depend on the swift-atomics package which is no longer necessary.

Modifications:

Remove usages of swift-atomics from v2

Result:

Fewer dependencies