### PR TITLE
Ensure file path isn't percent encoded in the plugin

### DIFF
--- a/Plugins/GRPCSwiftPlugin/plugin.swift
+++ b/Plugins/GRPCSwiftPlugin/plugin.swift
@@ -319,7 +319,7 @@ struct PathLike: CustomStringConvertible {
     #if compiler(<6.0)
     return String(describing: self.value)
     #elseif canImport(Darwin)
-    return self.value.path()
+    return self.value.path(percentEncoded: false)
     #else
     return self.value.path
     #endif


### PR DESCRIPTION
Motivation:

In Swift 6, SwiftPM deprecated its Path based API for plugins and moved to Foundation's URL. On Darwin, getting the path of a URL percent encodes it which leads to build issues in Xcode.

Modifications:

- Make sure the path isn't percent encoded

Result:

- Plugin works again
- Resolves #2085