### PR TITLE
Stop using deprecated protobuf API

### DIFF
--- a/Sources/GRPC/Serialization.swift
+++ b/Sources/GRPC/Serialization.swift
@@ -76,7 +76,7 @@ public struct ProtobufDeserializer<Message: SwiftProtobuf.Message>: MessageDeser
     var buffer = byteBuffer
     // '!' is okay; we can always read 'readableBytes'.
     let data = buffer.readData(length: buffer.readableBytes)!
-    return try Message(serializedData: data)
+    return try Message(serializedBytes: data)
   }
 }
 

--- a/Sources/GRPCReflectionService/Server/ReflectionService.swift
+++ b/Sources/GRPCReflectionService/Server/ReflectionService.swift
@@ -366,7 +366,7 @@ extension ReflectionService {
           """
       )
     }
-    return try Google_Protobuf_FileDescriptorProto(serializedData: serializedData)
+    return try Google_Protobuf_FileDescriptorProto(serializedBytes: serializedData)
   }
 
   static func readSerializedFileDescriptorProtos(

--- a/Tests/GRPCTests/Codegen/Serialization/SerializationTests.swift
+++ b/Tests/GRPCTests/Codegen/Serialization/SerializationTests.swift
@@ -28,9 +28,7 @@ final class SerializationTests: GRPCTestCase {
       .deletingLastPathComponent().appendingPathComponent("echo.grpc.reflection")
     let base64EncodedData = try! Data(contentsOf: binaryFileURL)
     let binaryData = Data(base64Encoded: base64EncodedData)!
-    self
-      .fileDescriptorProto =
-      try! Google_Protobuf_FileDescriptorProto(serializedData: binaryData)
+    self.fileDescriptorProto = try! Google_Protobuf_FileDescriptorProto(serializedBytes: binaryData)
   }
 
   func testFileDescriptorMetadata() throws {

--- a/Tests/GRPCTests/GRPCReflectionServiceTests/ReflectionServiceIntegrationTests.swift
+++ b/Tests/GRPCTests/GRPCReflectionServiceTests/ReflectionServiceIntegrationTests.swift
@@ -128,8 +128,7 @@ final class ReflectionServiceIntegrationTests: GRPCTestCase {
       // response can't be nil as we just checked it.
       let receivedFileDescriptorProto =
         try Google_Protobuf_FileDescriptorProto(
-          serializedData: (message.fileDescriptorResponse
-            .fileDescriptorProto[0])
+          serializedBytes: message.fileDescriptorResponse.fileDescriptorProto[0]
         )
 
       XCTAssertEqual(receivedFileDescriptorProto.name, "bar1.proto")
@@ -177,7 +176,7 @@ final class ReflectionServiceIntegrationTests: GRPCTestCase {
       let receivedData: [Google_Protobuf_FileDescriptorProto]
       do {
         receivedData = try message.fileDescriptorResponse.fileDescriptorProto.map {
-          try Google_Protobuf_FileDescriptorProto(serializedData: $0)
+          try Google_Protobuf_FileDescriptorProto(serializedBytes: $0)
         }
       } catch {
         return XCTFail("Could not serialize data received as a message.")
@@ -221,7 +220,7 @@ final class ReflectionServiceIntegrationTests: GRPCTestCase {
       let receivedData: [Google_Protobuf_FileDescriptorProto]
       do {
         receivedData = try message.fileDescriptorResponse.fileDescriptorProto.map {
-          try Google_Protobuf_FileDescriptorProto(serializedData: $0)
+          try Google_Protobuf_FileDescriptorProto(serializedBytes: $0)
         }
       } catch {
         return XCTFail("Could not serialize data received as a message.")

--- a/Tests/GRPCTests/GRPCReflectionServiceTests/ReflectionServiceUnitTests.swift
+++ b/Tests/GRPCTests/GRPCReflectionServiceTests/ReflectionServiceUnitTests.swift
@@ -178,7 +178,7 @@ final class ReflectionServiceUnitTests: GRPCTestCase {
     switch serializedFileDescriptorProtosResult {
     case .success(let serializedFileDescriptorProtos):
       let fileDescriptorProtos = try serializedFileDescriptorProtos.map {
-        try Google_Protobuf_FileDescriptorProto(serializedData: $0)
+        try Google_Protobuf_FileDescriptorProto(serializedBytes: $0)
       }
       // Tests that the functions returns all the transitive dependencies, with their services and
       // methods, together with the initial proto, as serialized data.
@@ -233,7 +233,7 @@ final class ReflectionServiceUnitTests: GRPCTestCase {
     switch serializedFileDescriptorProtosResult {
     case .success(let serializedFileDescriptorProtos):
       let fileDescriptorProtos = try serializedFileDescriptorProtos.map {
-        try Google_Protobuf_FileDescriptorProto(serializedData: $0)
+        try Google_Protobuf_FileDescriptorProto(serializedBytes: $0)
       }
       // Tests that the functions returns all the tranzitive dependencies, with their services and
       // methods, together with the initial proto, as serialized data.
@@ -292,7 +292,7 @@ final class ReflectionServiceUnitTests: GRPCTestCase {
     switch serializedFileDescriptorProtosResult {
     case .success(let serializedFileDescriptorProtos):
       let fileDescriptorProtos = try serializedFileDescriptorProtos.map {
-        try Google_Protobuf_FileDescriptorProto(serializedData: $0)
+        try Google_Protobuf_FileDescriptorProto(serializedBytes: $0)
       }
       // Test that we get only 4 serialized File Descriptor Protos as response.
       XCTAssertEqual(fileDescriptorProtos.count, 4)


### PR DESCRIPTION
Motivation:

swift-protobuf 1.27.0 deprecated the `init` from `serializedData` in favor of the `serializedBytes` variant.

Modifications:

- Stop using `serializedData`

Result:

Fewer warnings