### PR TITLE
Rename client interceptor context

### DIFF
--- a/Sources/GRPCCore/Call/Client/ClientContext.swift
+++ b/Sources/GRPCCore/Call/Client/ClientContext.swift
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// A context passed to the client containing additional information about the RPC.
+public struct ClientContext: Sendable {
+  /// A description of the method being called.
+  public var descriptor: MethodDescriptor
+
+  /// Create a new client interceptor context.
+  public init(descriptor: MethodDescriptor) {
+    self.descriptor = descriptor
+  }
+}

--- a/Sources/GRPCCore/Call/Client/ClientInterceptor.swift
+++ b/Sources/GRPCCore/Call/Client/ClientInterceptor.swift
@@ -23,7 +23,7 @@
 ///
 /// Interceptors are registered with a client and apply to all RPCs. If you need to modify the
 /// behavior of an interceptor on a per-RPC basis then you can use the
-/// ``ClientInterceptorContext/descriptor`` to determine which RPC is being called and
+/// ``ClientContext/descriptor`` to determine which RPC is being called and
 /// conditionalise behavior accordingly.
 ///
 /// - TODO: Update example and documentation to show how to register an interceptor.
@@ -41,10 +41,10 @@
 ///
 ///   func intercept<Input: Sendable, Output: Sendable>(
 ///     request: ClientRequest.Stream<Input>,
-///     context: ClientInterceptorContext,
+///     context: ClientContext,
 ///     next: @Sendable (
 ///       _ request: ClientRequest.Stream<Input>,
-///       _ context: ClientInterceptorContext
+///       _ context: ClientContext
 ///     ) async throws -> ClientResponse.Stream<Output>
 ///   ) async throws -> ClientResponse.Stream<Output> {
 ///     // Fetch the metadata value and attach it.
@@ -66,10 +66,10 @@
 /// struct LoggingClientInterceptor: ClientInterceptor {
 ///   func intercept<Input: Sendable, Output: Sendable>(
 ///     request: ClientRequest.Stream<Input>,
-///     context: ClientInterceptorContext,
+///     context: ClientContext,
 ///     next: @Sendable (
 ///       _ request: ClientRequest.Stream<Input>,
-///       _ context: ClientInterceptorContext
+///       _ context: ClientContext
 ///     ) async throws -> ClientResponse.Stream<Output>
 ///   ) async throws -> ClientResponse.Stream<Output> {
 ///     print("Invoking method '\(context.descriptor)'")
@@ -101,21 +101,10 @@ public protocol ClientInterceptor: Sendable {
   /// - Returns: A response object.
   func intercept<Input: Sendable, Output: Sendable>(
     request: ClientRequest.Stream<Input>,
-    context: ClientInterceptorContext,
+    context: ClientContext,
     next: (
       _ request: ClientRequest.Stream<Input>,
-      _ context: ClientInterceptorContext
+      _ context: ClientContext
     ) async throws -> ClientResponse.Stream<Output>
   ) async throws -> ClientResponse.Stream<Output>
-}
-
-/// A context passed to client interceptors containing additional information about the RPC.
-public struct ClientInterceptorContext: Sendable {
-  /// A description of the method being called.
-  public var descriptor: MethodDescriptor
-
-  /// Create a new client interceptor context.
-  public init(descriptor: MethodDescriptor) {
-    self.descriptor = descriptor
-  }
 }

--- a/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor.swift
@@ -124,7 +124,7 @@ extension ClientRPCExecutor {
     interceptors: [any ClientInterceptor],
     stream: RPCStream<ClientTransport.Inbound, ClientTransport.Outbound>
   ) async -> ClientResponse.Stream<Output> {
-    let context = ClientInterceptorContext(descriptor: method)
+    let context = ClientContext(descriptor: method)
 
     if interceptors.isEmpty {
       return await ClientStreamExecutor.execute(
@@ -160,12 +160,12 @@ extension ClientRPCExecutor {
   static func _intercept<Input, Output>(
     in group: inout TaskGroup<Void>,
     request: ClientRequest.Stream<Input>,
-    context: ClientInterceptorContext,
+    context: ClientContext,
     iterator: Array<any ClientInterceptor>.Iterator,
     finally: (
       _ group: inout TaskGroup<Void>,
       _ request: ClientRequest.Stream<Input>,
-      _ context: ClientInterceptorContext
+      _ context: ClientContext
     ) async -> ClientResponse.Stream<Output>
   ) async -> ClientResponse.Stream<Output> {
     var iterator = iterator

--- a/Sources/GRPCCore/Call/Client/Internal/ClientStreamExecutor.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientStreamExecutor.swift
@@ -29,7 +29,7 @@ internal enum ClientStreamExecutor {
   static func execute<Input: Sendable, Output: Sendable>(
     in group: inout TaskGroup<Void>,
     request: ClientRequest.Stream<Input>,
-    context: ClientInterceptorContext,
+    context: ClientContext,
     attempt: Int,
     serializer: some MessageSerializer<Input>,
     deserializer: some MessageDeserializer<Output>,

--- a/Sources/GRPCInterceptors/ClientTracingInterceptor.swift
+++ b/Sources/GRPCInterceptors/ClientTracingInterceptor.swift
@@ -45,10 +45,10 @@ public struct ClientTracingInterceptor: ClientInterceptor {
   /// that has been configured when bootstrapping `swift-distributed-tracing` in your application.
   public func intercept<Input, Output>(
     request: ClientRequest.Stream<Input>,
-    context: ClientInterceptorContext,
+    context: ClientContext,
     next: (
       ClientRequest.Stream<Input>,
-      ClientInterceptorContext
+      ClientContext
     ) async throws -> ClientResponse.Stream<Output>
   ) async throws -> ClientResponse.Stream<Output> where Input: Sendable, Output: Sendable {
     var request = request

--- a/Tests/GRPCCoreTests/Test Utilities/Call/Client/ClientInterceptors.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/Call/Client/ClientInterceptors.swift
@@ -51,10 +51,10 @@ struct RejectAllClientInterceptor: ClientInterceptor {
 
   func intercept<Input: Sendable, Output: Sendable>(
     request: ClientRequest.Stream<Input>,
-    context: ClientInterceptorContext,
+    context: ClientContext,
     next: (
       ClientRequest.Stream<Input>,
-      ClientInterceptorContext
+      ClientContext
     ) async throws -> ClientResponse.Stream<Output>
   ) async throws -> ClientResponse.Stream<Output> {
     if self.throw {
@@ -76,10 +76,10 @@ struct RequestCountingClientInterceptor: ClientInterceptor {
 
   func intercept<Input: Sendable, Output: Sendable>(
     request: ClientRequest.Stream<Input>,
-    context: ClientInterceptorContext,
+    context: ClientContext,
     next: (
       ClientRequest.Stream<Input>,
-      ClientInterceptorContext
+      ClientContext
     ) async throws -> ClientResponse.Stream<Output>
   ) async throws -> ClientResponse.Stream<Output> {
     self.counter.increment()


### PR DESCRIPTION
Motivation:

The `ServerInterceptorContext` was renamed to `ServerContext`. The same should be done for the client.

Modifications:

- Rename `ClientInterceptorContext` to `ClientContext`

Result:

More consistent naming