### PR TITLE
Bump min version of swift-nio-extras

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -44,7 +44,7 @@ let packageDependencies: [Package.Dependency] = [
   ),
   .package(
     url: "https://github.com/apple/swift-nio-extras.git",
-    from: "1.4.0"
+    from: "1.24.0"
   ),
   .package(
     url: "https://github.com/apple/swift-collections.git",

--- a/Package@swift-6.swift
+++ b/Package@swift-6.swift
@@ -44,7 +44,7 @@ let packageDependencies: [Package.Dependency] = [
   ),
   .package(
     url: "https://github.com/apple/swift-nio-extras.git",
-    from: "1.4.0"
+    from: "1.24.0"
   ),
   .package(
     url: "https://github.com/apple/swift-collections.git",


### PR DESCRIPTION
Motivation:

We require that the ServerQuiescingHelper is Sendable, which it is as of version 1.12.0, however our depenencies our depenency requirements don't express that and if an older version is resolved then compilation will fail.

Modifications:

- Bump the required version to 1.24.0

Result:

More accurate version requirement