### PR TITLE
Flatten `RPCError` causes if they're also `RPCError`s with the same code

### DIFF
--- a/Sources/GRPCCore/RPCError.swift
+++ b/Sources/GRPCCore/RPCError.swift
@@ -49,13 +49,13 @@ public struct RPCError: Sendable, Hashable, Error {
     metadata: Metadata = [:],
     cause: (any Error)? = nil
   ) {
-    if let rpcErrorCause = cause as? RPCError, rpcErrorCause.code == code {
-      self.code = code
-      self.message = message + " \(rpcErrorCause.message)"
-      var mergedMetadata = metadata
-      mergedMetadata.add(contentsOf: rpcErrorCause.metadata)
-      self.metadata = mergedMetadata
-      self.cause = rpcErrorCause.cause
+    if let rpcErrorCause = cause as? RPCError {
+      self = .init(
+        code: code,
+        message: message,
+        metadata: metadata,
+        cause: rpcErrorCause
+      )
     } else {
       self.code = code
       self.message = message

--- a/Sources/GRPCCore/RPCError.swift
+++ b/Sources/GRPCCore/RPCError.swift
@@ -58,7 +58,7 @@ public struct RPCError: Sendable, Hashable, Error {
       while let nextRPCErrorCause = nextCause as? RPCError {
         if code == nextRPCErrorCause.code {
           finalMessage = finalMessage + " \(nextRPCErrorCause.message)"
-          finalMetadata.merge(nextRPCErrorCause.metadata)
+          finalMetadata.add(contentsOf: nextRPCErrorCause.metadata)
           nextCause = nextRPCErrorCause.cause
         } else {
           nextCause = RPCError(

--- a/Tests/GRPCCoreTests/RPCErrorTests.swift
+++ b/Tests/GRPCCoreTests/RPCErrorTests.swift
@@ -39,19 +39,17 @@ struct RPCErrorTests {
     #expect(RPCError(status: status) == nil)
 
     status.code = .invalidArgument
-    var error = RPCError(status: status)
-    try #require(error != nil)
-    #expect(error!.code == .invalidArgument)
-    #expect(error!.message == "")
-    #expect(error!.metadata == [:])
+    var error = try #require(RPCError(status: status))
+    #expect(error.code == .invalidArgument)
+    #expect(error.message == "")
+    #expect(error.metadata == [:])
 
     status.code = .cancelled
     status.message = "an error message"
-    error = RPCError(status: status)
-    try #require(error != nil)
-    #expect(error!.code == .cancelled)
-    #expect(error!.message == "an error message")
-    #expect(error!.metadata == [:])
+    error = try #require(RPCError(status: status))
+    #expect(error.code == .cancelled)
+    #expect(error.message == "an error message")
+    #expect(error.metadata == [:])
   }
 
   @Test(

--- a/Tests/GRPCCoreTests/RPCErrorTests.swift
+++ b/Tests/GRPCCoreTests/RPCErrorTests.swift
@@ -21,14 +21,17 @@ struct RPCErrorTests {
   @Test("Custom String Convertible")
   func testCustomStringConvertible() {
     #expect(String(describing: RPCError(code: .dataLoss, message: "")) == #"dataLoss: """#)
-    #expect(String(describing: RPCError(code: .unknown, message: "message")) == #"unknown: "message""#)
-    #expect(String(describing: RPCError(code: .aborted, message: "message")) == #"aborted: "message""#)
+    #expect(
+      String(describing: RPCError(code: .unknown, message: "message")) == #"unknown: "message""#
+    )
+    #expect(
+      String(describing: RPCError(code: .aborted, message: "message")) == #"aborted: "message""#
+    )
 
     struct TestError: Error {}
     #expect(
       String(describing: RPCError(code: .aborted, message: "message", cause: TestError()))
-      ==
-      #"aborted: "message" (cause: "TestError()")"#
+        == #"aborted: "message" (cause: "TestError()")"#
     )
   }
 
@@ -71,7 +74,7 @@ struct RPCErrorTests {
       (Status.Code.internalError, RPCError.Code.internalError),
       (Status.Code.unavailable, RPCError.Code.unavailable),
       (Status.Code.dataLoss, RPCError.Code.dataLoss),
-      (Status.Code.unauthenticated, RPCError.Code.unauthenticated)
+      (Status.Code.unauthenticated, RPCError.Code.unauthenticated),
     ]
   )
   func testErrorCodeFromStatusCode(statusCode: Status.Code, rpcErrorCode: RPCError.Code?) throws {
@@ -82,59 +85,56 @@ struct RPCErrorTests {
   func testEquatableConformance() {
     #expect(
       RPCError(code: .cancelled, message: "")
-      ==
-      RPCError(code: .cancelled, message: "")
+        == RPCError(code: .cancelled, message: "")
     )
 
     #expect(
       RPCError(code: .cancelled, message: "message")
-      ==
-      RPCError(code: .cancelled, message: "message")
+        == RPCError(code: .cancelled, message: "message")
     )
 
     #expect(
       RPCError(code: .cancelled, message: "message", metadata: ["foo": "bar"])
-      ==
-      RPCError(code: .cancelled, message: "message", metadata: ["foo": "bar"])
+        == RPCError(code: .cancelled, message: "message", metadata: ["foo": "bar"])
     )
 
     #expect(
       RPCError(code: .cancelled, message: "")
-      !=
-      RPCError(code: .cancelled, message: "message")
+        != RPCError(code: .cancelled, message: "message")
     )
 
     #expect(
       RPCError(code: .cancelled, message: "message")
-      !=
-      RPCError(code: .unknown, message: "message")
+        != RPCError(code: .unknown, message: "message")
     )
 
     #expect(
       RPCError(code: .cancelled, message: "message", metadata: ["foo": "bar"])
-      !=
-      RPCError(code: .cancelled, message: "message", metadata: ["foo": "baz"])
+        != RPCError(code: .cancelled, message: "message", metadata: ["foo": "baz"])
     )
   }
 
-  @Test("Status Code Raw Values", arguments: [
-    (RPCError.Code.cancelled, 1),
-    (.unknown, 2),
-    (.invalidArgument, 3),
-    (.deadlineExceeded, 4),
-    (.notFound, 5),
-    (.alreadyExists, 6),
-    (.permissionDenied, 7),
-    (.resourceExhausted, 8),
-    (.failedPrecondition, 9),
-    (.aborted, 10),
-    (.outOfRange, 11),
-    (.unimplemented, 12),
-    (.internalError, 13),
-    (.unavailable, 14),
-    (.dataLoss, 15),
-    (.unauthenticated, 16),
-  ])
+  @Test(
+    "Status Code Raw Values",
+    arguments: [
+      (RPCError.Code.cancelled, 1),
+      (.unknown, 2),
+      (.invalidArgument, 3),
+      (.deadlineExceeded, 4),
+      (.notFound, 5),
+      (.alreadyExists, 6),
+      (.permissionDenied, 7),
+      (.resourceExhausted, 8),
+      (.failedPrecondition, 9),
+      (.aborted, 10),
+      (.outOfRange, 11),
+      (.unimplemented, 12),
+      (.internalError, 13),
+      (.unavailable, 14),
+      (.dataLoss, 15),
+      (.unauthenticated, 16),
+    ]
+  )
   func testStatusCodeRawValues(statusCode: RPCError.Code, rawValue: Int) {
     #expect(statusCode.rawValue == rawValue, "\(statusCode) had unexpected raw value")
   }
@@ -145,11 +145,20 @@ struct RPCErrorTests {
     let error2 = RPCError(code: .unknown, message: "Error 2.", cause: error1)
     let error3 = RPCError(code: .dataLoss, message: "Error 3.", cause: error2)
     let error4 = RPCError(code: .aborted, message: "Error 4.", cause: error3)
-    let error5 = RPCError(code: .aborted, message: "Error 5.", cause: error4, flatteningCauses: true)
+    let error5 = RPCError(
+      code: .aborted,
+      message: "Error 5.",
+      cause: error4,
+      flatteningCauses: true
+    )
 
     let unknownMerged = RPCError(code: .unknown, message: "Error 2. Error 1.")
     let dataLossMerged = RPCError(code: .dataLoss, message: "Error 3.", cause: unknownMerged)
-    let abortedMerged = RPCError(code: .aborted, message: "Error 5. Error 4.", cause: dataLossMerged)
+    let abortedMerged = RPCError(
+      code: .aborted,
+      message: "Error 5. Error 4.",
+      cause: dataLossMerged
+    )
     #expect(error5 == abortedMerged)
   }
 }


### PR DESCRIPTION
## Motivation
For errors happening deep in the task tree, we'd wrap them in many layers of `RPCError`s. This isn't particularly nice.

## Modifications
This PR changes the behaviour of the `RPCError` initialiser to flatten the cause as long as it's an `RPCError` with the same status code as the wrapping error.

## Result
Friendlier errors.