### PR TITLE
Adopt swift-testing for status tests

### DIFF
--- a/Package@swift-6.swift
+++ b/Package@swift-6.swift
@@ -72,6 +72,10 @@ let packageDependencies: [Package.Dependency] = [
     url: "https://github.com/apple/swift-distributed-tracing.git",
     from: "1.0.0"
   ),
+  .package(
+    url: "https://github.com/swiftlang/swift-testing.git",
+    branch: "release/6.0"
+  ),
 ].appending(
   .package(
     url: "https://github.com/apple/swift-nio-ssl.git",
@@ -147,6 +151,13 @@ extension Target.Dependency {
   static var dequeModule: Self { .product(name: "DequeModule", package: "swift-collections") }
   static var atomics: Self { .product(name: "Atomics", package: "swift-atomics") }
   static var tracing: Self { .product(name: "Tracing", package: "swift-distributed-tracing") }
+  static var testing: Self {
+    .product(
+      name: "Testing",
+      package: "swift-testing",
+      condition: .when(platforms: [.linux]) // Already included in the toolchain on Darwin
+    )
+  }
 
   static var grpcCore: Self { .target(name: "GRPCCore") }
   static var grpcInProcessTransport: Self { .target(name: "GRPCInProcessTransport") }
@@ -402,6 +413,7 @@ extension Target {
         .grpcInProcessTransport,
         .dequeModule,
         .protobuf,
+        .testing,
       ],
       swiftSettings: [.swiftLanguageMode(.v6), .enableUpcomingFeature("ExistentialAny")]
     )

--- a/Sources/GRPCCore/RPCError.swift
+++ b/Sources/GRPCCore/RPCError.swift
@@ -107,6 +107,25 @@ extension RPCError {
     public var description: String {
       String(describing: self.wrapped)
     }
+
+    package static let all: [Self] = [
+      .cancelled,
+      .unknown,
+      .invalidArgument,
+      .deadlineExceeded,
+      .notFound,
+      .alreadyExists,
+      .permissionDenied,
+      .resourceExhausted,
+      .failedPrecondition,
+      .aborted,
+      .outOfRange,
+      .unimplemented,
+      .internalError,
+      .unavailable,
+      .dataLoss,
+      .unauthenticated,
+    ]
   }
 }
 

--- a/Sources/GRPCCore/Status.swift
+++ b/Sources/GRPCCore/Status.swift
@@ -166,6 +166,26 @@ extension Status {
     public var description: String {
       String(describing: self.wrapped)
     }
+
+    package static let all: [Self] = [
+      .ok,
+      .cancelled,
+      .unknown,
+      .invalidArgument,
+      .deadlineExceeded,
+      .notFound,
+      .alreadyExists,
+      .permissionDenied,
+      .resourceExhausted,
+      .failedPrecondition,
+      .aborted,
+      .outOfRange,
+      .unimplemented,
+      .internalError,
+      .unavailable,
+      .dataLoss,
+      .unauthenticated,
+    ]
   }
 }
 


### PR DESCRIPTION
Motivation:

swift-testing has a number of advantages over XCTest (parameterisation, organisation, failure messages etc.), we should start using it instead of XCTest.

Modifications:

- Convert the Status tests
- Add a dependency on swift-testing on Linux (this can be removed when it's included as part of the toolchain)
- Fixed a couple of bugs found by additional testing

Results:

Better tests