### PR TITLE
Simplify naming of code gen types

### DIFF
--- a/Sources/GRPCCodeGen/CodeGenerationRequest.swift
+++ b/Sources/GRPCCodeGen/CodeGenerationRequest.swift
@@ -79,123 +79,68 @@ public struct CodeGenerationRequest {
     self.lookupSerializer = lookupSerializer
     self.lookupDeserializer = lookupDeserializer
   }
+}
 
-  /// Represents an import: a module or a specific item from a module.
-  public struct Dependency: Equatable {
-    /// If the dependency is an item, the property's value is the item representation.
-    /// If the dependency is a module, this property is nil.
-    public var item: Item?
+/// Represents an import: a module or a specific item from a module.
+public struct Dependency: Equatable {
+  /// If the dependency is an item, the property's value is the item representation.
+  /// If the dependency is a module, this property is nil.
+  public var item: Item?
 
-    /// The access level to be included in imports of this dependency.
-    public var accessLevel: SourceGenerator.Config.AccessLevel
+  /// The access level to be included in imports of this dependency.
+  public var accessLevel: SourceGenerator.Config.AccessLevel
 
-    /// The name of the imported module or of the module an item is imported from.
-    public var module: String
+  /// The name of the imported module or of the module an item is imported from.
+  public var module: String
 
-    /// The name of the private interface for an `@_spi` import.
-    ///
-    /// For example, if `spi` was "Secret" and the module name was "Foo" then the import
-    /// would be `@_spi(Secret) import Foo`.
-    public var spi: String?
+  /// The name of the private interface for an `@_spi` import.
+  ///
+  /// For example, if `spi` was "Secret" and the module name was "Foo" then the import
+  /// would be `@_spi(Secret) import Foo`.
+  public var spi: String?
 
-    /// Requirements for the `@preconcurrency` attribute.
-    public var preconcurrency: PreconcurrencyRequirement
+  /// Requirements for the `@preconcurrency` attribute.
+  public var preconcurrency: PreconcurrencyRequirement
 
-    public init(
-      item: Item? = nil,
-      module: String,
-      spi: String? = nil,
-      preconcurrency: PreconcurrencyRequirement = .notRequired,
-      accessLevel: SourceGenerator.Config.AccessLevel
-    ) {
-      self.item = item
-      self.module = module
-      self.spi = spi
-      self.preconcurrency = preconcurrency
-      self.accessLevel = accessLevel
+  public init(
+    item: Item? = nil,
+    module: String,
+    spi: String? = nil,
+    preconcurrency: PreconcurrencyRequirement = .notRequired,
+    accessLevel: SourceGenerator.Config.AccessLevel
+  ) {
+    self.item = item
+    self.module = module
+    self.spi = spi
+    self.preconcurrency = preconcurrency
+    self.accessLevel = accessLevel
+  }
+
+  /// Represents an item imported from a module.
+  public struct Item: Equatable {
+    /// The keyword that specifies the item's kind (e.g. `func`, `struct`).
+    public var kind: Kind
+
+    /// The name of the imported item.
+    public var name: String
+
+    public init(kind: Kind, name: String) {
+      self.kind = kind
+      self.name = name
     }
 
-    /// Represents an item imported from a module.
-    public struct Item: Equatable {
-      /// The keyword that specifies the item's kind (e.g. `func`, `struct`).
-      public var kind: Kind
-
-      /// The name of the imported item.
-      public var name: String
-
-      public init(kind: Kind, name: String) {
-        self.kind = kind
-        self.name = name
-      }
-
-      /// Represents the imported item's kind.
-      public struct Kind: Equatable {
-        /// Describes the keyword associated with the imported item.
-        internal enum Value: String {
-          case `typealias`
-          case `struct`
-          case `class`
-          case `enum`
-          case `protocol`
-          case `let`
-          case `var`
-          case `func`
-        }
-
-        internal var value: Value
-
-        internal init(_ value: Value) {
-          self.value = value
-        }
-
-        /// The imported item is a typealias.
-        public static var `typealias`: Self {
-          Self(.`typealias`)
-        }
-
-        /// The imported item is a struct.
-        public static var `struct`: Self {
-          Self(.`struct`)
-        }
-
-        /// The imported item is a class.
-        public static var `class`: Self {
-          Self(.`class`)
-        }
-
-        /// The imported item is an enum.
-        public static var `enum`: Self {
-          Self(.`enum`)
-        }
-
-        /// The imported item is a protocol.
-        public static var `protocol`: Self {
-          Self(.`protocol`)
-        }
-
-        /// The imported item is a let.
-        public static var `let`: Self {
-          Self(.`let`)
-        }
-
-        /// The imported item is a var.
-        public static var `var`: Self {
-          Self(.`var`)
-        }
-
-        /// The imported item is a function.
-        public static var `func`: Self {
-          Self(.`func`)
-        }
-      }
-    }
-
-    /// Describes any requirement for the `@preconcurrency` attribute.
-    public struct PreconcurrencyRequirement: Equatable {
-      internal enum Value: Equatable {
-        case required
-        case notRequired
-        case requiredOnOS([String])
+    /// Represents the imported item's kind.
+    public struct Kind: Equatable {
+      /// Describes the keyword associated with the imported item.
+      internal enum Value: String {
+        case `typealias`
+        case `struct`
+        case `class`
+        case `enum`
+        case `protocol`
+        case `let`
+        case `var`
+        case `func`
       }
 
       internal var value: Value
@@ -204,130 +149,185 @@ public struct CodeGenerationRequest {
         self.value = value
       }
 
-      /// The attribute is always required.
-      public static var required: Self {
-        Self(.required)
+      /// The imported item is a typealias.
+      public static var `typealias`: Self {
+        Self(.`typealias`)
       }
 
-      /// The attribute is not required.
-      public static var notRequired: Self {
-        Self(.notRequired)
+      /// The imported item is a struct.
+      public static var `struct`: Self {
+        Self(.`struct`)
       }
 
-      /// The attribute is required only on the named operating systems.
-      public static func requiredOnOS(_ OSs: [String]) -> PreconcurrencyRequirement {
-        return Self(.requiredOnOS(OSs))
+      /// The imported item is a class.
+      public static var `class`: Self {
+        Self(.`class`)
       }
-    }
-  }
 
-  /// Represents a service described in an IDL file.
-  public struct ServiceDescriptor: Hashable {
-    /// Documentation from comments above the IDL service description.
-    /// It is already formatted, meaning it contains  "///" and new lines.
-    public var documentation: String
+      /// The imported item is an enum.
+      public static var `enum`: Self {
+        Self(.`enum`)
+      }
 
-    /// The service name in different formats.
-    ///
-    /// All properties of this object must be unique for each service from within a namespace.
-    public var name: Name
+      /// The imported item is a protocol.
+      public static var `protocol`: Self {
+        Self(.`protocol`)
+      }
 
-    /// The service namespace in different formats.
-    ///
-    /// All different services from within the same namespace must have
-    /// the same ``Name`` object as this property.
-    /// For `.proto` files the base name of this object is the package name.
-    public var namespace: Name
+      /// The imported item is a let.
+      public static var `let`: Self {
+        Self(.`let`)
+      }
 
-    /// A description of each method of a service.
-    ///
-    /// - SeeAlso: ``MethodDescriptor``.
-    public var methods: [MethodDescriptor]
+      /// The imported item is a var.
+      public static var `var`: Self {
+        Self(.`var`)
+      }
 
-    public init(
-      documentation: String,
-      name: Name,
-      namespace: Name,
-      methods: [MethodDescriptor]
-    ) {
-      self.documentation = documentation
-      self.name = name
-      self.namespace = namespace
-      self.methods = methods
-    }
-
-    /// Represents a method described in an IDL file.
-    public struct MethodDescriptor: Hashable {
-      /// Documentation from comments above the IDL method description.
-      /// It is already formatted, meaning it contains  "///" and new lines.
-      public var documentation: String
-
-      /// Method name in different formats.
-      ///
-      /// All properties of this object must be unique for each method
-      /// from within a service.
-      public var name: Name
-
-      /// Identifies if the method is input streaming.
-      public var isInputStreaming: Bool
-
-      /// Identifies if the method is output streaming.
-      public var isOutputStreaming: Bool
-
-      /// The generated input type for the described method.
-      public var inputType: String
-
-      /// The generated output type for the described method.
-      public var outputType: String
-
-      public init(
-        documentation: String,
-        name: Name,
-        isInputStreaming: Bool,
-        isOutputStreaming: Bool,
-        inputType: String,
-        outputType: String
-      ) {
-        self.documentation = documentation
-        self.name = name
-        self.isInputStreaming = isInputStreaming
-        self.isOutputStreaming = isOutputStreaming
-        self.inputType = inputType
-        self.outputType = outputType
+      /// The imported item is a function.
+      public static var `func`: Self {
+        Self(.`func`)
       }
     }
   }
 
-  /// Represents the name associated with a namespace, service or a method, in three different formats.
-  public struct Name: Hashable {
-    /// The base name is the name used for the namespace/service/method in the IDL file, so it should follow
-    /// the specific casing of the IDL.
-    ///
-    /// The base name is also used in the descriptors that identify a specific method or service :
-    /// `<service_namespace_baseName>.<service_baseName>.<method_baseName>`.
-    public var base: String
+  /// Describes any requirement for the `@preconcurrency` attribute.
+  public struct PreconcurrencyRequirement: Equatable {
+    internal enum Value: Equatable {
+      case required
+      case notRequired
+      case requiredOnOS([String])
+    }
 
-    /// The `generatedUpperCase` name is used in the generated code. It is expected
-    /// to be the UpperCamelCase version of the base name
-    ///
-    /// For example, if `base` is "fooBar", then `generatedUpperCase` is "FooBar".
-    public var generatedUpperCase: String
+    internal var value: Value
 
-    /// The `generatedLowerCase` name is used in the generated code. It is expected
-    /// to be the lowerCamelCase version of the base name
-    ///
-    /// For example, if `base` is "FooBar", then `generatedLowerCase` is "fooBar".
-    public var generatedLowerCase: String
+    internal init(_ value: Value) {
+      self.value = value
+    }
 
-    public init(base: String, generatedUpperCase: String, generatedLowerCase: String) {
-      self.base = base
-      self.generatedUpperCase = generatedUpperCase
-      self.generatedLowerCase = generatedLowerCase
+    /// The attribute is always required.
+    public static var required: Self {
+      Self(.required)
+    }
+
+    /// The attribute is not required.
+    public static var notRequired: Self {
+      Self(.notRequired)
+    }
+
+    /// The attribute is required only on the named operating systems.
+    public static func requiredOnOS(_ OSs: [String]) -> PreconcurrencyRequirement {
+      return Self(.requiredOnOS(OSs))
     }
   }
 }
 
-extension CodeGenerationRequest.Name {
+/// Represents a service described in an IDL file.
+public struct ServiceDescriptor: Hashable {
+  /// Documentation from comments above the IDL service description.
+  /// It is already formatted, meaning it contains  "///" and new lines.
+  public var documentation: String
+
+  /// The service name in different formats.
+  ///
+  /// All properties of this object must be unique for each service from within a namespace.
+  public var name: Name
+
+  /// The service namespace in different formats.
+  ///
+  /// All different services from within the same namespace must have
+  /// the same ``Name`` object as this property.
+  /// For `.proto` files the base name of this object is the package name.
+  public var namespace: Name
+
+  /// A description of each method of a service.
+  ///
+  /// - SeeAlso: ``MethodDescriptor``.
+  public var methods: [MethodDescriptor]
+
+  public init(
+    documentation: String,
+    name: Name,
+    namespace: Name,
+    methods: [MethodDescriptor]
+  ) {
+    self.documentation = documentation
+    self.name = name
+    self.namespace = namespace
+    self.methods = methods
+  }
+}
+
+/// Represents a method described in an IDL file.
+public struct MethodDescriptor: Hashable {
+  /// Documentation from comments above the IDL method description.
+  /// It is already formatted, meaning it contains  "///" and new lines.
+  public var documentation: String
+
+  /// Method name in different formats.
+  ///
+  /// All properties of this object must be unique for each method
+  /// from within a service.
+  public var name: Name
+
+  /// Identifies if the method is input streaming.
+  public var isInputStreaming: Bool
+
+  /// Identifies if the method is output streaming.
+  public var isOutputStreaming: Bool
+
+  /// The generated input type for the described method.
+  public var inputType: String
+
+  /// The generated output type for the described method.
+  public var outputType: String
+
+  public init(
+    documentation: String,
+    name: Name,
+    isInputStreaming: Bool,
+    isOutputStreaming: Bool,
+    inputType: String,
+    outputType: String
+  ) {
+    self.documentation = documentation
+    self.name = name
+    self.isInputStreaming = isInputStreaming
+    self.isOutputStreaming = isOutputStreaming
+    self.inputType = inputType
+    self.outputType = outputType
+  }
+}
+
+/// Represents the name associated with a namespace, service or a method, in three different formats.
+public struct Name: Hashable {
+  /// The base name is the name used for the namespace/service/method in the IDL file, so it should follow
+  /// the specific casing of the IDL.
+  ///
+  /// The base name is also used in the descriptors that identify a specific method or service :
+  /// `<service_namespace_baseName>.<service_baseName>.<method_baseName>`.
+  public var base: String
+
+  /// The `generatedUpperCase` name is used in the generated code. It is expected
+  /// to be the UpperCamelCase version of the base name
+  ///
+  /// For example, if `base` is "fooBar", then `generatedUpperCase` is "FooBar".
+  public var generatedUpperCase: String
+
+  /// The `generatedLowerCase` name is used in the generated code. It is expected
+  /// to be the lowerCamelCase version of the base name
+  ///
+  /// For example, if `base` is "FooBar", then `generatedLowerCase` is "fooBar".
+  public var generatedLowerCase: String
+
+  public init(base: String, generatedUpperCase: String, generatedLowerCase: String) {
+    self.base = base
+    self.generatedUpperCase = generatedUpperCase
+    self.generatedLowerCase = generatedLowerCase
+  }
+}
+
+extension Name {
   /// The base name replacing occurrences of "." with "_".
   ///
   /// For example, if `base` is "Foo.Bar", then `normalizedBase` is "Foo_Bar".

--- a/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
@@ -105,7 +105,7 @@ struct ClientCodeTranslator: SpecializedTranslator {
 
 extension ClientCodeTranslator {
   private func makeClientProtocol(
-    for service: CodeGenerationRequest.ServiceDescriptor,
+    for service: ServiceDescriptor,
     in codeGenerationRequest: CodeGenerationRequest
   ) -> Declaration {
     let methods = service.methods.map {
@@ -130,7 +130,7 @@ extension ClientCodeTranslator {
   }
 
   private func makeDefaultImplementation(
-    for service: CodeGenerationRequest.ServiceDescriptor,
+    for service: ServiceDescriptor,
     in codeGenerationRequest: CodeGenerationRequest
   ) -> Declaration {
     let methods = service.methods.map {
@@ -156,7 +156,7 @@ extension ClientCodeTranslator {
   }
 
   private func makeSugaredAPI(
-    forService service: CodeGenerationRequest.ServiceDescriptor,
+    forService service: ServiceDescriptor,
     request: CodeGenerationRequest
   ) -> Declaration {
     let sugaredAPIExtension = Declaration.extension(
@@ -175,7 +175,7 @@ extension ClientCodeTranslator {
   }
 
   private func makeSugaredMethodDeclaration(
-    method: CodeGenerationRequest.ServiceDescriptor.MethodDescriptor,
+    method: MethodDescriptor,
     accessModifier: AccessModifier?
   ) -> Declaration {
     let signature = FunctionSignatureDescription(
@@ -205,7 +205,7 @@ extension ClientCodeTranslator {
   }
 
   private func makeParametersForSugaredMethodDeclaration(
-    method: CodeGenerationRequest.ServiceDescriptor.MethodDescriptor
+    method: MethodDescriptor
   ) -> [ParameterDescription] {
     var parameters = [ParameterDescription]()
 
@@ -295,7 +295,7 @@ extension ClientCodeTranslator {
   }
 
   private func makeFunctionBodyForSugaredMethodDeclaration(
-    method: CodeGenerationRequest.ServiceDescriptor.MethodDescriptor
+    method: MethodDescriptor
   ) -> [CodeBlock] {
     // Produces the following:
     //
@@ -375,8 +375,8 @@ extension ClientCodeTranslator {
   }
 
   private func makeClientProtocolMethod(
-    for method: CodeGenerationRequest.ServiceDescriptor.MethodDescriptor,
-    in service: CodeGenerationRequest.ServiceDescriptor,
+    for method: MethodDescriptor,
+    in service: ServiceDescriptor,
     from codeGenerationRequest: CodeGenerationRequest,
     includeBody: Bool,
     accessModifier: AccessModifier? = nil,
@@ -421,8 +421,8 @@ extension ClientCodeTranslator {
   }
 
   private func makeClientProtocolMethodCall(
-    for method: CodeGenerationRequest.ServiceDescriptor.MethodDescriptor,
-    in service: CodeGenerationRequest.ServiceDescriptor,
+    for method: MethodDescriptor,
+    in service: ServiceDescriptor,
     from codeGenerationRequest: CodeGenerationRequest
   ) -> [CodeBlock] {
     let functionCall = Expression.functionCall(
@@ -455,8 +455,8 @@ extension ClientCodeTranslator {
   }
 
   private func makeParameters(
-    for method: CodeGenerationRequest.ServiceDescriptor.MethodDescriptor,
-    in service: CodeGenerationRequest.ServiceDescriptor,
+    for method: MethodDescriptor,
+    in service: ServiceDescriptor,
     from codeGenerationRequest: CodeGenerationRequest,
     includeSerializationParameters: Bool,
     includeDefaultCallOptions: Bool,
@@ -487,8 +487,8 @@ extension ClientCodeTranslator {
     return parameters
   }
   private func clientRequestParameter(
-    for method: CodeGenerationRequest.ServiceDescriptor.MethodDescriptor,
-    in service: CodeGenerationRequest.ServiceDescriptor
+    for method: MethodDescriptor,
+    in service: ServiceDescriptor
   ) -> ParameterDescription {
     let requestType = method.isInputStreaming ? "Streaming" : ""
     let clientRequestType = ExistingTypeDescription.member([
@@ -505,8 +505,8 @@ extension ClientCodeTranslator {
   }
 
   private func serializerParameter(
-    for method: CodeGenerationRequest.ServiceDescriptor.MethodDescriptor,
-    in service: CodeGenerationRequest.ServiceDescriptor
+    for method: MethodDescriptor,
+    in service: ServiceDescriptor
   ) -> ParameterDescription {
     return ParameterDescription(
       label: "serializer",
@@ -520,8 +520,8 @@ extension ClientCodeTranslator {
   }
 
   private func deserializerParameter(
-    for method: CodeGenerationRequest.ServiceDescriptor.MethodDescriptor,
-    in service: CodeGenerationRequest.ServiceDescriptor
+    for method: MethodDescriptor,
+    in service: ServiceDescriptor
   ) -> ParameterDescription {
     return ParameterDescription(
       label: "deserializer",
@@ -535,8 +535,8 @@ extension ClientCodeTranslator {
   }
 
   private func bodyParameter(
-    for method: CodeGenerationRequest.ServiceDescriptor.MethodDescriptor,
-    in service: CodeGenerationRequest.ServiceDescriptor,
+    for method: MethodDescriptor,
+    in service: ServiceDescriptor,
     includeDefaultResponseHandler: Bool
   ) -> ParameterDescription {
     let clientStreaming = method.isOutputStreaming ? "Streaming" : ""
@@ -571,7 +571,7 @@ extension ClientCodeTranslator {
   }
 
   private func makeClientStruct(
-    for service: CodeGenerationRequest.ServiceDescriptor,
+    for service: ServiceDescriptor,
     in codeGenerationRequest: CodeGenerationRequest
   ) -> Declaration {
     let clientProperty = Declaration.variable(
@@ -637,8 +637,8 @@ extension ClientCodeTranslator {
   }
 
   private func makeClientMethod(
-    for method: CodeGenerationRequest.ServiceDescriptor.MethodDescriptor,
-    in service: CodeGenerationRequest.ServiceDescriptor,
+    for method: MethodDescriptor,
+    in service: ServiceDescriptor,
     from codeGenerationRequest: CodeGenerationRequest
   ) -> Declaration {
     let parameters = self.makeParameters(

--- a/Sources/GRPCCodeGen/Internal/Translator/IDLToStructuredSwiftTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/IDLToStructuredSwiftTranslator.swift
@@ -62,7 +62,7 @@ struct IDLToStructuredSwiftTranslator: Translator {
   }
 
   private func makeImports(
-    dependencies: [CodeGenerationRequest.Dependency],
+    dependencies: [Dependency],
     accessLevel: SourceGenerator.Config.AccessLevel,
     accessLevelOnImports: Bool
   ) throws -> [ImportDescription] {
@@ -98,7 +98,7 @@ extension AccessModifier {
 
 extension IDLToStructuredSwiftTranslator {
   private func translateImport(
-    dependency: CodeGenerationRequest.Dependency,
+    dependency: Dependency,
     accessLevelOnImports: Bool
   ) throws -> ImportDescription {
     var importDescription = ImportDescription(
@@ -146,7 +146,7 @@ extension IDLToStructuredSwiftTranslator {
 
   // Verify service enum names are unique.
   private func checkServiceEnumNamesAreUnique(
-    for servicesByGeneratedEnumName: [String: [CodeGenerationRequest.ServiceDescriptor]]
+    for servicesByGeneratedEnumName: [String: [ServiceDescriptor]]
   ) throws {
     for (generatedEnumName, services) in servicesByGeneratedEnumName {
       if services.count > 1 {
@@ -163,7 +163,7 @@ extension IDLToStructuredSwiftTranslator {
 
   // Verify method names are unique within a service.
   private func checkMethodNamesAreUnique(
-    in service: CodeGenerationRequest.ServiceDescriptor
+    in service: ServiceDescriptor
   ) throws {
     // Check that the method descriptors are unique, by checking that the base names
     // of the methods of a specific service are unique.
@@ -206,7 +206,7 @@ extension IDLToStructuredSwiftTranslator {
   }
 
   private func checkServiceDescriptorsAreUnique(
-    _ services: [CodeGenerationRequest.ServiceDescriptor]
+    _ services: [ServiceDescriptor]
   ) throws {
     var descriptors: Set<String> = []
     for service in services {
@@ -227,7 +227,7 @@ extension IDLToStructuredSwiftTranslator {
   }
 }
 
-extension CodeGenerationRequest.ServiceDescriptor {
+extension ServiceDescriptor {
   var namespacedGeneratedName: String {
     if self.namespace.generatedUpperCase.isEmpty {
       return self.name.generatedUpperCase

--- a/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
@@ -107,7 +107,7 @@ struct ServerCodeTranslator: SpecializedTranslator {
 
 extension ServerCodeTranslator {
   private func makeStreamingProtocol(
-    for service: CodeGenerationRequest.ServiceDescriptor
+    for service: ServiceDescriptor
   ) -> Declaration {
     let methods = service.methods.compactMap {
       Declaration.commentable(
@@ -136,8 +136,8 @@ extension ServerCodeTranslator {
   }
 
   private func makeStreamingMethodSignature(
-    for method: CodeGenerationRequest.ServiceDescriptor.MethodDescriptor,
-    in service: CodeGenerationRequest.ServiceDescriptor,
+    for method: MethodDescriptor,
+    in service: ServiceDescriptor,
     accessModifier: AccessModifier? = nil
   ) -> FunctionSignatureDescription {
     return FunctionSignatureDescription(
@@ -164,7 +164,7 @@ extension ServerCodeTranslator {
   }
 
   private func makeConformanceToRPCServiceExtension(
-    for service: CodeGenerationRequest.ServiceDescriptor,
+    for service: ServiceDescriptor,
     in codeGenerationRequest: CodeGenerationRequest
   ) -> Declaration {
     let streamingProtocol = self.protocolNameTypealias(service: service, streaming: true)
@@ -179,7 +179,7 @@ extension ServerCodeTranslator {
   }
 
   private func makeRegisterRPCsMethod(
-    for service: CodeGenerationRequest.ServiceDescriptor,
+    for service: ServiceDescriptor,
     in codeGenerationRequest: CodeGenerationRequest
   ) -> Declaration {
     let registerRPCsSignature = FunctionSignatureDescription(
@@ -202,7 +202,7 @@ extension ServerCodeTranslator {
   }
 
   private func makeRegisterRPCsMethodBody(
-    for service: CodeGenerationRequest.ServiceDescriptor,
+    for service: ServiceDescriptor,
     in codeGenerationRequest: CodeGenerationRequest
   ) -> [CodeBlock] {
     let registerHandlerCalls = service.methods.compactMap {
@@ -224,8 +224,8 @@ extension ServerCodeTranslator {
   }
 
   private func makeArgumentsForRegisterHandler(
-    for method: CodeGenerationRequest.ServiceDescriptor.MethodDescriptor,
-    in service: CodeGenerationRequest.ServiceDescriptor,
+    for method: MethodDescriptor,
+    in service: ServiceDescriptor,
     from codeGenerationRequest: CodeGenerationRequest
   ) -> [FunctionArgumentDescription] {
     var arguments = [FunctionArgumentDescription]()
@@ -284,7 +284,7 @@ extension ServerCodeTranslator {
   }
 
   private func makeServiceProtocol(
-    for service: CodeGenerationRequest.ServiceDescriptor
+    for service: ServiceDescriptor
   ) -> Declaration {
     let methods = service.methods.compactMap {
       self.makeServiceProtocolMethod(for: $0, in: service)
@@ -309,8 +309,8 @@ extension ServerCodeTranslator {
   }
 
   private func makeServiceProtocolMethod(
-    for method: CodeGenerationRequest.ServiceDescriptor.MethodDescriptor,
-    in service: CodeGenerationRequest.ServiceDescriptor,
+    for method: MethodDescriptor,
+    in service: ServiceDescriptor,
     accessModifier: AccessModifier? = nil
   ) -> Declaration {
     let inputStreaming = method.isInputStreaming ? "Streaming" : ""
@@ -346,7 +346,7 @@ extension ServerCodeTranslator {
   }
 
   private func makeExtensionServiceProtocol(
-    for service: CodeGenerationRequest.ServiceDescriptor
+    for service: ServiceDescriptor
   ) -> Declaration {
     let methods = service.methods.compactMap {
       self.makeServiceProtocolExtensionMethod(for: $0, in: service)
@@ -363,8 +363,8 @@ extension ServerCodeTranslator {
   }
 
   private func makeServiceProtocolExtensionMethod(
-    for method: CodeGenerationRequest.ServiceDescriptor.MethodDescriptor,
-    in service: CodeGenerationRequest.ServiceDescriptor
+    for method: MethodDescriptor,
+    in service: ServiceDescriptor
   ) -> Declaration? {
     // The method has the same definition in StreamingServiceProtocol and ServiceProtocol.
     if method.isInputStreaming && method.isOutputStreaming {
@@ -385,7 +385,7 @@ extension ServerCodeTranslator {
   }
 
   private func makeResponse(
-    for method: CodeGenerationRequest.ServiceDescriptor.MethodDescriptor
+    for method: MethodDescriptor
   ) -> Declaration {
     let serverRequest: Expression
     if !method.isInputStreaming {
@@ -422,7 +422,7 @@ extension ServerCodeTranslator {
   }
 
   private func makeReturnStatement(
-    for method: CodeGenerationRequest.ServiceDescriptor.MethodDescriptor
+    for method: MethodDescriptor
   ) -> Expression {
     let returnValue: Expression
     // Transforming the unary response into a streaming one.
@@ -447,8 +447,8 @@ extension ServerCodeTranslator {
 
   /// Generates the fully qualified name of a method descriptor.
   private func methodDescriptorPath(
-    for method: CodeGenerationRequest.ServiceDescriptor.MethodDescriptor,
-    service: CodeGenerationRequest.ServiceDescriptor
+    for method: MethodDescriptor,
+    service: ServiceDescriptor
   ) -> String {
     return
       "\(service.namespacedGeneratedName).Method.\(method.name.generatedUpperCase).descriptor"
@@ -456,7 +456,7 @@ extension ServerCodeTranslator {
 
   /// Generates the fully qualified name of the type alias for a service protocol.
   internal func protocolNameTypealias(
-    service: CodeGenerationRequest.ServiceDescriptor,
+    service: ServiceDescriptor,
     streaming: Bool
   ) -> String {
     if streaming {
@@ -467,7 +467,7 @@ extension ServerCodeTranslator {
 
   /// Generates the name of a service protocol.
   internal func protocolName(
-    service: CodeGenerationRequest.ServiceDescriptor,
+    service: ServiceDescriptor,
     streaming: Bool
   ) -> String {
     if streaming {

--- a/Sources/GRPCCodeGen/Internal/Translator/TypealiasTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/TypealiasTranslator.swift
@@ -108,7 +108,7 @@ struct TypealiasTranslator: SpecializedTranslator {
 
 extension TypealiasTranslator {
   private func makeServiceEnum(
-    from service: CodeGenerationRequest.ServiceDescriptor,
+    from service: ServiceDescriptor,
     named name: String
   ) throws -> Declaration {
     var serviceEnum = EnumDescription(
@@ -154,8 +154,8 @@ extension TypealiasTranslator {
   }
 
   private func makeMethodEnum(
-    from method: CodeGenerationRequest.ServiceDescriptor.MethodDescriptor,
-    in service: CodeGenerationRequest.ServiceDescriptor
+    from method: MethodDescriptor,
+    in service: ServiceDescriptor
   ) -> Declaration {
     var methodEnum = EnumDescription(name: method.name.generatedUpperCase)
 
@@ -183,8 +183,8 @@ extension TypealiasTranslator {
   }
 
   private func makeMethodDescriptor(
-    from method: CodeGenerationRequest.ServiceDescriptor.MethodDescriptor,
-    in service: CodeGenerationRequest.ServiceDescriptor
+    from method: MethodDescriptor,
+    in service: ServiceDescriptor
   ) -> Declaration {
     let fullyQualifiedService = MemberAccessDescription(
       left: .memberAccess(
@@ -223,7 +223,7 @@ extension TypealiasTranslator {
   }
 
   private func makeMethodDescriptors(
-    for service: CodeGenerationRequest.ServiceDescriptor
+    for service: ServiceDescriptor
   ) -> Declaration {
     var methodDescriptors = [Expression]()
     let methodNames = service.methods.map { $0.name.generatedUpperCase }
@@ -251,7 +251,7 @@ extension TypealiasTranslator {
   }
 
   private func makeServiceProtocolsTypealiases(
-    for service: CodeGenerationRequest.ServiceDescriptor
+    for service: ServiceDescriptor
   ) -> [Declaration] {
     let streamingServiceProtocolTypealias = Declaration.typealias(
       accessModifier: self.accessModifier,
@@ -277,7 +277,7 @@ extension TypealiasTranslator {
   }
 
   private func makeClientProtocolTypealias(
-    for service: CodeGenerationRequest.ServiceDescriptor
+    for service: ServiceDescriptor
   ) -> Declaration {
     return .guarded(
       self.availabilityGuard,
@@ -290,7 +290,7 @@ extension TypealiasTranslator {
   }
 
   private func makeClientStructTypealias(
-    for service: CodeGenerationRequest.ServiceDescriptor
+    for service: ServiceDescriptor
   ) -> Declaration {
     return .guarded(
       self.availabilityGuard,
@@ -302,7 +302,7 @@ extension TypealiasTranslator {
     )
   }
 
-  private func makeServiceIdentifier(_ service: CodeGenerationRequest.ServiceDescriptor) -> String {
+  private func makeServiceIdentifier(_ service: ServiceDescriptor) -> String {
     let prefix: String
 
     if service.namespace.normalizedBase.isEmpty {
@@ -315,7 +315,7 @@ extension TypealiasTranslator {
   }
 
   private func makeStaticServiceDescriptorProperty(
-    for service: CodeGenerationRequest.ServiceDescriptor
+    for service: ServiceDescriptor
   ) -> VariableDescription {
     let serviceIdentifier = makeServiceIdentifier(service)
 
@@ -334,7 +334,7 @@ extension TypealiasTranslator {
   }
 
   private func makeServiceDescriptorExtension(
-    for service: CodeGenerationRequest.ServiceDescriptor
+    for service: ServiceDescriptor
   ) -> Declaration {
     let serviceIdentifier = makeServiceIdentifier(service)
 

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
@@ -21,10 +21,6 @@ import XCTest
 @testable import GRPCCodeGen
 
 final class ClientCodeTranslatorSnippetBasedTests: XCTestCase {
-  typealias MethodDescriptor = GRPCCodeGen.CodeGenerationRequest.ServiceDescriptor.MethodDescriptor
-  typealias ServiceDescriptor = GRPCCodeGen.CodeGenerationRequest.ServiceDescriptor
-  typealias Name = GRPCCodeGen.CodeGenerationRequest.Name
-
   func testClientCodeTranslatorUnaryMethod() throws {
     let method = MethodDescriptor(
       documentation: "/// Documentation for MethodA",

--- a/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
@@ -21,64 +21,60 @@ import XCTest
 @testable import GRPCCodeGen
 
 final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
-  typealias MethodDescriptor = GRPCCodeGen.CodeGenerationRequest.ServiceDescriptor.MethodDescriptor
-  typealias ServiceDescriptor = GRPCCodeGen.CodeGenerationRequest.ServiceDescriptor
-  typealias Name = GRPCCodeGen.CodeGenerationRequest.Name
-
   func testImports() throws {
-    var dependencies = [CodeGenerationRequest.Dependency]()
-    dependencies.append(CodeGenerationRequest.Dependency(module: "Foo", accessLevel: .public))
+    var dependencies = [Dependency]()
+    dependencies.append(Dependency(module: "Foo", accessLevel: .public))
     dependencies.append(
-      CodeGenerationRequest.Dependency(
+      Dependency(
         item: .init(kind: .typealias, name: "Bar"),
         module: "Foo",
         accessLevel: .internal
       )
     )
     dependencies.append(
-      CodeGenerationRequest.Dependency(
+      Dependency(
         item: .init(kind: .struct, name: "Baz"),
         module: "Foo",
         accessLevel: .package
       )
     )
     dependencies.append(
-      CodeGenerationRequest.Dependency(
+      Dependency(
         item: .init(kind: .class, name: "Bac"),
         module: "Foo",
         accessLevel: .package
       )
     )
     dependencies.append(
-      CodeGenerationRequest.Dependency(
+      Dependency(
         item: .init(kind: .enum, name: "Bap"),
         module: "Foo",
         accessLevel: .package
       )
     )
     dependencies.append(
-      CodeGenerationRequest.Dependency(
+      Dependency(
         item: .init(kind: .protocol, name: "Bat"),
         module: "Foo",
         accessLevel: .package
       )
     )
     dependencies.append(
-      CodeGenerationRequest.Dependency(
+      Dependency(
         item: .init(kind: .let, name: "Baq"),
         module: "Foo",
         accessLevel: .package
       )
     )
     dependencies.append(
-      CodeGenerationRequest.Dependency(
+      Dependency(
         item: .init(kind: .var, name: "Bag"),
         module: "Foo",
         accessLevel: .package
       )
     )
     dependencies.append(
-      CodeGenerationRequest.Dependency(
+      Dependency(
         item: .init(kind: .func, name: "Bak"),
         module: "Foo",
         accessLevel: .package
@@ -109,16 +105,16 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
   }
 
   func testPreconcurrencyImports() throws {
-    var dependencies = [CodeGenerationRequest.Dependency]()
+    var dependencies = [Dependency]()
     dependencies.append(
-      CodeGenerationRequest.Dependency(
+      Dependency(
         module: "Foo",
         preconcurrency: .required,
         accessLevel: .internal
       )
     )
     dependencies.append(
-      CodeGenerationRequest.Dependency(
+      Dependency(
         item: .init(kind: .enum, name: "Bar"),
         module: "Foo",
         preconcurrency: .required,
@@ -126,7 +122,7 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
       )
     )
     dependencies.append(
-      CodeGenerationRequest.Dependency(
+      Dependency(
         module: "Baz",
         preconcurrency: .requiredOnOS(["Deq", "Der"]),
         accessLevel: .internal
@@ -154,12 +150,12 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
   }
 
   func testSPIImports() throws {
-    var dependencies = [CodeGenerationRequest.Dependency]()
+    var dependencies = [Dependency]()
     dependencies.append(
-      CodeGenerationRequest.Dependency(module: "Foo", spi: "Secret", accessLevel: .internal)
+      Dependency(module: "Foo", spi: "Secret", accessLevel: .internal)
     )
     dependencies.append(
-      CodeGenerationRequest.Dependency(
+      Dependency(
         item: .init(kind: .enum, name: "Bar"),
         module: "Foo",
         spi: "Secret",
@@ -184,12 +180,12 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
   }
 
   func testGeneration() throws {
-    var dependencies = [CodeGenerationRequest.Dependency]()
+    var dependencies = [Dependency]()
     dependencies.append(
-      CodeGenerationRequest.Dependency(module: "Foo", spi: "Secret", accessLevel: .internal)
+      Dependency(module: "Foo", spi: "Secret", accessLevel: .internal)
     )
     dependencies.append(
-      CodeGenerationRequest.Dependency(
+      Dependency(
         item: .init(kind: .enum, name: "Bar"),
         module: "Foo",
         spi: "Secret",

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
@@ -21,10 +21,6 @@ import XCTest
 @testable import GRPCCodeGen
 
 final class ServerCodeTranslatorSnippetBasedTests: XCTestCase {
-  typealias MethodDescriptor = GRPCCodeGen.CodeGenerationRequest.ServiceDescriptor.MethodDescriptor
-  typealias ServiceDescriptor = GRPCCodeGen.CodeGenerationRequest.ServiceDescriptor
-  typealias Name = GRPCCodeGen.CodeGenerationRequest.Name
-
   func testServerCodeTranslatorUnaryMethod() throws {
     let method = MethodDescriptor(
       documentation: "/// Documentation for unaryMethod",

--- a/Tests/GRPCCodeGenTests/Internal/Translator/TestFunctions.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/TestFunctions.swift
@@ -72,8 +72,8 @@ internal func XCTAssertEqualWithDiff(
 }
 
 internal func makeCodeGenerationRequest(
-  services: [CodeGenerationRequest.ServiceDescriptor] = [],
-  dependencies: [CodeGenerationRequest.Dependency] = []
+  services: [ServiceDescriptor] = [],
+  dependencies: [Dependency] = []
 ) -> CodeGenerationRequest {
   return CodeGenerationRequest(
     fileName: "test.grpc",

--- a/Tests/GRPCCodeGenTests/Internal/Translator/TypealiasTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/TypealiasTranslatorSnippetBasedTests.swift
@@ -21,10 +21,6 @@ import XCTest
 @testable import GRPCCodeGen
 
 final class TypealiasTranslatorSnippetBasedTests: XCTestCase {
-  typealias MethodDescriptor = GRPCCodeGen.CodeGenerationRequest.ServiceDescriptor.MethodDescriptor
-  typealias ServiceDescriptor = GRPCCodeGen.CodeGenerationRequest.ServiceDescriptor
-  typealias Name = GRPCCodeGen.CodeGenerationRequest.Name
-
   func testTypealiasTranslator() throws {
     let method = MethodDescriptor(
       documentation: "Documentation for MethodA",


### PR DESCRIPTION
Motivation:

A number of types are nested within 'CodeGenerationRequest' which make them verbose to type out and a bit of a pain to work with.

Modification:

Remove the nesting of types.

Result:

Easier types to work with.