### PR TITLE
Update examples

### DIFF
--- a/Examples/echo/Sources/Generated/echo.grpc.swift
+++ b/Examples/echo/Sources/Generated/echo.grpc.swift
@@ -67,13 +67,13 @@ internal enum Echo_Echo {
         ]
     }
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-    internal typealias StreamingServiceProtocol = Echo_EchoStreamingServiceProtocol
+    internal typealias StreamingServiceProtocol = Echo_Echo_StreamingServiceProtocol
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-    internal typealias ServiceProtocol = Echo_EchoServiceProtocol
+    internal typealias ServiceProtocol = Echo_Echo_ServiceProtocol
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-    internal typealias ClientProtocol = Echo_EchoClientProtocol
+    internal typealias ClientProtocol = Echo_Echo_ClientProtocol
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-    internal typealias Client = Echo_EchoClient
+    internal typealias Client = Echo_Echo_Client
 }
 
 extension GRPCCore.ServiceDescriptor {
@@ -84,7 +84,7 @@ extension GRPCCore.ServiceDescriptor {
 }
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-internal protocol Echo_EchoStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
+internal protocol Echo_Echo_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {
     /// Immediately returns an echo of a request.
     func get(
         request: GRPCCore.ServerRequest.Stream<Echo_EchoRequest>,
@@ -163,7 +163,7 @@ extension Echo_Echo.StreamingServiceProtocol {
 }
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-internal protocol Echo_EchoServiceProtocol: Echo_Echo.StreamingServiceProtocol {
+internal protocol Echo_Echo_ServiceProtocol: Echo_Echo.StreamingServiceProtocol {
     /// Immediately returns an echo of a request.
     func get(
         request: GRPCCore.ServerRequest.Single<Echo_EchoRequest>,
@@ -189,7 +189,7 @@ internal protocol Echo_EchoServiceProtocol: Echo_Echo.StreamingServiceProtocol {
     ) async throws -> GRPCCore.ServerResponse.Stream<Echo_EchoResponse>
 }
 
-/// Partial conformance to `Echo_EchoStreamingServiceProtocol`.
+/// Partial conformance to `Echo_Echo_StreamingServiceProtocol`.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Echo_Echo.ServiceProtocol {
     internal func get(
@@ -227,7 +227,7 @@ extension Echo_Echo.ServiceProtocol {
 }
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-internal protocol Echo_EchoClientProtocol: Sendable {
+internal protocol Echo_Echo_ClientProtocol: Sendable {
     /// Immediately returns an echo of a request.
     func get<R>(
         request: GRPCCore.ClientRequest.Single<Echo_EchoRequest>,
@@ -408,7 +408,7 @@ extension Echo_Echo.ClientProtocol {
 }
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-internal struct Echo_EchoClient: Echo_Echo.ClientProtocol {
+internal struct Echo_Echo_Client: Echo_Echo.ClientProtocol {
     private let client: GRPCCore.GRPCClient
     
     internal init(wrapping client: GRPCCore.GRPCClient) {

--- a/Examples/echo/Sources/Subcommands/Collect.swift
+++ b/Examples/echo/Sources/Subcommands/Collect.swift
@@ -39,7 +39,7 @@ struct Collect: AsyncParsableCommand {
         try await client.run()
       }
 
-      let echo = Echo_EchoClient(wrapping: client)
+      let echo = Echo_Echo_Client(wrapping: client)
 
       for _ in 0 ..< self.arguments.repetitions {
         let message = try await echo.collect { writer in

--- a/Examples/echo/Sources/Subcommands/Expand.swift
+++ b/Examples/echo/Sources/Subcommands/Expand.swift
@@ -39,7 +39,7 @@ struct Expand: AsyncParsableCommand {
         try await client.run()
       }
 
-      let echo = Echo_EchoClient(wrapping: client)
+      let echo = Echo_Echo_Client(wrapping: client)
 
       for _ in 0 ..< self.arguments.repetitions {
         let message = Echo_EchoRequest.with { $0.text = self.arguments.message }

--- a/Examples/echo/Sources/Subcommands/Get.swift
+++ b/Examples/echo/Sources/Subcommands/Get.swift
@@ -37,7 +37,7 @@ struct Get: AsyncParsableCommand {
         try await client.run()
       }
 
-      let echo = Echo_EchoClient(wrapping: client)
+      let echo = Echo_Echo_Client(wrapping: client)
 
       for _ in 0 ..< self.arguments.repetitions {
         let message = Echo_EchoRequest.with { $0.text = self.arguments.message }

--- a/Examples/echo/Sources/Subcommands/Serve.swift
+++ b/Examples/echo/Sources/Subcommands/Serve.swift
@@ -43,7 +43,7 @@ struct Serve: AsyncParsableCommand {
 }
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-struct EchoService: Echo_EchoServiceProtocol {
+struct EchoService: Echo_Echo_ServiceProtocol {
   func get(
     request: ServerRequest.Single<Echo_EchoRequest>,
     context: ServerContext

--- a/Examples/echo/Sources/Subcommands/Update.swift
+++ b/Examples/echo/Sources/Subcommands/Update.swift
@@ -39,7 +39,7 @@ struct Update: AsyncParsableCommand {
         try await client.run()
       }
 
-      let echo = Echo_EchoClient(wrapping: client)
+      let echo = Echo_Echo_Client(wrapping: client)
 
       for _ in 0 ..< self.arguments.repetitions {
         try await echo.update { writer in

--- a/Examples/hello-world/Sources/Generated/helloworld.grpc.swift
+++ b/Examples/hello-world/Sources/Generated/helloworld.grpc.swift
@@ -40,13 +40,13 @@ internal enum Helloworld_Greeter {
         ]
     }
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-    internal typealias StreamingServiceProtocol = Helloworld_GreeterStreamingServiceProtocol
+    internal typealias StreamingServiceProtocol = Helloworld_Greeter_StreamingServiceProtocol
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-    internal typealias ServiceProtocol = Helloworld_GreeterServiceProtocol
+    internal typealias ServiceProtocol = Helloworld_Greeter_ServiceProtocol
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-    internal typealias ClientProtocol = Helloworld_GreeterClientProtocol
+    internal typealias ClientProtocol = Helloworld_Greeter_ClientProtocol
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-    internal typealias Client = Helloworld_GreeterClient
+    internal typealias Client = Helloworld_Greeter_Client
 }
 
 extension GRPCCore.ServiceDescriptor {
@@ -58,7 +58,7 @@ extension GRPCCore.ServiceDescriptor {
 
 /// The greeting service definition.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-internal protocol Helloworld_GreeterStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
+internal protocol Helloworld_Greeter_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {
     /// Sends a greeting
     func sayHello(
         request: GRPCCore.ServerRequest.Stream<Helloworld_HelloRequest>,
@@ -87,7 +87,7 @@ extension Helloworld_Greeter.StreamingServiceProtocol {
 
 /// The greeting service definition.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-internal protocol Helloworld_GreeterServiceProtocol: Helloworld_Greeter.StreamingServiceProtocol {
+internal protocol Helloworld_Greeter_ServiceProtocol: Helloworld_Greeter.StreamingServiceProtocol {
     /// Sends a greeting
     func sayHello(
         request: GRPCCore.ServerRequest.Single<Helloworld_HelloRequest>,
@@ -95,7 +95,7 @@ internal protocol Helloworld_GreeterServiceProtocol: Helloworld_Greeter.Streamin
     ) async throws -> GRPCCore.ServerResponse.Single<Helloworld_HelloReply>
 }
 
-/// Partial conformance to `Helloworld_GreeterStreamingServiceProtocol`.
+/// Partial conformance to `Helloworld_Greeter_StreamingServiceProtocol`.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Helloworld_Greeter.ServiceProtocol {
     internal func sayHello(
@@ -112,7 +112,7 @@ extension Helloworld_Greeter.ServiceProtocol {
 
 /// The greeting service definition.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-internal protocol Helloworld_GreeterClientProtocol: Sendable {
+internal protocol Helloworld_Greeter_ClientProtocol: Sendable {
     /// Sends a greeting
     func sayHello<R>(
         request: GRPCCore.ClientRequest.Single<Helloworld_HelloRequest>,
@@ -167,7 +167,7 @@ extension Helloworld_Greeter.ClientProtocol {
 
 /// The greeting service definition.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-internal struct Helloworld_GreeterClient: Helloworld_Greeter.ClientProtocol {
+internal struct Helloworld_Greeter_Client: Helloworld_Greeter.ClientProtocol {
     private let client: GRPCCore.GRPCClient
     
     internal init(wrapping client: GRPCCore.GRPCClient) {

--- a/Examples/hello-world/Sources/Subcommands/Greet.swift
+++ b/Examples/hello-world/Sources/Subcommands/Greet.swift
@@ -44,7 +44,7 @@ struct Greet: AsyncParsableCommand {
         client.beginGracefulShutdown()
       }
 
-      let greeter = Helloworld_GreeterClient(wrapping: client)
+      let greeter = Helloworld_Greeter_Client(wrapping: client)
       let reply = try await greeter.sayHello(.with { $0.name = self.name })
       print(reply.message)
     }

--- a/Examples/hello-world/Sources/Subcommands/Serve.swift
+++ b/Examples/hello-world/Sources/Subcommands/Serve.swift
@@ -42,7 +42,7 @@ struct Serve: AsyncParsableCommand {
   }
 }
 
-struct Greeter: Helloworld_GreeterServiceProtocol {
+struct Greeter: Helloworld_Greeter_ServiceProtocol {
   func sayHello(
     request: ServerRequest.Single<Helloworld_HelloRequest>,
     context: ServerContext

--- a/Examples/route-guide/Sources/Generated/route_guide.grpc.swift
+++ b/Examples/route-guide/Sources/Generated/route_guide.grpc.swift
@@ -67,13 +67,13 @@ internal enum Routeguide_RouteGuide {
         ]
     }
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-    internal typealias StreamingServiceProtocol = Routeguide_RouteGuideStreamingServiceProtocol
+    internal typealias StreamingServiceProtocol = Routeguide_RouteGuide_StreamingServiceProtocol
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-    internal typealias ServiceProtocol = Routeguide_RouteGuideServiceProtocol
+    internal typealias ServiceProtocol = Routeguide_RouteGuide_ServiceProtocol
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-    internal typealias ClientProtocol = Routeguide_RouteGuideClientProtocol
+    internal typealias ClientProtocol = Routeguide_RouteGuide_ClientProtocol
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-    internal typealias Client = Routeguide_RouteGuideClient
+    internal typealias Client = Routeguide_RouteGuide_Client
 }
 
 extension GRPCCore.ServiceDescriptor {
@@ -85,7 +85,7 @@ extension GRPCCore.ServiceDescriptor {
 
 /// Interface exported by the server.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-internal protocol Routeguide_RouteGuideStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
+internal protocol Routeguide_RouteGuide_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {
     /// A simple RPC.
     ///
     /// Obtains the feature at a given position.
@@ -181,7 +181,7 @@ extension Routeguide_RouteGuide.StreamingServiceProtocol {
 
 /// Interface exported by the server.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-internal protocol Routeguide_RouteGuideServiceProtocol: Routeguide_RouteGuide.StreamingServiceProtocol {
+internal protocol Routeguide_RouteGuide_ServiceProtocol: Routeguide_RouteGuide.StreamingServiceProtocol {
     /// A simple RPC.
     ///
     /// Obtains the feature at a given position.
@@ -223,7 +223,7 @@ internal protocol Routeguide_RouteGuideServiceProtocol: Routeguide_RouteGuide.St
     ) async throws -> GRPCCore.ServerResponse.Stream<Routeguide_RouteNote>
 }
 
-/// Partial conformance to `Routeguide_RouteGuideStreamingServiceProtocol`.
+/// Partial conformance to `Routeguide_RouteGuide_StreamingServiceProtocol`.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Routeguide_RouteGuide.ServiceProtocol {
     internal func getFeature(
@@ -262,7 +262,7 @@ extension Routeguide_RouteGuide.ServiceProtocol {
 
 /// Interface exported by the server.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-internal protocol Routeguide_RouteGuideClientProtocol: Sendable {
+internal protocol Routeguide_RouteGuide_ClientProtocol: Sendable {
     /// A simple RPC.
     ///
     /// Obtains the feature at a given position.
@@ -476,7 +476,7 @@ extension Routeguide_RouteGuide.ClientProtocol {
 
 /// Interface exported by the server.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-internal struct Routeguide_RouteGuideClient: Routeguide_RouteGuide.ClientProtocol {
+internal struct Routeguide_RouteGuide_Client: Routeguide_RouteGuide.ClientProtocol {
     private let client: GRPCCore.GRPCClient
     
     internal init(wrapping client: GRPCCore.GRPCClient) {

--- a/Examples/route-guide/Sources/Subcommands/GetFeature.swift
+++ b/Examples/route-guide/Sources/Subcommands/GetFeature.swift
@@ -47,7 +47,7 @@ struct GetFeature: AsyncParsableCommand {
         try await client.run()
       }
 
-      let routeGuide = Routeguide_RouteGuideClient(wrapping: client)
+      let routeGuide = Routeguide_RouteGuide_Client(wrapping: client)
 
       let point = Routeguide_Point.with {
         $0.latitude = self.latitude

--- a/Examples/route-guide/Sources/Subcommands/ListFeatures.swift
+++ b/Examples/route-guide/Sources/Subcommands/ListFeatures.swift
@@ -61,7 +61,7 @@ struct ListFeatures: AsyncParsableCommand {
         try await client.run()
       }
 
-      let routeGuide = Routeguide_RouteGuideClient(wrapping: client)
+      let routeGuide = Routeguide_RouteGuide_Client(wrapping: client)
       let boundingRectangle = Routeguide_Rectangle.with {
         $0.lo.latitude = self.minLatitude
         $0.hi.latitude = self.maxLatitude

--- a/Examples/route-guide/Sources/Subcommands/RecordRoute.swift
+++ b/Examples/route-guide/Sources/Subcommands/RecordRoute.swift
@@ -40,7 +40,7 @@ struct RecordRoute: AsyncParsableCommand {
         try await client.run()
       }
 
-      let routeGuide = Routeguide_RouteGuideClient(wrapping: client)
+      let routeGuide = Routeguide_RouteGuide_Client(wrapping: client)
 
       // Get all features.
       let rectangle = Routeguide_Rectangle.with {

--- a/Examples/route-guide/Sources/Subcommands/RouteChat.swift
+++ b/Examples/route-guide/Sources/Subcommands/RouteChat.swift
@@ -40,7 +40,7 @@ struct RouteChat: AsyncParsableCommand {
         try await client.run()
       }
 
-      let routeGuide = Routeguide_RouteGuideClient(wrapping: client)
+      let routeGuide = Routeguide_RouteGuide_Client(wrapping: client)
 
       try await routeGuide.routeChat { writer in
         let notes: [(String, (Int32, Int32))] = [


### PR DESCRIPTION
Motivation:

In #2072 the code gen was changed to add an underscore to the generated names. This wasn't picked up in CI because the examples depend on "main" at the moment.

Modifications:

- Update examples

Result:

CI passes