### PR TITLE
Allow metadata to be mutated on server response types

### DIFF
--- a/Sources/GRPCCore/Call/Server/ServerResponse.swift
+++ b/Sources/GRPCCore/Call/Server/ServerResponse.swift
@@ -244,15 +244,25 @@ extension ServerResponse {
     self.accepted = .failure(error)
   }
 
-  /// Returns the metadata to be sent to the client at the start of the response.
-  ///
-  /// For rejected RPCs (in other words, where ``accepted`` is `failure`) the metadata is empty.
+  /// The metadata to be sent to the client at the start of the response.
   public var metadata: Metadata {
-    switch self.accepted {
-    case let .success(contents):
-      return contents.metadata
-    case .failure:
-      return [:]
+    get {
+      switch self.accepted {
+      case let .success(contents):
+        return contents.metadata
+      case .failure(let error):
+        return error.metadata
+      }
+    }
+    set {
+      switch self.accepted {
+      case var .success(contents):
+        contents.metadata = newValue
+        self.accepted = .success(contents)
+      case var .failure(error):
+        error.metadata = newValue
+        self.accepted = .failure(error)
+      }
     }
   }
 
@@ -303,15 +313,25 @@ extension StreamingServerResponse {
     self.accepted = .failure(error)
   }
 
-  /// Returns metadata received from the server at the start of the response.
-  ///
-  /// For rejected RPCs (in other words, where ``accepted`` is `failure`) the metadata is empty.
+  /// The metadata to be sent to the client at the start of the response.
   public var metadata: Metadata {
-    switch self.accepted {
-    case let .success(contents):
-      return contents.metadata
-    case .failure:
-      return [:]
+    get {
+      switch self.accepted {
+      case let .success(contents):
+        return contents.metadata
+      case .failure(let error):
+        return error.metadata
+      }
+    }
+    set {
+      switch self.accepted {
+      case var .success(contents):
+        contents.metadata = newValue
+        self.accepted = .success(contents)
+      case var .failure(error):
+        error.metadata = newValue
+        self.accepted = .failure(error)
+      }
     }
   }
 }


### PR DESCRIPTION
Motivation:

The server response types have a metadata computed property with only a getter. It's entirely possible to mutate the metadata manually, it's just a bit of a faff. This should be easier.

Modifications:

- Add a setter to the computed property
- Migrate server response tests to swift-testing

Result:

- Easier to use API