### PR TITLE
Standardise some naming

### DIFF
--- a/Sources/GRPCCodeGen/CodeGenerationRequest.swift
+++ b/Sources/GRPCCodeGen/CodeGenerationRequest.swift
@@ -87,7 +87,7 @@ public struct CodeGenerationRequest {
     public var item: Item?
 
     /// The access level to be included in imports of this dependency.
-    public var accessLevel: SourceGenerator.Configuration.AccessLevel
+    public var accessLevel: SourceGenerator.Config.AccessLevel
 
     /// The name of the imported module or of the module an item is imported from.
     public var module: String
@@ -106,7 +106,7 @@ public struct CodeGenerationRequest {
       module: String,
       spi: String? = nil,
       preconcurrency: PreconcurrencyRequirement = .notRequired,
-      accessLevel: SourceGenerator.Configuration.AccessLevel
+      accessLevel: SourceGenerator.Config.AccessLevel
     ) {
       self.item = item
       self.module = module

--- a/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
@@ -76,9 +76,9 @@
 /// }
 ///```
 struct ClientCodeTranslator: SpecializedTranslator {
-  var accessLevel: SourceGenerator.Configuration.AccessLevel
+  var accessLevel: SourceGenerator.Config.AccessLevel
 
-  init(accessLevel: SourceGenerator.Configuration.AccessLevel) {
+  init(accessLevel: SourceGenerator.Config.AccessLevel) {
     self.accessLevel = accessLevel
   }
 

--- a/Sources/GRPCCodeGen/Internal/Translator/IDLToStructuredSwiftTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/IDLToStructuredSwiftTranslator.swift
@@ -20,7 +20,7 @@
 struct IDLToStructuredSwiftTranslator: Translator {
   func translate(
     codeGenerationRequest: CodeGenerationRequest,
-    accessLevel: SourceGenerator.Configuration.AccessLevel,
+    accessLevel: SourceGenerator.Config.AccessLevel,
     accessLevelOnImports: Bool,
     client: Bool,
     server: Bool
@@ -81,7 +81,7 @@ struct IDLToStructuredSwiftTranslator: Translator {
 }
 
 extension AccessModifier {
-  fileprivate init(_ accessLevel: SourceGenerator.Configuration.AccessLevel) {
+  fileprivate init(_ accessLevel: SourceGenerator.Config.AccessLevel) {
     switch accessLevel.level {
     case .internal: self = .internal
     case .package: self = .package

--- a/Sources/GRPCCodeGen/Internal/Translator/IDLToStructuredSwiftTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/IDLToStructuredSwiftTranslator.swift
@@ -63,7 +63,7 @@ struct IDLToStructuredSwiftTranslator: Translator {
 
   private func makeImports(
     dependencies: [CodeGenerationRequest.Dependency],
-    accessLevel: SourceGenerator.Configuration.AccessLevel,
+    accessLevel: SourceGenerator.Config.AccessLevel,
     accessLevelOnImports: Bool
   ) throws -> [ImportDescription] {
     var imports: [ImportDescription] = []

--- a/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
@@ -58,9 +58,9 @@
 /// }
 ///```
 struct ServerCodeTranslator: SpecializedTranslator {
-  var accessLevel: SourceGenerator.Configuration.AccessLevel
+  var accessLevel: SourceGenerator.Config.AccessLevel
 
-  init(accessLevel: SourceGenerator.Configuration.AccessLevel) {
+  init(accessLevel: SourceGenerator.Config.AccessLevel) {
     self.accessLevel = accessLevel
   }
 

--- a/Sources/GRPCCodeGen/Internal/Translator/SpecializedTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/SpecializedTranslator.swift
@@ -19,7 +19,7 @@
 protocol SpecializedTranslator {
 
   /// The ``SourceGenerator.Configuration.AccessLevel`` object used to represent the visibility level used in the generated code.
-  var accessLevel: SourceGenerator.Configuration.AccessLevel { get }
+  var accessLevel: SourceGenerator.Config.AccessLevel { get }
 
   /// Generates an array of ``CodeBlock`` elements that will be part of the ``StructuredSwiftRepresentation`` object
   /// created by the ``Translator``.

--- a/Sources/GRPCCodeGen/Internal/Translator/SpecializedTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/SpecializedTranslator.swift
@@ -18,7 +18,7 @@
 /// the server code translation or the client code translation.
 protocol SpecializedTranslator {
 
-  /// The ``SourceGenerator.Configuration.AccessLevel`` object used to represent the visibility level used in the generated code.
+  /// The ``SourceGenerator.Config.AccessLevel`` object used to represent the visibility level used in the generated code.
   var accessLevel: SourceGenerator.Config.AccessLevel { get }
 
   /// Generates an array of ``CodeBlock`` elements that will be part of the ``StructuredSwiftRepresentation`` object

--- a/Sources/GRPCCodeGen/Internal/Translator/Translator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/Translator.swift
@@ -29,7 +29,7 @@ protocol Translator {
   /// - Throws: An error if there are issues translating the codeGenerationRequest.
   func translate(
     codeGenerationRequest: CodeGenerationRequest,
-    accessLevel: SourceGenerator.Configuration.AccessLevel,
+    accessLevel: SourceGenerator.Config.AccessLevel,
     accessLevelOnImports: Bool,
     client: Bool,
     server: Bool

--- a/Sources/GRPCCodeGen/Internal/Translator/TypealiasTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/TypealiasTranslator.swift
@@ -71,9 +71,9 @@
 struct TypealiasTranslator: SpecializedTranslator {
   let client: Bool
   let server: Bool
-  let accessLevel: SourceGenerator.Configuration.AccessLevel
+  let accessLevel: SourceGenerator.Config.AccessLevel
 
-  init(client: Bool, server: Bool, accessLevel: SourceGenerator.Configuration.AccessLevel) {
+  init(client: Bool, server: Bool, accessLevel: SourceGenerator.Config.AccessLevel) {
     self.client = client
     self.server = server
     self.accessLevel = accessLevel

--- a/Sources/GRPCCodeGen/SourceGenerator.swift
+++ b/Sources/GRPCCodeGen/SourceGenerator.swift
@@ -18,14 +18,14 @@
 public struct SourceGenerator: Sendable {
   /// The options regarding the access level, indentation for the generated code
   /// and whether to generate server and client code.
-  public var configuration: Configuration
+  public var config: Config
 
-  public init(configuration: Configuration) {
-    self.configuration = configuration
+  public init(config: Config) {
+    self.config = config
   }
 
   /// User options for the CodeGeneration.
-  public struct Configuration: Sendable {
+  public struct Config: Sendable {
     /// The access level the generated code will have.
     public var accessLevel: AccessLevel
     /// Whether imports have explicit access levels.
@@ -85,14 +85,14 @@ public struct SourceGenerator: Sendable {
     _ request: CodeGenerationRequest
   ) throws -> SourceFile {
     let translator = IDLToStructuredSwiftTranslator()
-    let textRenderer = TextBasedRenderer(indentation: self.configuration.indentation)
+    let textRenderer = TextBasedRenderer(indentation: self.config.indentation)
 
     let structuredSwiftRepresentation = try translator.translate(
       codeGenerationRequest: request,
-      accessLevel: self.configuration.accessLevel,
-      accessLevelOnImports: self.configuration.accessLevelOnImports,
-      client: self.configuration.client,
-      server: self.configuration.server
+      accessLevel: self.config.accessLevel,
+      accessLevelOnImports: self.config.accessLevelOnImports,
+      client: self.config.client,
+      server: self.config.server
     )
     let sourceFile = try textRenderer.render(structured: structuredSwiftRepresentation)
 

--- a/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor+HedgingExecutor.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor+HedgingExecutor.swift
@@ -448,7 +448,7 @@ extension ClientRPCExecutor.HedgingExecutor {
   @usableFromInline
   struct State: Sendable {
     @usableFromInline
-    let _maximumAttempts: Int
+    let _maxAttempts: Int
     @usableFromInline
     private(set) var attempt: Int
     @usableFromInline
@@ -456,7 +456,7 @@ extension ClientRPCExecutor.HedgingExecutor {
 
     @inlinable
     init(policy: HedgingPolicy) {
-      self._maximumAttempts = policy.maximumAttempts
+      self._maxAttempts = policy.maxAttempts
       self.attempt = 1
       self.hasUsableResponse = false
     }
@@ -487,14 +487,14 @@ extension ClientRPCExecutor.HedgingExecutor {
 
     @inlinable
     mutating func nextAttemptNumber() -> NextAttemptResult? {
-      if self.hasUsableResponse || self.attempt > self._maximumAttempts {
+      if self.hasUsableResponse || self.attempt > self._maxAttempts {
         return nil
       } else {
         let attempt = self.attempt
         self.attempt += 1
         return NextAttemptResult(
           nextAttempt: attempt,
-          scheduleNext: self.attempt <= self._maximumAttempts
+          scheduleNext: self.attempt <= self._maxAttempts
         )
       }
     }

--- a/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor+RetryExecutor.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor+RetryExecutor.swift
@@ -115,7 +115,7 @@ extension ClientRPCExecutor.RetryExecutor {
       let delaySequence = RetryDelaySequence(policy: self.policy)
       var delayIterator = delaySequence.makeIterator()
 
-      for attempt in 1 ... self.policy.maximumAttempts {
+      for attempt in 1 ... self.policy.maxAttempts {
         do {
           let attemptResult = try await self.transport.withStream(
             descriptor: method,
@@ -253,7 +253,7 @@ extension ClientRPCExecutor.RetryExecutor {
           switch error.metadata.retryPushback {
           case .retryAfter(let delay):
             // Pushback: only retry if our config permits it.
-            shouldRetry = (attempt < self.policy.maximumAttempts) && !throttled
+            shouldRetry = (attempt < self.policy.maxAttempts) && !throttled
             retryDelayOverride = delay
           case .stopRetrying:
             // Server told us to stop trying.
@@ -261,7 +261,7 @@ extension ClientRPCExecutor.RetryExecutor {
             retryDelayOverride = nil
           case .none:
             // No pushback: only retry if our config permits it.
-            shouldRetry = (attempt < self.policy.maximumAttempts) && !throttled
+            shouldRetry = (attempt < self.policy.maxAttempts) && !throttled
             retryDelayOverride = nil
             break
           }

--- a/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor.swift
@@ -22,7 +22,7 @@ enum ClientRPCExecutor {
   /// - Parameters:
   ///   - request: The request to execute.
   ///   - method: A description of the method to execute the request against.
-  ///   - configuration: The execution configuration.
+  ///   - options: RPC options.
   ///   - serializer: A serializer to convert input messages to bytes.
   ///   - deserializer: A deserializer to convert bytes to output messages.
   ///   - transport: The transport to execute the request on.

--- a/Sources/GRPCCore/Call/Client/Internal/ClientStreamExecutor.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientStreamExecutor.swift
@@ -19,11 +19,14 @@
 internal enum ClientStreamExecutor {
   /// Execute a request on the stream executor.
   ///
-  /// The ``run()`` method must be running at the same time as this method.
-  ///
   /// - Parameters:
   ///   - request: A streaming request.
   ///   - method: A description of the method to call.
+  ///   - context: The client context.
+  ///   - attempt: The attempt number for the RPC that will be executed.
+  ///   - serializer: A request serializer.
+  ///   - deserializer: A response deserializer.
+  ///   - stream: The stream to excecute the RPC on.
   /// - Returns: A streamed response.
   @inlinable
   static func execute<Input: Sendable, Output: Sendable>(

--- a/Sources/GRPCCore/Call/Client/Internal/RetryDelaySequence.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/RetryDelaySequence.swift
@@ -56,8 +56,8 @@ struct RetryDelaySequence: Sequence {
     }
 
     @inlinable
-    var _maximumBackoffSeconds: Double {
-      Self._durationToTimeInterval(self.policy.maximumBackoff)
+    var _maxBackoffSeconds: Double {
+      Self._durationToTimeInterval(self.policy.maxBackoff)
     }
 
     @inlinable
@@ -65,10 +65,10 @@ struct RetryDelaySequence: Sequence {
       defer { self.n += 1 }
 
       /// The nth retry will happen after a randomly chosen delay between zero and
-      /// `min(initialBackoff * backoffMultiplier^(n-1), maximumBackoff)`.
+      /// `min(initialBackoff * backoffMultiplier^(n-1), maxBackoff)`.
       let factor = pow(self.policy.backoffMultiplier, Double(self.n - 1))
       let computedBackoff = self._initialBackoffSeconds * factor
-      let clampedBackoff = Swift.min(computedBackoff, self._maximumBackoffSeconds)
+      let clampedBackoff = Swift.min(computedBackoff, self._maxBackoffSeconds)
       let randomisedBackoff = Double.random(in: 0.0 ... clampedBackoff)
 
       return Self._timeIntervalToDuration(randomisedBackoff)

--- a/Sources/GRPCCore/Configuration/MethodConfig.swift
+++ b/Sources/GRPCCore/Configuration/MethodConfig.swift
@@ -259,7 +259,7 @@ public struct RetryPolicy: Hashable, Sendable {
   ///   - maxAttempts: The maximum number of attempts allowed for the RPC.
   ///   - initialBackoff: The initial backoff period for the first retry attempt. Must be
   ///       greater than zero.
-  ///   - maximumBackoff: The maximum period of time to wait between attempts. Must be greater than
+  ///   - maxBackoff: The maximum period of time to wait between attempts. Must be greater than
   ///       zero.
   ///   - backoffMultiplier: The exponential backoff multiplier. Must be greater than zero.
   ///   - retryableStatusCodes: The set of status codes which may be retried. Must not be empty.

--- a/Sources/GRPCCore/Configuration/MethodConfig.swift
+++ b/Sources/GRPCCore/Configuration/MethodConfig.swift
@@ -204,13 +204,13 @@ public struct RPCExecutionPolicy: Hashable, Sendable {
 /// first responds with metadata and later responds with a retryable status code then the RPC
 /// won't be retried.
 ///
-/// Execution attempts are limited by ``maximumAttempts`` which includes the original attempt. The
+/// Execution attempts are limited by ``maxAttempts`` which includes the original attempt. The
 /// maximum number of attempts is limited to five.
 ///
 /// Subsequent attempts are executed after some delay. The first _retry_, or second attempt, will
 /// be started after a randomly chosen delay between zero and ``initialBackoff``. More generally,
 /// the nth retry will happen after a randomly chosen delay between zero
-/// and `min(initialBackoff * backoffMultiplier^(n-1), maximumBackoff)`.
+/// and `min(initialBackoff * backoffMultiplier^(n-1), maxBackoff)`.
 ///
 /// For more information see [gRFC A6 Client
 /// Retries](https://github.com/grpc/proposal/blob/master/A6-client-retries.md).
@@ -219,8 +219,8 @@ public struct RetryPolicy: Hashable, Sendable {
   /// The maximum number of RPC attempts, including the original attempt.
   ///
   /// Must be greater than one, values greater than five are treated as five.
-  public var maximumAttempts: Int {
-    didSet { self.maximumAttempts = try! validateMaxAttempts(self.maximumAttempts) }
+  public var maxAttempts: Int {
+    didSet { self.maxAttempts = try! validateMaxAttempts(self.maxAttempts) }
   }
 
   /// The initial backoff duration.
@@ -235,7 +235,7 @@ public struct RetryPolicy: Hashable, Sendable {
   /// The maximum amount of time to backoff for.
   ///
   /// - Precondition: Must be greater than zero.
-  public var maximumBackoff: Duration {
+  public var maxBackoff: Duration {
     willSet { try! Self.validateMaxBackoff(newValue) }
   }
 
@@ -256,30 +256,30 @@ public struct RetryPolicy: Hashable, Sendable {
   /// Create a new retry policy.
   ///
   /// - Parameters:
-  ///   - maximumAttempts: The maximum number of attempts allowed for the RPC.
+  ///   - maxAttempts: The maximum number of attempts allowed for the RPC.
   ///   - initialBackoff: The initial backoff period for the first retry attempt. Must be
   ///       greater than zero.
   ///   - maximumBackoff: The maximum period of time to wait between attempts. Must be greater than
   ///       zero.
   ///   - backoffMultiplier: The exponential backoff multiplier. Must be greater than zero.
   ///   - retryableStatusCodes: The set of status codes which may be retried. Must not be empty.
-  /// - Precondition: `maximumAttempts`, `initialBackoff`, `maximumBackoff` and `backoffMultiplier`
+  /// - Precondition: `maxAttempts`, `initialBackoff`, `maxBackoff` and `backoffMultiplier`
   ///     must be greater than zero.
   /// - Precondition: `retryableStatusCodes` must not be empty.
   public init(
-    maximumAttempts: Int,
+    maxAttempts: Int,
     initialBackoff: Duration,
-    maximumBackoff: Duration,
+    maxBackoff: Duration,
     backoffMultiplier: Double,
     retryableStatusCodes: Set<Status.Code>
   ) {
-    self.maximumAttempts = try! validateMaxAttempts(maximumAttempts)
+    self.maxAttempts = try! validateMaxAttempts(maxAttempts)
 
     try! Self.validateInitialBackoff(initialBackoff)
     self.initialBackoff = initialBackoff
 
-    try! Self.validateMaxBackoff(maximumBackoff)
-    self.maximumBackoff = maximumBackoff
+    try! Self.validateMaxBackoff(maxBackoff)
+    self.maxBackoff = maxBackoff
 
     try! Self.validateBackoffMultiplier(backoffMultiplier)
     self.backoffMultiplier = backoffMultiplier
@@ -301,7 +301,7 @@ public struct RetryPolicy: Hashable, Sendable {
     if value <= .zero {
       throw RuntimeError(
         code: .invalidArgument,
-        message: "maximumBackoff must be greater than zero"
+        message: "maxBackoff must be greater than zero"
       )
     }
   }
@@ -327,7 +327,7 @@ public struct RetryPolicy: Hashable, Sendable {
 /// Hedged RPCs may execute more than once on a server so only idempotent methods should
 /// be hedged.
 ///
-/// gRPC executes the RPC at most ``maximumAttempts`` times, staggering each attempt
+/// gRPC executes the RPC at most ``maxAttempts`` times, staggering each attempt
 /// by ``hedgingDelay``.
 ///
 /// For more information see [gRFC A6 Client
@@ -339,8 +339,8 @@ public struct HedgingPolicy: Hashable, Sendable {
   /// Values greater than five are treated as five.
   ///
   /// - Precondition: Must be greater than one.
-  public var maximumAttempts: Int {
-    didSet { self.maximumAttempts = try! validateMaxAttempts(self.maximumAttempts) }
+  public var maxAttempts: Int {
+    didSet { self.maxAttempts = try! validateMaxAttempts(self.maxAttempts) }
   }
 
   /// The first RPC will be sent immediately, but each subsequent RPC will be sent at intervals
@@ -359,17 +359,17 @@ public struct HedgingPolicy: Hashable, Sendable {
   /// Create a new hedging policy.
   ///
   /// - Parameters:
-  ///   - maximumAttempts: The maximum number of attempts allowed for the RPC.
+  ///   - maxAttempts: The maximum number of attempts allowed for the RPC.
   ///   - hedgingDelay: The delay between each hedged RPC.
   ///   - nonFatalStatusCodes: The set of status codes which indicate other hedged RPCs may still
   ///       succeed.
-  /// - Precondition: `maximumAttempts` must be greater than zero.
+  /// - Precondition: `maxAttempts` must be greater than zero.
   public init(
-    maximumAttempts: Int,
+    maxAttempts: Int,
     hedgingDelay: Duration,
     nonFatalStatusCodes: Set<Status.Code>
   ) {
-    self.maximumAttempts = try! validateMaxAttempts(maximumAttempts)
+    self.maxAttempts = try! validateMaxAttempts(maxAttempts)
 
     try! Self.validateHedgingDelay(hedgingDelay)
     self.hedgingDelay = hedgingDelay
@@ -512,15 +512,15 @@ extension RetryPolicy: Codable {
     let container = try decoder.container(keyedBy: CodingKeys.self)
 
     let maxAttempts = try container.decode(Int.self, forKey: .maxAttempts)
-    self.maximumAttempts = try validateMaxAttempts(maxAttempts)
+    self.maxAttempts = try validateMaxAttempts(maxAttempts)
 
     let initialBackoff = try container.decode(String.self, forKey: .initialBackoff)
     self.initialBackoff = try Duration(googleProtobufDuration: initialBackoff)
     try Self.validateInitialBackoff(self.initialBackoff)
 
     let maxBackoff = try container.decode(String.self, forKey: .maxBackoff)
-    self.maximumBackoff = try Duration(googleProtobufDuration: maxBackoff)
-    try Self.validateMaxBackoff(self.maximumBackoff)
+    self.maxBackoff = try Duration(googleProtobufDuration: maxBackoff)
+    try Self.validateMaxBackoff(self.maxBackoff)
 
     self.backoffMultiplier = try container.decode(Double.self, forKey: .backoffMultiplier)
     try Self.validateBackoffMultiplier(self.backoffMultiplier)
@@ -532,12 +532,12 @@ extension RetryPolicy: Codable {
 
   public func encode(to encoder: any Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
-    try container.encode(self.maximumAttempts, forKey: .maxAttempts)
+    try container.encode(self.maxAttempts, forKey: .maxAttempts)
     try container.encode(
       GoogleProtobufDuration(duration: self.initialBackoff),
       forKey: .initialBackoff
     )
-    try container.encode(GoogleProtobufDuration(duration: self.maximumBackoff), forKey: .maxBackoff)
+    try container.encode(GoogleProtobufDuration(duration: self.maxBackoff), forKey: .maxBackoff)
     try container.encode(self.backoffMultiplier, forKey: .backoffMultiplier)
     try container.encode(
       self.retryableStatusCodes.map { $0.googleRPCCode },
@@ -558,7 +558,7 @@ extension HedgingPolicy: Codable {
     let container = try decoder.container(keyedBy: CodingKeys.self)
 
     let maxAttempts = try container.decode(Int.self, forKey: .maxAttempts)
-    self.maximumAttempts = try validateMaxAttempts(maxAttempts)
+    self.maxAttempts = try validateMaxAttempts(maxAttempts)
 
     let delay = try container.decode(String.self, forKey: .hedgingDelay)
     self.hedgingDelay = try Duration(googleProtobufDuration: delay)
@@ -569,7 +569,7 @@ extension HedgingPolicy: Codable {
 
   public func encode(to encoder: any Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
-    try container.encode(self.maximumAttempts, forKey: .maxAttempts)
+    try container.encode(self.maxAttempts, forKey: .maxAttempts)
     try container.encode(GoogleProtobufDuration(duration: self.hedgingDelay), forKey: .hedgingDelay)
     try container.encode(
       self.nonFatalStatusCodes.map { $0.googleRPCCode },

--- a/Sources/GRPCCore/GRPCClient.swift
+++ b/Sources/GRPCCore/GRPCClient.swift
@@ -359,7 +359,7 @@ public final class GRPCClient: Sendable {
     handler: @Sendable @escaping (ClientResponse.Stream<Response>) async throws -> ReturnValue
   ) async throws -> ReturnValue {
     try self.state.withLock { try $0.checkExecutable() }
-    let methodConfig = self.transport.configuration(forMethod: descriptor)
+    let methodConfig = self.transport.config(forMethod: descriptor)
     var options = options
     options.formUnion(with: methodConfig)
 

--- a/Sources/GRPCCore/GRPCServer.swift
+++ b/Sources/GRPCCore/GRPCServer.swift
@@ -54,7 +54,7 @@ private import Synchronization
 ///
 /// ## Starting and stopping the server
 ///
-/// Once you have configured the server call ``run()`` to start it. Calling ``run()`` starts the server's
+/// Once you have configured the server call ``serve()`` to start it. Calling ``serve()`` starts the server's
 /// transport too. A ``RuntimeError`` is thrown if the transport can't be started or encounters some other
 /// runtime error.
 ///
@@ -63,7 +63,7 @@ private import Synchronization
 /// try await server.serve()
 /// ```
 ///
-/// The ``run()`` method won't return until the server has finished handling all requests. You can
+/// The ``serve()`` method won't return until the server has finished handling all requests. You can
 /// signal to the server that it should stop accepting new requests by calling ``beginGracefulShutdown()``.
 /// This allows the server to drain existing requests gracefully. To stop the server more abruptly
 /// you can cancel the task running your server. If your application requires additional resources
@@ -221,7 +221,7 @@ public final class GRPCServer: Sendable {
   /// Signal to the server that it should stop listening for new requests.
   ///
   /// By calling this function you indicate to clients that they mustn't start new requests
-  /// against this server. Once the server has processed all requests the ``run()`` method returns.
+  /// against this server. Once the server has processed all requests the ``serve()`` method returns.
   ///
   /// Calling this on a server which is already stopping or has stopped has no effect.
   public func beginGracefulShutdown() {

--- a/Sources/GRPCCore/Internal/MethodConfigs.swift
+++ b/Sources/GRPCCore/Internal/MethodConfigs.swift
@@ -18,8 +18,8 @@
 ///
 /// When creating a new instance, no overrides and no default will be set for using when getting
 /// a configuration for a method that has not been given a specific override.
-/// Use ``setDefaultConfiguration(_:forService:)`` to set a specific override for a whole
-/// service, or set a default configuration for all methods by calling ``setDefaultConfiguration(_:)``.
+/// Use ``setDefaultConfig(_:forService:)`` to set a specific override for a whole
+/// service, or set a default configuration for all methods by calling ``setDefaultConfig(_:)``.
 ///
 /// Use the subscript to get and set configurations for specific methods.
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
@@ -42,7 +42,7 @@ package struct MethodConfigs: Sendable, Hashable {
   /// Get or set the corresponding ``MethodConfig`` for the given ``MethodDescriptor``.
   ///
   /// Configuration is hierarchical and can be set per-method, per-service
-  /// (``setDefaultConfiguration(_:forService:)``) and globally (``setDefaultConfiguration(_:)``).
+  /// (``setDefaultConfig(_:forService:)``) and globally (``setDefaultConfig(_:)``).
   /// This subscript sets the per-method configuration but retrieves a configuration respecting
   /// the hierarchy. If no per-method configuration is present, the per-service configuration is
   /// checked and returned if present. If the per-service configuration isn't present then the
@@ -78,10 +78,10 @@ package struct MethodConfigs: Sendable, Hashable {
 
   /// Set a default configuration for all methods that have no overrides.
   ///
-  /// - Parameter configuration: The default configuration.
-  package mutating func setDefaultConfiguration(_ configuration: MethodConfig?) {
+  /// - Parameter config: The default configuration.
+  package mutating func setDefaultConfig(_ config: MethodConfig?) {
     let name = MethodConfig.Name(service: "", method: "")
-    self.elements[name] = configuration
+    self.elements[name] = config
   }
 
   /// Set a default configuration for a service.
@@ -91,13 +91,13 @@ package struct MethodConfigs: Sendable, Hashable {
   /// this instance of ``MethodConfigs``.
   ///
   /// - Parameters:
-  ///   - configuration: The default configuration for the service.
+  ///   - config: The default configuration for the service.
   ///   - service: The name of the service for which this override applies.
-  package mutating func setDefaultConfiguration(
-    _ configuration: MethodConfig?,
+  package mutating func setDefaultConfig(
+    _ config: MethodConfig?,
     forService service: String
   ) {
     let name = MethodConfig.Name(service: "", method: "")
-    self.elements[name] = configuration
+    self.elements[name] = config
   }
 }

--- a/Sources/GRPCCore/Timeout.swift
+++ b/Sources/GRPCCore/Timeout.swift
@@ -77,7 +77,7 @@ struct Timeout: CustomStringConvertible, Hashable, Sendable {
   /// - Important: It's not possible to know with what precision the duration was created: that is,
   /// it's not possible to know whether `Duration.seconds(value)` or `Duration.milliseconds(value)`
   /// was used. For this reason, the unit chosen for the ``Timeout`` (and thus the wire encoding) may be
-  /// different from the one originally used to create the ``Duration``. Despite this, we guarantee that
+  /// different from the one originally used to create the `Duration`. Despite this, we guarantee that
   /// both durations will be equivalent if there was no loss in precision during the transformation.
   /// For example, `Duration.hours(123)` will yield a ``Timeout`` with `wireEncoding` equal to
   /// `"442800S"`, which is in seconds. However, 442800 seconds and 123 hours are equivalent.

--- a/Sources/GRPCCore/Transport/ClientTransport.swift
+++ b/Sources/GRPCCore/Transport/ClientTransport.swift
@@ -72,5 +72,5 @@ public protocol ClientTransport: Sendable {
   ///
   /// - Parameter descriptor: The method to lookup configuration for.
   /// - Returns: Configuration for the method, if it exists.
-  func configuration(forMethod descriptor: MethodDescriptor) -> MethodConfig?
+  func config(forMethod descriptor: MethodDescriptor) -> MethodConfig?
 }

--- a/Sources/GRPCHTTP2Core/Client/Connection/Connection.swift
+++ b/Sources/GRPCHTTP2Core/Client/Connection/Connection.swift
@@ -206,7 +206,7 @@ package final class Connection: Sendable {
             scheme: scheme,
             outboundEncoding: compression,
             acceptedEncodings: self.enabledCompression,
-            maximumPayloadSize: maxRequestSize
+            maxPayloadSize: maxRequestSize
           )
           try channel.pipeline.syncOperations.addHandler(streamHandler)
 

--- a/Sources/GRPCHTTP2Core/Client/Connection/GRPCChannel.swift
+++ b/Sources/GRPCHTTP2Core/Client/Connection/GRPCChannel.swift
@@ -114,7 +114,7 @@ package final class GRPCChannel: ClientTransport {
   ///
   /// - Parameter descriptor: The method to lookup configuration for.
   /// - Returns: Configuration for the method, if it exists.
-  package func configuration(forMethod descriptor: MethodDescriptor) -> MethodConfig? {
+  package func config(forMethod descriptor: MethodDescriptor) -> MethodConfig? {
     self._methodConfig.withLock { $0[descriptor] }
   }
 
@@ -193,7 +193,7 @@ package final class GRPCChannel: ClientTransport {
     _ closure: (_ stream: RPCStream<Inbound, Outbound>) async throws -> T
   ) async throws -> T {
     // Merge options from the call with those from the service config.
-    let methodConfig = self.configuration(forMethod: descriptor)
+    let methodConfig = self.config(forMethod: descriptor)
     var options = options
     options.formUnion(with: methodConfig)
 
@@ -306,7 +306,7 @@ extension GRPCChannel {
       return .tryAgain(RPCError(code: .unavailable, message: "channel isn't ready"))
     }
 
-    let methodConfig = self.configuration(forMethod: descriptor)
+    let methodConfig = self.config(forMethod: descriptor)
     var options = options
     options.formUnion(with: methodConfig)
 

--- a/Sources/GRPCHTTP2Core/Client/GRPCClientStreamHandler.swift
+++ b/Sources/GRPCHTTP2Core/Client/GRPCClientStreamHandler.swift
@@ -36,7 +36,7 @@ final class GRPCClientStreamHandler: ChannelDuplexHandler {
     scheme: Scheme,
     outboundEncoding: CompressionAlgorithm,
     acceptedEncodings: CompressionAlgorithmSet,
-    maximumPayloadSize: Int,
+    maxPayloadSize: Int,
     skipStateMachineAssertions: Bool = false
   ) {
     self.stateMachine = .init(
@@ -48,7 +48,7 @@ final class GRPCClientStreamHandler: ChannelDuplexHandler {
           acceptedEncodings: acceptedEncodings
         )
       ),
-      maximumPayloadSize: maximumPayloadSize,
+      maxPayloadSize: maxPayloadSize,
       skipAssertions: skipStateMachineAssertions
     )
   }

--- a/Sources/GRPCHTTP2Core/GRPCMessageFramer.swift
+++ b/Sources/GRPCHTTP2Core/GRPCMessageFramer.swift
@@ -31,7 +31,7 @@ struct GRPCMessageFramer {
   /// frames with messages over 64KB can still be written.
   /// - Note: This is expressed as the power of 2 closer to 64KB (i.e., 64KiB) because `ByteBuffer`
   /// reserves capacity in powers of 2. This way, we can take advantage of the whole buffer.
-  static let maximumWriteBufferLength = 65_536
+  static let maxWriteBufferLength = 65_536
 
   private var pendingMessages: OneOrManyQueue<(bytes: [UInt8], promise: EventLoopPromise<Void>?)>
 
@@ -64,8 +64,8 @@ struct GRPCMessageFramer {
 
     defer {
       // To avoid holding an excessively large buffer, if its size is larger than
-      // our threshold (`maximumWriteBufferLength`), then reset it to a new `ByteBuffer`.
-      if self.writeBuffer.capacity > Self.maximumWriteBufferLength {
+      // our threshold (`maxWriteBufferLength`), then reset it to a new `ByteBuffer`.
+      if self.writeBuffer.capacity > Self.maxWriteBufferLength {
         self.writeBuffer = ByteBuffer()
       }
     }

--- a/Sources/GRPCHTTP2Core/GRPCStreamStateMachine.swift
+++ b/Sources/GRPCHTTP2Core/GRPCStreamStateMachine.swift
@@ -69,11 +69,11 @@ private enum GRPCStreamStateMachineState {
   case _modifying
 
   struct ClientIdleServerIdleState {
-    let maximumPayloadSize: Int
+    let maxPayloadSize: Int
   }
 
   struct ClientOpenServerIdleState {
-    let maximumPayloadSize: Int
+    let maxPayloadSize: Int
     var framer: GRPCMessageFramer
     var compressor: Zlib.Compressor?
     var outboundCompression: CompressionAlgorithm
@@ -100,7 +100,7 @@ private enum GRPCStreamStateMachineState {
       deframer: GRPCMessageDeframer?,
       headers: HPACKHeaders
     ) {
-      self.maximumPayloadSize = previousState.maximumPayloadSize
+      self.maxPayloadSize = previousState.maxPayloadSize
       self.compressor = compressor
       self.outboundCompression = outboundCompression
       self.framer = framer
@@ -194,7 +194,7 @@ private enum GRPCStreamStateMachineState {
   }
 
   struct ClientClosedServerIdleState {
-    let maximumPayloadSize: Int
+    let maxPayloadSize: Int
     var framer: GRPCMessageFramer
     var compressor: Zlib.Compressor?
     var outboundCompression: CompressionAlgorithm
@@ -212,7 +212,7 @@ private enum GRPCStreamStateMachineState {
     /// It can happen if the request times out before the client outbound can be opened, or if the stream is
     /// unexpectedly closed for some other reason on the client before it can transition to open.
     init(previousState: ClientIdleServerIdleState) {
-      self.maximumPayloadSize = previousState.maximumPayloadSize
+      self.maxPayloadSize = previousState.maxPayloadSize
       // We don't need a compressor since we won't be sending any messages.
       self.framer = GRPCMessageFramer()
       self.compressor = nil
@@ -235,7 +235,7 @@ private enum GRPCStreamStateMachineState {
       compressionAlgorithm: CompressionAlgorithm,
       headers: HPACKHeaders
     ) {
-      self.maximumPayloadSize = previousState.maximumPayloadSize
+      self.maxPayloadSize = previousState.maxPayloadSize
 
       if let zlibMethod = Zlib.Method(encoding: compressionAlgorithm) {
         self.compressor = Zlib.Compressor(method: zlibMethod)
@@ -253,7 +253,7 @@ private enum GRPCStreamStateMachineState {
     }
 
     init(previousState: ClientOpenServerIdleState) {
-      self.maximumPayloadSize = previousState.maximumPayloadSize
+      self.maxPayloadSize = previousState.maxPayloadSize
       self.framer = previousState.framer
       self.compressor = previousState.compressor
       self.outboundCompression = previousState.outboundCompression
@@ -319,7 +319,7 @@ private enum GRPCStreamStateMachineState {
       }
 
       self.deframer = GRPCMessageDeframer(
-        maxPayloadSize: previousState.maximumPayloadSize,
+        maxPayloadSize: previousState.maxPayloadSize,
         decompressor: self.decompressor
       )
 
@@ -405,10 +405,10 @@ struct GRPCStreamStateMachine {
 
   init(
     configuration: GRPCStreamStateMachineConfiguration,
-    maximumPayloadSize: Int,
+    maxPayloadSize: Int,
     skipAssertions: Bool = false
   ) {
-    self.state = .clientIdleServerIdle(.init(maximumPayloadSize: maximumPayloadSize))
+    self.state = .clientIdleServerIdle(.init(maxPayloadSize: maxPayloadSize))
     self.configuration = configuration
     self.skipAssertions = skipAssertions
   }
@@ -981,7 +981,7 @@ extension GRPCStreamStateMachine {
             .init(
               previousState: state,
               deframer: GRPCMessageDeframer(
-                maxPayloadSize: state.maximumPayloadSize,
+                maxPayloadSize: state.maxPayloadSize,
                 decompressor: decompressor
               ),
               decompressor: decompressor
@@ -1539,7 +1539,7 @@ extension GRPCStreamStateMachine {
             framer: GRPCMessageFramer(),
             decompressor: decompressor,
             deframer: GRPCMessageDeframer(
-              maxPayloadSize: state.maximumPayloadSize,
+              maxPayloadSize: state.maxPayloadSize,
               decompressor: decompressor
             ),
             headers: headers

--- a/Sources/GRPCHTTP2Core/Internal/NIOChannelPipeline+GRPC.swift
+++ b/Sources/GRPCHTTP2Core/Internal/NIOChannelPipeline+GRPC.swift
@@ -85,7 +85,7 @@ extension ChannelPipeline.SynchronousOperations {
         let streamHandler = GRPCServerStreamHandler(
           scheme: scheme,
           acceptedEncodings: compressionConfig.enabledAlgorithms,
-          maximumPayloadSize: rpcConfig.maxRequestPayloadSize,
+          maxPayloadSize: rpcConfig.maxRequestPayloadSize,
           methodDescriptorPromise: methodDescriptorPromise
         )
         try streamChannel.pipeline.syncOperations.addHandler(streamHandler)

--- a/Sources/GRPCHTTP2Core/Server/GRPCServerStreamHandler.swift
+++ b/Sources/GRPCHTTP2Core/Server/GRPCServerStreamHandler.swift
@@ -49,13 +49,13 @@ package final class GRPCServerStreamHandler: ChannelDuplexHandler, RemovableChan
   package init(
     scheme: Scheme,
     acceptedEncodings: CompressionAlgorithmSet,
-    maximumPayloadSize: Int,
+    maxPayloadSize: Int,
     methodDescriptorPromise: EventLoopPromise<MethodDescriptor>,
     skipStateMachineAssertions: Bool = false
   ) {
     self.stateMachine = .init(
       configuration: .server(.init(scheme: scheme, acceptedEncodings: acceptedEncodings)),
-      maximumPayloadSize: maximumPayloadSize,
+      maxPayloadSize: maxPayloadSize,
       skipAssertions: skipStateMachineAssertions
     )
     self.methodDescriptorPromise = methodDescriptorPromise

--- a/Sources/GRPCHTTP2TransportNIOPosix/HTTP2ClientTransport+Posix.swift
+++ b/Sources/GRPCHTTP2TransportNIOPosix/HTTP2ClientTransport+Posix.swift
@@ -25,12 +25,12 @@ private import NIOSSL
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension HTTP2ClientTransport {
-  /// A ``GRPCCore/ClientTransport`` using HTTP/2 built on top of `NIOPosix`.
+  /// A `ClientTransport` using HTTP/2 built on top of `NIOPosix`.
   ///
   /// This transport builds on top of SwiftNIO's Posix networking layer and is suitable for use
   /// on Linux and Darwin based platforms (macOS, iOS, etc.). However, it's *strongly* recommended
   /// that if you are targeting Darwin platforms then you should use the `NIOTS` variant of
-  /// the ``GRPCHTTP2Core/HTTP2ClientTransport``.
+  /// the `HTTP2ClientTransport`.
   ///
   /// To use this transport you need to provide a 'target' to connect to which will be resolved
   /// by an appropriate resolver from the resolver registry. By default the resolver registry can
@@ -40,7 +40,7 @@ extension HTTP2ClientTransport {
   ///
   /// You can control various aspects of connection creation, management, security and RPC behavior via
   /// the ``Config``. Load balancing policies and other RPC specific behavior can be configured via
-  /// the ``ServiceConfig`` (if it isn't provided by a resolver).
+  /// the `ServiceConfig` (if it isn't provided by a resolver).
   ///
   /// Beyond creating the transport you don't need to interact with it directly, instead, pass it
   /// to a `GRPCClient`:
@@ -217,7 +217,7 @@ extension HTTP2ClientTransport.Posix {
     ///   - compression: Compression configuration.
     ///   - transportSecurity: The transport's security configuration.
     ///
-    /// - SeeAlso: ``defaults(_:)``.
+    /// - SeeAlso: ``defaults(transportSecurity:configure:)``
     public init(
       http2: HTTP2ClientTransport.Config.HTTP2,
       backoff: HTTP2ClientTransport.Config.Backoff,

--- a/Sources/GRPCHTTP2TransportNIOPosix/HTTP2ClientTransport+Posix.swift
+++ b/Sources/GRPCHTTP2TransportNIOPosix/HTTP2ClientTransport+Posix.swift
@@ -107,8 +107,8 @@ extension HTTP2ClientTransport {
       await self.channel.connect()
     }
 
-    public func configuration(forMethod descriptor: MethodDescriptor) -> MethodConfig? {
-      self.channel.configuration(forMethod: descriptor)
+    public func config(forMethod descriptor: MethodDescriptor) -> MethodConfig? {
+      self.channel.config(forMethod: descriptor)
     }
 
     public func beginGracefulShutdown() {

--- a/Sources/GRPCHTTP2TransportNIOPosix/HTTP2ServerTransport+Posix.swift
+++ b/Sources/GRPCHTTP2TransportNIOPosix/HTTP2ServerTransport+Posix.swift
@@ -27,12 +27,12 @@ import NIOSSL
 #endif
 
 extension HTTP2ServerTransport {
-  /// A ``GRPCCore/ServerTransport`` using HTTP/2 built on top of `NIOPosix`.
+  /// A `ServerTransport` using HTTP/2 built on top of `NIOPosix`.
   ///
   /// This transport builds on top of SwiftNIO's Posix networking layer and is suitable for use
   /// on Linux and Darwin based platform (macOS, iOS, etc.) However, it's *strongly* recommended
   /// that if you are targeting Darwin platforms then you should use the `NIOTS` variant of
-  /// the ``GRPCHTTP2Core/HTTP2ServerTransport``.
+  /// the `HTTP2ServerTransport`.
   ///
   /// You can control various aspects of connection creation, management, security and RPC behavior via
   /// the ``Config``.

--- a/Sources/GRPCHTTP2TransportNIOTransportServices/HTTP2ClientTransport+TransportServices.swift
+++ b/Sources/GRPCHTTP2TransportNIOTransportServices/HTTP2ClientTransport+TransportServices.swift
@@ -24,12 +24,12 @@ private import Network
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension HTTP2ClientTransport {
-  /// A ``GRPCCore/ClientTransport`` using HTTP/2 built on top of `NIOTransportServices`.
+  /// A `ClientTransport` using HTTP/2 built on top of `NIOTransportServices`.
   ///
   /// This transport builds on top of SwiftNIO's Transport Services networking layer and is the recommended
   /// variant for use on Darwin-based platforms (macOS, iOS, etc.).
   /// If you are targeting Linux platforms then you should use the `NIOPosix` variant of
-  /// the ``GRPCHTTP2Core/HTTP2ClientTransport``.
+  /// the `HTTP2ClientTransport`.
   ///
   /// To use this transport you need to provide a 'target' to connect to which will be resolved
   /// by an appropriate resolver from the resolver registry. By default the resolver registry can
@@ -39,7 +39,7 @@ extension HTTP2ClientTransport {
   ///
   /// You can control various aspects of connection creation, management, security and RPC behavior via
   /// the ``Config``. Load balancing policies and other RPC specific behavior can be configured via
-  /// the ``ServiceConfig`` (if it isn't provided by a resolver).
+  /// the `ServiceConfig` (if it isn't provided by a resolver).
   ///
   /// Beyond creating the transport you don't need to interact with it directly, instead, pass it
   /// to a `GRPCClient`:
@@ -200,7 +200,7 @@ extension HTTP2ClientTransport.TransportServices {
     ///   - compression: Compression configuration.
     ///   - transportSecurity: The transport's security configuration.
     ///
-    /// - SeeAlso: ``defaults(_:)``.
+    /// - SeeAlso: ``defaults(transportSecurity:configure:)``
     public init(
       http2: HTTP2ClientTransport.Config.HTTP2,
       backoff: HTTP2ClientTransport.Config.Backoff,

--- a/Sources/GRPCHTTP2TransportNIOTransportServices/HTTP2ClientTransport+TransportServices.swift
+++ b/Sources/GRPCHTTP2TransportNIOTransportServices/HTTP2ClientTransport+TransportServices.swift
@@ -118,8 +118,8 @@ extension HTTP2ClientTransport {
       try await self.channel.withStream(descriptor: descriptor, options: options, closure)
     }
 
-    public func configuration(forMethod descriptor: MethodDescriptor) -> MethodConfig? {
-      self.channel.configuration(forMethod: descriptor)
+    public func config(forMethod descriptor: MethodDescriptor) -> MethodConfig? {
+      self.channel.config(forMethod: descriptor)
     }
   }
 }

--- a/Sources/GRPCInProcessTransport/InProcessClientTransport.swift
+++ b/Sources/GRPCInProcessTransport/InProcessClientTransport.swift
@@ -345,7 +345,7 @@ public final class InProcessClientTransport: ClientTransport {
   ///
   /// - Parameter descriptor: The method to lookup configuration for.
   /// - Returns: Execution configuration for the method, if it exists.
-  public func configuration(
+  public func config(
     forMethod descriptor: MethodDescriptor
   ) -> MethodConfig? {
     self.methodConfig[descriptor]

--- a/Sources/GRPCInProcessTransport/InProcessClientTransport.swift
+++ b/Sources/GRPCInProcessTransport/InProcessClientTransport.swift
@@ -26,7 +26,7 @@ private import Synchronization
 /// as a ``ServiceConfig``.
 ///
 /// Once you have a client, you must keep a long-running task executing ``connect()``, which
-/// will return only once all streams have been finished and ``close()`` has been called on this client; or
+/// will return only once all streams have been finished and ``beginGracefulShutdown()`` has been called on this client; or
 /// when the containing task is cancelled.
 ///
 /// To execute requests using this client, use ``withStream(descriptor:options:_:)``. If this function is
@@ -126,7 +126,7 @@ public final class InProcessClientTransport: ClientTransport {
   ///
   /// Implementations of this function will typically create a long-lived task group which
   /// maintains connections. The function exits when all open streams have been closed and new connections
-  /// are no longer required by the caller who signals this by calling ``close()``, or by cancelling the
+  /// are no longer required by the caller who signals this by calling ``beginGracefulShutdown()``, or by cancelling the
   /// task this function runs in.
   public func connect() async throws {
     let (stream, continuation) = AsyncStream<Void>.makeStream()

--- a/Sources/GRPCProtobufCodeGen/ProtobufCodeGenParser.swift
+++ b/Sources/GRPCProtobufCodeGen/ProtobufCodeGenParser.swift
@@ -27,13 +27,13 @@ internal struct ProtobufCodeGenParser {
   let namer: SwiftProtobufNamer
   let extraModuleImports: [String]
   let protoToModuleMappings: ProtoFileToModuleMappings
-  let accessLevel: SourceGenerator.Configuration.AccessLevel
+  let accessLevel: SourceGenerator.Config.AccessLevel
 
   internal init(
     input: FileDescriptor,
     protoFileModuleMappings: ProtoFileToModuleMappings,
     extraModuleImports: [String],
-    accessLevel: SourceGenerator.Configuration.AccessLevel
+    accessLevel: SourceGenerator.Config.AccessLevel
   ) {
     self.input = input
     self.extraModuleImports = extraModuleImports

--- a/Sources/GRPCProtobufCodeGen/ProtobufCodeGenerator.swift
+++ b/Sources/GRPCProtobufCodeGen/ProtobufCodeGenerator.swift
@@ -18,10 +18,10 @@ public import GRPCCodeGen
 public import SwiftProtobufPluginLibrary
 
 public struct ProtobufCodeGenerator {
-  internal var configuration: SourceGenerator.Configuration
+  internal var configuration: SourceGenerator.Config
 
   public init(
-    configuration: SourceGenerator.Configuration
+    configuration: SourceGenerator.Config
   ) {
     self.configuration = configuration
   }
@@ -37,7 +37,7 @@ public struct ProtobufCodeGenerator {
       extraModuleImports: extraModuleImports,
       accessLevel: self.configuration.accessLevel
     )
-    let sourceGenerator = SourceGenerator(configuration: self.configuration)
+    let sourceGenerator = SourceGenerator(config: self.configuration)
 
     let codeGenerationRequest = try parser.parse()
     let sourceFile = try sourceGenerator.generate(codeGenerationRequest)

--- a/Sources/protoc-gen-grpc-swift/GenerateGRPC.swift
+++ b/Sources/protoc-gen-grpc-swift/GenerateGRPC.swift
@@ -123,7 +123,7 @@ final class GenerateGRPC: CodeGenerator {
       fileNamingOption: options.fileNaming
     )
 
-    let config = SourceGenerator.Configuration(options: options)
+    let config = SourceGenerator.Config(options: options)
     let fileGenerator = ProtobufCodeGenerator(configuration: config)
     let contents = try fileGenerator.generateCode(
       from: descriptor,
@@ -212,9 +212,9 @@ private func splitPath(pathname: String) -> (dir: String, base: String, suffix: 
 }
 
 #if compiler(>=6.0)
-extension SourceGenerator.Configuration {
+extension SourceGenerator.Config {
   init(options: GeneratorOptions) {
-    let accessLevel: SourceGenerator.Configuration.AccessLevel
+    let accessLevel: SourceGenerator.Config.AccessLevel
     switch options.visibility {
     case .internal:
       accessLevel = .internal

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
@@ -797,7 +797,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
   private func assertClientCodeTranslation(
     codeGenerationRequest: CodeGenerationRequest,
     expectedSwift: String,
-    accessLevel: SourceGenerator.Configuration.AccessLevel,
+    accessLevel: SourceGenerator.Config.AccessLevel,
     file: StaticString = #filePath,
     line: UInt = #line
   ) throws {

--- a/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
@@ -268,7 +268,7 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
   private func assertIDLToStructuredSwiftTranslation(
     codeGenerationRequest: CodeGenerationRequest,
     expectedSwift: String,
-    accessLevel: SourceGenerator.Configuration.AccessLevel,
+    accessLevel: SourceGenerator.Config.AccessLevel,
     server: Bool = false
   ) throws {
     let translator = IDLToStructuredSwiftTranslator()

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
@@ -541,7 +541,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
   private func assertServerCodeTranslation(
     codeGenerationRequest: CodeGenerationRequest,
     expectedSwift: String,
-    accessLevel: SourceGenerator.Configuration.AccessLevel
+    accessLevel: SourceGenerator.Config.AccessLevel
   ) throws {
     let translator = ServerCodeTranslator(accessLevel: accessLevel)
     let codeBlocks = try translator.translate(from: codeGenerationRequest)

--- a/Tests/GRPCCodeGenTests/Internal/Translator/TypealiasTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/TypealiasTranslatorSnippetBasedTests.swift
@@ -725,7 +725,7 @@ extension TypealiasTranslatorSnippetBasedTests {
     expectedSwift: String,
     client: Bool,
     server: Bool,
-    accessLevel: SourceGenerator.Configuration.AccessLevel
+    accessLevel: SourceGenerator.Config.AccessLevel
   ) throws {
     let translator = TypealiasTranslator(client: client, server: server, accessLevel: accessLevel)
     let codeBlocks = try translator.translate(from: codeGenerationRequest)

--- a/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTestSupport/ClientRPCExecutorTestHarness+Transport.swift
+++ b/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTestSupport/ClientRPCExecutorTestHarness+Transport.swift
@@ -20,7 +20,7 @@ import GRPCInProcessTransport
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension InProcessServerTransport {
   func spawnClientTransport(
-    throttle: RetryThrottle = RetryThrottle(maximumTokens: 10, tokenRatio: 0.1)
+    throttle: RetryThrottle = RetryThrottle(maxTokens: 10, tokenRatio: 0.1)
   ) -> InProcessClientTransport {
     return InProcessClientTransport(server: self)
   }

--- a/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests+Hedging.swift
+++ b/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests+Hedging.swift
@@ -90,7 +90,7 @@ extension ClientRPCExecutorTests {
         try await $0.write([2])
       },
       options: .hedge(
-        maximumAttempts: 5,
+        maxAttempts: 5,
         delay: .milliseconds(10),
         nonFatalCodes: [.unavailable]
       )
@@ -134,7 +134,7 @@ extension ClientRPCExecutorTests {
         try await $0.write([2])
       },
       options: .hedge(
-        maximumAttempts: 5,
+        maxAttempts: 5,
         delay: .seconds(60),  // High delay, server pushback will override this.
         nonFatalCodes: [.unavailable]
       )
@@ -189,13 +189,13 @@ extension ClientRPCExecutorTests {
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension CallOptions {
   fileprivate static func hedge(
-    maximumAttempts: Int = 5,
+    maxAttempts: Int = 5,
     delay: Duration = .milliseconds(25),
     nonFatalCodes: Set<Status.Code>,
     timeout: Duration? = nil
   ) -> Self {
     let policy = HedgingPolicy(
-      maximumAttempts: maximumAttempts,
+      maxAttempts: maxAttempts,
       hedgingDelay: delay,
       nonFatalStatusCodes: nonFatalCodes
     )

--- a/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests+Retries.swift
+++ b/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests+Retries.swift
@@ -224,9 +224,9 @@ extension ClientRPCExecutorTests {
     )
 
     let retryPolicy = RetryPolicy(
-      maximumAttempts: 5,
+      maxAttempts: 5,
       initialBackoff: .seconds(60),
-      maximumBackoff: .seconds(50),
+      maxBackoff: .seconds(50),
       backoffMultiplier: 1,
       retryableStatusCodes: [.unavailable]
     )
@@ -261,9 +261,9 @@ extension ClientRPCExecutorTests {
       )
 
       let retryPolicy = RetryPolicy(
-        maximumAttempts: 5,
+        maxAttempts: 5,
         initialBackoff: .seconds(60),
-        maximumBackoff: .seconds(50),
+        maxBackoff: .seconds(50),
         backoffMultiplier: 1,
         retryableStatusCodes: [.unavailable]
       )
@@ -305,9 +305,9 @@ extension CallOptions {
     timeout: Duration? = nil
   ) -> Self {
     let policy = RetryPolicy(
-      maximumAttempts: maximumAttempts,
+      maxAttempts: maximumAttempts,
       initialBackoff: .milliseconds(10),
-      maximumBackoff: .milliseconds(100),
+      maxBackoff: .milliseconds(100),
       backoffMultiplier: 1.6,
       retryableStatusCodes: codes
     )

--- a/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests.swift
+++ b/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests.swift
@@ -231,16 +231,16 @@ final class ClientRPCExecutorTests: XCTestCase {
     var policies: [RPCExecutionPolicy?] = [nil]
 
     let retryPolicy = RetryPolicy(
-      maximumAttempts: 5,
+      maxAttempts: 5,
       initialBackoff: .seconds(1),
-      maximumBackoff: .seconds(1),
+      maxBackoff: .seconds(1),
       backoffMultiplier: 1.6,
       retryableStatusCodes: [.unavailable]
     )
     policies.append(.retry(retryPolicy))
 
     let hedgingPolicy = HedgingPolicy(
-      maximumAttempts: 5,
+      maxAttempts: 5,
       hedgingDelay: .seconds(1),
       nonFatalStatusCodes: [.unavailable]
     )

--- a/Tests/GRPCCoreTests/Call/Client/RetryDelaySequenceTests.swift
+++ b/Tests/GRPCCoreTests/Call/Client/RetryDelaySequenceTests.swift
@@ -21,9 +21,9 @@ import XCTest
 final class RetryDelaySequenceTests: XCTestCase {
   func testSequence() {
     let policy = RetryPolicy(
-      maximumAttempts: 3,  // ignored here
+      maxAttempts: 3,  // ignored here
       initialBackoff: .seconds(1),
-      maximumBackoff: .seconds(8),
+      maxBackoff: .seconds(8),
       backoffMultiplier: 2.0,
       retryableStatusCodes: [.aborted]  // ignored here
     )
@@ -41,9 +41,9 @@ final class RetryDelaySequenceTests: XCTestCase {
 
   func testSequenceSupportsMultipleIteration() {
     let policy = RetryPolicy(
-      maximumAttempts: 3,  // ignored here
+      maxAttempts: 3,  // ignored here
       initialBackoff: .seconds(1),
-      maximumBackoff: .seconds(8),
+      maxBackoff: .seconds(8),
       backoffMultiplier: 2.0,
       retryableStatusCodes: [.aborted]  // ignored here
     )

--- a/Tests/GRPCCoreTests/Configuration/MethodConfigCodingTests.swift
+++ b/Tests/GRPCCoreTests/Configuration/MethodConfigCodingTests.swift
@@ -91,9 +91,9 @@ struct MethodConfigCodingTests {
     @Test("RetryPolicy")
     func retryPolicy() throws {
       let policy = RetryPolicy(
-        maximumAttempts: 3,
+        maxAttempts: 3,
         initialBackoff: .seconds(1),
-        maximumBackoff: .seconds(3),
+        maxBackoff: .seconds(3),
         backoffMultiplier: 1.6,
         retryableStatusCodes: [.aborted]
       )
@@ -107,7 +107,7 @@ struct MethodConfigCodingTests {
     @Test("HedgingPolicy")
     func hedgingPolicy() throws {
       let policy = HedgingPolicy(
-        maximumAttempts: 3,
+        maxAttempts: 3,
         hedgingDelay: .seconds(1),
         nonFatalStatusCodes: [.aborted]
       )
@@ -233,9 +233,9 @@ struct MethodConfigCodingTests {
     func retryPolicy() throws {
       let decoded = try self.decodeFromFile("method_config.retry_policy", as: RetryPolicy.self)
       let expected = RetryPolicy(
-        maximumAttempts: 3,
+        maxAttempts: 3,
         initialBackoff: .seconds(1),
-        maximumBackoff: .seconds(3),
+        maxBackoff: .seconds(3),
         backoffMultiplier: 1.6,
         retryableStatusCodes: [.aborted, .unavailable]
       )
@@ -262,7 +262,7 @@ struct MethodConfigCodingTests {
     func hedgingPolicy() throws {
       let decoded = try self.decodeFromFile("method_config.hedging_policy", as: HedgingPolicy.self)
       let expected = HedgingPolicy(
-        maximumAttempts: 3,
+        maxAttempts: 3,
         hedgingDelay: .seconds(1),
         nonFatalStatusCodes: [.aborted]
       )
@@ -315,7 +315,7 @@ struct MethodConfigCodingTests {
         maxResponseMessageBytes: 2048,
         executionPolicy: .hedge(
           HedgingPolicy(
-            maximumAttempts: 3,
+            maxAttempts: 3,
             hedgingDelay: .seconds(42),
             nonFatalStatusCodes: [.aborted, .unimplemented]
           )
@@ -341,9 +341,9 @@ struct MethodConfigCodingTests {
         maxResponseMessageBytes: 2048,
         executionPolicy: .retry(
           RetryPolicy(
-            maximumAttempts: 3,
+            maxAttempts: 3,
             initialBackoff: .seconds(1),
-            maximumBackoff: .seconds(3),
+            maxBackoff: .seconds(3),
             backoffMultiplier: 1.6,
             retryableStatusCodes: [.aborted, .unimplemented]
           )

--- a/Tests/GRPCCoreTests/Configuration/MethodConfigTests.swift
+++ b/Tests/GRPCCoreTests/Configuration/MethodConfigTests.swift
@@ -21,32 +21,32 @@ struct MethodConfigTests {
   @Test("RetryPolicy clamps max attempts")
   func retryPolicyClampsMaxAttempts() {
     var policy = RetryPolicy(
-      maximumAttempts: 10,
+      maxAttempts: 10,
       initialBackoff: .seconds(1),
-      maximumBackoff: .seconds(1),
+      maxBackoff: .seconds(1),
       backoffMultiplier: 1.0,
       retryableStatusCodes: [.unavailable]
     )
 
     // Should be clamped on init
-    #expect(policy.maximumAttempts == 5)
+    #expect(policy.maxAttempts == 5)
     // and when modifying
-    policy.maximumAttempts = 10
-    #expect(policy.maximumAttempts == 5)
+    policy.maxAttempts = 10
+    #expect(policy.maxAttempts == 5)
   }
 
   @Test("HedgingPolicy clamps max attempts")
   func hedgingPolicyClampsMaxAttempts() {
     var policy = HedgingPolicy(
-      maximumAttempts: 10,
+      maxAttempts: 10,
       hedgingDelay: .seconds(1),
       nonFatalStatusCodes: []
     )
 
     // Should be clamped on init
-    #expect(policy.maximumAttempts == 5)
+    #expect(policy.maxAttempts == 5)
     // and when modifying
-    policy.maximumAttempts = 10
-    #expect(policy.maximumAttempts == 5)
+    policy.maxAttempts = 10
+    #expect(policy.maxAttempts == 5)
   }
 }

--- a/Tests/GRPCCoreTests/Configuration/ServiceConfigCodingTests.swift
+++ b/Tests/GRPCCoreTests/Configuration/ServiceConfigCodingTests.swift
@@ -229,7 +229,7 @@ final class ServiceConfigCodingTests: XCTestCase {
           maxResponseMessageBytes: 4096,
           executionPolicy: .hedge(
             HedgingPolicy(
-              maximumAttempts: 3,
+              maxAttempts: 3,
               hedgingDelay: .seconds(1),
               nonFatalStatusCodes: [.aborted]
             )

--- a/Tests/GRPCCoreTests/Internal/MethodConfigsTests.swift
+++ b/Tests/GRPCCoreTests/Internal/MethodConfigsTests.swift
@@ -20,18 +20,18 @@ import XCTest
 final class MethodConfigsTests: XCTestCase {
   func testGetConfigurationForKnownMethod() async throws {
     let policy = HedgingPolicy(
-      maximumAttempts: 10,
+      maxAttempts: 10,
       hedgingDelay: .seconds(1),
       nonFatalStatusCodes: []
     )
     let defaultConfiguration = MethodConfig(names: [], executionPolicy: .hedge(policy))
     var configurations = MethodConfigs()
-    configurations.setDefaultConfiguration(defaultConfiguration)
+    configurations.setDefaultConfig(defaultConfiguration)
     let descriptor = MethodDescriptor(service: "test", method: "first")
     let retryPolicy = RetryPolicy(
-      maximumAttempts: 10,
+      maxAttempts: 10,
       initialBackoff: .seconds(1),
-      maximumBackoff: .seconds(1),
+      maxBackoff: .seconds(1),
       backoffMultiplier: 1.0,
       retryableStatusCodes: [.unavailable]
     )
@@ -43,18 +43,18 @@ final class MethodConfigsTests: XCTestCase {
 
   func testGetConfigurationForUnknownMethodButServiceOverride() {
     let policy = HedgingPolicy(
-      maximumAttempts: 10,
+      maxAttempts: 10,
       hedgingDelay: .seconds(1),
       nonFatalStatusCodes: []
     )
     let defaultConfiguration = MethodConfig(names: [], executionPolicy: .hedge(policy))
     var configurations = MethodConfigs()
-    configurations.setDefaultConfiguration(defaultConfiguration)
+    configurations.setDefaultConfig(defaultConfiguration)
     let firstDescriptor = MethodDescriptor(service: "test", method: "")
     let retryPolicy = RetryPolicy(
-      maximumAttempts: 10,
+      maxAttempts: 10,
       initialBackoff: .seconds(1),
-      maximumBackoff: .seconds(1),
+      maxBackoff: .seconds(1),
       backoffMultiplier: 1.0,
       retryableStatusCodes: [.unavailable]
     )
@@ -67,18 +67,18 @@ final class MethodConfigsTests: XCTestCase {
 
   func testGetConfigurationForUnknownMethodDefaultValue() {
     let policy = HedgingPolicy(
-      maximumAttempts: 10,
+      maxAttempts: 10,
       hedgingDelay: .seconds(1),
       nonFatalStatusCodes: []
     )
     let defaultConfiguration = MethodConfig(names: [], executionPolicy: .hedge(policy))
     var configurations = MethodConfigs()
-    configurations.setDefaultConfiguration(defaultConfiguration)
+    configurations.setDefaultConfig(defaultConfiguration)
     let firstDescriptor = MethodDescriptor(service: "test1", method: "first")
     let retryPolicy = RetryPolicy(
-      maximumAttempts: 10,
+      maxAttempts: 10,
       initialBackoff: .seconds(1),
-      maximumBackoff: .seconds(1),
+      maxBackoff: .seconds(1),
       backoffMultiplier: 1.0,
       retryableStatusCodes: [.unavailable]
     )

--- a/Tests/GRPCCoreTests/Test Utilities/Transport/AnyTransport.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/Transport/AnyTransport.swift
@@ -49,7 +49,7 @@ struct AnyClientTransport: ClientTransport, Sendable {
     }
 
     self._configuration = { descriptor in
-      transport.configuration(forMethod: descriptor)
+      transport.config(forMethod: descriptor)
     }
   }
 
@@ -74,7 +74,7 @@ struct AnyClientTransport: ClientTransport, Sendable {
     return result as! T
   }
 
-  func configuration(
+  func config(
     forMethod descriptor: MethodDescriptor
   ) -> MethodConfig? {
     self._configuration(descriptor)

--- a/Tests/GRPCCoreTests/Test Utilities/Transport/StreamCountingTransport.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/Transport/StreamCountingTransport.swift
@@ -71,10 +71,10 @@ struct StreamCountingClientTransport: ClientTransport, Sendable {
     }
   }
 
-  func configuration(
+  func config(
     forMethod descriptor: MethodDescriptor
   ) -> MethodConfig? {
-    self.transport.configuration(forMethod: descriptor)
+    self.transport.config(forMethod: descriptor)
   }
 }
 

--- a/Tests/GRPCCoreTests/Test Utilities/Transport/ThrowingTransport.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/Transport/ThrowingTransport.swift
@@ -26,7 +26,7 @@ struct ThrowOnStreamCreationTransport: ClientTransport {
     self.code = code
   }
 
-  let retryThrottle: RetryThrottle? = RetryThrottle(maximumTokens: 10, tokenRatio: 0.1)
+  let retryThrottle: RetryThrottle? = RetryThrottle(maxTokens: 10, tokenRatio: 0.1)
 
   func connect() async throws {
     // no-op
@@ -36,7 +36,7 @@ struct ThrowOnStreamCreationTransport: ClientTransport {
     // no-op
   }
 
-  func configuration(
+  func config(
     forMethod descriptor: MethodDescriptor
   ) -> MethodConfig? {
     return nil

--- a/Tests/GRPCCoreTests/Transport/RetryThrottleTests.swift
+++ b/Tests/GRPCCoreTests/Transport/RetryThrottleTests.swift
@@ -21,21 +21,21 @@ import XCTest
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class RetryThrottleTests: XCTestCase {
   func testThrottleOnInit() {
-    let throttle = RetryThrottle(maximumTokens: 10, tokenRatio: 0.1)
+    let throttle = RetryThrottle(maxTokens: 10, tokenRatio: 0.1)
     // Start with max tokens, so permitted.
     XCTAssertTrue(throttle.isRetryPermitted)
-    XCTAssertEqual(throttle.maximumTokens, 10)
+    XCTAssertEqual(throttle.maxTokens, 10)
     XCTAssertEqual(throttle.tokens, 10)
     XCTAssertEqual(throttle.tokenRatio, 0.1)
   }
 
   func testThrottleIgnoresMoreThanThreeDecimals() {
-    let throttle = RetryThrottle(maximumTokens: 10, tokenRatio: 0.1239)
+    let throttle = RetryThrottle(maxTokens: 10, tokenRatio: 0.1239)
     XCTAssertEqual(throttle.tokenRatio, 0.123)
   }
 
   func testFailureReducesTokens() {
-    let throttle = RetryThrottle(maximumTokens: 10, tokenRatio: 0.1)
+    let throttle = RetryThrottle(maxTokens: 10, tokenRatio: 0.1)
     XCTAssertEqual(throttle.tokens, 10)
     XCTAssert(throttle.isRetryPermitted)
 
@@ -62,7 +62,7 @@ final class RetryThrottleTests: XCTestCase {
   }
 
   func testTokensCantDropBelowZero() {
-    let throttle = RetryThrottle(maximumTokens: 10, tokenRatio: 0.1)
+    let throttle = RetryThrottle(maxTokens: 10, tokenRatio: 0.1)
     for _ in 0 ..< 1000 {
       throttle.recordFailure()
       XCTAssertGreaterThanOrEqual(throttle.tokens, 0)
@@ -71,7 +71,7 @@ final class RetryThrottleTests: XCTestCase {
   }
 
   func testSuccessIncreasesTokens() {
-    let throttle = RetryThrottle(maximumTokens: 10, tokenRatio: 0.1)
+    let throttle = RetryThrottle(maxTokens: 10, tokenRatio: 0.1)
 
     // Drop to zero.
     for _ in 0 ..< 10 {
@@ -91,7 +91,7 @@ final class RetryThrottleTests: XCTestCase {
   }
 
   func testTokensCantRiseAboveMax() {
-    let throttle = RetryThrottle(maximumTokens: 10, tokenRatio: 0.1)
+    let throttle = RetryThrottle(maxTokens: 10, tokenRatio: 0.1)
     XCTAssertEqual(throttle.tokens, 10)
     throttle.recordSuccess()
     XCTAssertEqual(throttle.tokens, 10)

--- a/Tests/GRPCHTTP2CoreTests/Client/Connection/GRPCChannelTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Client/Connection/GRPCChannelTests.swift
@@ -38,11 +38,11 @@ final class GRPCChannelTests: XCTestCase {
       defaultServiceConfig: serviceConfig
     )
 
-    XCTAssertNotNil(channel.configuration(forMethod: .echoGet))
-    XCTAssertNil(channel.configuration(forMethod: .echoUpdate))
+    XCTAssertNotNil(channel.config(forMethod: .echoGet))
+    XCTAssertNil(channel.config(forMethod: .echoUpdate))
 
     let throttle = try XCTUnwrap(channel.retryThrottle)
-    XCTAssertEqual(throttle.maximumTokens, 100)
+    XCTAssertEqual(throttle.maxTokens, 100)
     XCTAssertEqual(throttle.tokenRatio, 0.1)
   }
 
@@ -71,8 +71,8 @@ final class GRPCChannelTests: XCTestCase {
     )
 
     // Not resolved yet so the default (empty) service config is used.
-    XCTAssertNil(channel.configuration(forMethod: .echoGet))
-    XCTAssertNil(channel.configuration(forMethod: .echoUpdate))
+    XCTAssertNil(channel.config(forMethod: .echoGet))
+    XCTAssertNil(channel.config(forMethod: .echoUpdate))
     XCTAssertNil(channel.retryThrottle)
 
     try await withThrowingDiscardingTaskGroup { group in
@@ -88,11 +88,11 @@ final class GRPCChannelTests: XCTestCase {
         switch event {
         case .ready:
           // When the channel is ready it must have the service config from the resolver.
-          XCTAssertNotNil(channel.configuration(forMethod: .echoGet))
-          XCTAssertNil(channel.configuration(forMethod: .echoUpdate))
+          XCTAssertNotNil(channel.config(forMethod: .echoGet))
+          XCTAssertNil(channel.config(forMethod: .echoUpdate))
 
           let throttle = try XCTUnwrap(channel.retryThrottle)
-          XCTAssertEqual(throttle.maximumTokens, 100)
+          XCTAssertEqual(throttle.maxTokens, 100)
           XCTAssertEqual(throttle.tokenRatio, 0.1)
 
           // Now close.
@@ -124,8 +124,8 @@ final class GRPCChannelTests: XCTestCase {
     )
 
     // Not resolved yet so the default (empty) service config is used.
-    XCTAssertNil(channel.configuration(forMethod: .echoGet))
-    XCTAssertNil(channel.configuration(forMethod: .echoUpdate))
+    XCTAssertNil(channel.config(forMethod: .echoGet))
+    XCTAssertNil(channel.config(forMethod: .echoUpdate))
     XCTAssertNil(channel.retryThrottle)
 
     // Yield the first address list and service config.
@@ -155,10 +155,10 @@ final class GRPCChannelTests: XCTestCase {
         switch event {
         case .ready:
           // When the channel it must have the service config from the resolver.
-          XCTAssertNotNil(channel.configuration(forMethod: .echoGet))
-          XCTAssertNil(channel.configuration(forMethod: .echoUpdate))
+          XCTAssertNotNil(channel.config(forMethod: .echoGet))
+          XCTAssertNil(channel.config(forMethod: .echoUpdate))
           let throttle = try XCTUnwrap(channel.retryThrottle)
-          XCTAssertEqual(throttle.maximumTokens, 100)
+          XCTAssertEqual(throttle.maxTokens, 100)
           XCTAssertEqual(throttle.tokenRatio, 0.1)
 
           // Now yield a new service config with the same addresses.
@@ -170,8 +170,8 @@ final class GRPCChannelTests: XCTestCase {
 
           // This should be propagated quickly.
           try await XCTPoll(every: .milliseconds(10)) {
-            let noConfigForGet = channel.configuration(forMethod: .echoGet) == nil
-            let configForUpdate = channel.configuration(forMethod: .echoUpdate) != nil
+            let noConfigForGet = channel.config(forMethod: .echoGet) == nil
+            let configForUpdate = channel.config(forMethod: .echoUpdate) != nil
             let noThrottle = channel.retryThrottle == nil
             return noConfigForGet && configForUpdate && noThrottle
           }

--- a/Tests/GRPCHTTP2CoreTests/Client/Connection/Utilities/ConnectionTest.swift
+++ b/Tests/GRPCHTTP2CoreTests/Client/Connection/Utilities/ConnectionTest.swift
@@ -118,7 +118,7 @@ extension ConnectionTest {
               let handler = GRPCServerStreamHandler(
                 scheme: .http,
                 acceptedEncodings: .none,
-                maximumPayloadSize: .max,
+                maxPayloadSize: .max,
                 methodDescriptorPromise: channel.eventLoop.makePromise(of: MethodDescriptor.self)
               )
 

--- a/Tests/GRPCHTTP2CoreTests/Client/Connection/Utilities/TestServer.swift
+++ b/Tests/GRPCHTTP2CoreTests/Client/Connection/Utilities/TestServer.swift
@@ -74,7 +74,7 @@ final class TestServer: Sendable {
             let handler = GRPCServerStreamHandler(
               scheme: .http,
               acceptedEncodings: .all,
-              maximumPayloadSize: .max,
+              maxPayloadSize: .max,
               methodDescriptorPromise: channel.eventLoop.makePromise(of: MethodDescriptor.self)
             )
 

--- a/Tests/GRPCHTTP2CoreTests/Client/GRPCClientStreamHandlerTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Client/GRPCClientStreamHandlerTests.swift
@@ -32,7 +32,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
       scheme: .http,
       outboundEncoding: .none,
       acceptedEncodings: [],
-      maximumPayloadSize: 1
+      maxPayloadSize: 1
     )
 
     let channel = EmbeddedChannel(handler: handler)
@@ -63,7 +63,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
       scheme: .http,
       outboundEncoding: .none,
       acceptedEncodings: [],
-      maximumPayloadSize: 1,
+      maxPayloadSize: 1,
       skipStateMachineAssertions: true
     )
 
@@ -99,7 +99,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
       scheme: .http,
       outboundEncoding: .none,
       acceptedEncodings: [],
-      maximumPayloadSize: 1,
+      maxPayloadSize: 1,
       skipStateMachineAssertions: true
     )
 
@@ -130,7 +130,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
       scheme: .http,
       outboundEncoding: .none,
       acceptedEncodings: [],
-      maximumPayloadSize: 1,
+      maxPayloadSize: 1,
       skipStateMachineAssertions: true
     )
 
@@ -167,7 +167,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
       scheme: .http,
       outboundEncoding: .none,
       acceptedEncodings: [],
-      maximumPayloadSize: 1,
+      maxPayloadSize: 1,
       skipStateMachineAssertions: true
     )
 
@@ -203,7 +203,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
       scheme: .http,
       outboundEncoding: .deflate,
       acceptedEncodings: [.deflate],
-      maximumPayloadSize: 1
+      maxPayloadSize: 1
     )
 
     let channel = EmbeddedChannel(handler: handler)
@@ -261,7 +261,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
       scheme: .http,
       outboundEncoding: .none,
       acceptedEncodings: [],
-      maximumPayloadSize: 1,
+      maxPayloadSize: 1,
       skipStateMachineAssertions: true
     )
 
@@ -328,7 +328,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
       scheme: .http,
       outboundEncoding: .none,
       acceptedEncodings: [],
-      maximumPayloadSize: 100,
+      maxPayloadSize: 100,
       skipStateMachineAssertions: true
     )
 
@@ -396,7 +396,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
       scheme: .http,
       outboundEncoding: .none,
       acceptedEncodings: [],
-      maximumPayloadSize: 1,
+      maxPayloadSize: 1,
       skipStateMachineAssertions: true
     )
 
@@ -462,7 +462,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
       scheme: .http,
       outboundEncoding: .none,
       acceptedEncodings: [],
-      maximumPayloadSize: 100,
+      maxPayloadSize: 100,
       skipStateMachineAssertions: true
     )
 
@@ -580,7 +580,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
       scheme: .http,
       outboundEncoding: .none,
       acceptedEncodings: [],
-      maximumPayloadSize: 100,
+      maxPayloadSize: 100,
       skipStateMachineAssertions: true
     )
 
@@ -685,7 +685,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
       scheme: .http,
       outboundEncoding: .none,
       acceptedEncodings: [],
-      maximumPayloadSize: 100,
+      maxPayloadSize: 100,
       skipStateMachineAssertions: true
     )
 
@@ -769,7 +769,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
       scheme: .http,
       outboundEncoding: .none,
       acceptedEncodings: [],
-      maximumPayloadSize: 1,
+      maxPayloadSize: 1,
       skipStateMachineAssertions: true
     )
 
@@ -819,7 +819,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
       scheme: .http,
       outboundEncoding: .none,
       acceptedEncodings: [],
-      maximumPayloadSize: 1,
+      maxPayloadSize: 1,
       skipStateMachineAssertions: true
     )
 
@@ -865,7 +865,7 @@ final class GRPCClientStreamHandlerTests: XCTestCase {
       scheme: .http,
       outboundEncoding: .none,
       acceptedEncodings: [],
-      maximumPayloadSize: 1,
+      maxPayloadSize: 1,
       skipStateMachineAssertions: true
     )
 

--- a/Tests/GRPCHTTP2CoreTests/GRPCMessageDecoderTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/GRPCMessageDecoderTests.swift
@@ -44,12 +44,12 @@ final class GRPCMessageDecoderTests: XCTestCase {
         (firstMessage, [Array(repeating: UInt8(42), count: 16)]),
         (secondMessage, [Array(repeating: UInt8(43), count: 8)]),
       ]) {
-        GRPCMessageDecoder(maximumPayloadSize: .max)
+        GRPCMessageDecoder(maxPayloadSize: .max)
       }
   }
 
   func testReadMessageOverSizeLimitWithoutCompression() throws {
-    let deframer = GRPCMessageDecoder(maximumPayloadSize: 100)
+    let deframer = GRPCMessageDecoder(maxPayloadSize: 100)
     let processor = NIOSingleStepByteToMessageProcessor(deframer)
 
     var buffer = ByteBuffer()
@@ -72,7 +72,7 @@ final class GRPCMessageDecoderTests: XCTestCase {
   }
 
   func testReadMessageOverSizeLimitButWithoutActualMessageBytes() throws {
-    let deframer = GRPCMessageDecoder(maximumPayloadSize: 100)
+    let deframer = GRPCMessageDecoder(maxPayloadSize: 100)
     let processor = NIOSingleStepByteToMessageProcessor(deframer)
 
     var buffer = ByteBuffer()
@@ -97,7 +97,7 @@ final class GRPCMessageDecoderTests: XCTestCase {
   }
 
   func testCompressedMessageWithoutConfiguringDecompressor() throws {
-    let deframer = GRPCMessageDecoder(maximumPayloadSize: 100)
+    let deframer = GRPCMessageDecoder(maxPayloadSize: 100)
     let processor = NIOSingleStepByteToMessageProcessor(deframer)
 
     var buffer = ByteBuffer()
@@ -143,7 +143,7 @@ final class GRPCMessageDecoderTests: XCTestCase {
         (firstMessage.bytes, [Array(repeating: 42, count: 100)]),
         (secondMessage.bytes, [Array(repeating: 43, count: 110)]),
       ]) {
-        GRPCMessageDecoder(maximumPayloadSize: 1000, decompressor: decompressor)
+        GRPCMessageDecoder(maxPayloadSize: 1000, decompressor: decompressor)
       }
   }
 
@@ -156,7 +156,7 @@ final class GRPCMessageDecoderTests: XCTestCase {
   }
 
   func testReadCompressedMessageOverSizeLimitBeforeDecompressing() throws {
-    let deframer = GRPCMessageDecoder(maximumPayloadSize: 1)
+    let deframer = GRPCMessageDecoder(maxPayloadSize: 1)
     let processor = NIOSingleStepByteToMessageProcessor(deframer)
     let compressor = Zlib.Compressor(method: .gzip)
     var framer = GRPCMessageFramer()
@@ -186,7 +186,7 @@ final class GRPCMessageDecoderTests: XCTestCase {
 
   private func testReadDecompressedMessageOverSizeLimit(method: Zlib.Method) throws {
     let decompressor = Zlib.Decompressor(method: method)
-    let deframer = GRPCMessageDecoder(maximumPayloadSize: 100, decompressor: decompressor)
+    let deframer = GRPCMessageDecoder(maxPayloadSize: 100, decompressor: decompressor)
     let processor = NIOSingleStepByteToMessageProcessor(deframer)
     let compressor = Zlib.Compressor(method: method)
     var framer = GRPCMessageFramer()

--- a/Tests/GRPCHTTP2CoreTests/GRPCStreamStateMachineTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/GRPCStreamStateMachineTests.swift
@@ -150,7 +150,7 @@ final class GRPCStreamClientStateMachineTests: XCTestCase {
           acceptedEncodings: [.deflate]
         )
       ),
-      maximumPayloadSize: 100,
+      maxPayloadSize: 100,
       skipAssertions: true
     )
 
@@ -1346,7 +1346,7 @@ final class GRPCStreamServerStateMachineTests: XCTestCase {
           acceptedEncodings: deflateCompressionEnabled ? [.deflate] : []
         )
       ),
-      maximumPayloadSize: 100,
+      maxPayloadSize: 100,
       skipAssertions: true
     )
 

--- a/Tests/GRPCHTTP2CoreTests/Server/GRPCServerStreamHandlerTests.swift
+++ b/Tests/GRPCHTTP2CoreTests/Server/GRPCServerStreamHandlerTests.swift
@@ -30,7 +30,7 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
     let handler = GRPCServerStreamHandler(
       scheme: .http,
       acceptedEncodings: [],
-      maximumPayloadSize: 1,
+      maxPayloadSize: 1,
       methodDescriptorPromise: channel.eventLoop.makePromise(of: MethodDescriptor.self)
     )
     try channel.pipeline.syncOperations.addHandler(handler)
@@ -60,7 +60,7 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
     let handler = GRPCServerStreamHandler(
       scheme: .http,
       acceptedEncodings: [],
-      maximumPayloadSize: 1,
+      maxPayloadSize: 1,
       methodDescriptorPromise: channel.eventLoop.makePromise(of: MethodDescriptor.self)
     )
     try channel.pipeline.syncOperations.addHandler(handler)
@@ -90,7 +90,7 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
     let handler = GRPCServerStreamHandler(
       scheme: .http,
       acceptedEncodings: [],
-      maximumPayloadSize: 1,
+      maxPayloadSize: 1,
       methodDescriptorPromise: channel.eventLoop.makePromise(of: MethodDescriptor.self)
     )
     try channel.pipeline.syncOperations.addHandler(handler)
@@ -129,7 +129,7 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
     let handler = GRPCServerStreamHandler(
       scheme: .http,
       acceptedEncodings: [],
-      maximumPayloadSize: 1,
+      maxPayloadSize: 1,
       methodDescriptorPromise: channel.eventLoop.makePromise(of: MethodDescriptor.self)
     )
     try channel.pipeline.syncOperations.addHandler(handler)
@@ -168,7 +168,7 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
     let handler = GRPCServerStreamHandler(
       scheme: .http,
       acceptedEncodings: [],
-      maximumPayloadSize: 1,
+      maxPayloadSize: 1,
       methodDescriptorPromise: channel.eventLoop.makePromise(of: MethodDescriptor.self)
     )
     try channel.pipeline.syncOperations.addHandler(handler)
@@ -206,7 +206,7 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
     let handler = GRPCServerStreamHandler(
       scheme: .http,
       acceptedEncodings: [],
-      maximumPayloadSize: 100,
+      maxPayloadSize: 100,
       methodDescriptorPromise: channel.eventLoop.makePromise(of: MethodDescriptor.self)
     )
     try channel.pipeline.syncOperations.addHandler(handler)
@@ -248,7 +248,7 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
     let handler = GRPCServerStreamHandler(
       scheme: .http,
       acceptedEncodings: [],
-      maximumPayloadSize: 1,
+      maxPayloadSize: 1,
       methodDescriptorPromise: channel.eventLoop.makePromise(of: MethodDescriptor.self)
     )
     try channel.pipeline.syncOperations.addHandler(handler)
@@ -317,7 +317,7 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
     let handler = GRPCServerStreamHandler(
       scheme: .http,
       acceptedEncodings: [],
-      maximumPayloadSize: 1,
+      maxPayloadSize: 1,
       methodDescriptorPromise: channel.eventLoop.makePromise(of: MethodDescriptor.self),
       skipStateMachineAssertions: true
     )
@@ -383,7 +383,7 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
     let handler = GRPCServerStreamHandler(
       scheme: .http,
       acceptedEncodings: [],
-      maximumPayloadSize: 42,
+      maxPayloadSize: 42,
       methodDescriptorPromise: channel.eventLoop.makePromise(of: MethodDescriptor.self),
       skipStateMachineAssertions: true
     )
@@ -493,7 +493,7 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
     let handler = GRPCServerStreamHandler(
       scheme: .http,
       acceptedEncodings: [],
-      maximumPayloadSize: 100,
+      maxPayloadSize: 100,
       methodDescriptorPromise: channel.eventLoop.makePromise(of: MethodDescriptor.self)
     )
     try channel.pipeline.syncOperations.addHandler(handler)
@@ -589,7 +589,7 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
     let handler = GRPCServerStreamHandler(
       scheme: .http,
       acceptedEncodings: [],
-      maximumPayloadSize: 100,
+      maxPayloadSize: 100,
       methodDescriptorPromise: channel.eventLoop.makePromise(of: MethodDescriptor.self)
     )
     try channel.pipeline.syncOperations.addHandler(handler)
@@ -629,7 +629,7 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
     let handler = GRPCServerStreamHandler(
       scheme: .http,
       acceptedEncodings: [],
-      maximumPayloadSize: 100,
+      maxPayloadSize: 100,
       methodDescriptorPromise: channel.eventLoop.makePromise(of: MethodDescriptor.self)
     )
     try channel.pipeline.syncOperations.addHandler(handler)
@@ -707,7 +707,7 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
     let handler = GRPCServerStreamHandler(
       scheme: .http,
       acceptedEncodings: [],
-      maximumPayloadSize: 100,
+      maxPayloadSize: 100,
       methodDescriptorPromise: channel.eventLoop.makePromise(of: MethodDescriptor.self)
     )
     try channel.pipeline.syncOperations.addHandler(handler)
@@ -789,7 +789,7 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
     let handler = GRPCServerStreamHandler(
       scheme: .http,
       acceptedEncodings: [],
-      maximumPayloadSize: 100,
+      maxPayloadSize: 100,
       methodDescriptorPromise: promise,
       skipStateMachineAssertions: true
     )
@@ -828,7 +828,7 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
     let handler = GRPCServerStreamHandler(
       scheme: .http,
       acceptedEncodings: [],
-      maximumPayloadSize: 100,
+      maxPayloadSize: 100,
       methodDescriptorPromise: promise,
       skipStateMachineAssertions: true
     )
@@ -851,7 +851,7 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
     let handler = GRPCServerStreamHandler(
       scheme: .http,
       acceptedEncodings: [],
-      maximumPayloadSize: 100,
+      maxPayloadSize: 100,
       methodDescriptorPromise: promise,
       skipStateMachineAssertions: true
     )
@@ -886,7 +886,7 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
     let handler = GRPCServerStreamHandler(
       scheme: .http,
       acceptedEncodings: [],
-      maximumPayloadSize: 100,
+      maxPayloadSize: 100,
       methodDescriptorPromise: promise,
       skipStateMachineAssertions: true
     )
@@ -941,7 +941,7 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
     let handler = GRPCServerStreamHandler(
       scheme: .http,
       acceptedEncodings: [],
-      maximumPayloadSize: 100,
+      maxPayloadSize: 100,
       methodDescriptorPromise: promise,
       skipStateMachineAssertions: true
     )
@@ -996,7 +996,7 @@ final class GRPCServerStreamHandlerTests: XCTestCase {
     let handler = GRPCServerStreamHandler(
       scheme: .http,
       acceptedEncodings: [],
-      maximumPayloadSize: 100,
+      maxPayloadSize: 100,
       methodDescriptorPromise: promise,
       skipStateMachineAssertions: true
     )

--- a/Tests/GRPCInProcessTransportTests/InProcessClientTransportTests.swift
+++ b/Tests/GRPCInProcessTransportTests/InProcessClientTransportTests.swift
@@ -192,7 +192,7 @@ final class InProcessClientTransportTests: XCTestCase {
 
   func testExecutionConfiguration() {
     let policy = HedgingPolicy(
-      maximumAttempts: 10,
+      maxAttempts: 10,
       hedgingDelay: .seconds(1),
       nonFatalStatusCodes: []
     )
@@ -215,14 +215,14 @@ final class InProcessClientTransportTests: XCTestCase {
 
     let firstDescriptor = MethodDescriptor(service: "test", method: "first")
     XCTAssertEqual(
-      client.configuration(forMethod: firstDescriptor),
+      client.config(forMethod: firstDescriptor),
       serviceConfig.methodConfig.first
     )
 
     let retryPolicy = RetryPolicy(
-      maximumAttempts: 10,
+      maxAttempts: 10,
       initialBackoff: .seconds(1),
-      maximumBackoff: .seconds(1),
+      maxBackoff: .seconds(1),
       backoffMultiplier: 1.0,
       retryableStatusCodes: [.unavailable]
     )
@@ -239,11 +239,11 @@ final class InProcessClientTransportTests: XCTestCase {
 
     let secondDescriptor = MethodDescriptor(service: "test", method: "second")
     XCTAssertEqual(
-      client.configuration(forMethod: firstDescriptor),
+      client.config(forMethod: firstDescriptor),
       serviceConfig.methodConfig.first
     )
     XCTAssertEqual(
-      client.configuration(forMethod: secondDescriptor),
+      client.config(forMethod: secondDescriptor),
       serviceConfig.methodConfig.last
     )
   }
@@ -288,9 +288,9 @@ final class InProcessClientTransportTests: XCTestCase {
     server: InProcessServerTransport = InProcessServerTransport()
   ) -> InProcessClientTransport {
     let defaultPolicy = RetryPolicy(
-      maximumAttempts: 10,
+      maxAttempts: 10,
       initialBackoff: .seconds(1),
-      maximumBackoff: .seconds(1),
+      maxBackoff: .seconds(1),
       backoffMultiplier: 1.0,
       retryableStatusCodes: [.unavailable]
     )

--- a/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGeneratorTests.swift
+++ b/Tests/GRPCProtobufCodeGenTests/ProtobufCodeGeneratorTests.swift
@@ -501,7 +501,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
   func testCodeGeneration(
     proto: Google_Protobuf_FileDescriptorProto,
     indentation: Int,
-    visibility: SourceGenerator.Configuration.AccessLevel,
+    visibility: SourceGenerator.Config.AccessLevel,
     client: Bool,
     server: Bool,
     accessLevelOnImports: Bool = true,
@@ -509,7 +509,7 @@ final class ProtobufCodeGeneratorTests: XCTestCase {
     file: StaticString = #filePath,
     line: UInt = #line
   ) throws {
-    let config = SourceGenerator.Configuration(
+    let config = SourceGenerator.Config(
       accessLevel: visibility,
       accessLevelOnImports: accessLevelOnImports,
       client: client,


### PR DESCRIPTION
Motivation:

In v2 we've predominantly used 'max' instead of 'maximum' and 'config' instead of 'configuration'. We should apply these consistently.

Modifications:

- Replaces occurrences of 'maximum' with 'max', and 'configuration' with 'config'.

Result:

More consistent naming