### PR TITLE
Fix decoding of durations in MethodConfig

### DIFF
--- a/Tests/GRPCCoreTests/Call/Server/Internal/ServerCancellationManagerTests.swift
+++ b/Tests/GRPCCoreTests/Call/Server/Internal/ServerCancellationManagerTests.swift
@@ -65,7 +65,6 @@ struct ServerCancellationManagerTests {
   @Test("Remove cancellation handler")
   func removeCancellationHandler() async throws {
     let manager = ServerCancellationManager()
-    let signal = AsyncStream.makeStream(of: Void.self)
 
     let id = manager.addRPCCancelledHandler {
       Issue.record("Unexpected cancellation")

--- a/Tests/GRPCCoreTests/Configuration/MethodConfigCodingTests.swift
+++ b/Tests/GRPCCoreTests/Configuration/MethodConfigCodingTests.swift
@@ -186,6 +186,7 @@ struct MethodConfigCodingTests {
         ("1s", .seconds(1)),
         ("1.000000s", .seconds(1)),
         ("0s", .zero),
+        ("0.1s", .milliseconds(100)),
         ("100.123s", .milliseconds(100_123)),
       ] as [(String, Duration)]
     )


### PR DESCRIPTION
Motivation:

MethodConfig uses a particular string based format for durations based on the "google.protobuf.duration" message. On some decoding paths a string was read and then decoded into a `Swift.Duration` rather than decoding the `GoogleProtobufDuration` message directly.

The string-to-Swift.Duration path had a bug meaning fractional seconds were incorrectly decoded.

Modifications:

- Add a test
- Remove the string to `Swift.Duration` path and always decode via `GoogleProtobufDuration` which has a correct implementation.

Result:

Fewer bugs