### PR TITLE
Add deployment targets to the package manifest

### DIFF
--- a/Examples/echo/Sources/Subcommands/Serve.swift
+++ b/Examples/echo/Sources/Subcommands/Serve.swift
@@ -42,7 +42,6 @@ struct Serve: AsyncParsableCommand {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct EchoService: Echo_Echo_ServiceProtocol {
   func get(
     request: ServerRequest<Echo_EchoRequest>,

--- a/Examples/route-guide/Sources/RouteGuide.swift
+++ b/Examples/route-guide/Sources/RouteGuide.swift
@@ -17,7 +17,6 @@
 import ArgumentParser
 
 @main
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct RouteGuide: AsyncParsableCommand {
   static let configuration = CommandConfiguration(
     commandName: "route-guide",

--- a/Package.swift
+++ b/Package.swift
@@ -105,6 +105,13 @@ let targets: [Target] = [
 
 let package = Package(
   name: "grpc-swift",
+  platforms: [
+    .macOS(.v15),
+    .iOS(.v18),
+    .tvOS(.v18),
+    .watchOS(.v11),
+    .visionOS(.v2),
+  ],
   products: products,
   dependencies: dependencies,
   targets: targets

--- a/Sources/GRPCCore/Call/Client/CallOptions.swift
+++ b/Sources/GRPCCore/Call/Client/CallOptions.swift
@@ -21,7 +21,6 @@
 ///
 /// You can create the default set of options, which defers all possible
 /// configuration to the transport, by using ``CallOptions/defaults``.
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 public struct CallOptions: Sendable {
   /// The default timeout for the RPC.
   ///
@@ -108,7 +107,6 @@ public struct CallOptions: Sendable {
   }
 }
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension CallOptions {
   /// Default call options.
   ///
@@ -125,7 +123,6 @@ extension CallOptions {
   }
 }
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension CallOptions {
   package mutating func formUnion(with methodConfig: MethodConfig?) {
     guard let methodConfig = methodConfig else { return }

--- a/Sources/GRPCCore/Call/Client/ClientInterceptor.swift
+++ b/Sources/GRPCCore/Call/Client/ClientInterceptor.swift
@@ -88,7 +88,6 @@
 /// ```
 ///
 /// For server-side interceptors see ``ServerInterceptor``.
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 public protocol ClientInterceptor: Sendable {
   /// Intercept a request object.
   ///

--- a/Sources/GRPCCore/Call/Client/ClientRequest.swift
+++ b/Sources/GRPCCore/Call/Client/ClientRequest.swift
@@ -61,7 +61,6 @@ public struct ClientRequest<Message: Sendable>: Sendable {
 ///
 /// See ``ClientRequest`` for single-message requests and ``StreamingServerRequest`` for the
 /// servers representation of a streaming-message request.
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public struct StreamingClientRequest<Message: Sendable>: Sendable {
   /// Caller-specified metadata sent to the server at the start of the RPC.
   ///

--- a/Sources/GRPCCore/Call/Client/ClientResponse.swift
+++ b/Sources/GRPCCore/Call/Client/ClientResponse.swift
@@ -198,7 +198,6 @@ public struct ClientResponse<Message: Sendable>: Sendable {
 ///   print("RPC failed with code '\(error.code)'")
 /// }
 /// ```
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 public struct StreamingClientResponse<Message: Sendable>: Sendable {
   public struct Contents: Sendable {
     /// Metadata received from the server at the beginning of the response.
@@ -325,7 +324,6 @@ extension ClientResponse {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension StreamingClientResponse {
   /// Creates a new accepted response.
   ///

--- a/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor+HedgingExecutor.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor+HedgingExecutor.swift
@@ -16,7 +16,6 @@
 
 public import Synchronization  // would be internal but for usableFromInline
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension ClientRPCExecutor {
   @usableFromInline
   struct HedgingExecutor<
@@ -62,7 +61,6 @@ extension ClientRPCExecutor {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension ClientRPCExecutor.HedgingExecutor {
   @inlinable
   func execute<R: Sendable>(
@@ -545,7 +543,6 @@ extension ClientRPCExecutor.HedgingExecutor {
   }
 }
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 @usableFromInline
 enum _HedgingTaskResult<R: Sendable>: Sendable {
   case rpcHandled(Result<R, any Error>)
@@ -553,7 +550,6 @@ enum _HedgingTaskResult<R: Sendable>: Sendable {
   case timedOut(Result<Void, any Error>)
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 @usableFromInline
 enum _HedgingAttemptTaskResult<R: Sendable, Output: Sendable>: Sendable {
   case attemptPicked(Bool)

--- a/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor+OneShotExecutor.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor+OneShotExecutor.swift
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension ClientRPCExecutor {
   /// An executor for requests which doesn't apply retries or hedging. The request has just one
   /// attempt at execution.
@@ -54,7 +53,6 @@ extension ClientRPCExecutor {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension ClientRPCExecutor.OneShotExecutor {
   @inlinable
   func execute<R: Sendable>(
@@ -90,7 +88,6 @@ extension ClientRPCExecutor.OneShotExecutor {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension ClientRPCExecutor.OneShotExecutor {
   @inlinable
   func _execute<R: Sendable>(
@@ -129,7 +126,6 @@ extension ClientRPCExecutor.OneShotExecutor {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 @inlinable
 func withDeadline<Result: Sendable>(
   _ deadline: ContinuousClock.Instant,

--- a/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor+RetryExecutor.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor+RetryExecutor.swift
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension ClientRPCExecutor {
   @usableFromInline
   struct RetryExecutor<
@@ -60,7 +59,6 @@ extension ClientRPCExecutor {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension ClientRPCExecutor.RetryExecutor {
   @inlinable
   func execute<R: Sendable>(
@@ -302,7 +300,6 @@ extension ClientRPCExecutor.RetryExecutor {
   }
 }
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 @usableFromInline
 enum _RetryExecutorTask<R: Sendable>: Sendable {
   case timedOut(Result<Void, any Error>)

--- a/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor.swift
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 @usableFromInline
 enum ClientRPCExecutor {
   /// Execute the request and handle its response.
@@ -100,7 +99,6 @@ enum ClientRPCExecutor {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension ClientRPCExecutor {
   /// Executes a request on a given stream processor.
   ///

--- a/Sources/GRPCCore/Call/Client/Internal/ClientRequest+Convenience.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientRequest+Convenience.swift
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension StreamingClientRequest {
   internal init(single request: ClientRequest<Message>) {
     self.init(metadata: request.metadata) {

--- a/Sources/GRPCCore/Call/Client/Internal/ClientResponse+Convenience.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientResponse+Convenience.swift
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension ClientResponse {
   /// Converts a streaming response into a single response.
   ///
@@ -82,7 +81,6 @@ extension ClientResponse {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension StreamingClientResponse {
   /// Creates a streaming response from the given status and metadata.
   ///
@@ -103,7 +101,6 @@ extension StreamingClientResponse {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension StreamingClientResponse {
   /// Returns a new response which maps the messages of this response.
   ///

--- a/Sources/GRPCCore/Call/Client/Internal/ClientStreamExecutor.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientStreamExecutor.swift
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 @usableFromInline
 internal enum ClientStreamExecutor {
   /// Execute a request on the stream executor.
@@ -165,7 +164,6 @@ internal enum ClientStreamExecutor {
   }
 
   @usableFromInline
-  @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
   struct RawBodyPartToMessageSequence<
     Base: AsyncSequence<RPCResponsePart, Failure>,
     Message: Sendable,

--- a/Sources/GRPCCore/Call/Client/Internal/RetryDelaySequence.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/RetryDelaySequence.swift
@@ -19,7 +19,6 @@ public import Darwin  // should be @usableFromInline
 public import Glibc  // should be @usableFromInline
 #endif
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 @usableFromInline
 struct RetryDelaySequence: Sequence {
   @usableFromInline

--- a/Sources/GRPCCore/Call/Server/Internal/ServerRPCExecutor.swift
+++ b/Sources/GRPCCore/Call/Server/Internal/ServerRPCExecutor.swift
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 @usableFromInline
 struct ServerRPCExecutor {
   /// Executes an RPC using the provided handler.
@@ -296,7 +295,6 @@ struct ServerRPCExecutor {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension ServerRPCExecutor {
   @inlinable
   static func _intercept<Input, Output>(

--- a/Sources/GRPCCore/Call/Server/RPCRouter.swift
+++ b/Sources/GRPCCore/Call/Server/RPCRouter.swift
@@ -32,7 +32,6 @@
 /// 1. Remove individual methods by calling ``removeHandler(forMethod:)``, or
 /// 2. Implement ``RegistrableRPCService/registerMethods(with:)`` to register only the methods you
 ///    want to be served.
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 public struct RPCRouter: Sendable {
   @usableFromInline
   struct RPCHandler: Sendable {
@@ -145,7 +144,6 @@ public struct RPCRouter: Sendable {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension RPCRouter {
   internal func handle(
     stream: RPCStream<

--- a/Sources/GRPCCore/Call/Server/RegistrableRPCService.swift
+++ b/Sources/GRPCCore/Call/Server/RegistrableRPCService.swift
@@ -22,7 +22,6 @@
 /// generated conformance by implementing ``registerMethods(with:)`` manually by calling
 /// ``RPCRouter/registerHandler(forMethod:deserializer:serializer:handler:)`` for each method
 /// you want to register with the router.
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 public protocol RegistrableRPCService: Sendable {
   /// Registers methods to server with the provided ``RPCRouter``.
   ///

--- a/Sources/GRPCCore/Call/Server/ServerInterceptor.swift
+++ b/Sources/GRPCCore/Call/Server/ServerInterceptor.swift
@@ -59,7 +59,6 @@
 /// ```
 ///
 /// For client-side interceptors see ``ClientInterceptor``.
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 public protocol ServerInterceptor: Sendable {
   /// Intercept a request object.
   ///

--- a/Sources/GRPCCore/Call/Server/ServerRequest.swift
+++ b/Sources/GRPCCore/Call/Server/ServerRequest.swift
@@ -36,7 +36,6 @@ public struct ServerRequest<Message: Sendable>: Sendable {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 /// A request received at the server containing a stream of messages.
 public struct StreamingServerRequest<Message: Sendable>: Sendable {
   /// Metadata received from the client at the start of the RPC.
@@ -63,14 +62,12 @@ public struct StreamingServerRequest<Message: Sendable>: Sendable {
 
 // MARK: - Conversion
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension StreamingServerRequest {
   public init(single request: ServerRequest<Message>) {
     self.init(metadata: request.metadata, messages: .one(request.message))
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension ServerRequest {
   public init(stream request: StreamingServerRequest<Message>) async throws {
     var iterator = request.messages.makeAsyncIterator()

--- a/Sources/GRPCCore/Call/Server/ServerResponse.swift
+++ b/Sources/GRPCCore/Call/Server/ServerResponse.swift
@@ -168,7 +168,6 @@ public struct ServerResponse<Message: Sendable>: Sendable {
 ///   return ["goodbye": "trailing metadata"]
 /// }
 /// ```
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public struct StreamingServerResponse<Message: Sendable>: Sendable {
   /// The contents of a response to a request which has been accepted for processing.
   public struct Contents: Sendable {
@@ -279,7 +278,6 @@ extension ServerResponse {
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension StreamingServerResponse {
   /// Creates a new accepted response.
   ///
@@ -318,7 +316,6 @@ extension StreamingServerResponse {
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension StreamingServerResponse {
   public init(single response: ServerResponse<Message>) {
     switch response.accepted {

--- a/Sources/GRPCCore/Configuration/MethodConfig.swift
+++ b/Sources/GRPCCore/Configuration/MethodConfig.swift
@@ -17,7 +17,6 @@
 /// Configuration values for executing an RPC.
 ///
 /// See also: https://github.com/grpc/grpc-proto/blob/master/grpc/service_config/service_config.proto
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 public struct MethodConfig: Hashable, Sendable {
   public struct Name: Sendable, Hashable {
     /// The name of the service, including the namespace.
@@ -144,7 +143,6 @@ public struct MethodConfig: Hashable, Sendable {
   }
 }
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 public struct RPCExecutionPolicy: Hashable, Sendable {
   @usableFromInline
   enum Wrapped: Hashable, Sendable {
@@ -214,7 +212,6 @@ public struct RPCExecutionPolicy: Hashable, Sendable {
 ///
 /// For more information see [gRFC A6 Client
 /// Retries](https://github.com/grpc/proposal/blob/master/A6-client-retries.md).
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 public struct RetryPolicy: Hashable, Sendable {
   /// The maximum number of RPC attempts, including the original attempt.
   ///
@@ -332,7 +329,6 @@ public struct RetryPolicy: Hashable, Sendable {
 ///
 /// For more information see [gRFC A6 Client
 /// Retries](https://github.com/grpc/proposal/blob/master/A6-client-retries.md).
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 public struct HedgingPolicy: Hashable, Sendable {
   /// The maximum number of RPC attempts, including the original attempt.
   ///
@@ -397,7 +393,6 @@ private func validateMaxAttempts(_ value: Int) throws -> Int {
   return min(value, 5)
 }
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension Duration {
   fileprivate init(googleProtobufDuration duration: String) throws {
     guard duration.utf8.last == UInt8(ascii: "s"),
@@ -413,7 +408,6 @@ extension Duration {
   }
 }
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension MethodConfig: Codable {
   private enum CodingKeys: String, CodingKey {
     case name
@@ -472,7 +466,6 @@ extension MethodConfig: Codable {
   }
 }
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension MethodConfig.Name: Codable {
   private enum CodingKeys: String, CodingKey {
     case service
@@ -498,7 +491,6 @@ extension MethodConfig.Name: Codable {
   }
 }
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension RetryPolicy: Codable {
   private enum CodingKeys: String, CodingKey {
     case maxAttempts
@@ -546,7 +538,6 @@ extension RetryPolicy: Codable {
   }
 }
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension HedgingPolicy: Codable {
   private enum CodingKeys: String, CodingKey {
     case maxAttempts
@@ -578,7 +569,6 @@ extension HedgingPolicy: Codable {
   }
 }
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 struct GoogleProtobufDuration: Codable {
   var duration: Duration
 

--- a/Sources/GRPCCore/Configuration/ServiceConfig.swift
+++ b/Sources/GRPCCore/Configuration/ServiceConfig.swift
@@ -17,7 +17,6 @@
 /// Service configuration values.
 ///
 /// See also: https://github.com/grpc/grpc-proto/blob/master/grpc/service_config/service_config.proto
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 public struct ServiceConfig: Hashable, Sendable {
   /// Per-method configuration.
   public var methodConfig: [MethodConfig]
@@ -63,7 +62,6 @@ public struct ServiceConfig: Hashable, Sendable {
   }
 }
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension ServiceConfig: Codable {
   private enum CodingKeys: String, CodingKey {
     case methodConfig
@@ -100,7 +98,6 @@ extension ServiceConfig: Codable {
   }
 }
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension ServiceConfig {
   /// Configuration used by clients for load-balancing.
   public struct LoadBalancingConfig: Hashable, Sendable {
@@ -166,7 +163,6 @@ extension ServiceConfig {
   }
 }
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension ServiceConfig.LoadBalancingConfig {
   /// Configuration for the pick-first load balancing policy.
   public struct PickFirst: Hashable, Sendable, Codable {
@@ -194,7 +190,6 @@ extension ServiceConfig.LoadBalancingConfig {
   }
 }
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension ServiceConfig.LoadBalancingConfig: Codable {
   private enum CodingKeys: String, CodingKey {
     case roundRobin = "round_robin"
@@ -225,7 +220,6 @@ extension ServiceConfig.LoadBalancingConfig: Codable {
   }
 }
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension ServiceConfig {
   public struct RetryThrottling: Hashable, Sendable, Codable {
     /// The initial, and maximum number of tokens.

--- a/Sources/GRPCCore/GRPCClient.swift
+++ b/Sources/GRPCCore/GRPCClient.swift
@@ -108,7 +108,6 @@ private import Synchronization
 /// more abruptly you can cancel the task running your client. If your application requires
 /// additional resources that need their lifecycles managed you should consider using [Swift Service
 /// Lifecycle](https://github.com/swift-server/swift-service-lifecycle).
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 public final class GRPCClient: Sendable {
   /// The transport which provides a bidirectional communication channel with the server.
   private let transport: any ClientTransport

--- a/Sources/GRPCCore/GRPCServer.swift
+++ b/Sources/GRPCCore/GRPCServer.swift
@@ -69,7 +69,6 @@ private import Synchronization
 /// you can cancel the task running your server. If your application requires additional resources
 /// that need their lifecycles managed you should consider using [Swift Service
 /// Lifecycle](https://github.com/swift-server/swift-service-lifecycle).
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 public final class GRPCServer: Sendable {
   typealias Stream = RPCStream<ServerTransport.Inbound, ServerTransport.Outbound>
 

--- a/Sources/GRPCCore/Internal/Metadata+GRPC.swift
+++ b/Sources/GRPCCore/Internal/Metadata+GRPC.swift
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension Metadata {
   @inlinable
   var previousRPCAttempts: Int? {
@@ -77,7 +76,6 @@ extension Metadata {
 }
 
 extension Metadata {
-  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
   @usableFromInline
   enum RetryPushback: Hashable, Sendable {
     case retryAfter(Duration)

--- a/Sources/GRPCCore/Internal/MethodConfigs.swift
+++ b/Sources/GRPCCore/Internal/MethodConfigs.swift
@@ -22,7 +22,6 @@
 /// service, or set a default configuration for all methods by calling ``setDefaultConfig(_:)``.
 ///
 /// Use the subscript to get and set configurations for specific methods.
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 package struct MethodConfigs: Sendable, Hashable {
   private var elements: [MethodConfig.Name: MethodConfig]
 

--- a/Sources/GRPCCore/Internal/Result+Catching.swift
+++ b/Sources/GRPCCore/Internal/Result+Catching.swift
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Result where Failure == any Error {
   /// Like `Result(catching:)`, but `async`.
   ///

--- a/Sources/GRPCCore/Internal/TaskGroup+CancellableTask.swift
+++ b/Sources/GRPCCore/Internal/TaskGroup+CancellableTask.swift
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension TaskGroup {
   /// Adds a child task to the group which is individually cancellable.
   ///
@@ -65,7 +64,6 @@ extension TaskGroup {
 }
 
 @usableFromInline
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 struct CancellableTaskHandle: Sendable {
   @usableFromInline
   private(set) var continuation: AsyncStream<Void>.Continuation

--- a/Sources/GRPCCore/Streaming/Internal/AsyncSequenceOfOne.swift
+++ b/Sources/GRPCCore/Streaming/Internal/AsyncSequenceOfOne.swift
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension RPCAsyncSequence {
   /// Returns an ``RPCAsyncSequence`` containing just the given element.
   @inlinable
@@ -33,7 +32,6 @@ extension RPCAsyncSequence {
 
 /// An `AsyncSequence` of a single value.
 @usableFromInline
-@available(macOS 10.15, iOS 13.0, tvOS 13, watchOS 6, *)
 struct AsyncSequenceOfOne<Element: Sendable, Failure: Error>: AsyncSequence, Sendable {
   @usableFromInline
   let result: Result<Element, Failure>

--- a/Sources/GRPCCore/Streaming/Internal/BroadcastAsyncSequence+RPCWriter.swift
+++ b/Sources/GRPCCore/Streaming/Internal/BroadcastAsyncSequence+RPCWriter.swift
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension BroadcastAsyncSequence.Source: ClosableRPCWriterProtocol {
   @inlinable
   func write(contentsOf elements: some Sequence<Element>) async throws {

--- a/Sources/GRPCCore/Streaming/Internal/BroadcastAsyncSequence.swift
+++ b/Sources/GRPCCore/Streaming/Internal/BroadcastAsyncSequence.swift
@@ -30,7 +30,6 @@ public import DequeModule  // should be @usableFromInline
 ///
 /// The expectation is that the number of subscribers will be low; for retries there will be at most
 /// one subscriber at a time, for hedging there may be at most five subscribers at a time.
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 @usableFromInline
 struct BroadcastAsyncSequence<Element: Sendable>: Sendable, AsyncSequence {
   @usableFromInline
@@ -85,7 +84,6 @@ struct BroadcastAsyncSequence<Element: Sendable>: Sendable, AsyncSequence {
 
 // MARK: - AsyncIterator
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension BroadcastAsyncSequence {
   @usableFromInline
   struct AsyncIterator: AsyncIteratorProtocol {
@@ -112,7 +110,6 @@ extension BroadcastAsyncSequence {
 
 // MARK: - Continuation
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension BroadcastAsyncSequence {
   @usableFromInline
   struct Source: Sendable {
@@ -156,7 +153,6 @@ enum BroadcastAsyncSequenceError: Error {
 
 // MARK: - Storage
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 @usableFromInline
 final class _BroadcastSequenceStorage<Element: Sendable>: Sendable {
   @usableFromInline
@@ -331,7 +327,6 @@ final class _BroadcastSequenceStorage<Element: Sendable>: Sendable {
 
 // MARK: - State machine
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 @usableFromInline
 struct _BroadcastSequenceStateMachine<Element: Sendable>: Sendable {
   @usableFromInline
@@ -1369,7 +1364,6 @@ struct _BroadcastSequenceStateMachine<Element: Sendable>: Sendable {
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension _BroadcastSequenceStateMachine {
   /// A collection of elements tagged with an identifier.
   ///
@@ -1524,7 +1518,6 @@ extension _BroadcastSequenceStateMachine {
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension _BroadcastSequenceStateMachine {
   /// A collection of subscriptions.
   @usableFromInline
@@ -1788,7 +1781,6 @@ extension _BroadcastSequenceStateMachine {
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension _BroadcastSequenceStateMachine {
   // TODO: tiny array
   @usableFromInline

--- a/Sources/GRPCCore/Streaming/Internal/GRPCAsyncThrowingStream.swift
+++ b/Sources/GRPCCore/Streaming/Internal/GRPCAsyncThrowingStream.swift
@@ -19,7 +19,6 @@
 // 'RPCWriterProtocol'. (Adding a constrained conformance to 'RPCWriterProtocol' on
 // 'AsyncThrowingStream.Continuation' isn't possible because 'Sendable' is a marker protocol.)
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 package struct GRPCAsyncThrowingStream<Element: Sendable>: AsyncSequence, Sendable {
   package typealias Element = Element
   package typealias Failure = any Error
@@ -78,7 +77,6 @@ package struct GRPCAsyncThrowingStream<Element: Sendable>: AsyncSequence, Sendab
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension GRPCAsyncThrowingStream.Continuation: RPCWriterProtocol {
   package func write(_ element: Element) async throws {
     self.yield(element)
@@ -91,7 +89,6 @@ extension GRPCAsyncThrowingStream.Continuation: RPCWriterProtocol {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension GRPCAsyncThrowingStream.Continuation: ClosableRPCWriterProtocol {
   package func finish() async {
     self.finish(throwing: nil)

--- a/Sources/GRPCCore/Streaming/Internal/RPCWriter+Map.swift
+++ b/Sources/GRPCCore/Streaming/Internal/RPCWriter+Map.swift
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 @usableFromInline
 struct MapRPCWriter<
   Value: Sendable,
@@ -47,7 +46,6 @@ struct MapRPCWriter<
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension RPCWriter {
   @inlinable
   static func map<Mapped>(

--- a/Sources/GRPCCore/Streaming/Internal/RPCWriter+MessageToRPCResponsePart.swift
+++ b/Sources/GRPCCore/Streaming/Internal/RPCWriter+MessageToRPCResponsePart.swift
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 @usableFromInline
 struct MessageToRPCResponsePartWriter<
   Serializer: MessageSerializer
@@ -48,7 +47,6 @@ struct MessageToRPCResponsePartWriter<
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension RPCWriter {
   @inlinable
   static func serializingToRPCResponsePart(

--- a/Sources/GRPCCore/Streaming/Internal/RPCWriter+Serialize.swift
+++ b/Sources/GRPCCore/Streaming/Internal/RPCWriter+Serialize.swift
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 @usableFromInline
 struct SerializingRPCWriter<
   Base: RPCWriterProtocol<[UInt8]>,
@@ -49,7 +48,6 @@ struct SerializingRPCWriter<
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension RPCWriter {
   @inlinable
   static func serializing(

--- a/Sources/GRPCCore/Streaming/Internal/UncheckedAsyncIteratorSequence.swift
+++ b/Sources/GRPCCore/Streaming/Internal/UncheckedAsyncIteratorSequence.swift
@@ -16,7 +16,6 @@
 
 public import Synchronization  // should be @usableFromInline
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 @usableFromInline
 /// An `AsyncSequence` which wraps an existing async iterator.
 final class UncheckedAsyncIteratorSequence<

--- a/Sources/GRPCCore/Streaming/RPCAsyncSequence.swift
+++ b/Sources/GRPCCore/Streaming/RPCAsyncSequence.swift
@@ -15,7 +15,6 @@
  */
 
 /// A type-erasing `AsyncSequence`.
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 public struct RPCAsyncSequence<
   Element: Sendable,
   Failure: Error

--- a/Sources/GRPCCore/Streaming/RPCWriter+Closable.swift
+++ b/Sources/GRPCCore/Streaming/RPCWriter+Closable.swift
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension RPCWriter {
   public struct Closable: ClosableRPCWriterProtocol {
     @usableFromInline

--- a/Sources/GRPCCore/Streaming/RPCWriter.swift
+++ b/Sources/GRPCCore/Streaming/RPCWriter.swift
@@ -15,7 +15,6 @@
  */
 
 /// A type-erasing ``RPCWriterProtocol``.
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public struct RPCWriter<Element: Sendable>: Sendable, RPCWriterProtocol {
   private let writer: any RPCWriterProtocol<Element>
 

--- a/Sources/GRPCCore/Streaming/RPCWriterProtocol.swift
+++ b/Sources/GRPCCore/Streaming/RPCWriterProtocol.swift
@@ -15,7 +15,6 @@
  */
 
 /// A sink for values which are produced over time.
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public protocol RPCWriterProtocol<Element>: Sendable {
   /// The type of value written.
   associatedtype Element: Sendable
@@ -37,7 +36,6 @@ public protocol RPCWriterProtocol<Element>: Sendable {
   func write(contentsOf elements: some Sequence<Element>) async throws
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension RPCWriterProtocol {
   /// Writes an `AsyncSequence` of values into the sink.
   ///
@@ -51,7 +49,6 @@ extension RPCWriterProtocol {
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public protocol ClosableRPCWriterProtocol<Element>: RPCWriterProtocol {
   /// Indicate to the writer that no more writes are to be accepted.
   ///

--- a/Sources/GRPCCore/Timeout.swift
+++ b/Sources/GRPCCore/Timeout.swift
@@ -22,7 +22,6 @@ internal import Dispatch
 /// one of ``Timeout/Unit`` (hours, minutes, seconds, milliseconds, microseconds or nanoseconds).
 ///
 /// Timeouts must be positive and at most 8-digits long.
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 @usableFromInline
 struct Timeout: CustomStringConvertible, Hashable, Sendable {
   /// Possible units for a ``Timeout``.
@@ -182,7 +181,6 @@ extension Int64 {
   }
 }
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension Duration {
   /// Construct a `Duration` given a number of minutes represented as an `Int64`.
   ///

--- a/Sources/GRPCCore/Transport/ClientTransport.swift
+++ b/Sources/GRPCCore/Transport/ClientTransport.swift
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 public protocol ClientTransport: Sendable {
   typealias Inbound = RPCAsyncSequence<RPCResponsePart, any Error>
   typealias Outbound = RPCWriter<RPCRequestPart>.Closable

--- a/Sources/GRPCCore/Transport/RPCStream.swift
+++ b/Sources/GRPCCore/Transport/RPCStream.swift
@@ -15,7 +15,6 @@
  */
 
 /// A bidirectional communication channel between a client and server for a given method.
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public struct RPCStream<
   Inbound: AsyncSequence & Sendable,
   Outbound: ClosableRPCWriterProtocol & Sendable

--- a/Sources/GRPCCore/Transport/RetryThrottle.swift
+++ b/Sources/GRPCCore/Transport/RetryThrottle.swift
@@ -30,7 +30,6 @@ private import Synchronization
 /// the server.
 ///
 /// See also [gRFC A6: client retries](https://github.com/grpc/proposal/blob/master/A6-client-retries.md).
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 public final class RetryThrottle: Sendable {
   // Note: only three figures after the decimal point from the original token ratio are used so
   //   all computation is done a scaled number of tokens (tokens * 1000). This allows us to do all

--- a/Sources/GRPCCore/Transport/ServerTransport.swift
+++ b/Sources/GRPCCore/Transport/ServerTransport.swift
@@ -15,7 +15,6 @@
  */
 
 /// A protocol server transport implementations must conform to.
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 public protocol ServerTransport: Sendable {
   typealias Inbound = RPCAsyncSequence<RPCRequestPart, any Error>
   typealias Outbound = RPCWriter<RPCResponsePart>.Closable

--- a/Sources/GRPCInProcessTransport/InProcessTransport+Client.swift
+++ b/Sources/GRPCInProcessTransport/InProcessTransport+Client.swift
@@ -17,7 +17,6 @@
 public import GRPCCore
 private import Synchronization
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension InProcessTransport {
   /// An in-process implementation of a ``ClientTransport``.
   ///
@@ -36,7 +35,6 @@ extension InProcessTransport {
   /// block until ``connect()`` is called or the task is cancelled.
   ///
   /// - SeeAlso: ``ClientTransport``
-  @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
   public final class Client: ClientTransport {
     private enum State: Sendable {
       struct UnconnectedState {

--- a/Sources/GRPCInProcessTransport/InProcessTransport+Server.swift
+++ b/Sources/GRPCInProcessTransport/InProcessTransport+Server.swift
@@ -16,7 +16,6 @@
 
 public import GRPCCore
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension InProcessTransport {
   /// An in-process implementation of a ``ServerTransport``.
   ///
@@ -28,7 +27,6 @@ extension InProcessTransport {
   /// To stop listening to new requests, call ``beginGracefulShutdown()``.
   ///
   /// - SeeAlso: ``ClientTransport``
-  @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
   public struct Server: ServerTransport, Sendable {
     public typealias Inbound = RPCAsyncSequence<RPCRequestPart, any Error>
     public typealias Outbound = RPCWriter<RPCResponsePart>.Closable

--- a/Sources/GRPCInProcessTransport/InProcessTransport.swift
+++ b/Sources/GRPCInProcessTransport/InProcessTransport.swift
@@ -16,7 +16,6 @@
 
 public import GRPCCore
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 public struct InProcessTransport: Sendable {
   public let server: Self.Server
   public let client: Self.Client

--- a/Tests/GRPCCodeGenTests/Internal/Renderer/TextBasedRendererTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Renderer/TextBasedRendererTests.swift
@@ -734,7 +734,6 @@ final class Test_TextBasedRenderer: XCTestCase {
       ]),
       renderedBy: { $0.renderAvailability(_:) },
       rendersAs: #"""
-        @available(macOS 12.0, iOS 13.1.2, watchOS 8.1.2, tvOS 15.0.2, *)
         """#
     )
   }

--- a/Tests/GRPCCodeGenTests/Internal/Renderer/TextBasedRendererTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Renderer/TextBasedRendererTests.swift
@@ -734,6 +734,7 @@ final class Test_TextBasedRenderer: XCTestCase {
       ]),
       renderedBy: { $0.renderAvailability(_:) },
       rendersAs: #"""
+        @available(macOS 12.0, iOS 13.1.2, watchOS 8.1.2, tvOS 15.0.2, *)
         """#
     )
   }

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
@@ -43,6 +43,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public protocol NamespaceA_ServiceA_ClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
@@ -53,6 +54,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               _ body: @Sendable @escaping (GRPCCore.ClientResponse<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable
       }
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
           public func methodA<R>(
               request: GRPCCore.ClientRequest<NamespaceA_ServiceARequest>,
@@ -70,6 +72,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               )
           }
       }
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
           /// Documentation for MethodA
           public func methodA<Result>(
@@ -92,6 +95,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           }
       }
       /// Documentation for ServiceA
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public struct NamespaceA_ServiceA_Client: NamespaceA_ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
@@ -146,6 +150,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public protocol NamespaceA_ServiceA_ClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
@@ -156,6 +161,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               _ body: @Sendable @escaping (GRPCCore.ClientResponse<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable
       }
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
           public func methodA<R>(
               request: GRPCCore.StreamingClientRequest<NamespaceA_ServiceARequest>,
@@ -173,6 +179,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               )
           }
       }
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
           /// Documentation for MethodA
           public func methodA<Result>(
@@ -195,6 +202,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           }
       }
       /// Documentation for ServiceA
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public struct NamespaceA_ServiceA_Client: NamespaceA_ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
@@ -249,6 +257,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public protocol NamespaceA_ServiceA_ClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
@@ -259,6 +268,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               _ body: @Sendable @escaping (GRPCCore.StreamingClientResponse<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable
       }
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
           public func methodA<R>(
               request: GRPCCore.ClientRequest<NamespaceA_ServiceARequest>,
@@ -274,6 +284,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               )
           }
       }
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
           /// Documentation for MethodA
           public func methodA<Result>(
@@ -294,6 +305,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           }
       }
       /// Documentation for ServiceA
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public struct NamespaceA_ServiceA_Client: NamespaceA_ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
@@ -346,6 +358,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public protocol NamespaceA_ServiceA_ClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
@@ -356,6 +369,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               _ body: @Sendable @escaping (GRPCCore.StreamingClientResponse<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable
       }
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
           public func methodA<R>(
               request: GRPCCore.StreamingClientRequest<NamespaceA_ServiceARequest>,
@@ -371,6 +385,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               )
           }
       }
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
           /// Documentation for MethodA
           public func methodA<Result>(
@@ -391,6 +406,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           }
       }
       /// Documentation for ServiceA
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public struct NamespaceA_ServiceA_Client: NamespaceA_ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
@@ -451,6 +467,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       package protocol NamespaceA_ServiceA_ClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
@@ -470,6 +487,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               _ body: @Sendable @escaping (GRPCCore.StreamingClientResponse<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable
       }
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
           package func methodA<R>(
               request: GRPCCore.StreamingClientRequest<NamespaceA_ServiceARequest>,
@@ -501,6 +519,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               )
           }
       }
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
           /// Documentation for MethodA
           package func methodA<Result>(
@@ -541,6 +560,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           }
       }
       /// Documentation for ServiceA
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       package struct NamespaceA_ServiceA_Client: NamespaceA_ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
@@ -613,6 +633,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       internal protocol ServiceA_ClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
@@ -623,6 +644,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               _ body: @Sendable @escaping (GRPCCore.ClientResponse<ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable
       }
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension ServiceA.ClientProtocol {
           internal func methodA<R>(
               request: GRPCCore.ClientRequest<ServiceARequest>,
@@ -640,6 +662,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               )
           }
       }
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension ServiceA.ClientProtocol {
           /// Documentation for MethodA
           internal func methodA<Result>(
@@ -662,6 +685,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           }
       }
       /// Documentation for ServiceA
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       internal struct ServiceA_Client: ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
@@ -722,12 +746,16 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public protocol NamespaceA_ServiceA_ClientProtocol: Sendable {}
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
       }
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
       }
       /// Documentation for ServiceA
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public struct NamespaceA_ServiceA_Client: NamespaceA_ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
@@ -738,14 +766,18 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       /// Documentation for ServiceB
       ///
       /// Line 2
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public protocol ServiceB_ClientProtocol: Sendable {}
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension ServiceB.ClientProtocol {
       }
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension ServiceB.ClientProtocol {
       }
       /// Documentation for ServiceB
       ///
       /// Line 2
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public struct ServiceB_Client: ServiceB.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
@@ -43,7 +43,6 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public protocol NamespaceA_ServiceA_ClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
@@ -54,7 +53,6 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               _ body: @Sendable @escaping (GRPCCore.ClientResponse<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable
       }
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
           public func methodA<R>(
               request: GRPCCore.ClientRequest<NamespaceA_ServiceARequest>,
@@ -72,7 +70,6 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               )
           }
       }
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
           /// Documentation for MethodA
           public func methodA<Result>(
@@ -95,7 +92,6 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           }
       }
       /// Documentation for ServiceA
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public struct NamespaceA_ServiceA_Client: NamespaceA_ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
@@ -150,7 +146,6 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public protocol NamespaceA_ServiceA_ClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
@@ -161,7 +156,6 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               _ body: @Sendable @escaping (GRPCCore.ClientResponse<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable
       }
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
           public func methodA<R>(
               request: GRPCCore.StreamingClientRequest<NamespaceA_ServiceARequest>,
@@ -179,7 +173,6 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               )
           }
       }
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
           /// Documentation for MethodA
           public func methodA<Result>(
@@ -202,7 +195,6 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           }
       }
       /// Documentation for ServiceA
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public struct NamespaceA_ServiceA_Client: NamespaceA_ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
@@ -257,7 +249,6 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public protocol NamespaceA_ServiceA_ClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
@@ -268,7 +259,6 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               _ body: @Sendable @escaping (GRPCCore.StreamingClientResponse<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable
       }
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
           public func methodA<R>(
               request: GRPCCore.ClientRequest<NamespaceA_ServiceARequest>,
@@ -284,7 +274,6 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               )
           }
       }
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
           /// Documentation for MethodA
           public func methodA<Result>(
@@ -305,7 +294,6 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           }
       }
       /// Documentation for ServiceA
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public struct NamespaceA_ServiceA_Client: NamespaceA_ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
@@ -358,7 +346,6 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public protocol NamespaceA_ServiceA_ClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
@@ -369,7 +356,6 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               _ body: @Sendable @escaping (GRPCCore.StreamingClientResponse<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable
       }
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
           public func methodA<R>(
               request: GRPCCore.StreamingClientRequest<NamespaceA_ServiceARequest>,
@@ -385,7 +371,6 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               )
           }
       }
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
           /// Documentation for MethodA
           public func methodA<Result>(
@@ -406,7 +391,6 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           }
       }
       /// Documentation for ServiceA
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public struct NamespaceA_ServiceA_Client: NamespaceA_ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
@@ -467,7 +451,6 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       package protocol NamespaceA_ServiceA_ClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
@@ -487,7 +470,6 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               _ body: @Sendable @escaping (GRPCCore.StreamingClientResponse<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable
       }
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
           package func methodA<R>(
               request: GRPCCore.StreamingClientRequest<NamespaceA_ServiceARequest>,
@@ -519,7 +501,6 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               )
           }
       }
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
           /// Documentation for MethodA
           package func methodA<Result>(
@@ -560,7 +541,6 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           }
       }
       /// Documentation for ServiceA
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       package struct NamespaceA_ServiceA_Client: NamespaceA_ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
@@ -633,7 +613,6 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       internal protocol ServiceA_ClientProtocol: Sendable {
           /// Documentation for MethodA
           func methodA<R>(
@@ -644,7 +623,6 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               _ body: @Sendable @escaping (GRPCCore.ClientResponse<ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable
       }
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension ServiceA.ClientProtocol {
           internal func methodA<R>(
               request: GRPCCore.ClientRequest<ServiceARequest>,
@@ -662,7 +640,6 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               )
           }
       }
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension ServiceA.ClientProtocol {
           /// Documentation for MethodA
           internal func methodA<Result>(
@@ -685,7 +662,6 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
           }
       }
       /// Documentation for ServiceA
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       internal struct ServiceA_Client: ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
@@ -746,16 +722,12 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public protocol NamespaceA_ServiceA_ClientProtocol: Sendable {}
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
       }
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ClientProtocol {
       }
       /// Documentation for ServiceA
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public struct NamespaceA_ServiceA_Client: NamespaceA_ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           
@@ -766,18 +738,14 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       /// Documentation for ServiceB
       ///
       /// Line 2
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public protocol ServiceB_ClientProtocol: Sendable {}
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension ServiceB.ClientProtocol {
       }
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension ServiceB.ClientProtocol {
       }
       /// Documentation for ServiceB
       ///
       /// Line 2
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public struct ServiceB_Client: ServiceB.ClientProtocol {
           private let client: GRPCCore.GRPCClient
           

--- a/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
@@ -221,9 +221,7 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
           public enum Method {
               public static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias StreamingServiceProtocol = NamespaceA_ServiceA_StreamingServiceProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ServiceProtocol = NamespaceA_ServiceA_ServiceProtocol
       }
 
@@ -235,22 +233,17 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
       }
 
       /// Documentation for AService
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public protocol NamespaceA_ServiceA_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {}
 
       /// Conformance to `GRPCCore.RegistrableRPCService`.
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.StreamingServiceProtocol {
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {}
       }
 
       /// Documentation for AService
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public protocol NamespaceA_ServiceA_ServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {}
 
       /// Partial conformance to `NamespaceA_ServiceA_StreamingServiceProtocol`.
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ServiceProtocol {
       }
       """

--- a/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
@@ -221,7 +221,9 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
           public enum Method {
               public static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias StreamingServiceProtocol = NamespaceA_ServiceA_StreamingServiceProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ServiceProtocol = NamespaceA_ServiceA_ServiceProtocol
       }
 
@@ -233,17 +235,22 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
       }
 
       /// Documentation for AService
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public protocol NamespaceA_ServiceA_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {}
 
       /// Conformance to `GRPCCore.RegistrableRPCService`.
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.StreamingServiceProtocol {
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {}
       }
 
       /// Documentation for AService
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public protocol NamespaceA_ServiceA_ServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {}
 
       /// Partial conformance to `NamespaceA_ServiceA_StreamingServiceProtocol`.
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ServiceProtocol {
       }
       """

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
@@ -51,7 +51,6 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public protocol NamespaceA_ServiceA_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for unaryMethod
           func unary(
@@ -60,9 +59,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           ) async throws -> GRPCCore.StreamingServerResponse<NamespaceA_ServiceAResponse>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.StreamingServiceProtocol {
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
                   forMethod: NamespaceA_ServiceA.Method.Unary.descriptor,
@@ -78,7 +75,6 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           }
       }
       /// Documentation for ServiceA
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public protocol NamespaceA_ServiceA_ServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
           /// Documentation for unaryMethod
           func unary(
@@ -87,7 +83,6 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           ) async throws -> GRPCCore.ServerResponse<NamespaceA_ServiceAResponse>
       }
       /// Partial conformance to `NamespaceA_ServiceA_StreamingServiceProtocol`.
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ServiceProtocol {
           public func unary(
               request: GRPCCore.StreamingServerRequest<NamespaceA_ServiceARequest>,
@@ -135,7 +130,6 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       package protocol NamespaceA_ServiceA_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for inputStreamingMethod
           func inputStreaming(
@@ -144,9 +138,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           ) async throws -> GRPCCore.StreamingServerResponse<NamespaceA_ServiceAResponse>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.StreamingServiceProtocol {
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package func registerMethods(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
                   forMethod: NamespaceA_ServiceA.Method.InputStreaming.descriptor,
@@ -162,7 +154,6 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           }
       }
       /// Documentation for ServiceA
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       package protocol NamespaceA_ServiceA_ServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
           /// Documentation for inputStreamingMethod
           func inputStreaming(
@@ -171,7 +162,6 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           ) async throws -> GRPCCore.ServerResponse<NamespaceA_ServiceAResponse>
       }
       /// Partial conformance to `NamespaceA_ServiceA_StreamingServiceProtocol`.
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ServiceProtocol {
           package func inputStreaming(
               request: GRPCCore.StreamingServerRequest<NamespaceA_ServiceARequest>,
@@ -223,7 +213,6 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public protocol NamespaceA_ServiceA_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for outputStreamingMethod
           func outputStreaming(
@@ -232,9 +221,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           ) async throws -> GRPCCore.StreamingServerResponse<NamespaceA_ServiceAResponse>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.StreamingServiceProtocol {
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
                   forMethod: NamespaceA_ServiceA.Method.OutputStreaming.descriptor,
@@ -250,7 +237,6 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           }
       }
       /// Documentation for ServiceA
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public protocol NamespaceA_ServiceA_ServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
           /// Documentation for outputStreamingMethod
           func outputStreaming(
@@ -259,7 +245,6 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           ) async throws -> GRPCCore.StreamingServerResponse<NamespaceA_ServiceAResponse>
       }
       /// Partial conformance to `NamespaceA_ServiceA_StreamingServiceProtocol`.
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ServiceProtocol {
           public func outputStreaming(
               request: GRPCCore.StreamingServerRequest<NamespaceA_ServiceARequest>,
@@ -311,7 +296,6 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       package protocol NamespaceA_ServiceA_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for bidirectionalStreamingMethod
           func bidirectionalStreaming(
@@ -320,9 +304,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           ) async throws -> GRPCCore.StreamingServerResponse<NamespaceA_ServiceAResponse>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.StreamingServiceProtocol {
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package func registerMethods(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
                   forMethod: NamespaceA_ServiceA.Method.BidirectionalStreaming.descriptor,
@@ -338,7 +320,6 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           }
       }
       /// Documentation for ServiceA
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       package protocol NamespaceA_ServiceA_ServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
           /// Documentation for bidirectionalStreamingMethod
           func bidirectionalStreaming(
@@ -347,7 +328,6 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           ) async throws -> GRPCCore.StreamingServerResponse<NamespaceA_ServiceAResponse>
       }
       /// Partial conformance to `NamespaceA_ServiceA_StreamingServiceProtocol`.
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ServiceProtocol {
       }
       """
@@ -401,7 +381,6 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       internal protocol NamespaceA_ServiceA_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for inputStreamingMethod
           func inputStreaming(
@@ -416,9 +395,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           ) async throws -> GRPCCore.StreamingServerResponse<NamespaceA_ServiceAResponse>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.StreamingServiceProtocol {
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           internal func registerMethods(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
                   forMethod: NamespaceA_ServiceA.Method.InputStreaming.descriptor,
@@ -445,7 +422,6 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           }
       }
       /// Documentation for ServiceA
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       internal protocol NamespaceA_ServiceA_ServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
           /// Documentation for inputStreamingMethod
           func inputStreaming(
@@ -460,7 +436,6 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           ) async throws -> GRPCCore.StreamingServerResponse<NamespaceA_ServiceAResponse>
       }
       /// Partial conformance to `NamespaceA_ServiceA_StreamingServiceProtocol`.
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ServiceProtocol {
           internal func inputStreaming(
               request: GRPCCore.StreamingServerRequest<NamespaceA_ServiceARequest>,
@@ -515,7 +490,6 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       internal protocol ServiceA_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for MethodA
           func methodA(
@@ -524,9 +498,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           ) async throws -> GRPCCore.StreamingServerResponse<NamespaceA_ServiceAResponse>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension ServiceA.StreamingServiceProtocol {
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           internal func registerMethods(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
                   forMethod: ServiceA.Method.MethodA.descriptor,
@@ -542,7 +514,6 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           }
       }
       /// Documentation for ServiceA
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       internal protocol ServiceA_ServiceProtocol: ServiceA.StreamingServiceProtocol {
           /// Documentation for MethodA
           func methodA(
@@ -551,7 +522,6 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           ) async throws -> GRPCCore.ServerResponse<NamespaceA_ServiceAResponse>
       }
       /// Partial conformance to `ServiceA_StreamingServiceProtocol`.
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension ServiceA.ServiceProtocol {
           internal func methodA(
               request: GRPCCore.StreamingServerRequest<NamespaceA_ServiceARequest>,
@@ -597,35 +567,25 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public protocol NamespaceA_ServiceA_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {}
       /// Conformance to `GRPCCore.RegistrableRPCService`.
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.StreamingServiceProtocol {
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {}
       }
       /// Documentation for ServiceA
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public protocol NamespaceA_ServiceA_ServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {}
       /// Partial conformance to `NamespaceA_ServiceA_StreamingServiceProtocol`.
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ServiceProtocol {
       }
       /// Documentation for ServiceB
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public protocol NamespaceA_ServiceB_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {}
       /// Conformance to `GRPCCore.RegistrableRPCService`.
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceB.StreamingServiceProtocol {
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {}
       }
       /// Documentation for ServiceB
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public protocol NamespaceA_ServiceB_ServiceProtocol: NamespaceA_ServiceB.StreamingServiceProtocol {}
       /// Partial conformance to `NamespaceA_ServiceB_StreamingServiceProtocol`.
-      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceB.ServiceProtocol {
       }
       """

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
@@ -51,6 +51,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public protocol NamespaceA_ServiceA_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for unaryMethod
           func unary(
@@ -59,7 +60,9 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           ) async throws -> GRPCCore.StreamingServerResponse<NamespaceA_ServiceAResponse>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.StreamingServiceProtocol {
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
                   forMethod: NamespaceA_ServiceA.Method.Unary.descriptor,
@@ -75,6 +78,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           }
       }
       /// Documentation for ServiceA
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public protocol NamespaceA_ServiceA_ServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
           /// Documentation for unaryMethod
           func unary(
@@ -83,6 +87,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           ) async throws -> GRPCCore.ServerResponse<NamespaceA_ServiceAResponse>
       }
       /// Partial conformance to `NamespaceA_ServiceA_StreamingServiceProtocol`.
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ServiceProtocol {
           public func unary(
               request: GRPCCore.StreamingServerRequest<NamespaceA_ServiceARequest>,
@@ -130,6 +135,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       package protocol NamespaceA_ServiceA_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for inputStreamingMethod
           func inputStreaming(
@@ -138,7 +144,9 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           ) async throws -> GRPCCore.StreamingServerResponse<NamespaceA_ServiceAResponse>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.StreamingServiceProtocol {
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package func registerMethods(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
                   forMethod: NamespaceA_ServiceA.Method.InputStreaming.descriptor,
@@ -154,6 +162,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           }
       }
       /// Documentation for ServiceA
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       package protocol NamespaceA_ServiceA_ServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
           /// Documentation for inputStreamingMethod
           func inputStreaming(
@@ -162,6 +171,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           ) async throws -> GRPCCore.ServerResponse<NamespaceA_ServiceAResponse>
       }
       /// Partial conformance to `NamespaceA_ServiceA_StreamingServiceProtocol`.
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ServiceProtocol {
           package func inputStreaming(
               request: GRPCCore.StreamingServerRequest<NamespaceA_ServiceARequest>,
@@ -213,6 +223,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public protocol NamespaceA_ServiceA_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for outputStreamingMethod
           func outputStreaming(
@@ -221,7 +232,9 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           ) async throws -> GRPCCore.StreamingServerResponse<NamespaceA_ServiceAResponse>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.StreamingServiceProtocol {
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
                   forMethod: NamespaceA_ServiceA.Method.OutputStreaming.descriptor,
@@ -237,6 +250,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           }
       }
       /// Documentation for ServiceA
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public protocol NamespaceA_ServiceA_ServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
           /// Documentation for outputStreamingMethod
           func outputStreaming(
@@ -245,6 +259,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           ) async throws -> GRPCCore.StreamingServerResponse<NamespaceA_ServiceAResponse>
       }
       /// Partial conformance to `NamespaceA_ServiceA_StreamingServiceProtocol`.
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ServiceProtocol {
           public func outputStreaming(
               request: GRPCCore.StreamingServerRequest<NamespaceA_ServiceARequest>,
@@ -296,6 +311,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       package protocol NamespaceA_ServiceA_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for bidirectionalStreamingMethod
           func bidirectionalStreaming(
@@ -304,7 +320,9 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           ) async throws -> GRPCCore.StreamingServerResponse<NamespaceA_ServiceAResponse>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.StreamingServiceProtocol {
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package func registerMethods(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
                   forMethod: NamespaceA_ServiceA.Method.BidirectionalStreaming.descriptor,
@@ -320,6 +338,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           }
       }
       /// Documentation for ServiceA
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       package protocol NamespaceA_ServiceA_ServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
           /// Documentation for bidirectionalStreamingMethod
           func bidirectionalStreaming(
@@ -328,6 +347,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           ) async throws -> GRPCCore.StreamingServerResponse<NamespaceA_ServiceAResponse>
       }
       /// Partial conformance to `NamespaceA_ServiceA_StreamingServiceProtocol`.
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ServiceProtocol {
       }
       """
@@ -381,6 +401,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       internal protocol NamespaceA_ServiceA_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for inputStreamingMethod
           func inputStreaming(
@@ -395,7 +416,9 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           ) async throws -> GRPCCore.StreamingServerResponse<NamespaceA_ServiceAResponse>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.StreamingServiceProtocol {
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           internal func registerMethods(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
                   forMethod: NamespaceA_ServiceA.Method.InputStreaming.descriptor,
@@ -422,6 +445,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           }
       }
       /// Documentation for ServiceA
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       internal protocol NamespaceA_ServiceA_ServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
           /// Documentation for inputStreamingMethod
           func inputStreaming(
@@ -436,6 +460,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           ) async throws -> GRPCCore.StreamingServerResponse<NamespaceA_ServiceAResponse>
       }
       /// Partial conformance to `NamespaceA_ServiceA_StreamingServiceProtocol`.
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ServiceProtocol {
           internal func inputStreaming(
               request: GRPCCore.StreamingServerRequest<NamespaceA_ServiceARequest>,
@@ -490,6 +515,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       internal protocol ServiceA_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {
           /// Documentation for MethodA
           func methodA(
@@ -498,7 +524,9 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           ) async throws -> GRPCCore.StreamingServerResponse<NamespaceA_ServiceAResponse>
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension ServiceA.StreamingServiceProtocol {
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           internal func registerMethods(with router: inout GRPCCore.RPCRouter) {
               router.registerHandler(
                   forMethod: ServiceA.Method.MethodA.descriptor,
@@ -514,6 +542,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           }
       }
       /// Documentation for ServiceA
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       internal protocol ServiceA_ServiceProtocol: ServiceA.StreamingServiceProtocol {
           /// Documentation for MethodA
           func methodA(
@@ -522,6 +551,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
           ) async throws -> GRPCCore.ServerResponse<NamespaceA_ServiceAResponse>
       }
       /// Partial conformance to `ServiceA_StreamingServiceProtocol`.
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension ServiceA.ServiceProtocol {
           internal func methodA(
               request: GRPCCore.StreamingServerRequest<NamespaceA_ServiceARequest>,
@@ -567,25 +597,35 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
     let expectedSwift =
       """
       /// Documentation for ServiceA
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public protocol NamespaceA_ServiceA_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {}
       /// Conformance to `GRPCCore.RegistrableRPCService`.
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.StreamingServiceProtocol {
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {}
       }
       /// Documentation for ServiceA
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public protocol NamespaceA_ServiceA_ServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {}
       /// Partial conformance to `NamespaceA_ServiceA_StreamingServiceProtocol`.
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceA.ServiceProtocol {
       }
       /// Documentation for ServiceB
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public protocol NamespaceA_ServiceB_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {}
       /// Conformance to `GRPCCore.RegistrableRPCService`.
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceB.StreamingServiceProtocol {
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {}
       }
       /// Documentation for ServiceB
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public protocol NamespaceA_ServiceB_ServiceProtocol: NamespaceA_ServiceB.StreamingServiceProtocol {}
       /// Partial conformance to `NamespaceA_ServiceB_StreamingServiceProtocol`.
+      @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       extension NamespaceA_ServiceB.ServiceProtocol {
       }
       """

--- a/Tests/GRPCCodeGenTests/Internal/Translator/TypealiasTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/TypealiasTranslatorSnippetBasedTests.swift
@@ -61,9 +61,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
                   MethodA.descriptor
               ]
           }
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias StreamingServiceProtocol = NamespaceA_ServiceA_StreamingServiceProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ServiceProtocol = NamespaceA_ServiceA_ServiceProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ClientProtocol = NamespaceA_ServiceA_ClientProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias Client = NamespaceA_ServiceA_Client
       }
       extension GRPCCore.ServiceDescriptor {
@@ -101,9 +105,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public enum Method {
               public static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias StreamingServiceProtocol = NamespaceA_ServiceA_StreamingServiceProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ServiceProtocol = NamespaceA_ServiceA_ServiceProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ClientProtocol = NamespaceA_ServiceA_ClientProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias Client = NamespaceA_ServiceA_Client
       }
       extension GRPCCore.ServiceDescriptor {
@@ -141,7 +149,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public enum Method {
               public static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias StreamingServiceProtocol = NamespaceA_ServiceA_StreamingServiceProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ServiceProtocol = NamespaceA_ServiceA_ServiceProtocol
       }
       extension GRPCCore.ServiceDescriptor {
@@ -179,7 +189,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public enum Method {
               public static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ClientProtocol = NamespaceA_ServiceA_ClientProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias Client = NamespaceA_ServiceA_Client
       }
       extension GRPCCore.ServiceDescriptor {
@@ -267,9 +279,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
                   MethodA.descriptor
               ]
           }
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias StreamingServiceProtocol = ServiceA_StreamingServiceProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ServiceProtocol = ServiceA_ServiceProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ClientProtocol = ServiceA_ClientProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias Client = ServiceA_Client
       }
       extension GRPCCore.ServiceDescriptor {
@@ -342,9 +358,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
                   MethodB.descriptor
               ]
           }
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias StreamingServiceProtocol = NamespaceA_ServiceA_StreamingServiceProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ServiceProtocol = NamespaceA_ServiceA_ServiceProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ClientProtocol = NamespaceA_ServiceA_ClientProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias Client = NamespaceA_ServiceA_Client
       }
       extension GRPCCore.ServiceDescriptor {
@@ -382,9 +402,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           package enum Method {
               package static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package typealias StreamingServiceProtocol = NamespaceA_ServiceA_StreamingServiceProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package typealias ServiceProtocol = NamespaceA_ServiceA_ServiceProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package typealias ClientProtocol = NamespaceA_ServiceA_ClientProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package typealias Client = NamespaceA_ServiceA_Client
       }
       extension GRPCCore.ServiceDescriptor {
@@ -434,9 +458,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public enum Method {
               public static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias StreamingServiceProtocol = NamespaceA_Aservice_StreamingServiceProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ServiceProtocol = NamespaceA_Aservice_ServiceProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ClientProtocol = NamespaceA_Aservice_ClientProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias Client = NamespaceA_Aservice_Client
       }
       extension GRPCCore.ServiceDescriptor {
@@ -450,9 +478,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public enum Method {
               public static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias StreamingServiceProtocol = NamespaceA_Bservice_StreamingServiceProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ServiceProtocol = NamespaceA_Bservice_ServiceProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ClientProtocol = NamespaceA_Bservice_ClientProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias Client = NamespaceA_Bservice_Client
       }
       extension GRPCCore.ServiceDescriptor {
@@ -494,9 +526,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           package enum Method {
               package static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package typealias StreamingServiceProtocol = AService_StreamingServiceProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package typealias ServiceProtocol = AService_ServiceProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package typealias ClientProtocol = AService_ClientProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package typealias Client = AService_Client
       }
       extension GRPCCore.ServiceDescriptor {
@@ -510,9 +546,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           package enum Method {
               package static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package typealias StreamingServiceProtocol = BService_StreamingServiceProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package typealias ServiceProtocol = BService_ServiceProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package typealias ClientProtocol = BService_ClientProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package typealias Client = BService_Client
       }
       extension GRPCCore.ServiceDescriptor {
@@ -562,9 +602,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           internal enum Method {
               internal static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           internal typealias StreamingServiceProtocol = Anamespace_AService_StreamingServiceProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           internal typealias ServiceProtocol = Anamespace_AService_ServiceProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           internal typealias ClientProtocol = Anamespace_AService_ClientProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           internal typealias Client = Anamespace_AService_Client
       }
       extension GRPCCore.ServiceDescriptor {
@@ -578,9 +622,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           internal enum Method {
               internal static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           internal typealias StreamingServiceProtocol = Bnamespace_BService_StreamingServiceProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           internal typealias ServiceProtocol = Bnamespace_BService_ServiceProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           internal typealias ClientProtocol = Bnamespace_BService_ClientProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           internal typealias Client = Bnamespace_BService_Client
       }
       extension GRPCCore.ServiceDescriptor {
@@ -624,9 +672,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public enum Method {
               public static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias StreamingServiceProtocol = Anamespace_AService_StreamingServiceProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ServiceProtocol = Anamespace_AService_ServiceProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ClientProtocol = Anamespace_AService_ClientProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias Client = Anamespace_AService_Client
       }
       extension GRPCCore.ServiceDescriptor {
@@ -640,9 +692,13 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public enum Method {
               public static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias StreamingServiceProtocol = BService_StreamingServiceProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ServiceProtocol = BService_ServiceProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ClientProtocol = BService_ClientProtocol
+          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias Client = BService_Client
       }
       extension GRPCCore.ServiceDescriptor {

--- a/Tests/GRPCCodeGenTests/Internal/Translator/TypealiasTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/TypealiasTranslatorSnippetBasedTests.swift
@@ -61,13 +61,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
                   MethodA.descriptor
               ]
           }
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias StreamingServiceProtocol = NamespaceA_ServiceA_StreamingServiceProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ServiceProtocol = NamespaceA_ServiceA_ServiceProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ClientProtocol = NamespaceA_ServiceA_ClientProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias Client = NamespaceA_ServiceA_Client
       }
       extension GRPCCore.ServiceDescriptor {
@@ -105,13 +101,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public enum Method {
               public static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias StreamingServiceProtocol = NamespaceA_ServiceA_StreamingServiceProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ServiceProtocol = NamespaceA_ServiceA_ServiceProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ClientProtocol = NamespaceA_ServiceA_ClientProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias Client = NamespaceA_ServiceA_Client
       }
       extension GRPCCore.ServiceDescriptor {
@@ -149,9 +141,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public enum Method {
               public static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias StreamingServiceProtocol = NamespaceA_ServiceA_StreamingServiceProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ServiceProtocol = NamespaceA_ServiceA_ServiceProtocol
       }
       extension GRPCCore.ServiceDescriptor {
@@ -189,9 +179,7 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public enum Method {
               public static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ClientProtocol = NamespaceA_ServiceA_ClientProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias Client = NamespaceA_ServiceA_Client
       }
       extension GRPCCore.ServiceDescriptor {
@@ -279,13 +267,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
                   MethodA.descriptor
               ]
           }
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias StreamingServiceProtocol = ServiceA_StreamingServiceProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ServiceProtocol = ServiceA_ServiceProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ClientProtocol = ServiceA_ClientProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias Client = ServiceA_Client
       }
       extension GRPCCore.ServiceDescriptor {
@@ -358,13 +342,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
                   MethodB.descriptor
               ]
           }
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias StreamingServiceProtocol = NamespaceA_ServiceA_StreamingServiceProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ServiceProtocol = NamespaceA_ServiceA_ServiceProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ClientProtocol = NamespaceA_ServiceA_ClientProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias Client = NamespaceA_ServiceA_Client
       }
       extension GRPCCore.ServiceDescriptor {
@@ -402,13 +382,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           package enum Method {
               package static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package typealias StreamingServiceProtocol = NamespaceA_ServiceA_StreamingServiceProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package typealias ServiceProtocol = NamespaceA_ServiceA_ServiceProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package typealias ClientProtocol = NamespaceA_ServiceA_ClientProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package typealias Client = NamespaceA_ServiceA_Client
       }
       extension GRPCCore.ServiceDescriptor {
@@ -458,13 +434,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public enum Method {
               public static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias StreamingServiceProtocol = NamespaceA_Aservice_StreamingServiceProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ServiceProtocol = NamespaceA_Aservice_ServiceProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ClientProtocol = NamespaceA_Aservice_ClientProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias Client = NamespaceA_Aservice_Client
       }
       extension GRPCCore.ServiceDescriptor {
@@ -478,13 +450,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public enum Method {
               public static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias StreamingServiceProtocol = NamespaceA_Bservice_StreamingServiceProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ServiceProtocol = NamespaceA_Bservice_ServiceProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ClientProtocol = NamespaceA_Bservice_ClientProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias Client = NamespaceA_Bservice_Client
       }
       extension GRPCCore.ServiceDescriptor {
@@ -526,13 +494,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           package enum Method {
               package static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package typealias StreamingServiceProtocol = AService_StreamingServiceProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package typealias ServiceProtocol = AService_ServiceProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package typealias ClientProtocol = AService_ClientProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package typealias Client = AService_Client
       }
       extension GRPCCore.ServiceDescriptor {
@@ -546,13 +510,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           package enum Method {
               package static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package typealias StreamingServiceProtocol = BService_StreamingServiceProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package typealias ServiceProtocol = BService_ServiceProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package typealias ClientProtocol = BService_ClientProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           package typealias Client = BService_Client
       }
       extension GRPCCore.ServiceDescriptor {
@@ -602,13 +562,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           internal enum Method {
               internal static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           internal typealias StreamingServiceProtocol = Anamespace_AService_StreamingServiceProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           internal typealias ServiceProtocol = Anamespace_AService_ServiceProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           internal typealias ClientProtocol = Anamespace_AService_ClientProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           internal typealias Client = Anamespace_AService_Client
       }
       extension GRPCCore.ServiceDescriptor {
@@ -622,13 +578,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           internal enum Method {
               internal static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           internal typealias StreamingServiceProtocol = Bnamespace_BService_StreamingServiceProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           internal typealias ServiceProtocol = Bnamespace_BService_ServiceProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           internal typealias ClientProtocol = Bnamespace_BService_ClientProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           internal typealias Client = Bnamespace_BService_Client
       }
       extension GRPCCore.ServiceDescriptor {
@@ -672,13 +624,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public enum Method {
               public static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias StreamingServiceProtocol = Anamespace_AService_StreamingServiceProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ServiceProtocol = Anamespace_AService_ServiceProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ClientProtocol = Anamespace_AService_ClientProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias Client = Anamespace_AService_Client
       }
       extension GRPCCore.ServiceDescriptor {
@@ -692,13 +640,9 @@ final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
           public enum Method {
               public static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias StreamingServiceProtocol = BService_StreamingServiceProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ServiceProtocol = BService_ServiceProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias ClientProtocol = BService_ClientProtocol
-          @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
           public typealias Client = BService_Client
       }
       extension GRPCCore.ServiceDescriptor {

--- a/Tests/GRPCCoreTests/Call/Client/ClientRequestTests.swift
+++ b/Tests/GRPCCoreTests/Call/Client/ClientRequestTests.swift
@@ -18,7 +18,6 @@ import XCTest
 
 @testable import GRPCCore
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class ClientRequestTests: XCTestCase {
   func testSingleToStreamConversion() async throws {
     let (messages, continuation) = AsyncStream.makeStream(of: String.self)

--- a/Tests/GRPCCoreTests/Call/Client/ClientResponseTests.swift
+++ b/Tests/GRPCCoreTests/Call/Client/ClientResponseTests.swift
@@ -18,7 +18,6 @@ import XCTest
 
 @testable import GRPCCore
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class ClientResponseTests: XCTestCase {
   func testAcceptedSingleResponseConvenienceMethods() {
     let response = ClientResponse(

--- a/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTestSupport/ClientRPCExecutorTestHarness+ServerBehavior.swift
+++ b/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTestSupport/ClientRPCExecutorTestHarness+ServerBehavior.swift
@@ -18,7 +18,6 @@ import XCTest
 
 @testable import GRPCCore
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension ClientRPCExecutorTestHarness {
   struct ServerStreamHandler: Sendable {
     private let handler:
@@ -59,7 +58,6 @@ extension ClientRPCExecutorTestHarness {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension ClientRPCExecutorTestHarness.ServerStreamHandler {
   static var echo: Self {
     return Self { stream in

--- a/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTestSupport/ClientRPCExecutorTestHarness+Transport.swift
+++ b/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTestSupport/ClientRPCExecutorTestHarness+Transport.swift
@@ -17,7 +17,6 @@
 import GRPCCore
 import GRPCInProcessTransport
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension InProcessTransport.Server {
   func spawnClientTransport(
     throttle: RetryThrottle = RetryThrottle(maxTokens: 10, tokenRatio: 0.1)

--- a/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTestSupport/ClientRPCExecutorTestHarness.swift
+++ b/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTestSupport/ClientRPCExecutorTestHarness.swift
@@ -25,7 +25,6 @@ import XCTest
 /// of the server to allow for flexible testing scenarios with minimal boilerplate. The harness
 /// also tracks how many streams the client has opened, how many streams the server accepted, and
 /// how many streams the client failed to open.
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct ClientRPCExecutorTestHarness {
   private let server: ServerStreamHandler
   private let clientTransport: StreamCountingClientTransport

--- a/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests+Hedging.swift
+++ b/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests+Hedging.swift
@@ -16,7 +16,6 @@
 import GRPCCore
 import XCTest
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension ClientRPCExecutorTests {
   func testHedgingWhenAllAttemptsResultInNonFatalCodes() async throws {
     let harness = ClientRPCExecutorTestHarness(
@@ -186,7 +185,6 @@ extension ClientRPCExecutorTests {
   }
 }
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension CallOptions {
   fileprivate static func hedge(
     maxAttempts: Int = 5,

--- a/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests+Retries.swift
+++ b/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests+Retries.swift
@@ -16,7 +16,6 @@
 import GRPCCore
 import XCTest
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension ClientRPCExecutorTests {
   fileprivate func makeHarnessForRetries(
     rejectUntilAttempt firstSuccessfulAttempt: Int,
@@ -289,7 +288,6 @@ extension ClientRPCExecutorTests {
   }
 }
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension CallOptions {
   fileprivate static func retry(
     _ policy: RetryPolicy

--- a/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests.swift
+++ b/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests.swift
@@ -18,7 +18,6 @@ import XCTest
 
 @testable import GRPCCore
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class ClientRPCExecutorTests: XCTestCase {
   func testUnaryEcho() async throws {
     let tester = ClientRPCExecutorTestHarness(server: .echo)

--- a/Tests/GRPCCoreTests/Call/Client/RetryDelaySequenceTests.swift
+++ b/Tests/GRPCCoreTests/Call/Client/RetryDelaySequenceTests.swift
@@ -17,7 +17,6 @@ import XCTest
 
 @testable import GRPCCore
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 final class RetryDelaySequenceTests: XCTestCase {
   func testSequence() {
     let policy = RetryPolicy(

--- a/Tests/GRPCCoreTests/Call/Server/Internal/ServerRPCExecutorTestSupport/ServerRPCExecutorTestHarness.swift
+++ b/Tests/GRPCCoreTests/Call/Server/Internal/ServerRPCExecutorTestSupport/ServerRPCExecutorTestHarness.swift
@@ -17,7 +17,6 @@ import XCTest
 
 @testable import GRPCCore
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct ServerRPCExecutorTestHarness {
   struct ServerHandler<Input: Sendable, Output: Sendable>: Sendable {
     let fn:
@@ -134,7 +133,6 @@ struct ServerRPCExecutorTestHarness {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension ServerRPCExecutorTestHarness.ServerHandler where Input == Output {
   static var echo: Self {
     return Self { request in

--- a/Tests/GRPCCoreTests/Call/Server/Internal/ServerRPCExecutorTests.swift
+++ b/Tests/GRPCCoreTests/Call/Server/Internal/ServerRPCExecutorTests.swift
@@ -18,7 +18,6 @@ import XCTest
 
 @testable import GRPCCore
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class ServerRPCExecutorTests: XCTestCase {
   func testEchoNoMessages() async throws {
     let harness = ServerRPCExecutorTestHarness()

--- a/Tests/GRPCCoreTests/Call/Server/RPCRouterTests.swift
+++ b/Tests/GRPCCoreTests/Call/Server/RPCRouterTests.swift
@@ -17,7 +17,6 @@
 import GRPCCore
 import XCTest
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class RPCRouterTests: XCTestCase {
   func testEmptyRouter() async throws {
     var router = RPCRouter()

--- a/Tests/GRPCCoreTests/Call/Server/ServerRequestTests.swift
+++ b/Tests/GRPCCoreTests/Call/Server/ServerRequestTests.swift
@@ -16,7 +16,6 @@
 @_spi(Testing) import GRPCCore
 import XCTest
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class ServerRequestTests: XCTestCase {
   func testSingleToStreamConversion() async throws {
     let single = ServerRequest(metadata: ["bar": "baz"], message: "foo")

--- a/Tests/GRPCCoreTests/Call/Server/ServerResponseTests.swift
+++ b/Tests/GRPCCoreTests/Call/Server/ServerResponseTests.swift
@@ -16,7 +16,6 @@
 @_spi(Testing) import GRPCCore
 import XCTest
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class ServerResponseTests: XCTestCase {
   func testSingleConvenienceInit() {
     var response = ServerResponse(

--- a/Tests/GRPCCoreTests/Configuration/ServiceConfigCodingTests.swift
+++ b/Tests/GRPCCoreTests/Configuration/ServiceConfigCodingTests.swift
@@ -18,7 +18,6 @@ import Foundation
 import GRPCCore
 import XCTest
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 final class ServiceConfigCodingTests: XCTestCase {
   private let encoder = JSONEncoder()
   private let decoder = JSONDecoder()

--- a/Tests/GRPCCoreTests/GRPCClientTests.swift
+++ b/Tests/GRPCCoreTests/GRPCClientTests.swift
@@ -18,7 +18,6 @@ import GRPCCore
 import GRPCInProcessTransport
 import XCTest
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class GRPCClientTests: XCTestCase {
   func withInProcessConnectedClient(
     services: [any RegistrableRPCService],

--- a/Tests/GRPCCoreTests/GRPCServerTests.swift
+++ b/Tests/GRPCCoreTests/GRPCServerTests.swift
@@ -18,7 +18,6 @@ import GRPCCore
 import GRPCInProcessTransport
 import XCTest
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class GRPCServerTests: XCTestCase {
   func withInProcessClientConnectedToServer(
     services: [any RegistrableRPCService],

--- a/Tests/GRPCCoreTests/Internal/Metadata+GRPCTests.swift
+++ b/Tests/GRPCCoreTests/Internal/Metadata+GRPCTests.swift
@@ -18,7 +18,6 @@ import XCTest
 
 @testable import GRPCCore
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 final class MetadataGRPCTests: XCTestCase {
   func testPreviousRPCAttemptsValidValues() {
     let testData = [("0", 0), ("1", 1), ("-1", -1)]

--- a/Tests/GRPCCoreTests/Internal/MethodConfigsTests.swift
+++ b/Tests/GRPCCoreTests/Internal/MethodConfigsTests.swift
@@ -16,7 +16,6 @@
 import GRPCCore
 import XCTest
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 final class MethodConfigsTests: XCTestCase {
   func testGetConfigurationForKnownMethod() async throws {
     let policy = HedgingPolicy(

--- a/Tests/GRPCCoreTests/Internal/Result+CatchingTests.swift
+++ b/Tests/GRPCCoreTests/Internal/Result+CatchingTests.swift
@@ -18,7 +18,6 @@ import XCTest
 
 @testable import GRPCCore
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class ResultCatchingTests: XCTestCase {
   func testResultCatching() async {
     let result = await Result {

--- a/Tests/GRPCCoreTests/RuntimeErrorTests.swift
+++ b/Tests/GRPCCoreTests/RuntimeErrorTests.swift
@@ -16,7 +16,6 @@
 import GRPCCore
 import XCTest
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class RuntimeErrorTests: XCTestCase {
   func testCopyOnWrite() {
     // RuntimeError has a heap based storage, so check CoW semantics are correctly implemented.

--- a/Tests/GRPCCoreTests/Streaming/Internal/AsyncSequenceOfOne.swift
+++ b/Tests/GRPCCoreTests/Streaming/Internal/AsyncSequenceOfOne.swift
@@ -18,7 +18,6 @@ import XCTest
 
 @testable import GRPCCore
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 internal final class AsyncSequenceOfOneTests: XCTestCase {
   func testSuccessPath() async throws {
     let sequence = RPCAsyncSequence<String, any Error>.one("foo")

--- a/Tests/GRPCCoreTests/Streaming/Internal/BroadcastAsyncSequenceTests.swift
+++ b/Tests/GRPCCoreTests/Streaming/Internal/BroadcastAsyncSequenceTests.swift
@@ -18,7 +18,6 @@ import XCTest
 
 @testable import GRPCCore
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class BroadcastAsyncSequenceTests: XCTestCase {
   func testSingleSubscriberToEmptyStream() async throws {
     let (stream, source) = BroadcastAsyncSequence.makeStream(of: Int.self, bufferSize: 16)

--- a/Tests/GRPCCoreTests/Test Utilities/AsyncSequence+Utilities.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/AsyncSequence+Utilities.swift
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension AsyncSequence {
   func collect() async throws -> [Element] {
     return try await self.reduce(into: []) { $0.append($1) }

--- a/Tests/GRPCCoreTests/Test Utilities/AtomicCounter.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/AtomicCounter.swift
@@ -16,7 +16,6 @@
 
 import Synchronization
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class AtomicCounter: Sendable {
   private let counter: Atomic<Int>
 

--- a/Tests/GRPCCoreTests/Test Utilities/Call/Client/ClientInterceptors.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/Call/Client/ClientInterceptors.swift
@@ -16,7 +16,6 @@
 
 import GRPCCore
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension ClientInterceptor where Self == RejectAllClientInterceptor {
   static func rejectAll(with error: RPCError) -> Self {
     return RejectAllClientInterceptor(error: error, throw: false)
@@ -28,7 +27,6 @@ extension ClientInterceptor where Self == RejectAllClientInterceptor {
 
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension ClientInterceptor where Self == RequestCountingClientInterceptor {
   static func requestCounter(_ counter: AtomicCounter) -> Self {
     return RequestCountingClientInterceptor(counter: counter)
@@ -36,7 +34,6 @@ extension ClientInterceptor where Self == RequestCountingClientInterceptor {
 }
 
 /// Rejects all RPCs with the provided error.
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct RejectAllClientInterceptor: ClientInterceptor {
   /// The error to reject all RPCs with.
   let error: RPCError
@@ -65,7 +62,6 @@ struct RejectAllClientInterceptor: ClientInterceptor {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct RequestCountingClientInterceptor: ClientInterceptor {
   /// The number of requests made.
   let counter: AtomicCounter

--- a/Tests/GRPCCoreTests/Test Utilities/Call/Server/ServerInterceptors.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/Call/Server/ServerInterceptors.swift
@@ -16,7 +16,6 @@
 
 import GRPCCore
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension ServerInterceptor where Self == RejectAllServerInterceptor {
   static func rejectAll(with error: RPCError) -> Self {
     return RejectAllServerInterceptor(error: error, throw: false)
@@ -27,7 +26,6 @@ extension ServerInterceptor where Self == RejectAllServerInterceptor {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension ServerInterceptor where Self == RequestCountingServerInterceptor {
   static func requestCounter(_ counter: AtomicCounter) -> Self {
     return RequestCountingServerInterceptor(counter: counter)
@@ -35,7 +33,6 @@ extension ServerInterceptor where Self == RequestCountingServerInterceptor {
 }
 
 /// Rejects all RPCs with the provided error.
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct RejectAllServerInterceptor: ServerInterceptor {
   /// The error to reject all RPCs with.
   let error: RPCError
@@ -64,7 +61,6 @@ struct RejectAllServerInterceptor: ServerInterceptor {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct RequestCountingServerInterceptor: ServerInterceptor {
   /// The number of requests made.
   let counter: AtomicCounter

--- a/Tests/GRPCCoreTests/Test Utilities/RPCAsyncSequence+Utilities.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/RPCAsyncSequence+Utilities.swift
@@ -15,7 +15,6 @@
  */
 import GRPCCore
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension RPCAsyncSequence where Failure == any Error {
   static func elements(_ elements: Element...) -> Self {
     return .elements(elements)

--- a/Tests/GRPCCoreTests/Test Utilities/RPCWriter+Utilities.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/RPCWriter+Utilities.swift
@@ -16,7 +16,6 @@
 import GRPCCore
 import XCTest
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension RPCWriter {
   /// Returns a writer which calls `XCTFail(_:)` on every write.
   static func failTestOnWrite(elementType: Element.Type = Element.self) -> Self {
@@ -29,7 +28,6 @@ extension RPCWriter {
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 private struct FailOnWrite<Element: Sendable>: RPCWriterProtocol {
   func write(_ element: Element) async throws {
     XCTFail("Unexpected write")
@@ -40,7 +38,6 @@ private struct FailOnWrite<Element: Sendable>: RPCWriterProtocol {
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 private struct AsyncStreamGatheringWriter<Element: Sendable>: RPCWriterProtocol {
   let continuation: AsyncStream<Element>.Continuation
 

--- a/Tests/GRPCCoreTests/Test Utilities/Services/BinaryEcho.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/Services/BinaryEcho.swift
@@ -16,7 +16,6 @@
 import GRPCCore
 import XCTest
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct BinaryEcho: RegistrableRPCService {
   func get(
     _ request: ServerRequest<[UInt8]>

--- a/Tests/GRPCCoreTests/Test Utilities/Transport/AnyTransport.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/Transport/AnyTransport.swift
@@ -15,7 +15,6 @@
  */
 @testable import GRPCCore
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct AnyClientTransport: ClientTransport, Sendable {
   typealias Inbound = RPCAsyncSequence<RPCResponsePart, any Error>
   typealias Outbound = RPCWriter<RPCRequestPart>.Closable
@@ -81,7 +80,6 @@ struct AnyClientTransport: ClientTransport, Sendable {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct AnyServerTransport: ServerTransport, Sendable {
   typealias Inbound = RPCAsyncSequence<RPCRequestPart, any Error>
   typealias Outbound = RPCWriter<RPCResponsePart>.Closable

--- a/Tests/GRPCCoreTests/Test Utilities/Transport/StreamCountingTransport.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/Transport/StreamCountingTransport.swift
@@ -16,7 +16,6 @@
 
 @testable import GRPCCore
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct StreamCountingClientTransport: ClientTransport, Sendable {
   typealias Inbound = RPCAsyncSequence<RPCResponsePart, any Error>
   typealias Outbound = RPCWriter<RPCRequestPart>.Closable
@@ -78,7 +77,6 @@ struct StreamCountingClientTransport: ClientTransport, Sendable {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct StreamCountingServerTransport: ServerTransport, Sendable {
   typealias Inbound = RPCAsyncSequence<RPCRequestPart, any Error>
   typealias Outbound = RPCWriter<RPCResponsePart>.Closable

--- a/Tests/GRPCCoreTests/Test Utilities/Transport/ThrowingTransport.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/Transport/ThrowingTransport.swift
@@ -15,7 +15,6 @@
  */
 @testable import GRPCCore
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct ThrowOnStreamCreationTransport: ClientTransport {
   typealias Inbound = RPCAsyncSequence<RPCResponsePart, any Error>
   typealias Outbound = RPCWriter<RPCRequestPart>.Closable
@@ -51,7 +50,6 @@ struct ThrowOnStreamCreationTransport: ClientTransport {
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 struct ThrowOnRunServerTransport: ServerTransport {
   func listen(
     streamHandler: (
@@ -70,7 +68,6 @@ struct ThrowOnRunServerTransport: ServerTransport {
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 struct ThrowOnSignalServerTransport: ServerTransport {
   let signal: AsyncStream<Void>
 

--- a/Tests/GRPCCoreTests/Test Utilities/XCTest+Utilities.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/XCTest+Utilities.swift
@@ -25,7 +25,6 @@ func XCTAssertDescription(
   XCTAssertEqual(String(describing: subject), expected, file: file, line: line)
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 func XCTAssertThrowsErrorAsync<T>(
   _ expression: () async throws -> T,
   errorHandler: (any Error) -> Void
@@ -51,7 +50,6 @@ func XCTAssertThrowsError<T, E: Error>(
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 func XCTAssertThrowsErrorAsync<T, E: Error>(
   ofType: E.Type = E.self,
   _ expression: () async throws -> T,
@@ -80,7 +78,6 @@ func XCTAssertThrowsRPCError<T>(
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 func XCTAssertThrowsRPCErrorAsync<T>(
   _ expression: () async throws -> T,
   errorHandler: (RPCError) -> Void
@@ -95,7 +92,6 @@ func XCTAssertThrowsRPCErrorAsync<T>(
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 func XCTAssertRejected<T>(
   _ response: StreamingClientResponse<T>,
   errorHandler: (RPCError) -> Void
@@ -132,7 +128,6 @@ func XCTAssertMetadata(
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 func XCTAssertMetadata(
   _ part: RPCRequestPart?,
   metadataHandler: (Metadata) async throws -> Void = { _ in }
@@ -157,7 +152,6 @@ func XCTAssertMessage(
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 func XCTAssertMessage(
   _ part: RPCRequestPart?,
   messageHandler: ([UInt8]) async throws -> Void = { _ in }

--- a/Tests/GRPCCoreTests/Transport/RetryThrottleTests.swift
+++ b/Tests/GRPCCoreTests/Transport/RetryThrottleTests.swift
@@ -18,7 +18,6 @@ import XCTest
 
 @testable import GRPCCore
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class RetryThrottleTests: XCTestCase {
   func testThrottleOnInit() {
     let throttle = RetryThrottle(maxTokens: 10, tokenRatio: 0.1)

--- a/Tests/GRPCInProcessTransportTests/InProcessClientTransportTests.swift
+++ b/Tests/GRPCInProcessTransportTests/InProcessClientTransportTests.swift
@@ -18,7 +18,6 @@ import GRPCCore
 import GRPCInProcessTransport
 import XCTest
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class InProcessClientTransportTests: XCTestCase {
   struct FailTest: Error {}
 

--- a/Tests/GRPCInProcessTransportTests/InProcessServerTransportTests.swift
+++ b/Tests/GRPCInProcessTransportTests/InProcessServerTransportTests.swift
@@ -19,7 +19,6 @@ import XCTest
 @testable import GRPCCore
 @testable import GRPCInProcessTransport
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class InProcessServerTransportTests: XCTestCase {
   func testStartListening() async throws {
     let transport = InProcessTransport.Server()

--- a/Tests/GRPCInProcessTransportTests/Test Utilities/XCTest+Utilities.swift
+++ b/Tests/GRPCInProcessTransportTests/Test Utilities/XCTest+Utilities.swift
@@ -28,7 +28,6 @@ func XCTAssertThrowsError<T, E: Error>(
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 func XCTAssertThrowsErrorAsync<T, E: Error>(
   ofType: E.Type = E.self,
   _ expression: () async throws -> T,


### PR DESCRIPTION
Motivation:

Core components of grpc-swift v2 require API from the latest SDKs. This causes a proliferation of availability annotations through our API. Rather than doing this we can set the minimum platforms in the package manifest.

Modifications:

- Remove availability annotations
- Set platforms in the package manifest

Result:

- Less boilerplate
- Users must set platforms in their package manifest