### PR TITLE
Remove unbounded variable from formatting script

### DIFF
--- a/dev/format.sh
+++ b/dev/format.sh
@@ -69,7 +69,7 @@ if "$lint"; then
 
     To fix, run the following command:
 
-    % $THIS_SCRIPT -f
+    % $here/format.sh -f
     "
     exit "${SWIFT_FORMAT_RC}"
   fi


### PR DESCRIPTION
The formatting script should print a helpful message when formatting check fails showing which command to run to fix it.
However, it fails to print this because it cannot find the `THIS_SCRIPT` env variable.