### PR TITLE
Allow adding `ClientInterceptor`s to specific services and methods

### DIFF
--- a/Sources/GRPCCore/Call/Client/ClientInterceptor.swift
+++ b/Sources/GRPCCore/Call/Client/ClientInterceptor.swift
@@ -21,10 +21,11 @@
 /// received from the transport. They are typically used for cross-cutting concerns like injecting
 /// metadata, validating messages, logging additional data, and tracing.
 ///
-/// Interceptors are registered with a client and apply to all RPCs. If you need to modify the
-/// behavior of an interceptor on a per-RPC basis then you can use the
-/// ``ClientContext/descriptor`` to determine which RPC is being called and
-/// conditionalise behavior accordingly.
+/// Interceptors are registered with the server via ``ClientInterceptorPipelineOperation``s.
+/// You may register them for all services registered with a server, for RPCs directed to specific services, or
+/// for RPCs directed to specific methods. If you need to modify the behavior of an interceptor on a
+/// per-RPC basis in more detail, then you can use the ``ClientContext/descriptor`` to determine
+/// which RPC is being called and conditionalise behavior accordingly.
 ///
 /// - TODO: Update example and documentation to show how to register an interceptor.
 ///

--- a/Sources/GRPCCore/Call/Client/ClientInterceptorPipelineOperation.swift
+++ b/Sources/GRPCCore/Call/Client/ClientInterceptorPipelineOperation.swift
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-/// A `ServerInterceptorPipelineOperation` describes to which RPCs a server interceptor should be applied.
+/// A `ClientInterceptorPipelineOperation` describes to which RPCs a client interceptor should be applied.
 ///
-/// You can configure a server interceptor to be applied to:
+/// You can configure a client interceptor to be applied to:
 /// - all RPCs and services;
-/// - requests directed only to specific services registered with your server; or
+/// - requests directed only to specific services; or
 /// - requests directed only to specific methods (of a specific service).
 ///
-/// - SeeAlso: ``ServerInterceptor`` for more information on server interceptors, and
-///  ``ClientInterceptorPipelineOperation`` for the client-side version of this type.
-public struct ServerInterceptorPipelineOperation: Sendable {
-  /// The subject of a ``ServerInterceptorPipelineOperation``.
+/// - SeeAlso: ``ClientInterceptor`` for more information on client interceptors, and
+///  ``ServerInterceptorPipelineOperation`` for the server-side version of this type.
+public struct ClientInterceptorPipelineOperation: Sendable {
+  /// The subject of a ``ClientInterceptorPipelineOperation``.
   /// The subject of an interceptor can either be all services and methods, only specific services, or only specific methods.
   public struct Subject: Sendable {
     internal enum Wrapped: Sendable {
@@ -35,13 +35,13 @@ public struct ServerInterceptorPipelineOperation: Sendable {
 
     private let wrapped: Wrapped
 
-    /// An operation subject specifying an interceptor that applies to all RPCs across all services will be registered with this server.
+    /// An operation subject specifying an interceptor that applies to all RPCs across all services will be registered with this client.
     public static var all: Self { .init(wrapped: .all) }
 
     /// An operation subject specifying an interceptor that will be applied only to RPCs directed to the specified services.
     /// - Parameters:
     ///   - services: The list of service names for which this interceptor should intercept RPCs.
-    /// - Returns: A ``ServerInterceptorPipelineOperation``.
+    /// - Returns: A ``ClientInterceptorPipelineOperation``.
     public static func services(_ services: Set<ServiceDescriptor>) -> Self {
       Self(wrapped: .services(services))
     }
@@ -49,7 +49,7 @@ public struct ServerInterceptorPipelineOperation: Sendable {
     /// An operation subject specifying an interceptor that will be applied only to RPCs directed to the specified service methods.
     /// - Parameters:
     ///   - methods: The list of method descriptors for which this interceptor should intercept RPCs.
-    /// - Returns: A ``ServerInterceptorPipelineOperation``.
+    /// - Returns: A ``ClientInterceptorPipelineOperation``.
     public static func methods(_ methods: Set<MethodDescriptor>) -> Self {
       Self(wrapped: .methods(methods))
     }
@@ -70,26 +70,26 @@ public struct ServerInterceptorPipelineOperation: Sendable {
   }
 
   /// The interceptor specified for this operation.
-  public let interceptor: any ServerInterceptor
+  public let interceptor: any ClientInterceptor
 
   @usableFromInline
   internal let subject: Subject
 
-  private init(interceptor: any ServerInterceptor, appliesTo: Subject) {
+  private init(interceptor: any ClientInterceptor, appliesTo: Subject) {
     self.interceptor = interceptor
     self.subject = appliesTo
   }
 
-  /// Create an operation, specifying which ``ServerInterceptor`` to apply and to which ``Subject``.
+  /// Create an operation, specifying which ``ClientInterceptor`` to apply and to which ``Subject``.
   /// - Parameters:
-  ///   - interceptor: The ``ServerInterceptor`` to register with the server.
+  ///   - interceptor: The ``ClientInterceptor`` to register with the client.
   ///   - subject: The ``Subject`` to which the `interceptor` applies.
-  /// - Returns: A ``ServerInterceptorPipelineOperation``.
-  public static func apply(_ interceptor: any ServerInterceptor, to subject: Subject) -> Self {
+  /// - Returns: A ``ClientInterceptorPipelineOperation``.
+  public static func apply(_ interceptor: any ClientInterceptor, to subject: Subject) -> Self {
     Self(interceptor: interceptor, appliesTo: subject)
   }
 
-  /// Returns whether this ``ServerInterceptorPipelineOperation`` applies to the given `descriptor`.
+  /// Returns whether this ``ClientInterceptorPipelineOperation`` applies to the given `descriptor`.
   /// - Parameter descriptor: A ``MethodDescriptor`` for which to test whether this interceptor applies.
   /// - Returns: `true` if this interceptor applies to the given `descriptor`, or `false` otherwise.
   @inlinable

--- a/Sources/GRPCCore/Call/Server/Internal/ServerRPCExecutor.swift
+++ b/Sources/GRPCCore/Call/Server/Internal/ServerRPCExecutor.swift
@@ -23,7 +23,8 @@ struct ServerRPCExecutor {
   ///   - stream: The accepted stream to execute the RPC on.
   ///   - deserializer: A deserializer for messages received from the client.
   ///   - serializer: A serializer for messages to send to the client.
-  ///   - interceptors: Server interceptors to apply to this RPC.
+  ///   - interceptors: Server interceptors to apply to this RPC.  The
+  ///       interceptors will be called in the order of the array.
   ///   - handler: A handler which turns the request into a response.
   @inlinable
   static func execute<Input, Output>(

--- a/Sources/GRPCCore/GRPCClient.swift
+++ b/Sources/GRPCCore/GRPCClient.swift
@@ -117,7 +117,7 @@ public final class GRPCClient: Sendable {
 
   /// The state of the client.
   private enum State: Sendable {
-    
+
     /// The client hasn't been started yet. Can transition to `running` or `stopped`.
     case notStarted
     /// The client is running and can send RPCs. Can transition to `stopping`.

--- a/Tests/GRPCCoreTests/Call/Client/ClientInterceptorPipelineOperationTests.swift
+++ b/Tests/GRPCCoreTests/Call/Client/ClientInterceptorPipelineOperationTests.swift
@@ -20,23 +20,26 @@ import Testing
 
 @Suite("ClientInterceptorPipelineOperation")
 struct ClientInterceptorPipelineOperationTests {
-  @Test("Applies to", arguments: [
-    (
-      .all,
-      [.fooBar, .fooBaz, .barFoo, .barBaz],
-      []
-    ),
-    (
-      .services([ServiceDescriptor(package: "pkg", service: "foo")]),
-      [.fooBar, .fooBaz],
-      [.barFoo, .barBaz]
-    ),
-    (
-      .methods([.barFoo]),
-      [.barFoo],
-      [.fooBar, .fooBaz, .barBaz]
-    )
-  ] as [(ClientInterceptorPipelineOperation.Subject, [MethodDescriptor], [MethodDescriptor])])
+  @Test(
+    "Applies to",
+    arguments: [
+      (
+        .all,
+        [.fooBar, .fooBaz, .barFoo, .barBaz],
+        []
+      ),
+      (
+        .services([ServiceDescriptor(package: "pkg", service: "foo")]),
+        [.fooBar, .fooBaz],
+        [.barFoo, .barBaz]
+      ),
+      (
+        .methods([.barFoo]),
+        [.barFoo],
+        [.fooBar, .fooBaz, .barBaz]
+      ),
+    ] as [(ClientInterceptorPipelineOperation.Subject, [MethodDescriptor], [MethodDescriptor])]
+  )
   func appliesTo(
     operationSubject: ClientInterceptorPipelineOperation.Subject,
     applicableMethods: [MethodDescriptor],

--- a/Tests/GRPCCoreTests/Call/Client/ClientInterceptorPipelineOperationTests.swift
+++ b/Tests/GRPCCoreTests/Call/Client/ClientInterceptorPipelineOperationTests.swift
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Testing
+
+@testable import GRPCCore
+
+@Suite("ClientInterceptorPipelineOperation")
+struct ClientInterceptorPipelineOperationTests {
+  @Suite("Applies to")
+  struct AppliesToTests {
+    @Test
+    func all() async throws {
+      let operation = ClientInterceptorPipelineOperation.apply(
+        .requestCounter(.init()),
+        to: .all
+      )
+
+      #expect(operation.applies(to: MethodDescriptor(service: "foo", method: "bar")))
+      #expect(operation.applies(to: MethodDescriptor(service: "foo", method: "baz")))
+      #expect(operation.applies(to: MethodDescriptor(service: "bar", method: "foo")))
+      #expect(operation.applies(to: MethodDescriptor(service: "bar", method: "baz")))
+    }
+
+    @Test
+    func serviceSpecific() async throws {
+      let operation = ClientInterceptorPipelineOperation.apply(
+        .requestCounter(.init()),
+        to: .services(Set([ServiceDescriptor(package: "pkg", service: "foo")]))
+      )
+
+      #expect(operation.applies(to: MethodDescriptor(service: "pkg.foo", method: "bar")))
+      #expect(operation.applies(to: MethodDescriptor(service: "pkg.foo", method: "baz")))
+
+      #expect(!operation.applies(to: MethodDescriptor(service: "pkg.bar", method: "foo")))
+      #expect(!operation.applies(to: MethodDescriptor(service: "pkg.bar", method: "baz")))
+    }
+
+    @Test
+    func methodSpecific() async throws {
+      let operation = ClientInterceptorPipelineOperation.apply(
+        .requestCounter(.init()),
+        to: .methods(Set([MethodDescriptor(service: "bar", method: "foo")]))
+      )
+
+      #expect(operation.applies(to: MethodDescriptor(service: "bar", method: "foo")))
+      
+      #expect(!operation.applies(to: MethodDescriptor(service: "foo", method: "bar")))
+      #expect(!operation.applies(to: MethodDescriptor(service: "foo", method: "baz")))
+      #expect(!operation.applies(to: MethodDescriptor(service: "bar", method: "baz")))
+    }
+  }
+}

--- a/Tests/GRPCCoreTests/Call/Server/ServerInterceptorPipelineOperation.swift
+++ b/Tests/GRPCCoreTests/Call/Server/ServerInterceptorPipelineOperation.swift
@@ -20,23 +20,26 @@ import Testing
 
 @Suite("ServerInterceptorPipelineOperation")
 struct ServerInterceptorPipelineOperationTests {
-  @Test("Applies to", arguments: [
-    (
-      .all,
-      [.fooBar, .fooBaz, .barFoo, .barBaz],
-      []
-    ),
-    (
-      .services([ServiceDescriptor(package: "pkg", service: "foo")]),
-      [.fooBar, .fooBaz],
-      [.barFoo, .barBaz]
-    ),
-    (
-      .methods([.barFoo]),
-      [.barFoo],
-      [.fooBar, .fooBaz, .barBaz]
-    )
-  ] as [(ServerInterceptorPipelineOperation.Subject, [MethodDescriptor], [MethodDescriptor])])
+  @Test(
+    "Applies to",
+    arguments: [
+      (
+        .all,
+        [.fooBar, .fooBaz, .barFoo, .barBaz],
+        []
+      ),
+      (
+        .services([ServiceDescriptor(package: "pkg", service: "foo")]),
+        [.fooBar, .fooBaz],
+        [.barFoo, .barBaz]
+      ),
+      (
+        .methods([.barFoo]),
+        [.barFoo],
+        [.fooBar, .fooBaz, .barBaz]
+      ),
+    ] as [(ServerInterceptorPipelineOperation.Subject, [MethodDescriptor], [MethodDescriptor])]
+  )
   func appliesTo(
     operationSubject: ServerInterceptorPipelineOperation.Subject,
     applicableMethods: [MethodDescriptor],

--- a/Tests/GRPCCoreTests/Call/Server/ServerInterceptorPipelineOperation.swift
+++ b/Tests/GRPCCoreTests/Call/Server/ServerInterceptorPipelineOperation.swift
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Testing
+
+@testable import GRPCCore
+
+@Suite("ServerInterceptorPipelineOperation")
+struct ServerInterceptorPipelineOperationTests {
+  @Suite("Applies to")
+  struct AppliesToTests {
+    @Test
+    func all() async throws {
+      let operation = ServerInterceptorPipelineOperation.apply(
+        .requestCounter(.init()),
+        to: .all
+      )
+
+      #expect(operation.applies(to: MethodDescriptor(service: "foo", method: "bar")))
+      #expect(operation.applies(to: MethodDescriptor(service: "foo", method: "baz")))
+      #expect(operation.applies(to: MethodDescriptor(service: "bar", method: "foo")))
+      #expect(operation.applies(to: MethodDescriptor(service: "bar", method: "baz")))
+    }
+
+    @Test
+    func serviceSpecific() async throws {
+      let operation = ServerInterceptorPipelineOperation.apply(
+        .requestCounter(.init()),
+        to: .services(Set([ServiceDescriptor(package: "pkg", service: "foo")]))
+      )
+
+      #expect(operation.applies(to: MethodDescriptor(service: "pkg.foo", method: "bar")))
+      #expect(operation.applies(to: MethodDescriptor(service: "pkg.foo", method: "baz")))
+
+      #expect(!operation.applies(to: MethodDescriptor(service: "pkg.bar", method: "foo")))
+      #expect(!operation.applies(to: MethodDescriptor(service: "pkg.bar", method: "baz")))
+    }
+
+    @Test
+    func methodSpecific() async throws {
+      let operation = ServerInterceptorPipelineOperation.apply(
+        .requestCounter(.init()),
+        to: .methods(Set([MethodDescriptor(service: "bar", method: "foo")]))
+      )
+
+      #expect(operation.applies(to: MethodDescriptor(service: "bar", method: "foo")))
+      
+      #expect(!operation.applies(to: MethodDescriptor(service: "foo", method: "bar")))
+      #expect(!operation.applies(to: MethodDescriptor(service: "foo", method: "baz")))
+      #expect(!operation.applies(to: MethodDescriptor(service: "bar", method: "baz")))
+    }
+  }
+}

--- a/Tests/GRPCCoreTests/Call/Server/ServerInterceptorPipelineOperation.swift
+++ b/Tests/GRPCCoreTests/Call/Server/ServerInterceptorPipelineOperation.swift
@@ -20,47 +20,46 @@ import Testing
 
 @Suite("ServerInterceptorPipelineOperation")
 struct ServerInterceptorPipelineOperationTests {
-  @Suite("Applies to")
-  struct AppliesToTests {
-    @Test
-    func all() async throws {
-      let operation = ServerInterceptorPipelineOperation.apply(
-        .requestCounter(.init()),
-        to: .all
-      )
+  @Test("Applies to", arguments: [
+    (
+      .all,
+      [.fooBar, .fooBaz, .barFoo, .barBaz],
+      []
+    ),
+    (
+      .services([ServiceDescriptor(package: "pkg", service: "foo")]),
+      [.fooBar, .fooBaz],
+      [.barFoo, .barBaz]
+    ),
+    (
+      .methods([.barFoo]),
+      [.barFoo],
+      [.fooBar, .fooBaz, .barBaz]
+    )
+  ] as [(ServerInterceptorPipelineOperation.Subject, [MethodDescriptor], [MethodDescriptor])])
+  func appliesTo(
+    operationSubject: ServerInterceptorPipelineOperation.Subject,
+    applicableMethods: [MethodDescriptor],
+    notApplicableMethods: [MethodDescriptor]
+  ) {
+    let operation = ServerInterceptorPipelineOperation.apply(
+      .requestCounter(.init()),
+      to: operationSubject
+    )
 
-      #expect(operation.applies(to: MethodDescriptor(service: "foo", method: "bar")))
-      #expect(operation.applies(to: MethodDescriptor(service: "foo", method: "baz")))
-      #expect(operation.applies(to: MethodDescriptor(service: "bar", method: "foo")))
-      #expect(operation.applies(to: MethodDescriptor(service: "bar", method: "baz")))
+    for applicableMethod in applicableMethods {
+      #expect(operation.applies(to: applicableMethod))
     }
 
-    @Test
-    func serviceSpecific() async throws {
-      let operation = ServerInterceptorPipelineOperation.apply(
-        .requestCounter(.init()),
-        to: .services(Set([ServiceDescriptor(package: "pkg", service: "foo")]))
-      )
-
-      #expect(operation.applies(to: MethodDescriptor(service: "pkg.foo", method: "bar")))
-      #expect(operation.applies(to: MethodDescriptor(service: "pkg.foo", method: "baz")))
-
-      #expect(!operation.applies(to: MethodDescriptor(service: "pkg.bar", method: "foo")))
-      #expect(!operation.applies(to: MethodDescriptor(service: "pkg.bar", method: "baz")))
-    }
-
-    @Test
-    func methodSpecific() async throws {
-      let operation = ServerInterceptorPipelineOperation.apply(
-        .requestCounter(.init()),
-        to: .methods(Set([MethodDescriptor(service: "bar", method: "foo")]))
-      )
-
-      #expect(operation.applies(to: MethodDescriptor(service: "bar", method: "foo")))
-      
-      #expect(!operation.applies(to: MethodDescriptor(service: "foo", method: "bar")))
-      #expect(!operation.applies(to: MethodDescriptor(service: "foo", method: "baz")))
-      #expect(!operation.applies(to: MethodDescriptor(service: "bar", method: "baz")))
+    for notApplicableMethod in notApplicableMethods {
+      #expect(!operation.applies(to: notApplicableMethod))
     }
   }
+}
+
+extension MethodDescriptor {
+  fileprivate static let fooBar = Self(service: "pkg.foo", method: "bar")
+  fileprivate static let fooBaz = Self(service: "pkg.foo", method: "baz")
+  fileprivate static let barFoo = Self(service: "pkg.bar", method: "foo")
+  fileprivate static let barBaz = Self(service: "pkg.bar", method: "Baz")
 }


### PR DESCRIPTION
## Motivation
We want to allow users to customise the RPCs a registered interceptor should apply to on the client:
- Intercept all requests
- Intercept requests only meant for specific services
- Intercept requests only meant for specific methods

## Modifications
This PR adds a new `ClientInterceptorPipelineOperation` type that allows users to specify what the target of the interceptor should be.
Existing APIs accepting `[any ClientInterceptor]` have been kept, but new initialisers taking `[ClientInterceptorPipelineOperation]` instead have been added.

## Result
Users can have more control over to which requests interceptors are applied.