### PR TITLE
Improve naming of request/response types

### DIFF
--- a/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
@@ -263,13 +263,13 @@ extension ClientCodeTranslator {
 
     // All methods have a response handler.
     var responseHandler = ParameterDescription(label: "onResponse", name: "handleResponse")
-    let responseKind = method.isOutputStreaming ? "Stream" : "Single"
+    let responseKind = method.isOutputStreaming ? "Streaming" : ""
     responseHandler.type = .closure(
       ClosureSignatureDescription(
         parameters: [
           ParameterDescription(
             type: .generic(
-              wrapper: .member(["GRPCCore", "ClientResponse", responseKind]),
+              wrapper: .member(["GRPCCore", "\(responseKind)ClientResponse"]),
               wrapped: .member(method.outputType)
             )
           )
@@ -308,12 +308,12 @@ extension ClientCodeTranslator {
     // return try await method(request: request, options: options, responseHandler: responseHandler)
 
     // First, make the init for the ClientRequest
-    let requestType = method.isInputStreaming ? "Stream" : "Single"
+    let requestType = method.isInputStreaming ? "Streaming" : ""
     var requestInit = FunctionCallDescription(
       calledExpression: .identifier(
         .type(
           .generic(
-            wrapper: .member(["GRPCCore", "ClientRequest", requestType]),
+            wrapper: .member(["GRPCCore", "\(requestType)ClientRequest"]),
             wrapped: .member(method.inputType)
           )
         )
@@ -490,9 +490,10 @@ extension ClientCodeTranslator {
     for method: CodeGenerationRequest.ServiceDescriptor.MethodDescriptor,
     in service: CodeGenerationRequest.ServiceDescriptor
   ) -> ParameterDescription {
-    let requestType = method.isInputStreaming ? "Stream" : "Single"
+    let requestType = method.isInputStreaming ? "Streaming" : ""
     let clientRequestType = ExistingTypeDescription.member([
-      "GRPCCore", "ClientRequest", requestType,
+      "GRPCCore",
+      "\(requestType)ClientRequest"
     ])
     return ParameterDescription(
       label: "request",
@@ -538,9 +539,9 @@ extension ClientCodeTranslator {
     in service: CodeGenerationRequest.ServiceDescriptor,
     includeDefaultResponseHandler: Bool
   ) -> ParameterDescription {
-    let clientStreaming = method.isOutputStreaming ? "Stream" : "Single"
+    let clientStreaming = method.isOutputStreaming ? "Streaming" : ""
     let closureParameterType = ExistingTypeDescription.generic(
-      wrapper: .member(["GRPCCore", "ClientResponse", clientStreaming]),
+      wrapper: .member(["GRPCCore", "\(clientStreaming)ClientResponse"]),
       wrapped: .member(method.outputType)
     )
 

--- a/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
@@ -493,7 +493,7 @@ extension ClientCodeTranslator {
     let requestType = method.isInputStreaming ? "Streaming" : ""
     let clientRequestType = ExistingTypeDescription.member([
       "GRPCCore",
-      "\(requestType)ClientRequest"
+      "\(requestType)ClientRequest",
     ])
     return ParameterDescription(
       label: "request",

--- a/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
@@ -25,19 +25,19 @@
 /// @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 /// public protocol Foo_BarClientProtocol: Sendable {
 ///   func baz<R>(
-///     request: GRPCCore.ClientRequest.Single<Foo_Bar_Input>,
+///     request: GRPCCore.ClientRequest<Foo_Bar_Input>,
 ///     serializer: some GRPCCore.MessageSerializer<Foo_Bar_Input>,
 ///     deserializer: some GRPCCore.MessageDeserializer<Foo_Bar_Output>,
 ///     options: GRPCCore.CallOptions = .defaults,
-///     _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Foo_Bar_Output>) async throws -> R
+///     _ body: @Sendable @escaping (GRPCCore.ClientResponse<Foo_Bar_Output>) async throws -> R
 ///   ) async throws -> R where R: Sendable
 /// }
 /// @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 /// extension Foo_Bar.ClientProtocol {
 ///   public func baz<R>(
-///     request: GRPCCore.ClientRequest.Single<Foo_Bar_Input>,
+///     request: GRPCCore.ClientRequest<Foo_Bar_Input>,
 ///     options: GRPCCore.CallOptions = .defaults,
-///     _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Foo_Bar_Output>) async throws -> R = {
+///     _ body: @Sendable @escaping (GRPCCore.ClientResponse<Foo_Bar_Output>) async throws -> R = {
 ///       try $0.message
 ///     }
 ///   ) async throws -> R where R: Sendable {
@@ -56,11 +56,11 @@
 ///     self.client = client
 ///   }
 ///   public func methodA<R>(
-///     request: GRPCCore.ClientRequest.Stream<Foo_Bar_Input>,
+///     request: GRPCCore.StreamingClientRequest<Foo_Bar_Input>,
 ///     serializer: some GRPCCore.MessageSerializer<Foo_Bar_Input>,
 ///     deserializer: some GRPCCore.MessageDeserializer<Foo_Bar_Output>,
 ///     options: GRPCCore.CallOptions = .defaults,
-///     _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Foo_Bar_Output>) async throws -> R = {
+///     _ body: @Sendable @escaping (GRPCCore.ClientResponse<Foo_Bar_Output>) async throws -> R = {
 ///       try $0.message
 ///     }
 ///   ) async throws -> R where R: Sendable {
@@ -299,12 +299,12 @@ extension ClientCodeTranslator {
   ) -> [CodeBlock] {
     // Produces the following:
     //
-    // let request = GRPCCore.ClientRequest.Single<Input>(message: message, metadata: metadata)
+    // let request = GRPCCore.ClientRequest<Input>(message: message, metadata: metadata)
     // return try await method(request: request, options: options, responseHandler: responseHandler)
     //
     // or:
     //
-    // let request = GRPCCore.ClientRequest.Stream<Input>(metadata: metadata, producer: writer)
+    // let request = GRPCCore.StreamingClientRequest<Input>(metadata: metadata, producer: writer)
     // return try await method(request: request, options: options, responseHandler: responseHandler)
 
     // First, make the init for the ClientRequest

--- a/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
@@ -25,8 +25,8 @@
 /// @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 /// public protocol Foo_BarStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
 ///   func baz(
-///     request: GRPCCore.ServerRequest.Stream<Foo_Bar_Input>
-///   ) async throws -> GRPCCore.ServerResponse.Stream<Foo_Bar_Output>
+///     request: GRPCCore.StreamingServerRequest<Foo_Bar_Input>
+///   ) async throws -> GRPCCore.StreamingServerResponse<Foo_Bar_Output>
 /// }
 /// // Conformance to `GRPCCore.RegistrableRPCService`.
 /// @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
@@ -43,17 +43,17 @@
 /// @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 /// public protocol Foo_BarServiceProtocol: Foo_Bar.StreamingServiceProtocol {
 ///   func baz(
-///     request: GRPCCore.ServerRequest.Single<Foo_Bar_Input>
-///   ) async throws -> GRPCCore.ServerResponse.Single<Foo_Bar_Output>
+///     request: GRPCCore.ServerRequest<Foo_Bar_Input>
+///   ) async throws -> GRPCCore.ServerResponse<Foo_Bar_Output>
 /// }
 /// // Partial conformance to `Foo_BarStreamingServiceProtocol`.
 /// @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 /// extension Foo_Bar.ServiceProtocol {
 ///   public func baz(
-///     request: GRPCCore.ServerRequest.Stream<Foo_Bar_Input>
-///   ) async throws -> GRPCCore.ServerResponse.Stream<Foo_Bar_Output> {
-///     let response = try await self.baz(request: GRPCCore.ServerRequest.Single(stream: request))
-///     return GRPCCore.ServerResponse.Stream(single: response)
+///     request: GRPCCore.StreamingServerRequest<Foo_Bar_Input>
+///   ) async throws -> GRPCCore.StreamingServerResponse<Foo_Bar_Output> {
+///     let response = try await self.baz(request: GRPCCore.ServerRequest(stream: request))
+///     return GRPCCore.StreamingServerResponse(single: response)
 ///   }
 /// }
 ///```

--- a/Sources/GRPCCore/Call/Client/ClientInterceptor.swift
+++ b/Sources/GRPCCore/Call/Client/ClientInterceptor.swift
@@ -40,13 +40,13 @@
 ///   let fetchMetadata: @Sendable () async -> String
 ///
 ///   func intercept<Input: Sendable, Output: Sendable>(
-///     request: ClientRequest.Stream<Input>,
+///     request: StreamingClientRequest<Input>,
 ///     context: ClientContext,
 ///     next: @Sendable (
-///       _ request: ClientRequest.Stream<Input>,
+///       _ request: StreamingClientRequest<Input>,
 ///       _ context: ClientContext
-///     ) async throws -> ClientResponse.Stream<Output>
-///   ) async throws -> ClientResponse.Stream<Output> {
+///     ) async throws -> StreamingClientResponse<Output>
+///   ) async throws -> StreamingClientResponse<Output> {
 ///     // Fetch the metadata value and attach it.
 ///     let value = await self.fetchMetadata()
 ///     var request = request
@@ -65,13 +65,13 @@
 /// ```swift
 /// struct LoggingClientInterceptor: ClientInterceptor {
 ///   func intercept<Input: Sendable, Output: Sendable>(
-///     request: ClientRequest.Stream<Input>,
+///     request: StreamingClientRequest<Input>,
 ///     context: ClientContext,
 ///     next: @Sendable (
-///       _ request: ClientRequest.Stream<Input>,
+///       _ request: StreamingClientRequest<Input>,
 ///       _ context: ClientContext
-///     ) async throws -> ClientResponse.Stream<Output>
-///   ) async throws -> ClientResponse.Stream<Output> {
+///     ) async throws -> StreamingClientResponse<Output>
+///   ) async throws -> StreamingClientResponse<Output> {
 ///     print("Invoking method '\(context.descriptor)'")
 ///     let response = try await next(request, context)
 ///
@@ -100,11 +100,11 @@ public protocol ClientInterceptor: Sendable {
   ///       interceptor in the chain.
   /// - Returns: A response object.
   func intercept<Input: Sendable, Output: Sendable>(
-    request: ClientRequest.Stream<Input>,
+    request: StreamingClientRequest<Input>,
     context: ClientContext,
     next: (
-      _ request: ClientRequest.Stream<Input>,
+      _ request: StreamingClientRequest<Input>,
       _ context: ClientContext
-    ) async throws -> ClientResponse.Stream<Output>
-  ) async throws -> ClientResponse.Stream<Output>
+    ) async throws -> StreamingClientResponse<Output>
+  ) async throws -> StreamingClientResponse<Output>
 }

--- a/Sources/GRPCCore/Call/Client/ClientRequest.swift
+++ b/Sources/GRPCCore/Call/Client/ClientRequest.swift
@@ -14,91 +14,84 @@
  * limitations under the License.
  */
 
-/// A namespace for request message types used by clients.
-public enum ClientRequest {}
+/// A request created by the client for a single message.
+///
+/// This is used for unary and server-streaming RPCs.
+///
+/// See ``StreamingClientRequest`` for streaming requests and ``ServerRequest`` for the
+/// servers representation of a single-message request.
+///
+/// ## Creating ``Single`` requests
+///
+/// ```swift
+/// let request = ClientRequest<String>(message: "Hello, gRPC!")
+/// print(request.metadata)  // prints '[:]'
+/// print(request.message)  // prints 'Hello, gRPC!'
+/// ```
+public struct ClientRequest<Message: Sendable>: Sendable {
+  /// Caller-specified metadata to send to the server at the start of the RPC.
+  ///
+  /// Both gRPC Swift and its transport layer may insert additional metadata. Keys prefixed with
+  /// "grpc-" are prohibited and may result in undefined behaviour. Transports may also insert
+  /// their own metadata, you should avoid using key names which may clash with transport specific
+  /// metadata. Note that transports may also impose limits in the amount of metadata which may
+  /// be sent.
+  public var metadata: Metadata
 
-extension ClientRequest {
-  /// A request created by the client for a single message.
-  ///
-  /// This is used for unary and server-streaming RPCs.
-  ///
-  /// See ``ClientRequest/Stream`` for streaming requests and ``ServerRequest/Single`` for the
-  /// servers representation of a single-message request.
-  ///
-  /// ## Creating ``Single`` requests
-  ///
-  /// ```swift
-  /// let request = ClientRequest.Single<String>(message: "Hello, gRPC!")
-  /// print(request.metadata)  // prints '[:]'
-  /// print(request.message)  // prints 'Hello, gRPC!'
-  /// ```
-  public struct Single<Message: Sendable>: Sendable {
-    /// Caller-specified metadata to send to the server at the start of the RPC.
-    ///
-    /// Both gRPC Swift and its transport layer may insert additional metadata. Keys prefixed with
-    /// "grpc-" are prohibited and may result in undefined behaviour. Transports may also insert
-    /// their own metadata, you should avoid using key names which may clash with transport specific
-    /// metadata. Note that transports may also impose limits in the amount of metadata which may
-    /// be sent.
-    public var metadata: Metadata
+  /// The message to send to the server.
+  public var message: Message
 
-    /// The message to send to the server.
-    public var message: Message
-
-    /// Create a new single client request.
-    ///
-    /// - Parameters:
-    ///   - message: The message to send to the server.
-    ///   - metadata: Metadata to send to the server at the start of the request. Defaults to empty.
-    public init(
-      message: Message,
-      metadata: Metadata = [:]
-    ) {
-      self.metadata = metadata
-      self.message = message
-    }
+  /// Create a new single client request.
+  ///
+  /// - Parameters:
+  ///   - message: The message to send to the server.
+  ///   - metadata: Metadata to send to the server at the start of the request. Defaults to empty.
+  public init(
+    message: Message,
+    metadata: Metadata = [:]
+  ) {
+    self.metadata = metadata
+    self.message = message
   }
 }
 
-extension ClientRequest {
-  /// A request created by the client for a stream of messages.
+/// A request created by the client for a stream of messages.
+///
+/// This is used for client-streaming and bidirectional-streaming RPCs.
+///
+/// See ``ClientRequest`` for single-message requests and ``StreamingServerRequest`` for the
+/// servers representation of a streaming-message request.
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+public struct StreamingClientRequest<Message: Sendable>: Sendable {
+  /// Caller-specified metadata sent to the server at the start of the RPC.
   ///
-  /// This is used for client-streaming and bidirectional-streaming RPCs.
+  /// Both gRPC Swift and its transport layer may insert additional metadata. Keys prefixed with
+  /// "grpc-" are prohibited and may result in undefined behaviour. Transports may also insert
+  /// their own metadata, you should avoid using key names which may clash with transport specific
+  /// metadata. Note that transports may also impose limits in the amount of metadata which may
+  /// be sent.
+  public var metadata: Metadata
+
+  /// A closure which, when called, writes messages in the writer.
   ///
-  /// See ``ClientRequest/Single`` for single-message requests and ``ServerRequest/Stream`` for the
-  /// servers representation of a streaming-message request.
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-  public struct Stream<Message: Sendable>: Sendable {
-    /// Caller-specified metadata sent to the server at the start of the RPC.
-    ///
-    /// Both gRPC Swift and its transport layer may insert additional metadata. Keys prefixed with
-    /// "grpc-" are prohibited and may result in undefined behaviour. Transports may also insert
-    /// their own metadata, you should avoid using key names which may clash with transport specific
-    /// metadata. Note that transports may also impose limits in the amount of metadata which may
-    /// be sent.
-    public var metadata: Metadata
+  /// The producer will only be consumed once by gRPC and therefore isn't required to be
+  /// idempotent. If the producer throws an error then the RPC will be cancelled. Once the
+  /// producer returns the request stream is closed.
+  public var producer: @Sendable (RPCWriter<Message>) async throws -> Void
 
-    /// A closure which, when called, writes messages in the writer.
-    ///
-    /// The producer will only be consumed once by gRPC and therefore isn't required to be
-    /// idempotent. If the producer throws an error then the RPC will be cancelled. Once the
-    /// producer returns the request stream is closed.
-    public var producer: @Sendable (RPCWriter<Message>) async throws -> Void
-
-    /// Create a new streaming client request.
-    ///
-    /// - Parameters:
-    ///   - messageType: The type of message contained in this request, defaults to `Message.self`.
-    ///   - metadata: Metadata to send to the server at the start of the request. Defaults to empty.
-    ///   - producer: A closure which writes messages to send to the server. The closure is called
-    ///       at most once and may not be called.
-    public init(
-      of messageType: Message.Type = Message.self,
-      metadata: Metadata = [:],
-      producer: @escaping @Sendable (RPCWriter<Message>) async throws -> Void
-    ) {
-      self.metadata = metadata
-      self.producer = producer
-    }
+  /// Create a new streaming client request.
+  ///
+  /// - Parameters:
+  ///   - messageType: The type of message contained in this request, defaults to `Message.self`.
+  ///   - metadata: Metadata to send to the server at the start of the request. Defaults to empty.
+  ///   - producer: A closure which writes messages to send to the server. The closure is called
+  ///       at most once and may not be called.
+  public init(
+    of messageType: Message.Type = Message.self,
+    metadata: Metadata = [:],
+    producer: @escaping @Sendable (RPCWriter<Message>) async throws -> Void
+  ) {
+    self.metadata = metadata
+    self.producer = producer
   }
 }

--- a/Sources/GRPCCore/Call/Client/ClientResponse.swift
+++ b/Sources/GRPCCore/Call/Client/ClientResponse.swift
@@ -14,255 +14,248 @@
  * limitations under the License.
  */
 
-/// A namespace for response message types used by clients.
-public enum ClientResponse {}
+/// A response for a single message received by a client.
+///
+/// Single responses are used for unary and client-streaming RPCs. For streaming responses
+/// see ``StreamingClientResponse``.
+///
+/// A single response captures every part of the response stream and distinguishes successful
+/// and unsuccessful responses via the ``accepted`` property. The value for the `success` case
+/// contains the initial metadata, response message, and the trailing metadata and implicitly
+/// has an ``Status/Code-swift.struct/ok`` status code.
+///
+/// The `failure` case indicates that the server chose not to process the RPC, or the processing
+/// of the RPC failed, or the client failed to execute the request. The failure case contains
+/// an ``RPCError`` describing why the RPC failed, including an error code, error message and any
+/// metadata sent by the server.
+///
+/// ### Using ``Single`` responses
+///
+/// Each response has a ``accepted`` property which contains all RPC information. You can create
+/// one by calling ``init(accepted:)`` or one of the two convenience initializers:
+/// - ``init(message:metadata:trailingMetadata:)`` to create a successful response, or
+/// - ``init(of:error:)`` to create a failed response.
+///
+/// You can interrogate a response by inspecting the ``accepted`` property directly or by using
+/// its convenience properties:
+/// - ``metadata`` extracts the initial metadata,
+/// - ``message`` extracts the message, or throws if the response failed, and
+/// - ``trailingMetadata`` extracts the trailing metadata.
+///
+/// The following example demonstrates how you can use the API:
+///
+/// ```swift
+/// // Create a successful response
+/// let response = ClientResponse<String>(
+///   message: "Hello, World!",
+///   metadata: ["hello": "initial metadata"],
+///   trailingMetadata: ["goodbye": "trailing metadata"]
+/// )
+///
+/// // The explicit API:
+/// switch response {
+/// case .success(let contents):
+///   print("Received response with message '\(try contents.message.get())'")
+/// case .failure(let error):
+///   print("RPC failed with code '\(error.code)'")
+/// }
+///
+/// // The convenience API:
+/// do {
+///   print("Received response with message '\(try response.message)'")
+/// } catch let error as RPCError {
+///   print("RPC failed with code '\(error.code)'")
+/// }
+/// ```
+public struct ClientResponse<Message: Sendable>: Sendable {
+  /// The contents of an accepted response with a single message.
+  public struct Contents: Sendable {
+    /// Metadata received from the server at the beginning of the response.
+    ///
+    /// The metadata may contain transport-specific information in addition to any application
+    /// level metadata provided by the service.
+    public var metadata: Metadata
 
-extension ClientResponse {
-  /// A response for a single message received by a client.
-  ///
-  /// Single responses are used for unary and client-streaming RPCs. For streaming responses
-  /// see ``ClientResponse/Stream``.
-  ///
-  /// A single response captures every part of the response stream and distinguishes successful
-  /// and unsuccessful responses via the ``accepted`` property. The value for the `success` case
-  /// contains the initial metadata, response message, and the trailing metadata and implicitly
-  /// has an ``Status/Code-swift.struct/ok`` status code.
-  ///
-  /// The `failure` case indicates that the server chose not to process the RPC, or the processing
-  /// of the RPC failed, or the client failed to execute the request. The failure case contains
-  /// an ``RPCError`` describing why the RPC failed, including an error code, error message and any
-  /// metadata sent by the server.
-  ///
-  /// ### Using ``Single`` responses
-  ///
-  /// Each response has a ``accepted`` property which contains all RPC information. You can create
-  /// one by calling ``init(accepted:)`` or one of the two convenience initializers:
-  /// - ``init(message:metadata:trailingMetadata:)`` to create a successful response, or
-  /// - ``init(of:error:)`` to create a failed response.
-  ///
-  /// You can interrogate a response by inspecting the ``accepted`` property directly or by using
-  /// its convenience properties:
-  /// - ``metadata`` extracts the initial metadata,
-  /// - ``message`` extracts the message, or throws if the response failed, and
-  /// - ``trailingMetadata`` extracts the trailing metadata.
-  ///
-  /// The following example demonstrates how you can use the API:
-  ///
-  /// ```swift
-  /// // Create a successful response
-  /// let response = ClientResponse.Single<String>(
-  ///   message: "Hello, World!",
-  ///   metadata: ["hello": "initial metadata"],
-  ///   trailingMetadata: ["goodbye": "trailing metadata"]
-  /// )
-  ///
-  /// // The explicit API:
-  /// switch response {
-  /// case .success(let contents):
-  ///   print("Received response with message '\(try contents.message.get())'")
-  /// case .failure(let error):
-  ///   print("RPC failed with code '\(error.code)'")
-  /// }
-  ///
-  /// // The convenience API:
-  /// do {
-  ///   print("Received response with message '\(try response.message)'")
-  /// } catch let error as RPCError {
-  ///   print("RPC failed with code '\(error.code)'")
-  /// }
-  /// ```
-  public struct Single<Message: Sendable>: Sendable {
-    /// The contents of an accepted response with a single message.
-    public struct Contents: Sendable {
-      /// Metadata received from the server at the beginning of the response.
-      ///
-      /// The metadata may contain transport-specific information in addition to any application
-      /// level metadata provided by the service.
-      public var metadata: Metadata
+    /// The response message received from the server, or an error of the RPC failed with a
+    /// non-ok status.
+    public var message: Result<Message, RPCError>
 
-      /// The response message received from the server, or an error of the RPC failed with a
-      /// non-ok status.
-      public var message: Result<Message, RPCError>
+    /// Metadata received from the server at the end of the response.
+    ///
+    /// The metadata may contain transport-specific information in addition to any application
+    /// level metadata provided by the service.
+    public var trailingMetadata: Metadata
 
-      /// Metadata received from the server at the end of the response.
-      ///
-      /// The metadata may contain transport-specific information in addition to any application
-      /// level metadata provided by the service.
-      public var trailingMetadata: Metadata
-
-      /// Creates a `Contents`.
-      ///
-      /// - Parameters:
-      ///   - metadata: Metadata received from the server at the beginning of the response.
-      ///   - message: The response message received from the server.
-      ///   - trailingMetadata: Metadata received from the server at the end of the response.
-      public init(
-        metadata: Metadata,
-        message: Message,
-        trailingMetadata: Metadata
-      ) {
-        self.metadata = metadata
-        self.message = .success(message)
-        self.trailingMetadata = trailingMetadata
-      }
-
-      /// Creates a `Contents`.
-      ///
-      /// - Parameters:
-      ///   - metadata: Metadata received from the server at the beginning of the response.
-      ///   - error: Error received from the server.
-      public init(
-        metadata: Metadata,
-        error: RPCError
-      ) {
-        self.metadata = metadata
-        self.message = .failure(error)
-        self.trailingMetadata = error.metadata
-      }
+    /// Creates a `Contents`.
+    ///
+    /// - Parameters:
+    ///   - metadata: Metadata received from the server at the beginning of the response.
+    ///   - message: The response message received from the server.
+    ///   - trailingMetadata: Metadata received from the server at the end of the response.
+    public init(
+      metadata: Metadata,
+      message: Message,
+      trailingMetadata: Metadata
+    ) {
+      self.metadata = metadata
+      self.message = .success(message)
+      self.trailingMetadata = trailingMetadata
     }
 
-    /// Whether the RPC was accepted or rejected.
+    /// Creates a `Contents`.
     ///
-    /// The `success` case indicates the RPC completed successfully with an
-    /// ``Status/Code-swift.struct/ok`` status code. The `failure` case indicates that the RPC was
-    /// rejected by the server and wasn't processed or couldn't be processed successfully.
-    public var accepted: Result<Contents, RPCError>
-
-    /// Creates a new response.
-    ///
-    /// - Parameter accepted: The result of the RPC.
-    public init(accepted: Result<Contents, RPCError>) {
-      self.accepted = accepted
+    /// - Parameters:
+    ///   - metadata: Metadata received from the server at the beginning of the response.
+    ///   - error: Error received from the server.
+    public init(
+      metadata: Metadata,
+      error: RPCError
+    ) {
+      self.metadata = metadata
+      self.message = .failure(error)
+      self.trailingMetadata = error.metadata
     }
+  }
+
+  /// Whether the RPC was accepted or rejected.
+  ///
+  /// The `success` case indicates the RPC completed successfully with an
+  /// ``Status/Code-swift.struct/ok`` status code. The `failure` case indicates that the RPC was
+  /// rejected by the server and wasn't processed or couldn't be processed successfully.
+  public var accepted: Result<Contents, RPCError>
+
+  /// Creates a new response.
+  ///
+  /// - Parameter accepted: The result of the RPC.
+  public init(accepted: Result<Contents, RPCError>) {
+    self.accepted = accepted
   }
 }
 
-extension ClientResponse {
-  /// A response for a stream of messages received by a client.
-  ///
-  /// Stream responses are used for server-streaming and bidirectional-streaming RPCs. For single
-  /// responses see ``ClientResponse/Single``.
-  ///
-  /// A stream response captures every part of the response stream over time and distinguishes
-  /// accepted and rejected requests via the ``accepted`` property. An "accepted" request is one
-  /// where the the server responds with initial metadata and attempts to process the request. A
-  /// "rejected" request is one where the server responds with a status as the first and only
-  /// response part and doesn't process the request body.
-  ///
-  /// The value for the `success` case contains the initial metadata and a ``RPCAsyncSequence`` of
-  /// message parts (messages followed by a single status). If the sequence completes without
-  /// throwing then the response implicitly has an ``Status/Code-swift.struct/ok`` status code.
-  /// However, the response sequence may also throw an ``RPCError`` if the server fails to complete
-  /// processing the request.
-  ///
-  /// The `failure` case indicates that the server chose not to process the RPC or the client failed
-  /// to execute the request. The failure case contains an ``RPCError`` describing why the RPC
-  /// failed, including an error code, error message and any metadata sent by the server.
-  ///
-  /// ### Using ``Stream`` responses
-  ///
-  /// Each response has a ``accepted`` property which contains RPC information. You can create
-  /// one by calling ``init(accepted:)`` or one of the two convenience initializers:
-  /// - ``init(of:metadata:bodyParts:)`` to create an accepted response, or
-  /// - ``init(of:error:)`` to create a failed response.
-  ///
-  /// You can interrogate a response by inspecting the ``accepted`` property directly or by using
-  /// its convenience properties:
-  /// - ``metadata`` extracts the initial metadata,
-  /// - ``messages`` extracts the sequence of response message, or throws if the response failed.
-  ///
-  /// The following example demonstrates how you can use the API:
-  ///
-  /// ```swift
-  /// // Create a failed response
-  /// let response = ClientResponse.Stream(
-  ///   of: String.self,
-  ///   error: RPCError(code: .notFound, message: "The requested resource couldn't be located")
-  /// )
-  ///
-  /// // The explicit API:
-  /// switch response {
-  /// case .success(let contents):
-  ///   for try await part in contents.bodyParts {
-  ///     switch part {
-  ///     case .message(let message):
-  ///       print("Received message '\(message)'")
-  ///     case .trailingMetadata(let metadata):
-  ///       print("Received trailing metadata '\(metadata)'")
-  ///     }
-  ///   }
-  /// case .failure(let error):
-  ///   print("RPC failed with code '\(error.code)'")
-  /// }
-  ///
-  /// // The convenience API:
-  /// do {
-  ///   for try await message in response.messages {
-  ///     print("Received message '\(message)'")
-  ///   }
-  /// } catch let error as RPCError {
-  ///   print("RPC failed with code '\(error.code)'")
-  /// }
-  /// ```
-  @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-  public struct Stream<Message: Sendable>: Sendable {
-    public struct Contents: Sendable {
-      /// Metadata received from the server at the beginning of the response.
-      ///
-      /// The metadata may contain transport-specific information in addition to any application
-      /// level metadata provided by the service.
-      public var metadata: Metadata
+/// A response for a stream of messages received by a client.
+///
+/// Stream responses are used for server-streaming and bidirectional-streaming RPCs. For single
+/// responses see ``ClientResponse``.
+///
+/// A stream response captures every part of the response stream over time and distinguishes
+/// accepted and rejected requests via the ``accepted`` property. An "accepted" request is one
+/// where the the server responds with initial metadata and attempts to process the request. A
+/// "rejected" request is one where the server responds with a status as the first and only
+/// response part and doesn't process the request body.
+///
+/// The value for the `success` case contains the initial metadata and a ``RPCAsyncSequence`` of
+/// message parts (messages followed by a single status). If the sequence completes without
+/// throwing then the response implicitly has an ``Status/Code-swift.struct/ok`` status code.
+/// However, the response sequence may also throw an ``RPCError`` if the server fails to complete
+/// processing the request.
+///
+/// The `failure` case indicates that the server chose not to process the RPC or the client failed
+/// to execute the request. The failure case contains an ``RPCError`` describing why the RPC
+/// failed, including an error code, error message and any metadata sent by the server.
+///
+/// ### Using ``Stream`` responses
+///
+/// Each response has a ``accepted`` property which contains RPC information. You can create
+/// one by calling ``init(accepted:)`` or one of the two convenience initializers:
+/// - ``init(of:metadata:bodyParts:)`` to create an accepted response, or
+/// - ``init(of:error:)`` to create a failed response.
+///
+/// You can interrogate a response by inspecting the ``accepted`` property directly or by using
+/// its convenience properties:
+/// - ``metadata`` extracts the initial metadata,
+/// - ``messages`` extracts the sequence of response message, or throws if the response failed.
+///
+/// The following example demonstrates how you can use the API:
+///
+/// ```swift
+/// // Create a failed response
+/// let response = StreamingClientResponse(
+///   of: String.self,
+///   error: RPCError(code: .notFound, message: "The requested resource couldn't be located")
+/// )
+///
+/// // The explicit API:
+/// switch response {
+/// case .success(let contents):
+///   for try await part in contents.bodyParts {
+///     switch part {
+///     case .message(let message):
+///       print("Received message '\(message)'")
+///     case .trailingMetadata(let metadata):
+///       print("Received trailing metadata '\(metadata)'")
+///     }
+///   }
+/// case .failure(let error):
+///   print("RPC failed with code '\(error.code)'")
+/// }
+///
+/// // The convenience API:
+/// do {
+///   for try await message in response.messages {
+///     print("Received message '\(message)'")
+///   }
+/// } catch let error as RPCError {
+///   print("RPC failed with code '\(error.code)'")
+/// }
+/// ```
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+public struct StreamingClientResponse<Message: Sendable>: Sendable {
+  public struct Contents: Sendable {
+    /// Metadata received from the server at the beginning of the response.
+    ///
+    /// The metadata may contain transport-specific information in addition to any application
+    /// level metadata provided by the service.
+    public var metadata: Metadata
 
-      /// A sequence of stream parts received from the server ending with metadata if the RPC
-      /// succeeded.
-      ///
-      /// If the RPC fails then the sequence will throw an ``RPCError``.
-      ///
-      /// The sequence may only be iterated once.
-      public var bodyParts: RPCAsyncSequence<BodyPart, any Error>
+    /// A sequence of stream parts received from the server ending with metadata if the RPC
+    /// succeeded.
+    ///
+    /// If the RPC fails then the sequence will throw an ``RPCError``.
+    ///
+    /// The sequence may only be iterated once.
+    public var bodyParts: RPCAsyncSequence<BodyPart, any Error>
 
-      /// Parts received from the server.
-      public enum BodyPart: Sendable {
-        /// A response message.
-        case message(Message)
-        /// Metadata. Must be the final value of the sequence unless the stream throws an error.
-        case trailingMetadata(Metadata)
-      }
-
-      /// Creates a ``Contents``.
-      ///
-      /// - Parameters:
-      ///   - metadata: Metadata received from the server at the beginning of the response.
-      ///   - bodyParts: An `AsyncSequence` of parts received from the server.
-      public init(
-        metadata: Metadata,
-        bodyParts: RPCAsyncSequence<BodyPart, any Error>
-      ) {
-        self.metadata = metadata
-        self.bodyParts = bodyParts
-      }
+    /// Parts received from the server.
+    public enum BodyPart: Sendable {
+      /// A response message.
+      case message(Message)
+      /// Metadata. Must be the final value of the sequence unless the stream throws an error.
+      case trailingMetadata(Metadata)
     }
 
-    /// Whether the RPC was accepted or rejected.
+    /// Creates a ``Contents``.
     ///
-    /// The `success` case indicates the RPC was accepted by the server for
-    /// processing, however, the RPC may still fail by throwing an error from its
-    /// `messages` sequence. The `failure` case indicates that the RPC was
-    /// rejected by the server.
-    public var accepted: Result<Contents, RPCError>
-
-    /// Creates a new response.
-    ///
-    /// - Parameter accepted: The result of the RPC.
-    public init(accepted: Result<Contents, RPCError>) {
-      self.accepted = accepted
+    /// - Parameters:
+    ///   - metadata: Metadata received from the server at the beginning of the response.
+    ///   - bodyParts: An `AsyncSequence` of parts received from the server.
+    public init(
+      metadata: Metadata,
+      bodyParts: RPCAsyncSequence<BodyPart, any Error>
+    ) {
+      self.metadata = metadata
+      self.bodyParts = bodyParts
     }
+  }
+
+  /// Whether the RPC was accepted or rejected.
+  ///
+  /// The `success` case indicates the RPC was accepted by the server for
+  /// processing, however, the RPC may still fail by throwing an error from its
+  /// `messages` sequence. The `failure` case indicates that the RPC was
+  /// rejected by the server.
+  public var accepted: Result<Contents, RPCError>
+
+  /// Creates a new response.
+  ///
+  /// - Parameter accepted: The result of the RPC.
+  public init(accepted: Result<Contents, RPCError>) {
+    self.accepted = accepted
   }
 }
 
 // MARK: - Convenience API
 
-extension ClientResponse.Single {
+extension ClientResponse {
   /// Creates a new accepted response.
   ///
   /// - Parameters:
@@ -333,7 +326,7 @@ extension ClientResponse.Single {
 }
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-extension ClientResponse.Stream {
+extension StreamingClientResponse {
   /// Creates a new accepted response.
   ///
   /// - Parameters:

--- a/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor+OneShotExecutor.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor+OneShotExecutor.swift
@@ -58,10 +58,10 @@ extension ClientRPCExecutor {
 extension ClientRPCExecutor.OneShotExecutor {
   @inlinable
   func execute<R: Sendable>(
-    request: ClientRequest.Stream<Input>,
+    request: StreamingClientRequest<Input>,
     method: MethodDescriptor,
     options: CallOptions,
-    responseHandler: @Sendable @escaping (ClientResponse.Stream<Output>) async throws -> R
+    responseHandler: @Sendable @escaping (StreamingClientResponse<Output>) async throws -> R
   ) async throws -> R {
     let result: Result<R, any Error>
 
@@ -94,10 +94,10 @@ extension ClientRPCExecutor.OneShotExecutor {
 extension ClientRPCExecutor.OneShotExecutor {
   @inlinable
   func _execute<R: Sendable>(
-    request: ClientRequest.Stream<Input>,
+    request: StreamingClientRequest<Input>,
     method: MethodDescriptor,
     options: CallOptions,
-    responseHandler: @Sendable @escaping (ClientResponse.Stream<Output>) async throws -> R
+    responseHandler: @Sendable @escaping (StreamingClientResponse<Output>) async throws -> R
   ) async -> Result<R, any Error> {
     return await withTaskGroup(of: Void.self, returning: Result<R, any Error>.self) { group in
       do {

--- a/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor+RetryExecutor.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor+RetryExecutor.swift
@@ -64,10 +64,10 @@ extension ClientRPCExecutor {
 extension ClientRPCExecutor.RetryExecutor {
   @inlinable
   func execute<R: Sendable>(
-    request: ClientRequest.Stream<Input>,
+    request: StreamingClientRequest<Input>,
     method: MethodDescriptor,
     options: CallOptions,
-    responseHandler: @Sendable @escaping (ClientResponse.Stream<Output>) async throws -> R
+    responseHandler: @Sendable @escaping (StreamingClientResponse<Output>) async throws -> R
   ) async throws -> R {
     // There's quite a lot going on here...
     //
@@ -201,13 +201,13 @@ extension ClientRPCExecutor.RetryExecutor {
     retryStream: BroadcastAsyncSequence<Input>,
     method: MethodDescriptor,
     attempt: Int,
-    responseHandler: @Sendable @escaping (ClientResponse.Stream<Output>) async throws -> R
+    responseHandler: @Sendable @escaping (StreamingClientResponse<Output>) async throws -> R
   ) async -> _RetryExecutorTask<R> {
     return await withTaskGroup(
       of: Void.self,
       returning: _RetryExecutorTask<R>.self
     ) { group in
-      let request = ClientRequest.Stream(metadata: metadata) {
+      let request = StreamingClientRequest(metadata: metadata) {
         try await $0.write(contentsOf: retryStream)
       }
 

--- a/Sources/GRPCCore/Call/Client/Internal/ClientRequest+Convenience.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientRequest+Convenience.swift
@@ -15,8 +15,8 @@
  */
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-extension ClientRequest.Stream {
-  internal init(single request: ClientRequest.Single<Message>) {
+extension StreamingClientRequest {
+  internal init(single request: ClientRequest<Message>) {
     self.init(metadata: request.metadata) {
       try await $0.write(request.message)
     }

--- a/Sources/GRPCCore/Call/Client/Internal/ClientResponse+Convenience.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientResponse+Convenience.swift
@@ -15,11 +15,11 @@
  */
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-extension ClientResponse.Single {
+extension ClientResponse {
   /// Converts a streaming response into a single response.
   ///
   /// - Parameter response: The streaming response to convert.
-  init(stream response: ClientResponse.Stream<Message>) async {
+  init(stream response: StreamingClientResponse<Message>) async {
     switch response.accepted {
     case .success(let contents):
       do {
@@ -83,7 +83,7 @@ extension ClientResponse.Single {
 }
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-extension ClientResponse.Stream {
+extension StreamingClientResponse {
   /// Creates a streaming response from the given status and metadata.
   ///
   /// If the ``Status`` has code ``Status/Code-swift.struct/ok`` then an accepted stream is created
@@ -104,7 +104,7 @@ extension ClientResponse.Stream {
 }
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-extension ClientResponse.Stream {
+extension StreamingClientResponse {
   /// Returns a new response which maps the messages of this response.
   ///
   /// - Parameter transform: The function to transform each message with.
@@ -112,10 +112,10 @@ extension ClientResponse.Stream {
   @inlinable
   func map<Mapped>(
     _ transform: @escaping @Sendable (Message) throws -> Mapped
-  ) -> ClientResponse.Stream<Mapped> {
+  ) -> StreamingClientResponse<Mapped> {
     switch self.accepted {
     case .success(let contents):
-      return ClientResponse.Stream(
+      return StreamingClientResponse<Mapped>(
         metadata: self.metadata,
         bodyParts: RPCAsyncSequence(
           wrapping: contents.bodyParts.map {
@@ -130,7 +130,7 @@ extension ClientResponse.Stream {
       )
 
     case .failure(let error):
-      return ClientResponse.Stream(accepted: .failure(error))
+      return StreamingClientResponse<Mapped>(accepted: .failure(error))
     }
   }
 }

--- a/Sources/GRPCCore/Call/Server/RPCRouter.swift
+++ b/Sources/GRPCCore/Call/Server/RPCRouter.swift
@@ -53,9 +53,9 @@ public struct RPCRouter: Sendable {
       deserializer: some MessageDeserializer<Input>,
       serializer: some MessageSerializer<Output>,
       handler: @Sendable @escaping (
-        _ request: ServerRequest.Stream<Input>,
+        _ request: StreamingServerRequest<Input>,
         _ context: ServerContext
-      ) async throws -> ServerResponse.Stream<Output>
+      ) async throws -> StreamingServerResponse<Output>
     ) {
       self._fn = { stream, context, interceptors in
         await ServerRPCExecutor.execute(
@@ -123,9 +123,9 @@ public struct RPCRouter: Sendable {
     deserializer: some MessageDeserializer<Input>,
     serializer: some MessageSerializer<Output>,
     handler: @Sendable @escaping (
-      _ request: ServerRequest.Stream<Input>,
+      _ request: StreamingServerRequest<Input>,
       _ context: ServerContext
-    ) async throws -> ServerResponse.Stream<Output>
+    ) async throws -> StreamingServerResponse<Output>
   ) {
     self.handlers[descriptor] = RPCHandler(
       method: descriptor,

--- a/Sources/GRPCCore/Call/Server/ServerInterceptor.swift
+++ b/Sources/GRPCCore/Call/Server/ServerInterceptor.swift
@@ -37,13 +37,13 @@
 ///   let isAuthorized: @Sendable (String, MethodDescriptor) async throws -> Void
 ///
 ///   func intercept<Input: Sendable, Output: Sendable>(
-///     request: ServerRequest.Stream<Input>,
+///     request: StreamingServerRequest<Input>,
 ///     context: ServerInterceptorContext,
 ///     next: @Sendable (
-///       _ request: ServerRequest.Stream<Input>,
+///       _ request: StreamingServerRequest<Input>,
 ///       _ context: ServerInterceptorContext
-///     ) async throws -> ServerResponse.Stream<Output>
-///   ) async throws -> ServerResponse.Stream<Output> {
+///     ) async throws -> StreamingServerResponse<Output>
+///   ) async throws -> StreamingServerResponse<Output> {
 ///     // Extract the auth token.
 ///     guard let token = request.metadata["authorization"] else {
 ///       throw RPCError(code: .unauthenticated, message: "Not authenticated")
@@ -71,11 +71,11 @@ public protocol ServerInterceptor: Sendable {
   ///       interceptor in the chain.
   /// - Returns: A response object.
   func intercept<Input: Sendable, Output: Sendable>(
-    request: ServerRequest.Stream<Input>,
+    request: StreamingServerRequest<Input>,
     context: ServerContext,
     next: @Sendable (
-      _ request: ServerRequest.Stream<Input>,
+      _ request: StreamingServerRequest<Input>,
       _ context: ServerContext
-    ) async throws -> ServerResponse.Stream<Output>
-  ) async throws -> ServerResponse.Stream<Output>
+    ) async throws -> StreamingServerResponse<Output>
+  ) async throws -> StreamingServerResponse<Output>
 }

--- a/Sources/GRPCCore/Call/Server/ServerResponse.swift
+++ b/Sources/GRPCCore/Call/Server/ServerResponse.swift
@@ -14,220 +14,213 @@
  * limitations under the License.
  */
 
-/// A namespace for response message types used by servers.
-public enum ServerResponse {}
-
-extension ServerResponse {
-  /// A response for a single message sent by a server.
-  ///
-  /// Single responses are used for unary and client-streaming RPCs. For streaming responses
-  /// see ``ServerResponse/Stream``.
-  ///
-  /// A single response captures every part of the response stream and distinguishes successful
-  /// and unsuccessful responses via the ``accepted`` property. The value for the `success` case
-  /// contains the initial metadata, response message, and the trailing metadata and implicitly
-  /// has an ``Status/Code-swift.struct/ok`` status code.
-  ///
-  /// The `failure` case indicates that the server chose not to process the RPC, or the processing
-  /// of the RPC failed. The failure case contains an ``RPCError`` describing why the RPC failed,
-  /// including an error code, error message and any metadata sent by the server.
-  ///
-  /// ### Using ``Single`` responses
-  ///
-  /// Each response has an ``accepted`` property which contains all RPC information. You can create
-  /// one by calling ``init(accepted:)`` or one of the two convenience initializers:
-  /// - ``init(message:metadata:trailingMetadata:)`` to create a successful response, or
-  /// - ``init(of:error:)`` to create a failed response.
-  ///
-  /// You can interrogate a response by inspecting the ``accepted`` property directly or by using
-  /// its convenience properties:
-  /// - ``metadata`` extracts the initial metadata,
-  /// - ``message`` extracts the message, or throws if the response failed, and
-  /// - ``trailingMetadata`` extracts the trailing metadata.
-  ///
-  /// The following example demonstrates how you can use the API:
-  ///
-  /// ```swift
-  /// // Create a successful response
-  /// let response = ServerResponse.Single<String>(
-  ///   message: "Hello, World!",
-  ///   metadata: ["hello": "initial metadata"],
-  ///   trailingMetadata: ["goodbye": "trailing metadata"]
-  /// )
-  ///
-  /// // The explicit API:
-  /// switch response {
-  /// case .success(let contents):
-  ///   print("Received response with message '\(contents.message)'")
-  /// case .failure(let error):
-  ///   print("RPC failed with code '\(error.code)'")
-  /// }
-  ///
-  /// // The convenience API:
-  /// do {
-  ///   print("Received response with message '\(try response.message)'")
-  /// } catch let error as RPCError {
-  ///   print("RPC failed with code '\(error.code)'")
-  /// }
-  /// ```
-  public struct Single<Message: Sendable>: Sendable {
-    /// An accepted RPC with a successful outcome.
-    public struct Contents: Sendable {
-      /// Caller-specified metadata to send to the client at the start of the response.
-      ///
-      /// Both gRPC Swift and its transport layer may insert additional metadata. Keys prefixed with
-      /// "grpc-" are prohibited and may result in undefined behaviour. Transports may also insert
-      /// their own metadata, you should avoid using key names which may clash with transport
-      /// specific metadata. Note that transports may also impose limits in the amount of metadata
-      /// which may be sent.
-      public var metadata: Metadata
-
-      /// The message to send to the client.
-      public var message: Message
-
-      /// Caller-specified metadata to send to the client at the end of the response.
-      ///
-      /// Both gRPC Swift and its transport layer may insert additional metadata. Keys prefixed with
-      /// "grpc-" are prohibited and may result in undefined behaviour. Transports may also insert
-      /// their own metadata, you should avoid using key names which may clash with transport
-      /// specific metadata. Note that transports may also impose limits in the amount of metadata
-      /// which may be sent.
-      public var trailingMetadata: Metadata
-
-      /// Create a new single client request.
-      ///
-      /// - Parameters:
-      ///   - message: The message to send to the server.
-      ///   - metadata: Metadata to send to the client at the start of the response. Defaults to
-      ///       empty.
-      ///   - trailingMetadata: Metadata to send to the client at the end of the response. Defaults
-      ///       to empty.
-      public init(
-        message: Message,
-        metadata: Metadata = [:],
-        trailingMetadata: Metadata = [:]
-      ) {
-        self.metadata = metadata
-        self.message = message
-        self.trailingMetadata = trailingMetadata
-      }
-    }
-
-    /// Whether the RPC was accepted or rejected.
+/// A response for a single message sent by a server.
+///
+/// Single responses are used for unary and client-streaming RPCs. For streaming responses
+/// see ``StreamingServerResponse``.
+///
+/// A single response captures every part of the response stream and distinguishes successful
+/// and unsuccessful responses via the ``accepted`` property. The value for the `success` case
+/// contains the initial metadata, response message, and the trailing metadata and implicitly
+/// has an ``Status/Code-swift.struct/ok`` status code.
+///
+/// The `failure` case indicates that the server chose not to process the RPC, or the processing
+/// of the RPC failed. The failure case contains an ``RPCError`` describing why the RPC failed,
+/// including an error code, error message and any metadata sent by the server.
+///
+/// ### Using ``Single`` responses
+///
+/// Each response has an ``accepted`` property which contains all RPC information. You can create
+/// one by calling ``init(accepted:)`` or one of the two convenience initializers:
+/// - ``init(message:metadata:trailingMetadata:)`` to create a successful response, or
+/// - ``init(of:error:)`` to create a failed response.
+///
+/// You can interrogate a response by inspecting the ``accepted`` property directly or by using
+/// its convenience properties:
+/// - ``metadata`` extracts the initial metadata,
+/// - ``message`` extracts the message, or throws if the response failed, and
+/// - ``trailingMetadata`` extracts the trailing metadata.
+///
+/// The following example demonstrates how you can use the API:
+///
+/// ```swift
+/// // Create a successful response
+/// let response = ServerResponse<String>(
+///   message: "Hello, World!",
+///   metadata: ["hello": "initial metadata"],
+///   trailingMetadata: ["goodbye": "trailing metadata"]
+/// )
+///
+/// // The explicit API:
+/// switch response {
+/// case .success(let contents):
+///   print("Received response with message '\(contents.message)'")
+/// case .failure(let error):
+///   print("RPC failed with code '\(error.code)'")
+/// }
+///
+/// // The convenience API:
+/// do {
+///   print("Received response with message '\(try response.message)'")
+/// } catch let error as RPCError {
+///   print("RPC failed with code '\(error.code)'")
+/// }
+/// ```
+public struct ServerResponse<Message: Sendable>: Sendable {
+  /// An accepted RPC with a successful outcome.
+  public struct Contents: Sendable {
+    /// Caller-specified metadata to send to the client at the start of the response.
     ///
-    /// The `success` indicates the server accepted the RPC for processing and the RPC completed
-    /// successfully and implies the RPC succeeded with the ``Status/Code-swift.struct/ok`` status
-    /// code. The `failure` case indicates that the service rejected the RPC without processing it
-    /// or could not process it successfully.
-    public var accepted: Result<Contents, RPCError>
+    /// Both gRPC Swift and its transport layer may insert additional metadata. Keys prefixed with
+    /// "grpc-" are prohibited and may result in undefined behaviour. Transports may also insert
+    /// their own metadata, you should avoid using key names which may clash with transport
+    /// specific metadata. Note that transports may also impose limits in the amount of metadata
+    /// which may be sent.
+    public var metadata: Metadata
 
-    /// Creates a response.
+    /// The message to send to the client.
+    public var message: Message
+
+    /// Caller-specified metadata to send to the client at the end of the response.
     ///
-    /// - Parameter accepted: Whether the RPC was accepted or rejected.
-    public init(accepted: Result<Contents, RPCError>) {
-      self.accepted = accepted
+    /// Both gRPC Swift and its transport layer may insert additional metadata. Keys prefixed with
+    /// "grpc-" are prohibited and may result in undefined behaviour. Transports may also insert
+    /// their own metadata, you should avoid using key names which may clash with transport
+    /// specific metadata. Note that transports may also impose limits in the amount of metadata
+    /// which may be sent.
+    public var trailingMetadata: Metadata
+
+    /// Create a new single client request.
+    ///
+    /// - Parameters:
+    ///   - message: The message to send to the server.
+    ///   - metadata: Metadata to send to the client at the start of the response. Defaults to
+    ///       empty.
+    ///   - trailingMetadata: Metadata to send to the client at the end of the response. Defaults
+    ///       to empty.
+    public init(
+      message: Message,
+      metadata: Metadata = [:],
+      trailingMetadata: Metadata = [:]
+    ) {
+      self.metadata = metadata
+      self.message = message
+      self.trailingMetadata = trailingMetadata
     }
+  }
+
+  /// Whether the RPC was accepted or rejected.
+  ///
+  /// The `success` indicates the server accepted the RPC for processing and the RPC completed
+  /// successfully and implies the RPC succeeded with the ``Status/Code-swift.struct/ok`` status
+  /// code. The `failure` case indicates that the service rejected the RPC without processing it
+  /// or could not process it successfully.
+  public var accepted: Result<Contents, RPCError>
+
+  /// Creates a response.
+  ///
+  /// - Parameter accepted: Whether the RPC was accepted or rejected.
+  public init(accepted: Result<Contents, RPCError>) {
+    self.accepted = accepted
+  }
+}
+
+/// A response for a stream of messages sent by a server.
+///
+/// Stream responses are used for server-streaming and bidirectional-streaming RPCs. For single
+/// responses see ``ServerResponse``.
+///
+/// A stream response captures every part of the response stream and distinguishes whether the
+/// request was processed by the server via the ``accepted`` property. The value for the `success`
+/// case contains the initial metadata and a closure which is provided with a message write and
+/// returns trailing metadata. If the closure returns without error then the response implicitly
+/// has an ``Status/Code-swift.struct/ok`` status code. You can throw an error from the producer
+/// to indicate that the request couldn't be handled successfully.  If an ``RPCError`` is thrown
+/// then the client will receive an equivalent error populated with the same code and message. If
+/// an error of any other type is thrown then the client will receive an error with the
+/// ``Status/Code-swift.struct/unknown`` status code.
+///
+/// The `failure` case indicates that the server chose not to process the RPC. The failure case
+/// contains an ``RPCError`` describing why the RPC failed, including an error code, error
+/// message and any metadata to send to the client.
+///
+/// ### Using ``Stream`` responses
+///
+/// Each response has an ``accepted`` property which contains all RPC information. You can create
+/// one by calling ``init(accepted:)`` or one of the two convenience initializers:
+/// - ``init(of:metadata:producer:)`` to create a successful response, or
+/// - ``init(of:error:)`` to create a failed response.
+///
+/// You can interrogate a response by inspecting the ``accepted`` property directly. The following
+/// example demonstrates how you can use the API:
+///
+/// ```swift
+/// // Create a successful response
+/// let response = StreamingServerResponse(
+///   of: String.self,
+///   metadata: ["hello": "initial metadata"]
+/// ) { writer in
+///   // Write a few messages.
+///   try await writer.write("Hello")
+///   try await writer.write("World")
+///
+///   // Send trailing metadata to the client.
+///   return ["goodbye": "trailing metadata"]
+/// }
+/// ```
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+public struct StreamingServerResponse<Message: Sendable>: Sendable {
+  /// The contents of a response to a request which has been accepted for processing.
+  public struct Contents: Sendable {
+    /// Metadata to send to the client at the beginning of the response stream.
+    public var metadata: Metadata
+
+    /// A closure which, when called, writes values into the provided writer and returns trailing
+    /// metadata indicating the end of the response stream.
+    ///
+    /// Returning metadata indicates a successful response and gRPC will terminate the RPC with
+    /// an ``Status/Code-swift.struct/ok`` status code. Throwing an error will terminate the RPC
+    /// with an appropriate status code. You can control the status code, message and metadata
+    /// returned to the client by throwing an ``RPCError``. If the error thrown is a type other
+    /// than ``RPCError`` then a status with code ``Status/Code-swift.struct/unknown`` will
+    /// be returned to the client.
+    ///
+    /// gRPC will invoke this function at most once therefore it isn't required to be idempotent.
+    public var producer: @Sendable (RPCWriter<Message>) async throws -> Metadata
+
+    /// Create a ``Contents``.
+    ///
+    /// - Parameters:
+    ///   - metadata: Metadata to send to the client at the start of the response.
+    ///   - producer: A function which produces values
+    public init(
+      metadata: Metadata,
+      producer: @escaping @Sendable (RPCWriter<Message>) async throws -> Metadata
+    ) {
+      self.metadata = metadata
+      self.producer = producer
+    }
+  }
+
+  /// Whether the RPC was accepted or rejected.
+  ///
+  /// The `success` case indicates that the service accepted the RPC for processing and will
+  /// send initial metadata back to the client before producing response messages. The RPC may
+  /// still result in failure by later throwing an error.
+  ///
+  /// The `failure` case indicates that the server rejected the RPC and will not process it. Only
+  /// the status and trailing metadata will be sent to the client.
+  public var accepted: Result<Contents, RPCError>
+
+  /// Creates a response.
+  ///
+  /// - Parameter accepted: Whether the RPC was accepted or rejected.
+  public init(accepted: Result<Contents, RPCError>) {
+    self.accepted = accepted
   }
 }
 
 extension ServerResponse {
-  /// A response for a stream of messages sent by a server.
-  ///
-  /// Stream responses are used for server-streaming and bidirectional-streaming RPCs. For single
-  /// responses see ``ServerResponse/Single``.
-  ///
-  /// A stream response captures every part of the response stream and distinguishes whether the
-  /// request was processed by the server via the ``accepted`` property. The value for the `success`
-  /// case contains the initial metadata and a closure which is provided with a message write and
-  /// returns trailing metadata. If the closure returns without error then the response implicitly
-  /// has an ``Status/Code-swift.struct/ok`` status code. You can throw an error from the producer
-  /// to indicate that the request couldn't be handled successfully.  If an ``RPCError`` is thrown
-  /// then the client will receive an equivalent error populated with the same code and message. If
-  /// an error of any other type is thrown then the client will receive an error with the
-  /// ``Status/Code-swift.struct/unknown`` status code.
-  ///
-  /// The `failure` case indicates that the server chose not to process the RPC. The failure case
-  /// contains an ``RPCError`` describing why the RPC failed, including an error code, error
-  /// message and any metadata to send to the client.
-  ///
-  /// ### Using ``Stream`` responses
-  ///
-  /// Each response has an ``accepted`` property which contains all RPC information. You can create
-  /// one by calling ``init(accepted:)`` or one of the two convenience initializers:
-  /// - ``init(of:metadata:producer:)`` to create a successful response, or
-  /// - ``init(of:error:)`` to create a failed response.
-  ///
-  /// You can interrogate a response by inspecting the ``accepted`` property directly. The following
-  /// example demonstrates how you can use the API:
-  ///
-  /// ```swift
-  /// // Create a successful response
-  /// let response = ServerResponse.Stream(
-  ///   of: String.self,
-  ///   metadata: ["hello": "initial metadata"]
-  /// ) { writer in
-  ///   // Write a few messages.
-  ///   try await writer.write("Hello")
-  ///   try await writer.write("World")
-  ///
-  ///   // Send trailing metadata to the client.
-  ///   return ["goodbye": "trailing metadata"]
-  /// }
-  /// ```
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-  public struct Stream<Message: Sendable>: Sendable {
-    /// The contents of a response to a request which has been accepted for processing.
-    public struct Contents: Sendable {
-      /// Metadata to send to the client at the beginning of the response stream.
-      public var metadata: Metadata
-
-      /// A closure which, when called, writes values into the provided writer and returns trailing
-      /// metadata indicating the end of the response stream.
-      ///
-      /// Returning metadata indicates a successful response and gRPC will terminate the RPC with
-      /// an ``Status/Code-swift.struct/ok`` status code. Throwing an error will terminate the RPC
-      /// with an appropriate status code. You can control the status code, message and metadata
-      /// returned to the client by throwing an ``RPCError``. If the error thrown is a type other
-      /// than ``RPCError`` then a status with code ``Status/Code-swift.struct/unknown`` will
-      /// be returned to the client.
-      ///
-      /// gRPC will invoke this function at most once therefore it isn't required to be idempotent.
-      public var producer: @Sendable (RPCWriter<Message>) async throws -> Metadata
-
-      /// Create a ``Contents``.
-      ///
-      /// - Parameters:
-      ///   - metadata: Metadata to send to the client at the start of the response.
-      ///   - producer: A function which produces values
-      public init(
-        metadata: Metadata,
-        producer: @escaping @Sendable (RPCWriter<Message>) async throws -> Metadata
-      ) {
-        self.metadata = metadata
-        self.producer = producer
-      }
-    }
-
-    /// Whether the RPC was accepted or rejected.
-    ///
-    /// The `success` case indicates that the service accepted the RPC for processing and will
-    /// send initial metadata back to the client before producing response messages. The RPC may
-    /// still result in failure by later throwing an error.
-    ///
-    /// The `failure` case indicates that the server rejected the RPC and will not process it. Only
-    /// the status and trailing metadata will be sent to the client.
-    public var accepted: Result<Contents, RPCError>
-
-    /// Creates a response.
-    ///
-    /// - Parameter accepted: Whether the RPC was accepted or rejected.
-    public init(accepted: Result<Contents, RPCError>) {
-      self.accepted = accepted
-    }
-  }
-}
-
-extension ServerResponse.Single {
   /// Creates a new accepted response.
   ///
   /// - Parameters:
@@ -287,7 +280,7 @@ extension ServerResponse.Single {
 }
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-extension ServerResponse.Stream {
+extension StreamingServerResponse {
   /// Creates a new accepted response.
   ///
   /// - Parameters:
@@ -326,8 +319,8 @@ extension ServerResponse.Stream {
 }
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-extension ServerResponse.Stream {
-  public init(single response: ServerResponse.Single<Message>) {
+extension StreamingServerResponse {
+  public init(single response: ServerResponse<Message>) {
     switch response.accepted {
     case .success(let contents):
       let contents = Contents(metadata: contents.metadata) {

--- a/Sources/GRPCCore/Documentation.docc/Tutorials/Hello-World/Resources/hello-world-sec04-step01.swift
+++ b/Sources/GRPCCore/Documentation.docc/Tutorials/Hello-World/Resources/hello-world-sec04-step01.swift
@@ -1,11 +1,11 @@
 struct Greeter: Helloworld_GreeterServiceProtocol {
   func sayHello(
-    request: ServerRequest.Single<Helloworld_HelloRequest>,
+    request: ServerRequest<Helloworld_HelloRequest>,
     context: ServerContext
-  ) async throws -> ServerResponse.Single<Helloworld_HelloReply> {
+  ) async throws -> ServerResponse<Helloworld_HelloReply> {
     var reply = Helloworld_HelloReply()
     let recipient = request.message.name.isEmpty ? "stranger" : request.message.name
     reply.message = "Hello, \(recipient)"
-    return ServerResponse.Single(message: reply)
+    return ServerResponse(message: reply)
   }
 }

--- a/Sources/GRPCCore/Documentation.docc/Tutorials/Hello-World/Resources/hello-world-sec04-step02.swift
+++ b/Sources/GRPCCore/Documentation.docc/Tutorials/Hello-World/Resources/hello-world-sec04-step02.swift
@@ -1,21 +1,21 @@
 struct Greeter: Helloworld_GreeterServiceProtocol {
   func sayHello(
-    request: ServerRequest.Single<Helloworld_HelloRequest>,
+    request: ServerRequest<Helloworld_HelloRequest>,
     context: ServerContext
-  ) async throws -> ServerResponse.Single<Helloworld_HelloReply> {
+  ) async throws -> ServerResponse<Helloworld_HelloReply> {
     var reply = Helloworld_HelloReply()
     let recipient = request.message.name.isEmpty ? "stranger" : request.message.name
     reply.message = "Hello, \(recipient)"
-    return ServerResponse.Single(message: reply)
+    return ServerResponse(message: reply)
   }
 
   func sayHelloAgain(
-    request: ServerRequest.Single<Helloworld_HelloRequest>,
+    request: ServerRequest<Helloworld_HelloRequest>,
     context: ServerContext
-  ) async throws -> ServerResponse.Single<Helloworld_HelloReply> {
+  ) async throws -> ServerResponse<Helloworld_HelloReply> {
     var reply = Helloworld_HelloReply()
     let recipient = request.message.name.isEmpty ? "stranger" : request.message.name
     reply.message = "Hello again, \(recipient)"
-    return ServerResponse.Single(message: reply)
+    return ServerResponse(message: reply)
   }
 }

--- a/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec04-step02-unimplemented.swift
+++ b/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec04-step02-unimplemented.swift
@@ -2,26 +2,26 @@ import GRPCCore
 
 struct RouteGuideService: Routeguide_RouteGuide.ServiceProtocol {
   func getFeature(
-    request: ServerRequest.Single<Routeguide_Point>,
+    request: ServerRequest<Routeguide_Point>,
     context: ServerContext
-  ) async throws -> ServerResponse.Single<Routeguide_Feature> {
+  ) async throws -> ServerResponse<Routeguide_Feature> {
   }
 
   func listFeatures(
-    request: ServerRequest.Single<Routeguide_Rectangle>,
+    request: ServerRequest<Routeguide_Rectangle>,
     context: ServerContext
-  ) async throws -> ServerResponse.Stream<Routeguide_Feature> {
+  ) async throws -> StreamingServerResponse<Routeguide_Feature> {
   }
 
   func recordRoute(
-    request: ServerRequest.Stream<Routeguide_Point>,
+    request: StreamingServerRequest<Routeguide_Point>,
     context: ServerContext
-  ) async throws -> ServerResponse.Single<Routeguide_RouteSummary> {
+  ) async throws -> ServerResponse<Routeguide_RouteSummary> {
   }
 
   func routeChat(
-    request: ServerRequest.Stream<Routeguide_RouteNote>,
+    request: StreamingServerRequest<Routeguide_RouteNote>,
     context: ServerContext
-  ) async throws -> ServerResponse.Stream<Routeguide_RouteNote> {
+  ) async throws -> StreamingServerResponse<Routeguide_RouteNote> {
   }
 }

--- a/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec04-step03-features.swift
+++ b/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec04-step03-features.swift
@@ -11,26 +11,26 @@ struct RouteGuideService: Routeguide_RouteGuide.ServiceProtocol {
   }
 
   func getFeature(
-    request: ServerRequest.Single<Routeguide_Point>,
+    request: ServerRequest<Routeguide_Point>,
     context: ServerContext
-  ) async throws -> ServerResponse.Single<Routeguide_Feature> {
+  ) async throws -> ServerResponse<Routeguide_Feature> {
   }
 
   func listFeatures(
-    request: ServerRequest.Single<Routeguide_Rectangle>,
+    request: ServerRequest<Routeguide_Rectangle>,
     context: ServerContext
-  ) async throws -> ServerResponse.Stream<Routeguide_Feature> {
+  ) async throws -> StreamingServerResponse<Routeguide_Feature> {
   }
 
   func recordRoute(
-    request: ServerRequest.Stream<Routeguide_Point>,
+    request: StreamingServerRequest<Routeguide_Point>,
     context: ServerContext
-  ) async throws -> ServerResponse.Single<Routeguide_RouteSummary> {
+  ) async throws -> ServerResponse<Routeguide_RouteSummary> {
   }
 
   func routeChat(
-    request: ServerRequest.Stream<Routeguide_RouteNote>,
+    request: StreamingServerRequest<Routeguide_RouteNote>,
     context: ServerContext
-  ) async throws -> ServerResponse.Stream<Routeguide_RouteNote> {
+  ) async throws -> StreamingServerResponse<Routeguide_RouteNote> {
   }
 }

--- a/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec04-step04-unary.swift
+++ b/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec04-step04-unary.swift
@@ -18,9 +18,9 @@ struct RouteGuideService: Routeguide_RouteGuide.ServiceProtocol {
   }
 
   func getFeature(
-    request: ServerRequest.Single<Routeguide_Point>,
+    request: ServerRequest<Routeguide_Point>,
     context: ServerContext
-  ) async throws -> ServerResponse.Single<Routeguide_Feature> {
+  ) async throws -> ServerResponse<Routeguide_Feature> {
     let feature = self.findFeature(
       latitude: request.message.latitude,
       longitude: request.message.longitude
@@ -28,20 +28,20 @@ struct RouteGuideService: Routeguide_RouteGuide.ServiceProtocol {
   }
 
   func listFeatures(
-    request: ServerRequest.Single<Routeguide_Rectangle>,
+    request: ServerRequest<Routeguide_Rectangle>,
     context: ServerContext
-  ) async throws -> ServerResponse.Stream<Routeguide_Feature> {
+  ) async throws -> StreamingServerResponse<Routeguide_Feature> {
   }
 
   func recordRoute(
-    request: ServerRequest.Stream<Routeguide_Point>,
+    request: StreamingServerRequest<Routeguide_Point>,
     context: ServerContext
-  ) async throws -> ServerResponse.Single<Routeguide_RouteSummary> {
+  ) async throws -> ServerResponse<Routeguide_RouteSummary> {
   }
 
   func routeChat(
-    request: ServerRequest.Stream<Routeguide_RouteNote>,
+    request: StreamingServerRequest<Routeguide_RouteNote>,
     context: ServerContext
-  ) async throws -> ServerResponse.Stream<Routeguide_RouteNote> {
+  ) async throws -> StreamingServerResponse<Routeguide_RouteNote> {
   }
 }

--- a/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec04-step05-unary.swift
+++ b/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec04-step05-unary.swift
@@ -18,16 +18,16 @@ struct RouteGuideService: Routeguide_RouteGuide.ServiceProtocol {
   }
 
   func getFeature(
-    request: ServerRequest.Single<Routeguide_Point>,
+    request: ServerRequest<Routeguide_Point>,
     context: ServerContext
-  ) async throws -> ServerResponse.Single<Routeguide_Feature> {
+  ) async throws -> ServerResponse<Routeguide_Feature> {
     let feature = self.findFeature(
       latitude: request.message.latitude,
       longitude: request.message.longitude
     )
 
     if let feature {
-      return ServerResponse.Single(message: feature)
+      return ServerResponse(message: feature)
     } else {
       // No feature: return a feature with an empty name.
       let unknownFeature = Routeguide_Feature.with {
@@ -37,25 +37,25 @@ struct RouteGuideService: Routeguide_RouteGuide.ServiceProtocol {
           $0.longitude = request.message.longitude
         }
       }
-      return ServerResponse.Single(message: unknownFeature)
+      return ServerResponse(message: unknownFeature)
     }
   }
 
   func listFeatures(
-    request: ServerRequest.Single<Routeguide_Rectangle>,
+    request: ServerRequest<Routeguide_Rectangle>,
     context: ServerContext
-  ) async throws -> ServerResponse.Stream<Routeguide_Feature> {
+  ) async throws -> StreamingServerResponse<Routeguide_Feature> {
   }
 
   func recordRoute(
-    request: ServerRequest.Stream<Routeguide_Point>,
+    request: StreamingServerRequest<Routeguide_Point>,
     context: ServerContext
-  ) async throws -> ServerResponse.Single<Routeguide_RouteSummary> {
+  ) async throws -> ServerResponse<Routeguide_RouteSummary> {
   }
 
   func routeChat(
-    request: ServerRequest.Stream<Routeguide_RouteNote>,
+    request: StreamingServerRequest<Routeguide_RouteNote>,
     context: ServerContext
-  ) async throws -> ServerResponse.Stream<Routeguide_RouteNote> {
+  ) async throws -> StreamingServerResponse<Routeguide_RouteNote> {
   }
 }

--- a/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec04-step06-server-streaming.swift
+++ b/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec04-step06-server-streaming.swift
@@ -18,16 +18,16 @@ struct RouteGuideService: Routeguide_RouteGuide.ServiceProtocol {
   }
 
   func getFeature(
-    request: ServerRequest.Single<Routeguide_Point>,
+    request: ServerRequest<Routeguide_Point>,
     context: ServerContext
-  ) async throws -> ServerResponse.Single<Routeguide_Feature> {
+  ) async throws -> ServerResponse<Routeguide_Feature> {
     let feature = self.findFeature(
       latitude: request.message.latitude,
       longitude: request.message.longitude
     )
 
     if let feature {
-      return ServerResponse.Single(message: feature)
+      return ServerResponse(message: feature)
     } else {
       // No feature: return a feature with an empty name.
       let unknownFeature = Routeguide_Feature.with {
@@ -37,15 +37,15 @@ struct RouteGuideService: Routeguide_RouteGuide.ServiceProtocol {
           $0.longitude = request.message.longitude
         }
       }
-      return ServerResponse.Single(message: unknownFeature)
+      return ServerResponse(message: unknownFeature)
     }
   }
 
   func listFeatures(
-    request: ServerRequest.Single<Routeguide_Rectangle>,
+    request: ServerRequest<Routeguide_Rectangle>,
     context: ServerContext
-  ) async throws -> ServerResponse.Stream<Routeguide_Feature> {
-    return ServerResponse.Stream { writer in
+  ) async throws -> StreamingServerResponse<Routeguide_Feature> {
+    return StreamingServerResponse { writer in
       for feature in self.features {
         if !feature.name.isEmpty, feature.isContained(by: request.message) {
           try await writer.write(feature)
@@ -55,15 +55,15 @@ struct RouteGuideService: Routeguide_RouteGuide.ServiceProtocol {
   }
 
   func recordRoute(
-    request: ServerRequest.Stream<Routeguide_Point>,
+    request: StreamingServerRequest<Routeguide_Point>,
     context: ServerContext
-  ) async throws -> ServerResponse.Single<Routeguide_RouteSummary> {
+  ) async throws -> ServerResponse<Routeguide_RouteSummary> {
   }
 
   func routeChat(
-    request: ServerRequest.Stream<Routeguide_RouteNote>,
+    request: StreamingServerRequest<Routeguide_RouteNote>,
     context: ServerContext
-  ) async throws -> ServerResponse.Stream<Routeguide_RouteNote> {
+  ) async throws -> StreamingServerResponse<Routeguide_RouteNote> {
   }
 }
 

--- a/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec04-step07-server-streaming.swift
+++ b/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec04-step07-server-streaming.swift
@@ -18,16 +18,16 @@ struct RouteGuideService: Routeguide_RouteGuide.ServiceProtocol {
   }
 
   func getFeature(
-    request: ServerRequest.Single<Routeguide_Point>,
+    request: ServerRequest<Routeguide_Point>,
     context: ServerContext
-  ) async throws -> ServerResponse.Single<Routeguide_Feature> {
+  ) async throws -> ServerResponse<Routeguide_Feature> {
     let feature = self.findFeature(
       latitude: request.message.latitude,
       longitude: request.message.longitude
     )
 
     if let feature {
-      return ServerResponse.Single(message: feature)
+      return ServerResponse(message: feature)
     } else {
       // No feature: return a feature with an empty name.
       let unknownFeature = Routeguide_Feature.with {
@@ -37,15 +37,15 @@ struct RouteGuideService: Routeguide_RouteGuide.ServiceProtocol {
           $0.longitude = request.message.longitude
         }
       }
-      return ServerResponse.Single(message: unknownFeature)
+      return ServerResponse(message: unknownFeature)
     }
   }
 
   func listFeatures(
-    request: ServerRequest.Single<Routeguide_Rectangle>,
+    request: ServerRequest<Routeguide_Rectangle>,
     context: ServerContext
-  ) async throws -> ServerResponse.Stream<Routeguide_Feature> {
-    return ServerResponse.Stream { writer in
+  ) async throws -> StreamingServerResponse<Routeguide_Feature> {
+    return StreamingServerResponse { writer in
       for feature in self.features {
         if !feature.name.isEmpty, feature.isContained(by: request.message) {
           try await writer.write(feature)
@@ -57,15 +57,15 @@ struct RouteGuideService: Routeguide_RouteGuide.ServiceProtocol {
   }
 
   func recordRoute(
-    request: ServerRequest.Stream<Routeguide_Point>,
+    request: StreamingServerRequest<Routeguide_Point>,
     context: ServerContext
-  ) async throws -> ServerResponse.Single<Routeguide_RouteSummary> {
+  ) async throws -> ServerResponse<Routeguide_RouteSummary> {
   }
 
   func routeChat(
-    request: ServerRequest.Stream<Routeguide_RouteNote>,
+    request: StreamingServerRequest<Routeguide_RouteNote>,
     context: ServerContext
-  ) async throws -> ServerResponse.Stream<Routeguide_RouteNote> {
+  ) async throws -> StreamingServerResponse<Routeguide_RouteNote> {
   }
 }
 

--- a/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec04-step08-client-streaming.swift
+++ b/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec04-step08-client-streaming.swift
@@ -19,16 +19,16 @@ struct RouteGuideService: Routeguide_RouteGuide.ServiceProtocol {
   }
 
   func getFeature(
-    request: ServerRequest.Single<Routeguide_Point>,
+    request: ServerRequest<Routeguide_Point>,
     context: ServerContext
-  ) async throws -> ServerResponse.Single<Routeguide_Feature> {
+  ) async throws -> ServerResponse<Routeguide_Feature> {
     let feature = self.findFeature(
       latitude: request.message.latitude,
       longitude: request.message.longitude
     )
 
     if let feature {
-      return ServerResponse.Single(message: feature)
+      return ServerResponse(message: feature)
     } else {
       // No feature: return a feature with an empty name.
       let unknownFeature = Routeguide_Feature.with {
@@ -38,15 +38,15 @@ struct RouteGuideService: Routeguide_RouteGuide.ServiceProtocol {
           $0.longitude = request.message.longitude
         }
       }
-      return ServerResponse.Single(message: unknownFeature)
+      return ServerResponse(message: unknownFeature)
     }
   }
 
   func listFeatures(
-    request: ServerRequest.Single<Routeguide_Rectangle>,
+    request: ServerRequest<Routeguide_Rectangle>,
     context: ServerContext
-  ) async throws -> ServerResponse.Stream<Routeguide_Feature> {
-    return ServerResponse.Stream { writer in
+  ) async throws -> StreamingServerResponse<Routeguide_Feature> {
+    return StreamingServerResponse { writer in
       for feature in self.features {
         if !feature.name.isEmpty, feature.isContained(by: request.message) {
           try await writer.write(feature)
@@ -58,9 +58,9 @@ struct RouteGuideService: Routeguide_RouteGuide.ServiceProtocol {
   }
 
   func recordRoute(
-    request: ServerRequest.Stream<Routeguide_Point>,
+    request: StreamingServerRequest<Routeguide_Point>,
     context: ServerContext
-  ) async throws -> ServerResponse.Single<Routeguide_RouteSummary> {
+  ) async throws -> ServerResponse<Routeguide_RouteSummary> {
     let startTime = ContinuousClock.now
     var pointsVisited = 0
     var featuresVisited = 0
@@ -89,13 +89,13 @@ struct RouteGuideService: Routeguide_RouteGuide.ServiceProtocol {
       $0.distance = Int32(distanceTravelled)
     }
 
-    return ServerResponse.Single(message: summary)
+    return ServerResponse(message: summary)
   }
 
   func routeChat(
-    request: ServerRequest.Stream<Routeguide_RouteNote>,
+    request: StreamingServerRequest<Routeguide_RouteNote>,
     context: ServerContext
-  ) async throws -> ServerResponse.Stream<Routeguide_RouteNote> {
+  ) async throws -> StreamingServerResponse<Routeguide_RouteNote> {
   }
 }
 

--- a/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec04-step09-bidi-streaming.swift
+++ b/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec04-step09-bidi-streaming.swift
@@ -50,16 +50,16 @@ struct RouteGuideService: Routeguide_RouteGuide.ServiceProtocol {
   }
 
   func getFeature(
-    request: ServerRequest.Single<Routeguide_Point>,
+    request: ServerRequest<Routeguide_Point>,
     context: ServerContext
-  ) async throws -> ServerResponse.Single<Routeguide_Feature> {
+  ) async throws -> ServerResponse<Routeguide_Feature> {
     let feature = self.findFeature(
       latitude: request.message.latitude,
       longitude: request.message.longitude
     )
 
     if let feature {
-      return ServerResponse.Single(message: feature)
+      return ServerResponse(message: feature)
     } else {
       // No feature: return a feature with an empty name.
       let unknownFeature = Routeguide_Feature.with {
@@ -69,15 +69,15 @@ struct RouteGuideService: Routeguide_RouteGuide.ServiceProtocol {
           $0.longitude = request.message.longitude
         }
       }
-      return ServerResponse.Single(message: unknownFeature)
+      return ServerResponse(message: unknownFeature)
     }
   }
 
   func listFeatures(
-    request: ServerRequest.Single<Routeguide_Rectangle>,
+    request: ServerRequest<Routeguide_Rectangle>,
     context: ServerContext
-  ) async throws -> ServerResponse.Stream<Routeguide_Feature> {
-    return ServerResponse.Stream { writer in
+  ) async throws -> StreamingServerResponse<Routeguide_Feature> {
+    return StreamingServerResponse { writer in
       for feature in self.features {
         if !feature.name.isEmpty, feature.isContained(by: request.message) {
           try await writer.write(feature)
@@ -89,9 +89,9 @@ struct RouteGuideService: Routeguide_RouteGuide.ServiceProtocol {
   }
 
   func recordRoute(
-    request: ServerRequest.Stream<Routeguide_Point>,
+    request: StreamingServerRequest<Routeguide_Point>,
     context: ServerContext
-  ) async throws -> ServerResponse.Single<Routeguide_RouteSummary> {
+  ) async throws -> ServerResponse<Routeguide_RouteSummary> {
     let startTime = ContinuousClock.now
     var pointsVisited = 0
     var featuresVisited = 0
@@ -120,13 +120,13 @@ struct RouteGuideService: Routeguide_RouteGuide.ServiceProtocol {
       $0.distance = Int32(distanceTravelled)
     }
 
-    return ServerResponse.Single(message: summary)
+    return ServerResponse(message: summary)
   }
 
   func routeChat(
-    request: ServerRequest.Stream<Routeguide_RouteNote>,
+    request: StreamingServerRequest<Routeguide_RouteNote>,
     context: ServerContext
-  ) async throws -> ServerResponse.Stream<Routeguide_RouteNote> {
+  ) async throws -> StreamingServerResponse<Routeguide_RouteNote> {
   }
 }
 

--- a/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec04-step10-bidi-streaming.swift
+++ b/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec04-step10-bidi-streaming.swift
@@ -50,16 +50,16 @@ struct RouteGuideService: Routeguide_RouteGuide.ServiceProtocol {
   }
 
   func getFeature(
-    request: ServerRequest.Single<Routeguide_Point>,
+    request: ServerRequest<Routeguide_Point>,
     context: ServerContext
-  ) async throws -> ServerResponse.Single<Routeguide_Feature> {
+  ) async throws -> ServerResponse<Routeguide_Feature> {
     let feature = self.findFeature(
       latitude: request.message.latitude,
       longitude: request.message.longitude
     )
 
     if let feature {
-      return ServerResponse.Single(message: feature)
+      return ServerResponse(message: feature)
     } else {
       // No feature: return a feature with an empty name.
       let unknownFeature = Routeguide_Feature.with {
@@ -69,15 +69,15 @@ struct RouteGuideService: Routeguide_RouteGuide.ServiceProtocol {
           $0.longitude = request.message.longitude
         }
       }
-      return ServerResponse.Single(message: unknownFeature)
+      return ServerResponse(message: unknownFeature)
     }
   }
 
   func listFeatures(
-    request: ServerRequest.Single<Routeguide_Rectangle>,
+    request: ServerRequest<Routeguide_Rectangle>,
     context: ServerContext
-  ) async throws -> ServerResponse.Stream<Routeguide_Feature> {
-    return ServerResponse.Stream { writer in
+  ) async throws -> StreamingServerResponse<Routeguide_Feature> {
+    return StreamingServerResponse { writer in
       for feature in self.features {
         if !feature.name.isEmpty, feature.isContained(by: request.message) {
           try await writer.write(feature)
@@ -89,9 +89,9 @@ struct RouteGuideService: Routeguide_RouteGuide.ServiceProtocol {
   }
 
   func recordRoute(
-    request: ServerRequest.Stream<Routeguide_Point>,
+    request: StreamingServerRequest<Routeguide_Point>,
     context: ServerContext
-  ) async throws -> ServerResponse.Single<Routeguide_RouteSummary> {
+  ) async throws -> ServerResponse<Routeguide_RouteSummary> {
     let startTime = ContinuousClock.now
     var pointsVisited = 0
     var featuresVisited = 0
@@ -120,14 +120,14 @@ struct RouteGuideService: Routeguide_RouteGuide.ServiceProtocol {
       $0.distance = Int32(distanceTravelled)
     }
 
-    return ServerResponse.Single(message: summary)
+    return ServerResponse(message: summary)
   }
 
   func routeChat(
-    request: ServerRequest.Stream<Routeguide_RouteNote>,
+    request: StreamingServerRequest<Routeguide_RouteNote>,
     context: ServerContext
-  ) async throws -> ServerResponse.Stream<Routeguide_RouteNote> {
-    return ServerResponse.Stream { writer in
+  ) async throws -> StreamingServerResponse<Routeguide_RouteNote> {
+    return StreamingServerResponse { writer in
       for try await note in request.messages {
         let notes = self.receivedNotes.recordNote(note)
         try await writer.write(contentsOf: notes)

--- a/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Route-Guide.tutorial
+++ b/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Route-Guide.tutorial
@@ -242,14 +242,14 @@
       @Step {
         `GetFeature` is a unary RPC which takes a single point as input and returns a single
         feature back to the client. Its generated method, `getFeature`, has one parameter:
-        `ServerRequest.Single<Routeguide_Point>` describing the request. To return our response to
+        `ServerRequest<Routeguide_Point>` describing the request. To return our response to
         the client and complete the call we must first lookup a feature at the given point.
 
         @Code(name: "Sources/RouteGuideService.swift", file: "route-guide-sec04-step04-unary.swift")
       }
 
       @Step {
-        Then create and return an appropriate `ServerResponse.Single<Routeguide_Feature>` to the
+        Then create and return an appropriate `ServerResponse<Routeguide_Feature>` to the
         client.
 
         @Code(name: "Sources/RouteGuideService.swift", file: "route-guide-sec04-step05-unary.swift")
@@ -257,11 +257,11 @@
 
       @Step {
         Next, let's look at one of our streaming RPCs. Like the unary RPC, this method gets a
-        request object, `ServerRequest.Single<Routeguide_Rectangle>`, which has a message describing
+        request object, `ServerRequest<Routeguide_Rectangle>`, which has a message describing
         the area in which the client wants to list features. As this is a server-side streaming RPC
         we can send back multiple `Routeguide_Feature` messages to our client.
 
-        To implement the method we must return a `ServerResponse.Stream` which is initialized with
+        To implement the method we must return a `StreamingServerResponse` which is initialized with
         a closure to produce messages. The closure is passed a writer allowing you to write back
         messages. We can write back a message for each feature we find in the rectangle.
 
@@ -280,8 +280,8 @@
         method `RecordRoute`, where we get a stream of `Routeguide_Point`s from the client and
         return a single `Routeguide_RouteSummary` with information about their trip.
 
-        As you can see our method gets a `ServerRequest.Stream<Routeguide_Point>` parameter and
-        returns a `ServerResponse.Single<Routeguide_RouteSummary>`. In the method we iterate over
+        As you can see our method gets a `StreamingServerRequest<Routeguide_Point>` parameter and
+        returns a `ServerResponse<Routeguide_RouteSummary>`. In the method we iterate over
         the asynchronous stream of points sent by the client. For each point we check if there's
         a feature at that point and calculate the distance between that and the last point we saw.
         After the *client* has finished sending points we populate a `Routeguide_RouteSummary` which
@@ -300,7 +300,7 @@
       }
 
       @Step {
-        To implement the RPC we return a `ServerResponse.Stream<Routeguide_RouteNote>`. Like in the
+        To implement the RPC we return a `StreamingServerResponse<Routeguide_RouteNote>`. Like in the
         server-side streaming RPC it's initialized with a closure for writing back messages. In
         the body of the closure we iterate the request messages and for each one call our helper
         class to record the note and get all other notes recorded in the same location. We then

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
@@ -47,19 +47,19 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       public protocol NamespaceA_ServiceA_ClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
-              request: GRPCCore.ClientRequest.Single<NamespaceA_ServiceARequest>,
+              request: GRPCCore.ClientRequest<NamespaceA_ServiceARequest>,
               serializer: some GRPCCore.MessageSerializer<NamespaceA_ServiceARequest>,
               deserializer: some GRPCCore.MessageDeserializer<NamespaceA_ServiceAResponse>,
               options: GRPCCore.CallOptions,
-              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R
+              _ body: @Sendable @escaping (GRPCCore.ClientResponse<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable
       }
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
           public func methodA<R>(
-              request: GRPCCore.ClientRequest.Single<NamespaceA_ServiceARequest>,
+              request: GRPCCore.ClientRequest<NamespaceA_ServiceARequest>,
               options: GRPCCore.CallOptions = .defaults,
-              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R = {
+              _ body: @Sendable @escaping (GRPCCore.ClientResponse<NamespaceA_ServiceAResponse>) async throws -> R = {
                   try $0.message
               }
           ) async throws -> R where R: Sendable {
@@ -79,11 +79,11 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               _ message: NamespaceA_ServiceARequest,
               metadata: GRPCCore.Metadata = [:],
               options: GRPCCore.CallOptions = .defaults,
-              onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> Result = {
+              onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<NamespaceA_ServiceAResponse>) async throws -> Result = {
                   try $0.message
               }
           ) async throws -> Result where Result: Sendable {
-              let request = GRPCCore.ClientRequest.Single<NamespaceA_ServiceARequest>(
+              let request = GRPCCore.ClientRequest<NamespaceA_ServiceARequest>(
                   message: message,
                   metadata: metadata
               )
@@ -105,11 +105,11 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           
           /// Documentation for MethodA
           public func methodA<R>(
-              request: GRPCCore.ClientRequest.Single<NamespaceA_ServiceARequest>,
+              request: GRPCCore.ClientRequest<NamespaceA_ServiceARequest>,
               serializer: some GRPCCore.MessageSerializer<NamespaceA_ServiceARequest>,
               deserializer: some GRPCCore.MessageDeserializer<NamespaceA_ServiceAResponse>,
               options: GRPCCore.CallOptions = .defaults,
-              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R = {
+              _ body: @Sendable @escaping (GRPCCore.ClientResponse<NamespaceA_ServiceAResponse>) async throws -> R = {
                   try $0.message
               }
           ) async throws -> R where R: Sendable {
@@ -154,19 +154,19 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       public protocol NamespaceA_ServiceA_ClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
-              request: GRPCCore.ClientRequest.Stream<NamespaceA_ServiceARequest>,
+              request: GRPCCore.StreamingClientRequest<NamespaceA_ServiceARequest>,
               serializer: some GRPCCore.MessageSerializer<NamespaceA_ServiceARequest>,
               deserializer: some GRPCCore.MessageDeserializer<NamespaceA_ServiceAResponse>,
               options: GRPCCore.CallOptions,
-              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R
+              _ body: @Sendable @escaping (GRPCCore.ClientResponse<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable
       }
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
           public func methodA<R>(
-              request: GRPCCore.ClientRequest.Stream<NamespaceA_ServiceARequest>,
+              request: GRPCCore.StreamingClientRequest<NamespaceA_ServiceARequest>,
               options: GRPCCore.CallOptions = .defaults,
-              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R = {
+              _ body: @Sendable @escaping (GRPCCore.ClientResponse<NamespaceA_ServiceAResponse>) async throws -> R = {
                   try $0.message
               }
           ) async throws -> R where R: Sendable {
@@ -186,11 +186,11 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               metadata: GRPCCore.Metadata = [:],
               options: GRPCCore.CallOptions = .defaults,
               requestProducer: @Sendable @escaping (GRPCCore.RPCWriter<NamespaceA_ServiceARequest>) async throws -> Void,
-              onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> Result = {
+              onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<NamespaceA_ServiceAResponse>) async throws -> Result = {
                   try $0.message
               }
           ) async throws -> Result where Result: Sendable {
-              let request = GRPCCore.ClientRequest.Stream<NamespaceA_ServiceARequest>(
+              let request = GRPCCore.StreamingClientRequest<NamespaceA_ServiceARequest>(
                   metadata: metadata,
                   producer: requestProducer
               )
@@ -212,11 +212,11 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           
           /// Documentation for MethodA
           public func methodA<R>(
-              request: GRPCCore.ClientRequest.Stream<NamespaceA_ServiceARequest>,
+              request: GRPCCore.StreamingClientRequest<NamespaceA_ServiceARequest>,
               serializer: some GRPCCore.MessageSerializer<NamespaceA_ServiceARequest>,
               deserializer: some GRPCCore.MessageDeserializer<NamespaceA_ServiceAResponse>,
               options: GRPCCore.CallOptions = .defaults,
-              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R = {
+              _ body: @Sendable @escaping (GRPCCore.ClientResponse<NamespaceA_ServiceAResponse>) async throws -> R = {
                   try $0.message
               }
           ) async throws -> R where R: Sendable {
@@ -261,19 +261,19 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       public protocol NamespaceA_ServiceA_ClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
-              request: GRPCCore.ClientRequest.Single<NamespaceA_ServiceARequest>,
+              request: GRPCCore.ClientRequest<NamespaceA_ServiceARequest>,
               serializer: some GRPCCore.MessageSerializer<NamespaceA_ServiceARequest>,
               deserializer: some GRPCCore.MessageDeserializer<NamespaceA_ServiceAResponse>,
               options: GRPCCore.CallOptions,
-              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> R
+              _ body: @Sendable @escaping (GRPCCore.StreamingClientResponse<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable
       }
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
           public func methodA<R>(
-              request: GRPCCore.ClientRequest.Single<NamespaceA_ServiceARequest>,
+              request: GRPCCore.ClientRequest<NamespaceA_ServiceARequest>,
               options: GRPCCore.CallOptions = .defaults,
-              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> R
+              _ body: @Sendable @escaping (GRPCCore.StreamingClientResponse<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.methodA(
                   request: request,
@@ -291,9 +291,9 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               _ message: NamespaceA_ServiceARequest,
               metadata: GRPCCore.Metadata = [:],
               options: GRPCCore.CallOptions = .defaults,
-              onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> Result
+              onResponse handleResponse: @Sendable @escaping (GRPCCore.StreamingClientResponse<NamespaceA_ServiceAResponse>) async throws -> Result
           ) async throws -> Result where Result: Sendable {
-              let request = GRPCCore.ClientRequest.Single<NamespaceA_ServiceARequest>(
+              let request = GRPCCore.ClientRequest<NamespaceA_ServiceARequest>(
                   message: message,
                   metadata: metadata
               )
@@ -315,11 +315,11 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           
           /// Documentation for MethodA
           public func methodA<R>(
-              request: GRPCCore.ClientRequest.Single<NamespaceA_ServiceARequest>,
+              request: GRPCCore.ClientRequest<NamespaceA_ServiceARequest>,
               serializer: some GRPCCore.MessageSerializer<NamespaceA_ServiceARequest>,
               deserializer: some GRPCCore.MessageDeserializer<NamespaceA_ServiceAResponse>,
               options: GRPCCore.CallOptions = .defaults,
-              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> R
+              _ body: @Sendable @escaping (GRPCCore.StreamingClientResponse<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.client.serverStreaming(
                   request: request,
@@ -362,19 +362,19 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       public protocol NamespaceA_ServiceA_ClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
-              request: GRPCCore.ClientRequest.Stream<NamespaceA_ServiceARequest>,
+              request: GRPCCore.StreamingClientRequest<NamespaceA_ServiceARequest>,
               serializer: some GRPCCore.MessageSerializer<NamespaceA_ServiceARequest>,
               deserializer: some GRPCCore.MessageDeserializer<NamespaceA_ServiceAResponse>,
               options: GRPCCore.CallOptions,
-              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> R
+              _ body: @Sendable @escaping (GRPCCore.StreamingClientResponse<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable
       }
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
           public func methodA<R>(
-              request: GRPCCore.ClientRequest.Stream<NamespaceA_ServiceARequest>,
+              request: GRPCCore.StreamingClientRequest<NamespaceA_ServiceARequest>,
               options: GRPCCore.CallOptions = .defaults,
-              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> R
+              _ body: @Sendable @escaping (GRPCCore.StreamingClientResponse<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.methodA(
                   request: request,
@@ -392,9 +392,9 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               metadata: GRPCCore.Metadata = [:],
               options: GRPCCore.CallOptions = .defaults,
               requestProducer: @Sendable @escaping (GRPCCore.RPCWriter<NamespaceA_ServiceARequest>) async throws -> Void,
-              onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> Result
+              onResponse handleResponse: @Sendable @escaping (GRPCCore.StreamingClientResponse<NamespaceA_ServiceAResponse>) async throws -> Result
           ) async throws -> Result where Result: Sendable {
-              let request = GRPCCore.ClientRequest.Stream<NamespaceA_ServiceARequest>(
+              let request = GRPCCore.StreamingClientRequest<NamespaceA_ServiceARequest>(
                   metadata: metadata,
                   producer: requestProducer
               )
@@ -416,11 +416,11 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           
           /// Documentation for MethodA
           public func methodA<R>(
-              request: GRPCCore.ClientRequest.Stream<NamespaceA_ServiceARequest>,
+              request: GRPCCore.StreamingClientRequest<NamespaceA_ServiceARequest>,
               serializer: some GRPCCore.MessageSerializer<NamespaceA_ServiceARequest>,
               deserializer: some GRPCCore.MessageDeserializer<NamespaceA_ServiceAResponse>,
               options: GRPCCore.CallOptions = .defaults,
-              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> R
+              _ body: @Sendable @escaping (GRPCCore.StreamingClientResponse<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.client.bidirectionalStreaming(
                   request: request,
@@ -471,28 +471,28 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       package protocol NamespaceA_ServiceA_ClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
-              request: GRPCCore.ClientRequest.Stream<NamespaceA_ServiceARequest>,
+              request: GRPCCore.StreamingClientRequest<NamespaceA_ServiceARequest>,
               serializer: some GRPCCore.MessageSerializer<NamespaceA_ServiceARequest>,
               deserializer: some GRPCCore.MessageDeserializer<NamespaceA_ServiceAResponse>,
               options: GRPCCore.CallOptions,
-              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R
+              _ body: @Sendable @escaping (GRPCCore.ClientResponse<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable
           
           /// Documentation for MethodB
           func methodB<R>(
-              request: GRPCCore.ClientRequest.Single<NamespaceA_ServiceARequest>,
+              request: GRPCCore.ClientRequest<NamespaceA_ServiceARequest>,
               serializer: some GRPCCore.MessageSerializer<NamespaceA_ServiceARequest>,
               deserializer: some GRPCCore.MessageDeserializer<NamespaceA_ServiceAResponse>,
               options: GRPCCore.CallOptions,
-              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> R
+              _ body: @Sendable @escaping (GRPCCore.StreamingClientResponse<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable
       }
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
           package func methodA<R>(
-              request: GRPCCore.ClientRequest.Stream<NamespaceA_ServiceARequest>,
+              request: GRPCCore.StreamingClientRequest<NamespaceA_ServiceARequest>,
               options: GRPCCore.CallOptions = .defaults,
-              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R = {
+              _ body: @Sendable @escaping (GRPCCore.ClientResponse<NamespaceA_ServiceAResponse>) async throws -> R = {
                   try $0.message
               }
           ) async throws -> R where R: Sendable {
@@ -506,9 +506,9 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           }
           
           package func methodB<R>(
-              request: GRPCCore.ClientRequest.Single<NamespaceA_ServiceARequest>,
+              request: GRPCCore.ClientRequest<NamespaceA_ServiceARequest>,
               options: GRPCCore.CallOptions = .defaults,
-              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> R
+              _ body: @Sendable @escaping (GRPCCore.StreamingClientResponse<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.methodB(
                   request: request,
@@ -526,11 +526,11 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               metadata: GRPCCore.Metadata = [:],
               options: GRPCCore.CallOptions = .defaults,
               requestProducer: @Sendable @escaping (GRPCCore.RPCWriter<NamespaceA_ServiceARequest>) async throws -> Void,
-              onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> Result = {
+              onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<NamespaceA_ServiceAResponse>) async throws -> Result = {
                   try $0.message
               }
           ) async throws -> Result where Result: Sendable {
-              let request = GRPCCore.ClientRequest.Stream<NamespaceA_ServiceARequest>(
+              let request = GRPCCore.StreamingClientRequest<NamespaceA_ServiceARequest>(
                   metadata: metadata,
                   producer: requestProducer
               )
@@ -546,9 +546,9 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               _ message: NamespaceA_ServiceARequest,
               metadata: GRPCCore.Metadata = [:],
               options: GRPCCore.CallOptions = .defaults,
-              onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> Result
+              onResponse handleResponse: @Sendable @escaping (GRPCCore.StreamingClientResponse<NamespaceA_ServiceAResponse>) async throws -> Result
           ) async throws -> Result where Result: Sendable {
-              let request = GRPCCore.ClientRequest.Single<NamespaceA_ServiceARequest>(
+              let request = GRPCCore.ClientRequest<NamespaceA_ServiceARequest>(
                   message: message,
                   metadata: metadata
               )
@@ -570,11 +570,11 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           
           /// Documentation for MethodA
           package func methodA<R>(
-              request: GRPCCore.ClientRequest.Stream<NamespaceA_ServiceARequest>,
+              request: GRPCCore.StreamingClientRequest<NamespaceA_ServiceARequest>,
               serializer: some GRPCCore.MessageSerializer<NamespaceA_ServiceARequest>,
               deserializer: some GRPCCore.MessageDeserializer<NamespaceA_ServiceAResponse>,
               options: GRPCCore.CallOptions = .defaults,
-              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<NamespaceA_ServiceAResponse>) async throws -> R = {
+              _ body: @Sendable @escaping (GRPCCore.ClientResponse<NamespaceA_ServiceAResponse>) async throws -> R = {
                   try $0.message
               }
           ) async throws -> R where R: Sendable {
@@ -590,11 +590,11 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           
           /// Documentation for MethodB
           package func methodB<R>(
-              request: GRPCCore.ClientRequest.Single<NamespaceA_ServiceARequest>,
+              request: GRPCCore.ClientRequest<NamespaceA_ServiceARequest>,
               serializer: some GRPCCore.MessageSerializer<NamespaceA_ServiceARequest>,
               deserializer: some GRPCCore.MessageDeserializer<NamespaceA_ServiceAResponse>,
               options: GRPCCore.CallOptions = .defaults,
-              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<NamespaceA_ServiceAResponse>) async throws -> R
+              _ body: @Sendable @escaping (GRPCCore.StreamingClientResponse<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable {
               try await self.client.serverStreaming(
                   request: request,
@@ -637,19 +637,19 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       internal protocol ServiceA_ClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
-              request: GRPCCore.ClientRequest.Single<ServiceARequest>,
+              request: GRPCCore.ClientRequest<ServiceARequest>,
               serializer: some GRPCCore.MessageSerializer<ServiceARequest>,
               deserializer: some GRPCCore.MessageDeserializer<ServiceAResponse>,
               options: GRPCCore.CallOptions,
-              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<ServiceAResponse>) async throws -> R
+              _ body: @Sendable @escaping (GRPCCore.ClientResponse<ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable
       }
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension ServiceA.ClientProtocol {
           internal func methodA<R>(
-              request: GRPCCore.ClientRequest.Single<ServiceARequest>,
+              request: GRPCCore.ClientRequest<ServiceARequest>,
               options: GRPCCore.CallOptions = .defaults,
-              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<ServiceAResponse>) async throws -> R = {
+              _ body: @Sendable @escaping (GRPCCore.ClientResponse<ServiceAResponse>) async throws -> R = {
                   try $0.message
               }
           ) async throws -> R where R: Sendable {
@@ -669,11 +669,11 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               _ message: ServiceARequest,
               metadata: GRPCCore.Metadata = [:],
               options: GRPCCore.CallOptions = .defaults,
-              onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse.Single<ServiceAResponse>) async throws -> Result = {
+              onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<ServiceAResponse>) async throws -> Result = {
                   try $0.message
               }
           ) async throws -> Result where Result: Sendable {
-              let request = GRPCCore.ClientRequest.Single<ServiceARequest>(
+              let request = GRPCCore.ClientRequest<ServiceARequest>(
                   message: message,
                   metadata: metadata
               )
@@ -695,11 +695,11 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           
           /// Documentation for MethodA
           internal func methodA<R>(
-              request: GRPCCore.ClientRequest.Single<ServiceARequest>,
+              request: GRPCCore.ClientRequest<ServiceARequest>,
               serializer: some GRPCCore.MessageSerializer<ServiceARequest>,
               deserializer: some GRPCCore.MessageDeserializer<ServiceAResponse>,
               options: GRPCCore.CallOptions = .defaults,
-              _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<ServiceAResponse>) async throws -> R = {
+              _ body: @Sendable @escaping (GRPCCore.ClientResponse<ServiceAResponse>) async throws -> R = {
                   try $0.message
               }
           ) async throws -> R where R: Sendable {

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
@@ -55,9 +55,9 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       public protocol NamespaceA_ServiceA_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for unaryMethod
           func unary(
-              request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>,
+              request: GRPCCore.StreamingServerRequest<NamespaceA_ServiceARequest>,
               context: GRPCCore.ServerContext
-          ) async throws -> GRPCCore.ServerResponse.Stream<NamespaceA_ServiceAResponse>
+          ) async throws -> GRPCCore.StreamingServerResponse<NamespaceA_ServiceAResponse>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
@@ -82,22 +82,22 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       public protocol NamespaceA_ServiceA_ServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
           /// Documentation for unaryMethod
           func unary(
-              request: GRPCCore.ServerRequest.Single<NamespaceA_ServiceARequest>,
+              request: GRPCCore.ServerRequest<NamespaceA_ServiceARequest>,
               context: GRPCCore.ServerContext
-          ) async throws -> GRPCCore.ServerResponse.Single<NamespaceA_ServiceAResponse>
+          ) async throws -> GRPCCore.ServerResponse<NamespaceA_ServiceAResponse>
       }
       /// Partial conformance to `NamespaceA_ServiceA_StreamingServiceProtocol`.
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ServiceProtocol {
           public func unary(
-              request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>,
+              request: GRPCCore.StreamingServerRequest<NamespaceA_ServiceARequest>,
               context: GRPCCore.ServerContext
-          ) async throws -> GRPCCore.ServerResponse.Stream<NamespaceA_ServiceAResponse> {
+          ) async throws -> GRPCCore.StreamingServerResponse<NamespaceA_ServiceAResponse> {
               let response = try await self.unary(
-                  request: GRPCCore.ServerRequest.Single(stream: request),
+                  request: GRPCCore.ServerRequest(stream: request),
                   context: context
               )
-              return GRPCCore.ServerResponse.Stream(single: response)
+              return GRPCCore.StreamingServerResponse(single: response)
           }
       }
       """
@@ -139,9 +139,9 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       package protocol NamespaceA_ServiceA_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for inputStreamingMethod
           func inputStreaming(
-              request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>,
+              request: GRPCCore.StreamingServerRequest<NamespaceA_ServiceARequest>,
               context: GRPCCore.ServerContext
-          ) async throws -> GRPCCore.ServerResponse.Stream<NamespaceA_ServiceAResponse>
+          ) async throws -> GRPCCore.StreamingServerResponse<NamespaceA_ServiceAResponse>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
@@ -166,22 +166,22 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       package protocol NamespaceA_ServiceA_ServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
           /// Documentation for inputStreamingMethod
           func inputStreaming(
-              request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>,
+              request: GRPCCore.StreamingServerRequest<NamespaceA_ServiceARequest>,
               context: GRPCCore.ServerContext
-          ) async throws -> GRPCCore.ServerResponse.Single<NamespaceA_ServiceAResponse>
+          ) async throws -> GRPCCore.ServerResponse<NamespaceA_ServiceAResponse>
       }
       /// Partial conformance to `NamespaceA_ServiceA_StreamingServiceProtocol`.
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ServiceProtocol {
           package func inputStreaming(
-              request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>,
+              request: GRPCCore.StreamingServerRequest<NamespaceA_ServiceARequest>,
               context: GRPCCore.ServerContext
-          ) async throws -> GRPCCore.ServerResponse.Stream<NamespaceA_ServiceAResponse> {
+          ) async throws -> GRPCCore.StreamingServerResponse<NamespaceA_ServiceAResponse> {
               let response = try await self.inputStreaming(
                   request: request,
                   context: context
               )
-              return GRPCCore.ServerResponse.Stream(single: response)
+              return GRPCCore.StreamingServerResponse(single: response)
           }
       }
       """
@@ -227,9 +227,9 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       public protocol NamespaceA_ServiceA_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for outputStreamingMethod
           func outputStreaming(
-              request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>,
+              request: GRPCCore.StreamingServerRequest<NamespaceA_ServiceARequest>,
               context: GRPCCore.ServerContext
-          ) async throws -> GRPCCore.ServerResponse.Stream<NamespaceA_ServiceAResponse>
+          ) async throws -> GRPCCore.StreamingServerResponse<NamespaceA_ServiceAResponse>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
@@ -254,19 +254,19 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       public protocol NamespaceA_ServiceA_ServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
           /// Documentation for outputStreamingMethod
           func outputStreaming(
-              request: GRPCCore.ServerRequest.Single<NamespaceA_ServiceARequest>,
+              request: GRPCCore.ServerRequest<NamespaceA_ServiceARequest>,
               context: GRPCCore.ServerContext
-          ) async throws -> GRPCCore.ServerResponse.Stream<NamespaceA_ServiceAResponse>
+          ) async throws -> GRPCCore.StreamingServerResponse<NamespaceA_ServiceAResponse>
       }
       /// Partial conformance to `NamespaceA_ServiceA_StreamingServiceProtocol`.
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ServiceProtocol {
           public func outputStreaming(
-              request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>,
+              request: GRPCCore.StreamingServerRequest<NamespaceA_ServiceARequest>,
               context: GRPCCore.ServerContext
-          ) async throws -> GRPCCore.ServerResponse.Stream<NamespaceA_ServiceAResponse> {
+          ) async throws -> GRPCCore.StreamingServerResponse<NamespaceA_ServiceAResponse> {
               let response = try await self.outputStreaming(
-                  request: GRPCCore.ServerRequest.Single(stream: request),
+                  request: GRPCCore.ServerRequest(stream: request),
                   context: context
               )
               return response
@@ -315,9 +315,9 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       package protocol NamespaceA_ServiceA_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for bidirectionalStreamingMethod
           func bidirectionalStreaming(
-              request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>,
+              request: GRPCCore.StreamingServerRequest<NamespaceA_ServiceARequest>,
               context: GRPCCore.ServerContext
-          ) async throws -> GRPCCore.ServerResponse.Stream<NamespaceA_ServiceAResponse>
+          ) async throws -> GRPCCore.StreamingServerResponse<NamespaceA_ServiceAResponse>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
@@ -342,9 +342,9 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       package protocol NamespaceA_ServiceA_ServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
           /// Documentation for bidirectionalStreamingMethod
           func bidirectionalStreaming(
-              request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>,
+              request: GRPCCore.StreamingServerRequest<NamespaceA_ServiceARequest>,
               context: GRPCCore.ServerContext
-          ) async throws -> GRPCCore.ServerResponse.Stream<NamespaceA_ServiceAResponse>
+          ) async throws -> GRPCCore.StreamingServerResponse<NamespaceA_ServiceAResponse>
       }
       /// Partial conformance to `NamespaceA_ServiceA_StreamingServiceProtocol`.
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
@@ -405,15 +405,15 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       internal protocol NamespaceA_ServiceA_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for inputStreamingMethod
           func inputStreaming(
-              request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>,
+              request: GRPCCore.StreamingServerRequest<NamespaceA_ServiceARequest>,
               context: GRPCCore.ServerContext
-          ) async throws -> GRPCCore.ServerResponse.Stream<NamespaceA_ServiceAResponse>
+          ) async throws -> GRPCCore.StreamingServerResponse<NamespaceA_ServiceAResponse>
           
           /// Documentation for outputStreamingMethod
           func outputStreaming(
-              request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>,
+              request: GRPCCore.StreamingServerRequest<NamespaceA_ServiceARequest>,
               context: GRPCCore.ServerContext
-          ) async throws -> GRPCCore.ServerResponse.Stream<NamespaceA_ServiceAResponse>
+          ) async throws -> GRPCCore.StreamingServerResponse<NamespaceA_ServiceAResponse>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
@@ -449,36 +449,36 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       internal protocol NamespaceA_ServiceA_ServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
           /// Documentation for inputStreamingMethod
           func inputStreaming(
-              request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>,
+              request: GRPCCore.StreamingServerRequest<NamespaceA_ServiceARequest>,
               context: GRPCCore.ServerContext
-          ) async throws -> GRPCCore.ServerResponse.Single<NamespaceA_ServiceAResponse>
+          ) async throws -> GRPCCore.ServerResponse<NamespaceA_ServiceAResponse>
           
           /// Documentation for outputStreamingMethod
           func outputStreaming(
-              request: GRPCCore.ServerRequest.Single<NamespaceA_ServiceARequest>,
+              request: GRPCCore.ServerRequest<NamespaceA_ServiceARequest>,
               context: GRPCCore.ServerContext
-          ) async throws -> GRPCCore.ServerResponse.Stream<NamespaceA_ServiceAResponse>
+          ) async throws -> GRPCCore.StreamingServerResponse<NamespaceA_ServiceAResponse>
       }
       /// Partial conformance to `NamespaceA_ServiceA_StreamingServiceProtocol`.
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ServiceProtocol {
           internal func inputStreaming(
-              request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>,
+              request: GRPCCore.StreamingServerRequest<NamespaceA_ServiceARequest>,
               context: GRPCCore.ServerContext
-          ) async throws -> GRPCCore.ServerResponse.Stream<NamespaceA_ServiceAResponse> {
+          ) async throws -> GRPCCore.StreamingServerResponse<NamespaceA_ServiceAResponse> {
               let response = try await self.inputStreaming(
                   request: request,
                   context: context
               )
-              return GRPCCore.ServerResponse.Stream(single: response)
+              return GRPCCore.StreamingServerResponse(single: response)
           }
           
           internal func outputStreaming(
-              request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>,
+              request: GRPCCore.StreamingServerRequest<NamespaceA_ServiceARequest>,
               context: GRPCCore.ServerContext
-          ) async throws -> GRPCCore.ServerResponse.Stream<NamespaceA_ServiceAResponse> {
+          ) async throws -> GRPCCore.StreamingServerResponse<NamespaceA_ServiceAResponse> {
               let response = try await self.outputStreaming(
-                  request: GRPCCore.ServerRequest.Single(stream: request),
+                  request: GRPCCore.ServerRequest(stream: request),
                   context: context
               )
               return response
@@ -519,9 +519,9 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       internal protocol ServiceA_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for MethodA
           func methodA(
-              request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>,
+              request: GRPCCore.StreamingServerRequest<NamespaceA_ServiceARequest>,
               context: GRPCCore.ServerContext
-          ) async throws -> GRPCCore.ServerResponse.Stream<NamespaceA_ServiceAResponse>
+          ) async throws -> GRPCCore.StreamingServerResponse<NamespaceA_ServiceAResponse>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
@@ -546,22 +546,22 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
       internal protocol ServiceA_ServiceProtocol: ServiceA.StreamingServiceProtocol {
           /// Documentation for MethodA
           func methodA(
-              request: GRPCCore.ServerRequest.Single<NamespaceA_ServiceARequest>,
+              request: GRPCCore.ServerRequest<NamespaceA_ServiceARequest>,
               context: GRPCCore.ServerContext
-          ) async throws -> GRPCCore.ServerResponse.Single<NamespaceA_ServiceAResponse>
+          ) async throws -> GRPCCore.ServerResponse<NamespaceA_ServiceAResponse>
       }
       /// Partial conformance to `ServiceA_StreamingServiceProtocol`.
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension ServiceA.ServiceProtocol {
           internal func methodA(
-              request: GRPCCore.ServerRequest.Stream<NamespaceA_ServiceARequest>,
+              request: GRPCCore.StreamingServerRequest<NamespaceA_ServiceARequest>,
               context: GRPCCore.ServerContext
-          ) async throws -> GRPCCore.ServerResponse.Stream<NamespaceA_ServiceAResponse> {
+          ) async throws -> GRPCCore.StreamingServerResponse<NamespaceA_ServiceAResponse> {
               let response = try await self.methodA(
-                  request: GRPCCore.ServerRequest.Single(stream: request),
+                  request: GRPCCore.ServerRequest(stream: request),
                   context: context
               )
-              return GRPCCore.ServerResponse.Stream(single: response)
+              return GRPCCore.StreamingServerResponse(single: response)
           }
       }
       """

--- a/Tests/GRPCCoreTests/Call/Client/ClientRequestTests.swift
+++ b/Tests/GRPCCoreTests/Call/Client/ClientRequestTests.swift
@@ -22,8 +22,8 @@ import XCTest
 final class ClientRequestTests: XCTestCase {
   func testSingleToStreamConversion() async throws {
     let (messages, continuation) = AsyncStream.makeStream(of: String.self)
-    let single = ClientRequest.Single(message: "foo", metadata: ["bar": "baz"])
-    let stream = ClientRequest.Stream(single: single)
+    let single = ClientRequest(message: "foo", metadata: ["bar": "baz"])
+    let stream = StreamingClientRequest(single: single)
 
     XCTAssertEqual(stream.metadata, ["bar": "baz"])
     try await stream.producer(.gathering(into: continuation))

--- a/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTestSupport/ClientRPCExecutorTestHarness.swift
+++ b/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTestSupport/ClientRPCExecutorTestHarness.swift
@@ -67,41 +67,41 @@ struct ClientRPCExecutorTestHarness {
   }
 
   func unary(
-    request: ClientRequest.Single<[UInt8]>,
+    request: ClientRequest<[UInt8]>,
     options: CallOptions = .defaults,
-    handler: @escaping @Sendable (ClientResponse.Single<[UInt8]>) async throws -> Void
+    handler: @escaping @Sendable (ClientResponse<[UInt8]>) async throws -> Void
   ) async throws {
-    try await self.bidirectional(request: ClientRequest.Stream(single: request), options: options) {
+    try await self.bidirectional(request: StreamingClientRequest(single: request), options: options) {
       response in
-      try await handler(ClientResponse.Single(stream: response))
+      try await handler(ClientResponse(stream: response))
     }
   }
 
   func clientStreaming(
-    request: ClientRequest.Stream<[UInt8]>,
+    request: StreamingClientRequest<[UInt8]>,
     options: CallOptions = .defaults,
-    handler: @escaping @Sendable (ClientResponse.Single<[UInt8]>) async throws -> Void
+    handler: @escaping @Sendable (ClientResponse<[UInt8]>) async throws -> Void
   ) async throws {
     try await self.bidirectional(request: request, options: options) { response in
-      try await handler(ClientResponse.Single(stream: response))
+      try await handler(ClientResponse(stream: response))
     }
   }
 
   func serverStreaming(
-    request: ClientRequest.Single<[UInt8]>,
+    request: ClientRequest<[UInt8]>,
     options: CallOptions = .defaults,
-    handler: @escaping @Sendable (ClientResponse.Stream<[UInt8]>) async throws -> Void
+    handler: @escaping @Sendable (StreamingClientResponse<[UInt8]>) async throws -> Void
   ) async throws {
-    try await self.bidirectional(request: ClientRequest.Stream(single: request), options: options) {
+    try await self.bidirectional(request: StreamingClientRequest(single: request), options: options) {
       response in
       try await handler(response)
     }
   }
 
   func bidirectional(
-    request: ClientRequest.Stream<[UInt8]>,
+    request: StreamingClientRequest<[UInt8]>,
     options: CallOptions = .defaults,
-    handler: @escaping @Sendable (ClientResponse.Stream<[UInt8]>) async throws -> Void
+    handler: @escaping @Sendable (StreamingClientResponse<[UInt8]>) async throws -> Void
   ) async throws {
     try await self.execute(
       request: request,
@@ -113,11 +113,11 @@ struct ClientRPCExecutorTestHarness {
   }
 
   private func execute<Input, Output>(
-    request: ClientRequest.Stream<Input>,
+    request: StreamingClientRequest<Input>,
     serializer: some MessageSerializer<Input>,
     deserializer: some MessageDeserializer<Output>,
     options: CallOptions,
-    handler: @escaping @Sendable (ClientResponse.Stream<Output>) async throws -> Void
+    handler: @escaping @Sendable (StreamingClientResponse<Output>) async throws -> Void
   ) async throws {
     try await withThrowingTaskGroup(of: Void.self) { group in
       group.addTask {

--- a/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTestSupport/ClientRPCExecutorTestHarness.swift
+++ b/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTestSupport/ClientRPCExecutorTestHarness.swift
@@ -71,8 +71,10 @@ struct ClientRPCExecutorTestHarness {
     options: CallOptions = .defaults,
     handler: @escaping @Sendable (ClientResponse<[UInt8]>) async throws -> Void
   ) async throws {
-    try await self.bidirectional(request: StreamingClientRequest(single: request), options: options) {
-      response in
+    try await self.bidirectional(
+      request: StreamingClientRequest(single: request),
+      options: options
+    ) { response in
       try await handler(ClientResponse(stream: response))
     }
   }
@@ -92,8 +94,10 @@ struct ClientRPCExecutorTestHarness {
     options: CallOptions = .defaults,
     handler: @escaping @Sendable (StreamingClientResponse<[UInt8]>) async throws -> Void
   ) async throws {
-    try await self.bidirectional(request: StreamingClientRequest(single: request), options: options) {
-      response in
+    try await self.bidirectional(
+      request: StreamingClientRequest(single: request),
+      options: options
+    ) { response in
       try await handler(response)
     }
   }

--- a/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests+Hedging.swift
+++ b/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests+Hedging.swift
@@ -24,7 +24,7 @@ extension ClientRPCExecutorTests {
     )
 
     try await harness.bidirectional(
-      request: ClientRequest.Stream {
+      request: StreamingClientRequest {
         try await $0.write([0])
         try await $0.write([1])
         try await $0.write([2])
@@ -48,7 +48,7 @@ extension ClientRPCExecutorTests {
     )
 
     try await harness.bidirectional(
-      request: ClientRequest.Stream {
+      request: StreamingClientRequest {
         try await $0.write([0])
         try await $0.write([1])
         try await $0.write([2])
@@ -84,7 +84,7 @@ extension ClientRPCExecutorTests {
 
     let start = ContinuousClock.now
     try await harness.bidirectional(
-      request: ClientRequest.Stream {
+      request: StreamingClientRequest {
         try await $0.write([0])
         try await $0.write([1])
         try await $0.write([2])
@@ -128,7 +128,7 @@ extension ClientRPCExecutorTests {
 
     let start = ContinuousClock.now
     try await harness.bidirectional(
-      request: ClientRequest.Stream {
+      request: StreamingClientRequest {
         try await $0.write([0])
         try await $0.write([1])
         try await $0.write([2])
@@ -169,7 +169,7 @@ extension ClientRPCExecutorTests {
       )
 
       try await harness.bidirectional(
-        request: ClientRequest.Stream {
+        request: StreamingClientRequest {
           try await $0.write([0])
         },
         options: .hedge(delay: .seconds(60), nonFatalCodes: [.unavailable])

--- a/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests+Retries.swift
+++ b/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests+Retries.swift
@@ -44,7 +44,7 @@ extension ClientRPCExecutorTests {
       consumeInboundStream: true
     )
     try await harness.bidirectional(
-      request: ClientRequest.Stream(metadata: ["foo": "bar"]) {
+      request: StreamingClientRequest(metadata: ["foo": "bar"]) {
         try await $0.write([0])
         try await $0.write([1])
         try await $0.write([2])
@@ -70,7 +70,7 @@ extension ClientRPCExecutorTests {
   func testRetriesRespectRetryableCodes() async throws {
     let harness = self.makeHarnessForRetries(rejectUntilAttempt: 3, withCode: .unavailable)
     try await harness.bidirectional(
-      request: ClientRequest.Stream(metadata: ["foo": "bar"]) {
+      request: StreamingClientRequest(metadata: ["foo": "bar"]) {
         try await $0.write([0, 1, 2])
       },
       options: .retry(codes: [.aborted])
@@ -91,7 +91,7 @@ extension ClientRPCExecutorTests {
   func testRetriesRespectRetryLimit() async throws {
     let harness = self.makeHarnessForRetries(rejectUntilAttempt: 5, withCode: .unavailable)
     try await harness.bidirectional(
-      request: ClientRequest.Stream(metadata: ["foo": "bar"]) {
+      request: StreamingClientRequest(metadata: ["foo": "bar"]) {
         try await $0.write([0, 1, 2])
       },
       options: .retry(maximumAttempts: 2, codes: [.unavailable])
@@ -118,7 +118,7 @@ extension ClientRPCExecutorTests {
     )
 
     try await harness.bidirectional(
-      request: ClientRequest.Stream {
+      request: StreamingClientRequest {
         for _ in 0 ..< 1000 {
           try await $0.write([])
         }
@@ -148,7 +148,7 @@ extension ClientRPCExecutorTests {
 
     await XCTAssertThrowsErrorAsync {
       try await harness.bidirectional(
-        request: ClientRequest.Stream {
+        request: StreamingClientRequest {
           try await $0.write([0])
           try await $0.write([1])
           try await $0.write([2])
@@ -169,7 +169,7 @@ extension ClientRPCExecutorTests {
 
     await XCTAssertThrowsErrorAsync {
       try await harness.bidirectional(
-        request: ClientRequest.Stream {
+        request: StreamingClientRequest {
           try await $0.write([0])
           try await $0.write([1])
           try await $0.write([2])
@@ -193,7 +193,7 @@ extension ClientRPCExecutorTests {
 
     await XCTAssertThrowsErrorAsync {
       try await harness.bidirectional(
-        request: ClientRequest.Stream {
+        request: StreamingClientRequest {
           try await $0.write([0])
           try await $0.write([1])
           try await $0.write([2])
@@ -233,7 +233,7 @@ extension ClientRPCExecutorTests {
 
     let start = ContinuousClock.now
     try await harness.bidirectional(
-      request: ClientRequest.Stream {
+      request: StreamingClientRequest {
         try await $0.write([0])
       },
       options: .retry(retryPolicy)
@@ -269,7 +269,7 @@ extension ClientRPCExecutorTests {
       )
 
       try await harness.bidirectional(
-        request: ClientRequest.Stream {
+        request: StreamingClientRequest {
           try await $0.write([0])
         },
         options: .retry(retryPolicy)

--- a/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests.swift
+++ b/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests.swift
@@ -23,7 +23,7 @@ final class ClientRPCExecutorTests: XCTestCase {
   func testUnaryEcho() async throws {
     let tester = ClientRPCExecutorTestHarness(server: .echo)
     try await tester.unary(
-      request: ClientRequest.Single(message: [1, 2, 3], metadata: ["foo": "bar"])
+      request: ClientRequest(message: [1, 2, 3], metadata: ["foo": "bar"])
     ) { response in
       XCTAssertEqual(response.metadata, ["foo": "bar"])
       XCTAssertEqual(try response.message, [1, 2, 3])
@@ -36,7 +36,7 @@ final class ClientRPCExecutorTests: XCTestCase {
   func testClientStreamingEcho() async throws {
     let tester = ClientRPCExecutorTestHarness(server: .echo)
     try await tester.clientStreaming(
-      request: ClientRequest.Stream(metadata: ["foo": "bar"]) {
+      request: StreamingClientRequest(metadata: ["foo": "bar"]) {
         try await $0.write([1, 2, 3])
       }
     ) { response in
@@ -51,7 +51,7 @@ final class ClientRPCExecutorTests: XCTestCase {
   func testServerStreamingEcho() async throws {
     let tester = ClientRPCExecutorTestHarness(server: .echo)
     try await tester.serverStreaming(
-      request: ClientRequest.Single(message: [1, 2, 3], metadata: ["foo": "bar"])
+      request: ClientRequest(message: [1, 2, 3], metadata: ["foo": "bar"])
     ) { response in
       XCTAssertEqual(response.metadata, ["foo": "bar"])
       let messages = try await response.messages.collect()
@@ -65,7 +65,7 @@ final class ClientRPCExecutorTests: XCTestCase {
   func testBidirectionalStreamingEcho() async throws {
     let tester = ClientRPCExecutorTestHarness(server: .echo)
     try await tester.bidirectional(
-      request: ClientRequest.Stream(metadata: ["foo": "bar"]) {
+      request: StreamingClientRequest(metadata: ["foo": "bar"]) {
         try await $0.write([1, 2, 3])
       }
     ) { response in
@@ -82,7 +82,7 @@ final class ClientRPCExecutorTests: XCTestCase {
     let error = RPCError(code: .unauthenticated, message: "", metadata: ["metadata": "error"])
     let tester = ClientRPCExecutorTestHarness(server: .reject(withError: error))
     try await tester.unary(
-      request: ClientRequest.Single(message: [1, 2, 3], metadata: ["foo": "bar"])
+      request: ClientRequest(message: [1, 2, 3], metadata: ["foo": "bar"])
     ) { response in
       XCTAssertThrowsRPCError(try response.message) {
         XCTAssertEqual($0, error)
@@ -97,7 +97,7 @@ final class ClientRPCExecutorTests: XCTestCase {
     let error = RPCError(code: .unauthenticated, message: "", metadata: ["metadata": "error"])
     let tester = ClientRPCExecutorTestHarness(server: .reject(withError: error))
     try await tester.clientStreaming(
-      request: ClientRequest.Stream(metadata: ["foo": "bar"]) {
+      request: StreamingClientRequest(metadata: ["foo": "bar"]) {
         try await $0.write([1, 2, 3])
       }
     ) { response in
@@ -114,7 +114,7 @@ final class ClientRPCExecutorTests: XCTestCase {
     let error = RPCError(code: .unauthenticated, message: "", metadata: ["metadata": "error"])
     let tester = ClientRPCExecutorTestHarness(server: .reject(withError: error))
     try await tester.serverStreaming(
-      request: ClientRequest.Single(message: [1, 2, 3], metadata: ["foo": "bar"])
+      request: ClientRequest(message: [1, 2, 3], metadata: ["foo": "bar"])
     ) { response in
       await XCTAssertThrowsRPCErrorAsync {
         try await response.messages.collect()
@@ -131,7 +131,7 @@ final class ClientRPCExecutorTests: XCTestCase {
     let error = RPCError(code: .unauthenticated, message: "", metadata: ["metadata": "error"])
     let tester = ClientRPCExecutorTestHarness(server: .reject(withError: error))
     try await tester.bidirectional(
-      request: ClientRequest.Stream(metadata: ["foo": "bar"]) {
+      request: StreamingClientRequest(metadata: ["foo": "bar"]) {
         try await $0.write([1, 2, 3])
       }
     ) { response in
@@ -154,7 +154,7 @@ final class ClientRPCExecutorTests: XCTestCase {
 
     await XCTAssertThrowsRPCErrorAsync {
       try await tester.unary(
-        request: ClientRequest.Single(message: [1, 2, 3], metadata: ["foo": "bar"])
+        request: ClientRequest(message: [1, 2, 3], metadata: ["foo": "bar"])
       ) { _ in }
     } errorHandler: { error in
       XCTAssertEqual(error.code, .aborted)
@@ -173,7 +173,7 @@ final class ClientRPCExecutorTests: XCTestCase {
 
     await XCTAssertThrowsRPCErrorAsync {
       try await tester.clientStreaming(
-        request: ClientRequest.Stream(metadata: ["foo": "bar"]) {
+        request: StreamingClientRequest(metadata: ["foo": "bar"]) {
           try await $0.write([1, 2, 3])
         }
       ) { _ in }
@@ -194,7 +194,7 @@ final class ClientRPCExecutorTests: XCTestCase {
 
     await XCTAssertThrowsRPCErrorAsync {
       try await tester.serverStreaming(
-        request: ClientRequest.Single(message: [1, 2, 3], metadata: ["foo": "bar"])
+        request: ClientRequest(message: [1, 2, 3], metadata: ["foo": "bar"])
       ) { _ in }
     } errorHandler: {
       XCTAssertEqual($0.code, .aborted)
@@ -213,7 +213,7 @@ final class ClientRPCExecutorTests: XCTestCase {
 
     await XCTAssertThrowsRPCErrorAsync {
       try await tester.bidirectional(
-        request: ClientRequest.Stream(metadata: ["foo": "bar"]) {
+        request: StreamingClientRequest(metadata: ["foo": "bar"]) {
           try await $0.write([1, 2, 3])
         }
       ) { _ in }
@@ -254,7 +254,7 @@ final class ClientRPCExecutorTests: XCTestCase {
 
       let tester = ClientRPCExecutorTestHarness(transport: .inProcess, server: .echo)
       try await tester.unary(
-        request: ClientRequest.Single(message: []),
+        request: ClientRequest(message: []),
         options: options
       ) { response in
         let timeoutMetadata = Array(response.metadata[stringValues: "grpc-timeout"])

--- a/Tests/GRPCCoreTests/Call/Server/Internal/ServerRPCExecutorTestSupport/ServerRPCExecutorTestHarness.swift
+++ b/Tests/GRPCCoreTests/Call/Server/Internal/ServerRPCExecutorTestSupport/ServerRPCExecutorTestHarness.swift
@@ -20,7 +20,8 @@ import XCTest
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct ServerRPCExecutorTestHarness {
   struct ServerHandler<Input: Sendable, Output: Sendable>: Sendable {
-    let fn: @Sendable (StreamingServerRequest<Input>) async throws -> StreamingServerResponse<Output>
+    let fn:
+      @Sendable (StreamingServerRequest<Input>) async throws -> StreamingServerResponse<Output>
 
     init(
       _ fn: @escaping @Sendable (

--- a/Tests/GRPCCoreTests/Call/Server/Internal/ServerRPCExecutorTestSupport/ServerRPCExecutorTestHarness.swift
+++ b/Tests/GRPCCoreTests/Call/Server/Internal/ServerRPCExecutorTestSupport/ServerRPCExecutorTestHarness.swift
@@ -20,19 +20,19 @@ import XCTest
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct ServerRPCExecutorTestHarness {
   struct ServerHandler<Input: Sendable, Output: Sendable>: Sendable {
-    let fn: @Sendable (ServerRequest.Stream<Input>) async throws -> ServerResponse.Stream<Output>
+    let fn: @Sendable (StreamingServerRequest<Input>) async throws -> StreamingServerResponse<Output>
 
     init(
       _ fn: @escaping @Sendable (
-        ServerRequest.Stream<Input>
-      ) async throws -> ServerResponse.Stream<Output>
+        StreamingServerRequest<Input>
+      ) async throws -> StreamingServerResponse<Output>
     ) {
       self.fn = fn
     }
 
     func handle(
-      _ request: ServerRequest.Stream<Input>
-    ) async throws -> ServerResponse.Stream<Output> {
+      _ request: StreamingServerRequest<Input>
+    ) async throws -> StreamingServerResponse<Output> {
       try await self.fn(request)
     }
 
@@ -51,8 +51,8 @@ struct ServerRPCExecutorTestHarness {
     deserializer: some MessageDeserializer<Input>,
     serializer: some MessageSerializer<Output>,
     handler: @escaping @Sendable (
-      ServerRequest.Stream<Input>
-    ) async throws -> ServerResponse.Stream<Output>,
+      StreamingServerRequest<Input>
+    ) async throws -> StreamingServerResponse<Output>,
     producer: @escaping @Sendable (
       RPCWriter<RPCRequestPart>.Closable
     ) async throws -> Void,
@@ -137,7 +137,7 @@ struct ServerRPCExecutorTestHarness {
 extension ServerRPCExecutorTestHarness.ServerHandler where Input == Output {
   static var echo: Self {
     return Self { request in
-      return ServerResponse.Stream(metadata: request.metadata) { writer in
+      return StreamingServerResponse(metadata: request.metadata) { writer in
         try await writer.write(contentsOf: request.messages)
         return [:]
       }

--- a/Tests/GRPCCoreTests/Call/Server/Internal/ServerRPCExecutorTests.swift
+++ b/Tests/GRPCCoreTests/Call/Server/Internal/ServerRPCExecutorTests.swift
@@ -87,7 +87,7 @@ final class ServerRPCExecutorTests: XCTestCase {
     ) { request in
       let messages = try await request.messages.collect()
       XCTAssertEqual(messages, ["hello"])
-      return ServerResponse.Stream(metadata: request.metadata) { writer in
+      return StreamingServerResponse(metadata: request.metadata) { writer in
         try await writer.write("hello")
         return [:]
       }
@@ -116,7 +116,7 @@ final class ServerRPCExecutorTests: XCTestCase {
     ) { request in
       let messages = try await request.messages.collect()
       XCTAssertEqual(messages, ["hello", "world"])
-      return ServerResponse.Stream(metadata: request.metadata) { writer in
+      return StreamingServerResponse(metadata: request.metadata) { writer in
         try await writer.write("hello")
         try await writer.write("world")
         return [:]
@@ -146,7 +146,7 @@ final class ServerRPCExecutorTests: XCTestCase {
       deserializer: IdentityDeserializer(),
       serializer: IdentitySerializer()
     ) { request in
-      return ServerResponse.Stream(metadata: request.metadata) { _ in
+      return StreamingServerResponse(metadata: request.metadata) { _ in
         return ["bar": "baz"]
       }
     } producer: { inbound in
@@ -244,7 +244,7 @@ final class ServerRPCExecutorTests: XCTestCase {
       }
 
       XCTFail("Server handler should've been cancelled by timeout.")
-      return ServerResponse.Stream(error: RPCError(code: .failedPrecondition, message: ""))
+      return StreamingServerResponse(error: RPCError(code: .failedPrecondition, message: ""))
     } producer: { inbound in
       try await inbound.write(.metadata(["grpc-timeout": "1000n"]))
       await inbound.finish()
@@ -271,7 +271,7 @@ final class ServerRPCExecutorTests: XCTestCase {
       serializer: IdentitySerializer()
     ) { request in
       XCTFail("Unexpected request")
-      return ServerResponse.Stream(
+      return StreamingServerResponse(
         of: [UInt8].self,
         error: RPCError(code: .failedPrecondition, message: "")
       )

--- a/Tests/GRPCCoreTests/Call/Server/ServerRequestTests.swift
+++ b/Tests/GRPCCoreTests/Call/Server/ServerRequestTests.swift
@@ -19,8 +19,8 @@ import XCTest
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class ServerRequestTests: XCTestCase {
   func testSingleToStreamConversion() async throws {
-    let single = ServerRequest.Single(metadata: ["bar": "baz"], message: "foo")
-    let stream = ServerRequest.Stream(single: single)
+    let single = ServerRequest(metadata: ["bar": "baz"], message: "foo")
+    let stream = StreamingServerRequest(single: single)
 
     XCTAssertEqual(stream.metadata, ["bar": "baz"])
     let collected = try await stream.messages.collect()

--- a/Tests/GRPCCoreTests/Call/Server/ServerResponseTests.swift
+++ b/Tests/GRPCCoreTests/Call/Server/ServerResponseTests.swift
@@ -19,7 +19,7 @@ import XCTest
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class ServerResponseTests: XCTestCase {
   func testSingleConvenienceInit() {
-    var response = ServerResponse.Single(
+    var response = ServerResponse(
       message: "message",
       metadata: ["metadata": "initial"],
       trailingMetadata: ["metadata": "trailing"]
@@ -35,7 +35,7 @@ final class ServerResponseTests: XCTestCase {
     }
 
     let error = RPCError(code: .aborted, message: "Aborted")
-    response = ServerResponse.Single(of: String.self, error: error)
+    response = ServerResponse(of: String.self, error: error)
     switch response.accepted {
     case .success:
       XCTFail("Unexpected success")
@@ -45,7 +45,7 @@ final class ServerResponseTests: XCTestCase {
   }
 
   func testStreamConvenienceInit() async throws {
-    var response = ServerResponse.Stream(of: String.self, metadata: ["metadata": "initial"]) { _ in
+    var response = StreamingServerResponse(of: String.self, metadata: ["metadata": "initial"]) { _ in
       // Empty body.
       return ["metadata": "trailing"]
     }
@@ -60,7 +60,7 @@ final class ServerResponseTests: XCTestCase {
     }
 
     let error = RPCError(code: .aborted, message: "Aborted")
-    response = ServerResponse.Stream(of: String.self, error: error)
+    response = StreamingServerResponse(of: String.self, error: error)
     switch response.accepted {
     case .success:
       XCTFail("Unexpected success")
@@ -70,13 +70,13 @@ final class ServerResponseTests: XCTestCase {
   }
 
   func testSingleToStreamConversionForSuccessfulResponse() async throws {
-    let single = ServerResponse.Single(
+    let single = ServerResponse(
       message: "foo",
       metadata: ["metadata": "initial"],
       trailingMetadata: ["metadata": "trailing"]
     )
 
-    let stream = ServerResponse.Stream(single: single)
+    let stream = StreamingServerResponse(single: single)
     let (messages, continuation) = AsyncStream.makeStream(of: String.self)
     let trailingMetadata: Metadata
 
@@ -96,8 +96,8 @@ final class ServerResponseTests: XCTestCase {
 
   func testSingleToStreamConversionForFailedResponse() async throws {
     let error = RPCError(code: .aborted, message: "aborted")
-    let single = ServerResponse.Single(of: String.self, error: error)
-    let stream = ServerResponse.Stream(single: single)
+    let single = ServerResponse(of: String.self, error: error)
+    let stream = StreamingServerResponse(single: single)
 
     XCTAssertThrowsRPCError(try stream.accepted.get()) {
       XCTAssertEqual($0, error)

--- a/Tests/GRPCCoreTests/Call/Server/ServerResponseTests.swift
+++ b/Tests/GRPCCoreTests/Call/Server/ServerResponseTests.swift
@@ -45,7 +45,10 @@ final class ServerResponseTests: XCTestCase {
   }
 
   func testStreamConvenienceInit() async throws {
-    var response = StreamingServerResponse(of: String.self, metadata: ["metadata": "initial"]) { _ in
+    var response = StreamingServerResponse(
+      of: String.self,
+      metadata: ["metadata": "initial"]
+    ) { _ in
       // Empty body.
       return ["metadata": "trailing"]
     }

--- a/Tests/GRPCCoreTests/GRPCClientTests.swift
+++ b/Tests/GRPCCoreTests/GRPCClientTests.swift
@@ -356,7 +356,7 @@ final class GRPCClientTests: XCTestCase {
 
       let task = Task {
         try await client.clientStreaming(
-          request: ClientRequest.Stream { writer in
+          request: StreamingClientRequest { writer in
             try await Task.sleep(for: .seconds(5))
           },
           descriptor: BinaryEcho.Methods.collect,

--- a/Tests/GRPCCoreTests/Test Utilities/Call/Client/ClientInterceptors.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/Call/Client/ClientInterceptors.swift
@@ -50,17 +50,17 @@ struct RejectAllClientInterceptor: ClientInterceptor {
   }
 
   func intercept<Input: Sendable, Output: Sendable>(
-    request: ClientRequest.Stream<Input>,
+    request: StreamingClientRequest<Input>,
     context: ClientContext,
     next: (
-      ClientRequest.Stream<Input>,
+      StreamingClientRequest<Input>,
       ClientContext
-    ) async throws -> ClientResponse.Stream<Output>
-  ) async throws -> ClientResponse.Stream<Output> {
+    ) async throws -> StreamingClientResponse<Output>
+  ) async throws -> StreamingClientResponse<Output> {
     if self.throw {
       throw self.error
     } else {
-      return ClientResponse.Stream(error: self.error)
+      return StreamingClientResponse(error: self.error)
     }
   }
 }
@@ -75,13 +75,13 @@ struct RequestCountingClientInterceptor: ClientInterceptor {
   }
 
   func intercept<Input: Sendable, Output: Sendable>(
-    request: ClientRequest.Stream<Input>,
+    request: StreamingClientRequest<Input>,
     context: ClientContext,
     next: (
-      ClientRequest.Stream<Input>,
+      StreamingClientRequest<Input>,
       ClientContext
-    ) async throws -> ClientResponse.Stream<Output>
-  ) async throws -> ClientResponse.Stream<Output> {
+    ) async throws -> StreamingClientResponse<Output>
+  ) async throws -> StreamingClientResponse<Output> {
     self.counter.increment()
     return try await next(request, context)
   }

--- a/Tests/GRPCCoreTests/Test Utilities/Call/Server/ServerInterceptors.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/Call/Server/ServerInterceptors.swift
@@ -49,17 +49,17 @@ struct RejectAllServerInterceptor: ServerInterceptor {
   }
 
   func intercept<Input: Sendable, Output: Sendable>(
-    request: ServerRequest.Stream<Input>,
+    request: StreamingServerRequest<Input>,
     context: ServerContext,
     next: @Sendable (
-      ServerRequest.Stream<Input>,
+      StreamingServerRequest<Input>,
       ServerContext
-    ) async throws -> ServerResponse.Stream<Output>
-  ) async throws -> ServerResponse.Stream<Output> {
+    ) async throws -> StreamingServerResponse<Output>
+  ) async throws -> StreamingServerResponse<Output> {
     if self.throw {
       throw self.error
     } else {
-      return ServerResponse.Stream(error: self.error)
+      return StreamingServerResponse(error: self.error)
     }
   }
 }
@@ -74,13 +74,13 @@ struct RequestCountingServerInterceptor: ServerInterceptor {
   }
 
   func intercept<Input: Sendable, Output: Sendable>(
-    request: ServerRequest.Stream<Input>,
+    request: StreamingServerRequest<Input>,
     context: ServerContext,
     next: @Sendable (
-      ServerRequest.Stream<Input>,
+      StreamingServerRequest<Input>,
       ServerContext
-    ) async throws -> ServerResponse.Stream<Output>
-  ) async throws -> ServerResponse.Stream<Output> {
+    ) async throws -> StreamingServerResponse<Output>
+  ) async throws -> StreamingServerResponse<Output> {
     self.counter.increment()
     return try await next(request, context)
   }

--- a/Tests/GRPCCoreTests/Test Utilities/XCTest+Utilities.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/XCTest+Utilities.swift
@@ -97,7 +97,7 @@ func XCTAssertThrowsRPCErrorAsync<T>(
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 func XCTAssertRejected<T>(
-  _ response: ClientResponse.Stream<T>,
+  _ response: StreamingClientResponse<T>,
   errorHandler: (RPCError) -> Void
 ) {
   switch response.accepted {
@@ -109,7 +109,7 @@ func XCTAssertRejected<T>(
 }
 
 func XCTAssertRejected<T>(
-  _ response: ClientResponse.Single<T>,
+  _ response: ClientResponse<T>,
   errorHandler: (RPCError) -> Void
 ) {
   switch response.accepted {


### PR DESCRIPTION
Motivation:

The names of the request/response types are quite stilted. We can improve them by removing the namespacing and by removing the explicit "Single".

Modifications:

- `ServerRequest.Single` -> `ServerRequest`
- `ServerRequest.Stream` -> `StreamingServerRequest`
- `ServerResponse.Single` -> `ServerResponse`
- `ServerResponse.Stream` -> `StreamingServerResponse`
- `ClientRequest.Single` -> `ClientRequest`
- `ClientRequest.Stream` -> `StreamingClientRequest`
- `ClientResponse.Single` -> `ClientResponse`
- `ClientResponse.Stream` -> `StreamingClientResponse`

Result:

Better naming