### PR TITLE
Add an underscore between generated service name and component

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -65,6 +65,7 @@ let targets: [Target] = [
     name: "GRPCCoreTests",
     dependencies: [
       .target(name: "GRPCCore"),
+      .target(name: "GRPCInProcessTransport"),
       .product(name: "SwiftProtobuf", package: "swift-protobuf")
     ],
     resources: [

--- a/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
@@ -121,7 +121,7 @@ extension ClientCodeTranslator {
     let clientProtocol = Declaration.protocol(
       ProtocolDescription(
         accessModifier: self.accessModifier,
-        name: "\(service.namespacedGeneratedName)ClientProtocol",
+        name: "\(service.namespacedGeneratedName)_ClientProtocol",
         conformances: ["Sendable"],
         members: methods
       )
@@ -592,7 +592,7 @@ extension ClientCodeTranslator {
       .struct(
         StructDescription(
           accessModifier: self.accessModifier,
-          name: "\(service.namespacedGeneratedName)Client",
+          name: "\(service.namespacedGeneratedName)_Client",
           conformances: ["\(service.namespacedGeneratedName).ClientProtocol"],
           members: [clientProperty, initializer] + methods
         )

--- a/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
@@ -481,8 +481,8 @@ extension ServerCodeTranslator {
     streaming: Bool
   ) -> String {
     if streaming {
-      return "\(service.namespacedGeneratedName)StreamingServiceProtocol"
+      return "\(service.namespacedGeneratedName)_StreamingServiceProtocol"
     }
-    return "\(service.namespacedGeneratedName)ServiceProtocol"
+    return "\(service.namespacedGeneratedName)_ServiceProtocol"
   }
 }

--- a/Sources/GRPCCodeGen/Internal/Translator/TypealiasTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/TypealiasTranslator.swift
@@ -256,12 +256,12 @@ extension TypealiasTranslator {
     let streamingServiceProtocolTypealias = Declaration.typealias(
       accessModifier: self.accessModifier,
       name: "StreamingServiceProtocol",
-      existingType: .member("\(service.namespacedGeneratedName)StreamingServiceProtocol")
+      existingType: .member("\(service.namespacedGeneratedName)_StreamingServiceProtocol")
     )
     let serviceProtocolTypealias = Declaration.typealias(
       accessModifier: self.accessModifier,
       name: "ServiceProtocol",
-      existingType: .member("\(service.namespacedGeneratedName)ServiceProtocol")
+      existingType: .member("\(service.namespacedGeneratedName)_ServiceProtocol")
     )
 
     return [
@@ -284,7 +284,7 @@ extension TypealiasTranslator {
       .typealias(
         accessModifier: self.accessModifier,
         name: "ClientProtocol",
-        existingType: .member("\(service.namespacedGeneratedName)ClientProtocol")
+        existingType: .member("\(service.namespacedGeneratedName)_ClientProtocol")
       )
     )
   }
@@ -297,7 +297,7 @@ extension TypealiasTranslator {
       .typealias(
         accessModifier: self.accessModifier,
         name: "Client",
-        existingType: .member("\(service.namespacedGeneratedName)Client")
+        existingType: .member("\(service.namespacedGeneratedName)_Client")
       )
     )
   }

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
@@ -44,7 +44,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       """
       /// Documentation for ServiceA
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-      public protocol NamespaceA_ServiceAClientProtocol: Sendable {
+      public protocol NamespaceA_ServiceA_ClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
               request: GRPCCore.ClientRequest.Single<NamespaceA_ServiceARequest>,
@@ -96,7 +96,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       }
       /// Documentation for ServiceA
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-      public struct NamespaceA_ServiceAClient: NamespaceA_ServiceA.ClientProtocol {
+      public struct NamespaceA_ServiceA_Client: NamespaceA_ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
           public init(wrapping client: GRPCCore.GRPCClient) {
@@ -151,7 +151,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       """
       /// Documentation for ServiceA
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-      public protocol NamespaceA_ServiceAClientProtocol: Sendable {
+      public protocol NamespaceA_ServiceA_ClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
               request: GRPCCore.ClientRequest.Stream<NamespaceA_ServiceARequest>,
@@ -203,7 +203,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       }
       /// Documentation for ServiceA
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-      public struct NamespaceA_ServiceAClient: NamespaceA_ServiceA.ClientProtocol {
+      public struct NamespaceA_ServiceA_Client: NamespaceA_ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
           public init(wrapping client: GRPCCore.GRPCClient) {
@@ -258,7 +258,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       """
       /// Documentation for ServiceA
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-      public protocol NamespaceA_ServiceAClientProtocol: Sendable {
+      public protocol NamespaceA_ServiceA_ClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
               request: GRPCCore.ClientRequest.Single<NamespaceA_ServiceARequest>,
@@ -306,7 +306,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       }
       /// Documentation for ServiceA
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-      public struct NamespaceA_ServiceAClient: NamespaceA_ServiceA.ClientProtocol {
+      public struct NamespaceA_ServiceA_Client: NamespaceA_ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
           public init(wrapping client: GRPCCore.GRPCClient) {
@@ -359,7 +359,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       """
       /// Documentation for ServiceA
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-      public protocol NamespaceA_ServiceAClientProtocol: Sendable {
+      public protocol NamespaceA_ServiceA_ClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
               request: GRPCCore.ClientRequest.Stream<NamespaceA_ServiceARequest>,
@@ -407,7 +407,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       }
       /// Documentation for ServiceA
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-      public struct NamespaceA_ServiceAClient: NamespaceA_ServiceA.ClientProtocol {
+      public struct NamespaceA_ServiceA_Client: NamespaceA_ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
           public init(wrapping client: GRPCCore.GRPCClient) {
@@ -468,7 +468,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       """
       /// Documentation for ServiceA
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-      package protocol NamespaceA_ServiceAClientProtocol: Sendable {
+      package protocol NamespaceA_ServiceA_ClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
               request: GRPCCore.ClientRequest.Stream<NamespaceA_ServiceARequest>,
@@ -561,7 +561,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       }
       /// Documentation for ServiceA
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-      package struct NamespaceA_ServiceAClient: NamespaceA_ServiceA.ClientProtocol {
+      package struct NamespaceA_ServiceA_Client: NamespaceA_ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
           package init(wrapping client: GRPCCore.GRPCClient) {
@@ -634,7 +634,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       """
       /// Documentation for ServiceA
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-      internal protocol ServiceAClientProtocol: Sendable {
+      internal protocol ServiceA_ClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
               request: GRPCCore.ClientRequest.Single<ServiceARequest>,
@@ -686,7 +686,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       }
       /// Documentation for ServiceA
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-      internal struct ServiceAClient: ServiceA.ClientProtocol {
+      internal struct ServiceA_Client: ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
           internal init(wrapping client: GRPCCore.GRPCClient) {
@@ -747,7 +747,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       """
       /// Documentation for ServiceA
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-      public protocol NamespaceA_ServiceAClientProtocol: Sendable {}
+      public protocol NamespaceA_ServiceA_ClientProtocol: Sendable {}
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
       }
@@ -756,7 +756,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       }
       /// Documentation for ServiceA
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-      public struct NamespaceA_ServiceAClient: NamespaceA_ServiceA.ClientProtocol {
+      public struct NamespaceA_ServiceA_Client: NamespaceA_ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
           public init(wrapping client: GRPCCore.GRPCClient) {
@@ -767,7 +767,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       ///
       /// Line 2
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-      public protocol ServiceBClientProtocol: Sendable {}
+      public protocol ServiceB_ClientProtocol: Sendable {}
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension ServiceB.ClientProtocol {
       }
@@ -778,7 +778,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       ///
       /// Line 2
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-      public struct ServiceBClient: ServiceB.ClientProtocol {
+      public struct ServiceB_Client: ServiceB.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
           public init(wrapping client: GRPCCore.GRPCClient) {

--- a/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
@@ -222,9 +222,9 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
               public static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
+          public typealias StreamingServiceProtocol = NamespaceA_ServiceA_StreamingServiceProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
+          public typealias ServiceProtocol = NamespaceA_ServiceA_ServiceProtocol
       }
 
       extension GRPCCore.ServiceDescriptor {
@@ -236,7 +236,7 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
 
       /// Documentation for AService
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-      public protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {}
+      public protocol NamespaceA_ServiceA_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {}
 
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
@@ -247,9 +247,9 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
 
       /// Documentation for AService
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-      public protocol NamespaceA_ServiceAServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {}
+      public protocol NamespaceA_ServiceA_ServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {}
 
-      /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
+      /// Partial conformance to `NamespaceA_ServiceA_StreamingServiceProtocol`.
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ServiceProtocol {
       }

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
@@ -52,7 +52,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       """
       /// Documentation for ServiceA
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-      public protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
+      public protocol NamespaceA_ServiceA_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for unaryMethod
           func unary(
               request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>,
@@ -79,14 +79,14 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       }
       /// Documentation for ServiceA
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-      public protocol NamespaceA_ServiceAServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
+      public protocol NamespaceA_ServiceA_ServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
           /// Documentation for unaryMethod
           func unary(
               request: GRPCCore.ServerRequest.Single<NamespaceA_ServiceARequest>,
               context: GRPCCore.ServerContext
           ) async throws -> GRPCCore.ServerResponse.Single<NamespaceA_ServiceAResponse>
       }
-      /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
+      /// Partial conformance to `NamespaceA_ServiceA_StreamingServiceProtocol`.
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ServiceProtocol {
           public func unary(
@@ -136,7 +136,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       """
       /// Documentation for ServiceA
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-      package protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
+      package protocol NamespaceA_ServiceA_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for inputStreamingMethod
           func inputStreaming(
               request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>,
@@ -163,14 +163,14 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       }
       /// Documentation for ServiceA
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-      package protocol NamespaceA_ServiceAServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
+      package protocol NamespaceA_ServiceA_ServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
           /// Documentation for inputStreamingMethod
           func inputStreaming(
               request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>,
               context: GRPCCore.ServerContext
           ) async throws -> GRPCCore.ServerResponse.Single<NamespaceA_ServiceAResponse>
       }
-      /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
+      /// Partial conformance to `NamespaceA_ServiceA_StreamingServiceProtocol`.
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ServiceProtocol {
           package func inputStreaming(
@@ -224,7 +224,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       """
       /// Documentation for ServiceA
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-      public protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
+      public protocol NamespaceA_ServiceA_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for outputStreamingMethod
           func outputStreaming(
               request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>,
@@ -251,14 +251,14 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       }
       /// Documentation for ServiceA
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-      public protocol NamespaceA_ServiceAServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
+      public protocol NamespaceA_ServiceA_ServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
           /// Documentation for outputStreamingMethod
           func outputStreaming(
               request: GRPCCore.ServerRequest.Single<NamespaceA_ServiceARequest>,
               context: GRPCCore.ServerContext
           ) async throws -> GRPCCore.ServerResponse.Stream<NamespaceA_ServiceAResponse>
       }
-      /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
+      /// Partial conformance to `NamespaceA_ServiceA_StreamingServiceProtocol`.
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ServiceProtocol {
           public func outputStreaming(
@@ -312,7 +312,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       """
       /// Documentation for ServiceA
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-      package protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
+      package protocol NamespaceA_ServiceA_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for bidirectionalStreamingMethod
           func bidirectionalStreaming(
               request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>,
@@ -339,14 +339,14 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       }
       /// Documentation for ServiceA
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-      package protocol NamespaceA_ServiceAServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
+      package protocol NamespaceA_ServiceA_ServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
           /// Documentation for bidirectionalStreamingMethod
           func bidirectionalStreaming(
               request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>,
               context: GRPCCore.ServerContext
           ) async throws -> GRPCCore.ServerResponse.Stream<NamespaceA_ServiceAResponse>
       }
-      /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
+      /// Partial conformance to `NamespaceA_ServiceA_StreamingServiceProtocol`.
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ServiceProtocol {
       }
@@ -402,7 +402,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       """
       /// Documentation for ServiceA
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-      internal protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
+      internal protocol NamespaceA_ServiceA_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for inputStreamingMethod
           func inputStreaming(
               request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>,
@@ -446,7 +446,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       }
       /// Documentation for ServiceA
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-      internal protocol NamespaceA_ServiceAServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
+      internal protocol NamespaceA_ServiceA_ServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
           /// Documentation for inputStreamingMethod
           func inputStreaming(
               request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>,
@@ -459,7 +459,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
               context: GRPCCore.ServerContext
           ) async throws -> GRPCCore.ServerResponse.Stream<NamespaceA_ServiceAResponse>
       }
-      /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
+      /// Partial conformance to `NamespaceA_ServiceA_StreamingServiceProtocol`.
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ServiceProtocol {
           internal func inputStreaming(
@@ -516,7 +516,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       """
       /// Documentation for ServiceA
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-      internal protocol ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
+      internal protocol ServiceA_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for MethodA
           func methodA(
               request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>,
@@ -543,14 +543,14 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       }
       /// Documentation for ServiceA
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-      internal protocol ServiceAServiceProtocol: ServiceA.StreamingServiceProtocol {
+      internal protocol ServiceA_ServiceProtocol: ServiceA.StreamingServiceProtocol {
           /// Documentation for MethodA
           func methodA(
               request: GRPCCore.ServerRequest.Single<NamespaceA_ServiceARequest>,
               context: GRPCCore.ServerContext
           ) async throws -> GRPCCore.ServerResponse.Single<NamespaceA_ServiceAResponse>
       }
-      /// Partial conformance to `ServiceAStreamingServiceProtocol`.
+      /// Partial conformance to `ServiceA_StreamingServiceProtocol`.
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension ServiceA.ServiceProtocol {
           internal func methodA(
@@ -598,7 +598,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       """
       /// Documentation for ServiceA
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-      public protocol NamespaceA_ServiceAStreamingServiceProtocol: GRPCCore.RegistrableRPCService {}
+      public protocol NamespaceA_ServiceA_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {}
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.StreamingServiceProtocol {
@@ -607,14 +607,14 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       }
       /// Documentation for ServiceA
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-      public protocol NamespaceA_ServiceAServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {}
-      /// Partial conformance to `NamespaceA_ServiceAStreamingServiceProtocol`.
+      public protocol NamespaceA_ServiceA_ServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {}
+      /// Partial conformance to `NamespaceA_ServiceA_StreamingServiceProtocol`.
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ServiceProtocol {
       }
       /// Documentation for ServiceB
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-      public protocol NamespaceA_ServiceBStreamingServiceProtocol: GRPCCore.RegistrableRPCService {}
+      public protocol NamespaceA_ServiceB_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {}
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceB.StreamingServiceProtocol {
@@ -623,8 +623,8 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       }
       /// Documentation for ServiceB
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-      public protocol NamespaceA_ServiceBServiceProtocol: NamespaceA_ServiceB.StreamingServiceProtocol {}
-      /// Partial conformance to `NamespaceA_ServiceBStreamingServiceProtocol`.
+      public protocol NamespaceA_ServiceB_ServiceProtocol: NamespaceA_ServiceB.StreamingServiceProtocol {}
+      /// Partial conformance to `NamespaceA_ServiceB_StreamingServiceProtocol`.
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceB.ServiceProtocol {
       }

--- a/Tests/GRPCCodeGenTests/Internal/Translator/TypealiasTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/TypealiasTranslatorSnippetBasedTests.swift
@@ -62,13 +62,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               ]
           }
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
+          public typealias StreamingServiceProtocol = NamespaceA_ServiceA_StreamingServiceProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
+          public typealias ServiceProtocol = NamespaceA_ServiceA_ServiceProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
+          public typealias ClientProtocol = NamespaceA_ServiceA_ClientProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias Client = NamespaceA_ServiceAClient
+          public typealias Client = NamespaceA_ServiceA_Client
       }
       extension GRPCCore.ServiceDescriptor {
           public static let namespaceA_ServiceA = Self(
@@ -106,13 +106,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               public static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
+          public typealias StreamingServiceProtocol = NamespaceA_ServiceA_StreamingServiceProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
+          public typealias ServiceProtocol = NamespaceA_ServiceA_ServiceProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
+          public typealias ClientProtocol = NamespaceA_ServiceA_ClientProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias Client = NamespaceA_ServiceAClient
+          public typealias Client = NamespaceA_ServiceA_Client
       }
       extension GRPCCore.ServiceDescriptor {
           public static let namespaceA_ServiceA = Self(
@@ -150,9 +150,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               public static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
+          public typealias StreamingServiceProtocol = NamespaceA_ServiceA_StreamingServiceProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
+          public typealias ServiceProtocol = NamespaceA_ServiceA_ServiceProtocol
       }
       extension GRPCCore.ServiceDescriptor {
           public static let namespaceA_ServiceA = Self(
@@ -190,9 +190,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               public static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
+          public typealias ClientProtocol = NamespaceA_ServiceA_ClientProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias Client = NamespaceA_ServiceAClient
+          public typealias Client = NamespaceA_ServiceA_Client
       }
       extension GRPCCore.ServiceDescriptor {
           public static let namespaceA_ServiceA = Self(
@@ -280,13 +280,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               ]
           }
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias StreamingServiceProtocol = ServiceAStreamingServiceProtocol
+          public typealias StreamingServiceProtocol = ServiceA_StreamingServiceProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias ServiceProtocol = ServiceAServiceProtocol
+          public typealias ServiceProtocol = ServiceA_ServiceProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias ClientProtocol = ServiceAClientProtocol
+          public typealias ClientProtocol = ServiceA_ClientProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias Client = ServiceAClient
+          public typealias Client = ServiceA_Client
       }
       extension GRPCCore.ServiceDescriptor {
           public static let ServiceA = Self(
@@ -359,13 +359,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               ]
           }
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
+          public typealias StreamingServiceProtocol = NamespaceA_ServiceA_StreamingServiceProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
+          public typealias ServiceProtocol = NamespaceA_ServiceA_ServiceProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
+          public typealias ClientProtocol = NamespaceA_ServiceA_ClientProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias Client = NamespaceA_ServiceAClient
+          public typealias Client = NamespaceA_ServiceA_Client
       }
       extension GRPCCore.ServiceDescriptor {
           public static let namespaceA_ServiceA = Self(
@@ -403,13 +403,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               package static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          package typealias StreamingServiceProtocol = NamespaceA_ServiceAStreamingServiceProtocol
+          package typealias StreamingServiceProtocol = NamespaceA_ServiceA_StreamingServiceProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          package typealias ServiceProtocol = NamespaceA_ServiceAServiceProtocol
+          package typealias ServiceProtocol = NamespaceA_ServiceA_ServiceProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          package typealias ClientProtocol = NamespaceA_ServiceAClientProtocol
+          package typealias ClientProtocol = NamespaceA_ServiceA_ClientProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          package typealias Client = NamespaceA_ServiceAClient
+          package typealias Client = NamespaceA_ServiceA_Client
       }
       extension GRPCCore.ServiceDescriptor {
           package static let namespaceA_ServiceA = Self(
@@ -459,13 +459,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               public static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias StreamingServiceProtocol = NamespaceA_AserviceStreamingServiceProtocol
+          public typealias StreamingServiceProtocol = NamespaceA_Aservice_StreamingServiceProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias ServiceProtocol = NamespaceA_AserviceServiceProtocol
+          public typealias ServiceProtocol = NamespaceA_Aservice_ServiceProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias ClientProtocol = NamespaceA_AserviceClientProtocol
+          public typealias ClientProtocol = NamespaceA_Aservice_ClientProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias Client = NamespaceA_AserviceClient
+          public typealias Client = NamespaceA_Aservice_Client
       }
       extension GRPCCore.ServiceDescriptor {
           public static let namespaceA_AService = Self(
@@ -479,13 +479,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               public static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias StreamingServiceProtocol = NamespaceA_BserviceStreamingServiceProtocol
+          public typealias StreamingServiceProtocol = NamespaceA_Bservice_StreamingServiceProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias ServiceProtocol = NamespaceA_BserviceServiceProtocol
+          public typealias ServiceProtocol = NamespaceA_Bservice_ServiceProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias ClientProtocol = NamespaceA_BserviceClientProtocol
+          public typealias ClientProtocol = NamespaceA_Bservice_ClientProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias Client = NamespaceA_BserviceClient
+          public typealias Client = NamespaceA_Bservice_Client
       }
       extension GRPCCore.ServiceDescriptor {
           public static let namespaceA_BService = Self(
@@ -527,13 +527,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               package static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          package typealias StreamingServiceProtocol = AServiceStreamingServiceProtocol
+          package typealias StreamingServiceProtocol = AService_StreamingServiceProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          package typealias ServiceProtocol = AServiceServiceProtocol
+          package typealias ServiceProtocol = AService_ServiceProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          package typealias ClientProtocol = AServiceClientProtocol
+          package typealias ClientProtocol = AService_ClientProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          package typealias Client = AServiceClient
+          package typealias Client = AService_Client
       }
       extension GRPCCore.ServiceDescriptor {
           package static let AService = Self(
@@ -547,13 +547,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               package static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          package typealias StreamingServiceProtocol = BServiceStreamingServiceProtocol
+          package typealias StreamingServiceProtocol = BService_StreamingServiceProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          package typealias ServiceProtocol = BServiceServiceProtocol
+          package typealias ServiceProtocol = BService_ServiceProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          package typealias ClientProtocol = BServiceClientProtocol
+          package typealias ClientProtocol = BService_ClientProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          package typealias Client = BServiceClient
+          package typealias Client = BService_Client
       }
       extension GRPCCore.ServiceDescriptor {
           package static let BService = Self(
@@ -603,13 +603,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               internal static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          internal typealias StreamingServiceProtocol = Anamespace_AServiceStreamingServiceProtocol
+          internal typealias StreamingServiceProtocol = Anamespace_AService_StreamingServiceProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          internal typealias ServiceProtocol = Anamespace_AServiceServiceProtocol
+          internal typealias ServiceProtocol = Anamespace_AService_ServiceProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          internal typealias ClientProtocol = Anamespace_AServiceClientProtocol
+          internal typealias ClientProtocol = Anamespace_AService_ClientProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          internal typealias Client = Anamespace_AServiceClient
+          internal typealias Client = Anamespace_AService_Client
       }
       extension GRPCCore.ServiceDescriptor {
           internal static let anamespace_AService = Self(
@@ -623,13 +623,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               internal static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          internal typealias StreamingServiceProtocol = Bnamespace_BServiceStreamingServiceProtocol
+          internal typealias StreamingServiceProtocol = Bnamespace_BService_StreamingServiceProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          internal typealias ServiceProtocol = Bnamespace_BServiceServiceProtocol
+          internal typealias ServiceProtocol = Bnamespace_BService_ServiceProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          internal typealias ClientProtocol = Bnamespace_BServiceClientProtocol
+          internal typealias ClientProtocol = Bnamespace_BService_ClientProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          internal typealias Client = Bnamespace_BServiceClient
+          internal typealias Client = Bnamespace_BService_Client
       }
       extension GRPCCore.ServiceDescriptor {
           internal static let bnamespace_BService = Self(
@@ -673,13 +673,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               public static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias StreamingServiceProtocol = Anamespace_AServiceStreamingServiceProtocol
+          public typealias StreamingServiceProtocol = Anamespace_AService_StreamingServiceProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias ServiceProtocol = Anamespace_AServiceServiceProtocol
+          public typealias ServiceProtocol = Anamespace_AService_ServiceProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias ClientProtocol = Anamespace_AServiceClientProtocol
+          public typealias ClientProtocol = Anamespace_AService_ClientProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias Client = Anamespace_AServiceClient
+          public typealias Client = Anamespace_AService_Client
       }
       extension GRPCCore.ServiceDescriptor {
           public static let anamespace_AService = Self(
@@ -693,13 +693,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
               public static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias StreamingServiceProtocol = BServiceStreamingServiceProtocol
+          public typealias StreamingServiceProtocol = BService_StreamingServiceProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias ServiceProtocol = BServiceServiceProtocol
+          public typealias ServiceProtocol = BService_ServiceProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias ClientProtocol = BServiceClientProtocol
+          public typealias ClientProtocol = BService_ClientProtocol
           @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-          public typealias Client = BServiceClient
+          public typealias Client = BService_Client
       }
       extension GRPCCore.ServiceDescriptor {
           public static let BService = Self(


### PR DESCRIPTION
Motivation:

A 'bar' package defining a 'FooService' service will have a number of types generateed for it, for example, `Bar_FooServiceServiceProtocol`, or `Bar_FooServiceClient`. The protocol buffers style guide reccomends that services are suffixed with "Service" (e.g. "FooService", not "Foo") which results in some strange protocol names (like `Bar_FooServiceServiceProtocol`).

There should be a clearer differentiation between the qualified service name ("bar.FooServce") and the type being generated. The code generator already replaces "." with "_" in fully qualified names, so "_" is a natural choice as a separator.

Modifications:

- Add an "_" between the generated fully qualified service name and the gRPC component being generated
- Update tests

Result:

Better names in generated code.

The `Bar_FooServiceServiceProtocol` example above becomes `Bar_FooService_ServiceProtocol`, while `Bar_FooServiceClient` becomes `Bar_FooService_Client`.