### PR TITLE
Update plugin bundling script

### DIFF
--- a/scripts/bundle-plugins-for-release.sh
+++ b/scripts/bundle-plugins-for-release.sh
@@ -44,6 +44,8 @@ stage=$(mktemp -d)
 stage_bin="${stage}/bin"
 mkdir -p "${stage_bin}"
 
+# Make sure dependencies are up-to-date
+swift package update
 # Make the plugins.
 swift build -c release --arch arm64 --arch x86_64 --product protoc-gen-grpc-swift
 swift build -c release --arch arm64 --arch x86_64 --product protoc-gen-swift


### PR DESCRIPTION
Motivation:

The plugin bundling script which is used when we do a release doesn't update the dependencies so will just use whatever version is currently resolved. This means protobuf might not be up-to-date and an older version of `protoc-gen-swift` might get build.

Modifications:

- Run package update before building

Result:

The bundled `protoc-gen-swift` should be up-to-date