### PR TITLE
Don't render just spaces in a line

### DIFF
--- a/Sources/GRPCCodeGen/Internal/Renderer/TextBasedRenderer.swift
+++ b/Sources/GRPCCodeGen/Internal/Renderer/TextBasedRenderer.swift
@@ -70,6 +70,9 @@ final class StringCodeWriter {
     if nextWriteAppendsToLastLine && !lines.isEmpty {
       let existingLine = lines.removeLast()
       newLine = existingLine + line
+    } else if line.isEmpty {
+      // Skip indentation to avoid trailing whitespace on blank lines.
+      newLine = line
     } else {
       let indentation = Array(repeating: " ", count: self.indentation * level).joined()
       newLine = indentation + line

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
@@ -98,11 +98,11 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public struct NamespaceA_ServiceA_Client: NamespaceA_ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
-          
+
           public init(wrapping client: GRPCCore.GRPCClient) {
               self.client = client
           }
-          
+
           /// Documentation for MethodA
           public func methodA<R>(
               request: GRPCCore.ClientRequest<NamespaceA_ServiceARequest>,
@@ -205,11 +205,11 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public struct NamespaceA_ServiceA_Client: NamespaceA_ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
-          
+
           public init(wrapping client: GRPCCore.GRPCClient) {
               self.client = client
           }
-          
+
           /// Documentation for MethodA
           public func methodA<R>(
               request: GRPCCore.StreamingClientRequest<NamespaceA_ServiceARequest>,
@@ -308,11 +308,11 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public struct NamespaceA_ServiceA_Client: NamespaceA_ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
-          
+
           public init(wrapping client: GRPCCore.GRPCClient) {
               self.client = client
           }
-          
+
           /// Documentation for MethodA
           public func methodA<R>(
               request: GRPCCore.ClientRequest<NamespaceA_ServiceARequest>,
@@ -409,11 +409,11 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public struct NamespaceA_ServiceA_Client: NamespaceA_ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
-          
+
           public init(wrapping client: GRPCCore.GRPCClient) {
               self.client = client
           }
-          
+
           /// Documentation for MethodA
           public func methodA<R>(
               request: GRPCCore.StreamingClientRequest<NamespaceA_ServiceARequest>,
@@ -477,7 +477,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
               options: GRPCCore.CallOptions,
               _ body: @Sendable @escaping (GRPCCore.ClientResponse<NamespaceA_ServiceAResponse>) async throws -> R
           ) async throws -> R where R: Sendable
-          
+
           /// Documentation for MethodB
           func methodB<R>(
               request: GRPCCore.ClientRequest<NamespaceA_ServiceARequest>,
@@ -504,7 +504,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
                   body
               )
           }
-          
+
           package func methodB<R>(
               request: GRPCCore.ClientRequest<NamespaceA_ServiceARequest>,
               options: GRPCCore.CallOptions = .defaults,
@@ -540,7 +540,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
                   handleResponse
               )
           }
-          
+
           /// Documentation for MethodB
           package func methodB<Result>(
               _ message: NamespaceA_ServiceARequest,
@@ -563,11 +563,11 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       package struct NamespaceA_ServiceA_Client: NamespaceA_ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
-          
+
           package init(wrapping client: GRPCCore.GRPCClient) {
               self.client = client
           }
-          
+
           /// Documentation for MethodA
           package func methodA<R>(
               request: GRPCCore.StreamingClientRequest<NamespaceA_ServiceARequest>,
@@ -587,7 +587,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
                   handler: body
               )
           }
-          
+
           /// Documentation for MethodB
           package func methodB<R>(
               request: GRPCCore.ClientRequest<NamespaceA_ServiceARequest>,
@@ -688,11 +688,11 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       internal struct ServiceA_Client: ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
-          
+
           internal init(wrapping client: GRPCCore.GRPCClient) {
               self.client = client
           }
-          
+
           /// Documentation for MethodA
           internal func methodA<R>(
               request: GRPCCore.ClientRequest<ServiceARequest>,
@@ -758,7 +758,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public struct NamespaceA_ServiceA_Client: NamespaceA_ServiceA.ClientProtocol {
           private let client: GRPCCore.GRPCClient
-          
+
           public init(wrapping client: GRPCCore.GRPCClient) {
               self.client = client
           }
@@ -780,7 +780,7 @@ final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
       @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
       public struct ServiceB_Client: ServiceB.ClientProtocol {
           private let client: GRPCCore.GRPCClient
-          
+
           public init(wrapping client: GRPCCore.GRPCClient) {
               self.client = client
           }

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
@@ -408,7 +408,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
               request: GRPCCore.StreamingServerRequest<NamespaceA_ServiceARequest>,
               context: GRPCCore.ServerContext
           ) async throws -> GRPCCore.StreamingServerResponse<NamespaceA_ServiceAResponse>
-          
+
           /// Documentation for outputStreamingMethod
           func outputStreaming(
               request: GRPCCore.StreamingServerRequest<NamespaceA_ServiceARequest>,
@@ -452,7 +452,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
               request: GRPCCore.StreamingServerRequest<NamespaceA_ServiceARequest>,
               context: GRPCCore.ServerContext
           ) async throws -> GRPCCore.ServerResponse<NamespaceA_ServiceAResponse>
-          
+
           /// Documentation for outputStreamingMethod
           func outputStreaming(
               request: GRPCCore.ServerRequest<NamespaceA_ServiceARequest>,
@@ -472,7 +472,7 @@ final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
               )
               return GRPCCore.StreamingServerResponse(single: response)
           }
-          
+
           internal func outputStreaming(
               request: GRPCCore.StreamingServerRequest<NamespaceA_ServiceARequest>,
               context: GRPCCore.ServerContext


### PR DESCRIPTION
Motivation:

If a blank line is render, the text based renderer will include the current indentation level resulting in lines with just spaces.

Modifications:

- Don't include indentation if the line to render is otherwise empty

Result:

Less trailing whitespace.