### PR TITLE
Add server stream events

### DIFF
--- a/Sources/GRPCCore/Call/Server/RPCRouter.swift
+++ b/Sources/GRPCCore/Call/Server/RPCRouter.swift
@@ -155,7 +155,7 @@ extension RPCRouter {
     context: ServerContext,
     interceptors: [any ServerInterceptor]
   ) async {
-    if let handler = self.handlers[stream.descriptor] {
+    if let handler = self.handlers[context.descriptor] {
       await handler.handle(stream: stream, context: context, interceptors: interceptors)
     } else {
       // If this throws then the stream must be closed which we can't do anything about, so ignore

--- a/Sources/GRPCCore/Call/Server/ServerContext.swift
+++ b/Sources/GRPCCore/Call/Server/ServerContext.swift
@@ -15,12 +15,17 @@
  */
 
 /// Additional information about an RPC handled by a server.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 public struct ServerContext: Sendable {
   /// A description of the method being called.
   public var descriptor: MethodDescriptor
 
+  /// The state of the server stream.
+  public var streamState: ServerStreamState
+
   /// Create a new server context.
-  public init(descriptor: MethodDescriptor) {
+  public init(descriptor: MethodDescriptor, streamState: ServerStreamState) {
     self.descriptor = descriptor
+    self.streamState = streamState
   }
 }

--- a/Sources/GRPCCore/Call/Server/ServerStreamEvent.swift
+++ b/Sources/GRPCCore/Call/Server/ServerStreamEvent.swift
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// An out-of-band event which can happen to the underlying stream
+/// which an RPC is executing on.
+public struct ServerStreamEvent: Hashable, Sendable {
+  internal enum Value: Hashable, Sendable {
+    case rpcCancelled
+  }
+
+  internal var value: Value
+
+  private init(_ value: Value) {
+    self.value = value
+  }
+
+  /// The RPC was cancelled and the service should stop processing it.
+  ///
+  /// RPCs can be cancelled for a number of reasons including, but not limited to:
+  /// - it took too long to complete
+  /// - the client closed the underlying stream
+  /// - the stream closed unexpectedly (due to a network failure, for example)
+  /// - the server initiated a graceful shutdown
+  ///
+  /// You should stop processing the RPC and cleanup any associated state if you
+  /// receive this event.
+  public static let rpcCancelled = Self(.rpcCancelled)
+}
+
+extension ServerStreamEvent: CustomStringConvertible {
+  public var description: String {
+    String(describing: self.value)
+  }
+}

--- a/Sources/GRPCCore/Call/Server/ServerStreamState.swift
+++ b/Sources/GRPCCore/Call/Server/ServerStreamState.swift
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Synchronization
+
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+public struct ServerStreamState: Sendable {
+  /// Returns whether the RPC has been cancelled.
+  ///
+  /// - SeeAlso: ``ServerStreamEvent/rpcCancelled``.
+  public var isRPCCancelled: Bool {
+    self.events.isRPCCancelled
+  }
+
+  /// Events which can happen to the underlying stream the RPC is being run on.
+  public let events: Events
+
+  private init(events: Events) {
+    self.events = events
+  }
+
+  public static func makeState() -> (streamState: Self, eventContinuation: Events.Continuation) {
+    let events = Events()
+    return (ServerStreamState(events: events), eventContinuation: events.continuation)
+  }
+}
+
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+extension ServerStreamState {
+  /// An `AsyncSequence` of events which can happen to the stream.
+  ///
+  /// Each event will be delivered at most once.
+  ///
+  /// - Note: This sequence supports _multiple_ concurrent iterators.
+  public struct Events {
+    private let storage: Storage
+    @usableFromInline
+    internal let continuation: Continuation
+  }
+}
+
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+extension ServerStreamState.Events: AsyncSequence, Sendable {
+  public typealias Element = ServerStreamEvent
+  public typealias Failure = Never
+
+  init() {
+    self.storage = Storage()
+    self.continuation = Continuation(storage: self.storage)
+  }
+
+  fileprivate var isRPCCancelled: Bool {
+    self.storage.eventSet(contains: .rpcCancelled)
+  }
+
+  public func makeAsyncIterator() -> AsyncIterator {
+    let streamEvents = AsyncStream.makeStream(of: ServerStreamEvent.self)
+    self.storage.registerContinuation(streamEvents.continuation)
+    return AsyncIterator(iterator: streamEvents.stream.makeAsyncIterator())
+  }
+
+  public struct AsyncIterator: AsyncIteratorProtocol {
+    private var iterator: AsyncStream<ServerStreamEvent>.AsyncIterator
+
+    fileprivate init(iterator: AsyncStream<ServerStreamEvent>.AsyncIterator) {
+      self.iterator = iterator
+    }
+
+    public mutating func next() async throws(Never) -> ServerStreamEvent? {
+      await self.next(isolation: nil)
+    }
+
+    public mutating func next(
+      isolation actor: isolated (any Actor)?
+    ) async throws(Never) -> ServerStreamEvent? {
+      return await self.iterator.next(isolation: actor)
+    }
+  }
+
+  public struct Continuation: Sendable {
+    private let storage: Storage
+
+    init(storage: Storage) {
+      self.storage = storage
+    }
+
+    /// Yield an event to the stream.
+    ///
+    /// - Important: Events are only delivered once. If the event has already been yielded
+    ///   then attempting to yield it again is a no-op.
+    /// - Parameter event: The event to yield.
+    public func yield(_ event: ServerStreamEvent) {
+      self.storage.yield(event)
+    }
+
+    /// Indicate that no more events will be delivered.
+    public func finish() {
+      self.storage.finish()
+    }
+  }
+}
+
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+extension ServerStreamState.Events {
+  final class Storage: Sendable {
+    private let state: Mutex<State>
+
+    init() {
+      self.state = Mutex(State())
+    }
+
+    func eventSet(contains event: ServerStreamEvent) -> Bool {
+      self.state.withLock { $0.eventSet.contains(EventSet(event)) }
+    }
+
+    func registerContinuation(_ continuation: AsyncStream<ServerStreamEvent>.Continuation) {
+      self.state.withLock {
+        let events = $0.registerContinuation(continuation)
+
+        if events.contains(.rpcCancelled) {
+          continuation.yield(.rpcCancelled)
+        }
+
+        if events.contains(.finished) {
+          continuation.finish()
+        }
+      }
+    }
+
+    func yield(_ event: ServerStreamEvent) {
+      self.state.withLock {
+        for continuation in $0.publishStreamEvent(event) {
+          continuation.yield(event)
+        }
+      }
+    }
+
+    func finish() {
+      self.state.withLock {
+        for continuation in $0.finish() {
+          continuation.finish()
+        }
+      }
+    }
+  }
+
+  private struct EventSet: OptionSet, Hashable, Sendable {
+    var rawValue: UInt8
+
+    init(rawValue: UInt8) {
+      self.rawValue = rawValue
+    }
+
+    init(_ event: ServerStreamEvent) {
+      switch event.value {
+      case .rpcCancelled:
+        self = .rpcCancelled
+      }
+    }
+
+    static let finished = EventSet(rawValue: 1 << 0)
+    static let rpcCancelled = EventSet(rawValue: 1 << 1)
+  }
+
+  private struct State: Sendable {
+    private(set) var eventSet: EventSet
+    private var continuations: [AsyncStream<ServerStreamEvent>.Continuation]
+
+    init() {
+      self.eventSet = EventSet()
+      self.continuations = []
+    }
+
+    mutating func registerContinuation(
+      _ continuation: AsyncStream<ServerStreamEvent>.Continuation
+    ) -> EventSet {
+      if !self.eventSet.contains(.finished) {
+        self.continuations.append(continuation)
+      }
+
+      return self.eventSet
+    }
+
+    mutating func publishStreamEvent(
+      _ streamEvent: ServerStreamEvent
+    ) -> [AsyncStream<ServerStreamEvent>.Continuation] {
+      if self.eventSet.contains(.finished) {
+        return []
+      } else {
+        let (inserted, _) = self.eventSet.insert(EventSet(streamEvent))
+        return inserted ? self.continuations : []
+      }
+    }
+
+    mutating func finish() -> [AsyncStream<ServerStreamEvent>.Continuation] {
+      let (inserted, _) = self.eventSet.insert(.finished)
+      return inserted ? self.continuations : []
+    }
+  }
+}

--- a/Tests/GRPCCoreTests/Call/Server/ServerStreamStateTests.swift
+++ b/Tests/GRPCCoreTests/Call/Server/ServerStreamStateTests.swift
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import GRPCCore
+import Testing
+
+@Suite("ServerStreamState")
+struct ServerStreamStateTests {
+  @Test("Does nothing on init")
+  @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+  func nothingOnInit() {
+    let (state, _) = ServerStreamState.makeState()
+    #expect(!state.isRPCCancelled)
+  }
+
+  @Test("Multiple iterators are allowed")
+  @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+  func multipleIteratorsAreAllowed() async {
+    let (state, continuation) = ServerStreamState.makeState()
+    await withTaskGroup(of: [ServerStreamEvent].self) { group in
+      for _ in 0 ..< 100 {
+        group.addTask {
+          await state.events.reduce(into: []) { $0.append($1) }
+        }
+      }
+
+      continuation.yield(.rpcCancelled)
+      continuation.finish()
+
+      for await events in group {
+        #expect(events == [.rpcCancelled])
+      }
+    }
+  }
+
+  @Test("State is set after event is yielded")
+  @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+  func stateSetAfterYield() async {
+    let (state, continuation) = ServerStreamState.makeState()
+    #expect(!state.isRPCCancelled)
+    continuation.yield(.rpcCancelled)
+    #expect(state.isRPCCancelled)
+  }
+
+  @Test("Events are only delivered once")
+  @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+  func eventsAreOnlyDeliveredOnce() async {
+    let (state, continuation) = ServerStreamState.makeState()
+    continuation.yield(.rpcCancelled)
+    continuation.yield(.rpcCancelled)
+    continuation.yield(.rpcCancelled)
+    continuation.finish()
+
+    let events = await state.events.reduce(into: []) { $0.append($1) }
+    #expect(events == [.rpcCancelled])
+  }
+}

--- a/Tests/GRPCCoreTests/Test Utilities/Transport/ThrowingTransport.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/Transport/ThrowingTransport.swift
@@ -51,7 +51,7 @@ struct ThrowOnStreamCreationTransport: ClientTransport {
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct ThrowOnRunServerTransport: ServerTransport {
   func listen(
     streamHandler: (
@@ -70,7 +70,7 @@ struct ThrowOnRunServerTransport: ServerTransport {
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct ThrowOnSignalServerTransport: ServerTransport {
   let signal: AsyncStream<Void>
 


### PR DESCRIPTION
Motivation:

As a service author it's useful to know if the underlying stream has been cancelled (because it's timed out, the remote peer closed it, the connection dropped etc).

For cases where the stream has already closed this can be surfaced by a read or write failing. However, for cases like server-streaming RPCs where there are no reads and writes can be infrequent it's useful to have a more explicit signal.

Modifications:

- Add a `ServerStreamState` which provides two API for this:
  - An explicit "has this RPC been cancelled?"
  - An async sequence of events which can happen the underlying stream
- Add the stream state to the server context
- Update the in-process transport to use this

Result:

Server context includes a way for users to know if their RPC has been cancelled.