### PR TITLE
Use nested protocols

### DIFF
--- a/Sources/GRPCCodeGen/Internal/Translator/IDLToStructuredSwiftTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/IDLToStructuredSwiftTranslator.swift
@@ -40,9 +40,7 @@ struct IDLToStructuredSwiftTranslator: Translator {
 
       let metadata = metadataTranslator.translate(
         accessModifier: accessModifier,
-        service: service,
-        client: client,
-        server: server
+        service: service
       )
       codeBlocks.append(contentsOf: metadata)
 

--- a/Sources/GRPCCodeGen/Internal/Translator/MetadataTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/MetadataTranslator.swift
@@ -19,15 +19,8 @@ struct MetadataTranslator {
 
   func translate(
     accessModifier: AccessModifier,
-    service: ServiceDescriptor,
-    client: Bool,
-    server: Bool
+    service: ServiceDescriptor
   ) -> [CodeBlock] {
-    .serviceMetadata(
-      accessModifier: accessModifier,
-      service: service,
-      client: client,
-      server: server
-    )
+    .serviceMetadata(accessModifier: accessModifier, service: service)
   }
 }

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
@@ -39,16 +39,47 @@ struct ClientCodeTranslatorSnippetBasedTests {
     )
 
     let expectedSwift = """
-      /// Documentation for ServiceA
-      public protocol NamespaceA_ServiceA_ClientProtocol: Sendable {
-          /// Documentation for MethodA
-          func methodA<Result>(
-              request: GRPCCore.ClientRequest<NamespaceA_ServiceARequest>,
-              serializer: some GRPCCore.MessageSerializer<NamespaceA_ServiceARequest>,
-              deserializer: some GRPCCore.MessageDeserializer<NamespaceA_ServiceAResponse>,
-              options: GRPCCore.CallOptions,
-              onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<NamespaceA_ServiceAResponse>) async throws -> Result
-          ) async throws -> Result where Result: Sendable
+      extension NamespaceA_ServiceA {
+          /// Documentation for ServiceA
+          public protocol ClientProtocol: Sendable {
+              /// Documentation for MethodA
+              func methodA<Result>(
+                  request: GRPCCore.ClientRequest<NamespaceA_ServiceARequest>,
+                  serializer: some GRPCCore.MessageSerializer<NamespaceA_ServiceARequest>,
+                  deserializer: some GRPCCore.MessageDeserializer<NamespaceA_ServiceAResponse>,
+                  options: GRPCCore.CallOptions,
+                  onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<NamespaceA_ServiceAResponse>) async throws -> Result
+              ) async throws -> Result where Result: Sendable
+          }
+
+          /// Documentation for ServiceA
+          public struct Client: ClientProtocol {
+              private let client: GRPCCore.GRPCClient
+
+              public init(wrapping client: GRPCCore.GRPCClient) {
+                  self.client = client
+              }
+
+              /// Documentation for MethodA
+              public func methodA<Result>(
+                  request: GRPCCore.ClientRequest<NamespaceA_ServiceARequest>,
+                  serializer: some GRPCCore.MessageSerializer<NamespaceA_ServiceARequest>,
+                  deserializer: some GRPCCore.MessageDeserializer<NamespaceA_ServiceAResponse>,
+                  options: GRPCCore.CallOptions = .defaults,
+                  onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<NamespaceA_ServiceAResponse>) async throws -> Result = { response in
+                      try response.message
+                  }
+              ) async throws -> Result where Result: Sendable {
+                  try await self.client.unary(
+                      request: request,
+                      descriptor: NamespaceA_ServiceA.Method.MethodA.descriptor,
+                      serializer: serializer,
+                      deserializer: deserializer,
+                      options: options,
+                      onResponse: handleResponse
+                  )
+              }
+          }
       }
       extension NamespaceA_ServiceA.ClientProtocol {
           public func methodA<Result>(
@@ -83,34 +114,6 @@ struct ClientCodeTranslatorSnippetBasedTests {
               )
               return try await self.methodA(
                   request: request,
-                  options: options,
-                  onResponse: handleResponse
-              )
-          }
-      }
-      /// Documentation for ServiceA
-      public struct NamespaceA_ServiceA_Client: NamespaceA_ServiceA.ClientProtocol {
-          private let client: GRPCCore.GRPCClient
-
-          public init(wrapping client: GRPCCore.GRPCClient) {
-              self.client = client
-          }
-
-          /// Documentation for MethodA
-          public func methodA<Result>(
-              request: GRPCCore.ClientRequest<NamespaceA_ServiceARequest>,
-              serializer: some GRPCCore.MessageSerializer<NamespaceA_ServiceARequest>,
-              deserializer: some GRPCCore.MessageDeserializer<NamespaceA_ServiceAResponse>,
-              options: GRPCCore.CallOptions = .defaults,
-              onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<NamespaceA_ServiceAResponse>) async throws -> Result = { response in
-                  try response.message
-              }
-          ) async throws -> Result where Result: Sendable {
-              try await self.client.unary(
-                  request: request,
-                  descriptor: NamespaceA_ServiceA.Method.MethodA.descriptor,
-                  serializer: serializer,
-                  deserializer: deserializer,
                   options: options,
                   onResponse: handleResponse
               )

--- a/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
@@ -215,35 +215,31 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
       // MARK: - namespaceA.ServiceA
 
       public enum NamespaceA_ServiceA {
-          public static let descriptor = GRPCCore.ServiceDescriptor.namespaceA_ServiceA
+          public static let descriptor = GRPCCore.ServiceDescriptor(fullyQualifiedService: "namespaceA.ServiceA")
           public enum Method {
               public static let descriptors: [GRPCCore.MethodDescriptor] = []
           }
-          public typealias StreamingServiceProtocol = NamespaceA_ServiceA_StreamingServiceProtocol
-          public typealias ServiceProtocol = NamespaceA_ServiceA_ServiceProtocol
       }
 
       extension GRPCCore.ServiceDescriptor {
-          public static let namespaceA_ServiceA = Self(
-              package: "namespaceA",
-              service: "ServiceA"
-          )
+          public static let namespaceA_ServiceA = GRPCCore.ServiceDescriptor(fullyQualifiedService: "namespaceA.ServiceA")
       }
 
       // MARK: namespaceA.ServiceA (server)
 
-      /// Documentation for AService
-      public protocol NamespaceA_ServiceA_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {}
+      extension NamespaceA_ServiceA {
+          /// Documentation for AService
+          public protocol StreamingServiceProtocol: GRPCCore.RegistrableRPCService {}
+
+          /// Documentation for AService
+          public protocol ServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {}
+      }
 
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       extension NamespaceA_ServiceA.StreamingServiceProtocol {
           public func registerMethods(with router: inout GRPCCore.RPCRouter) {}
       }
 
-      /// Documentation for AService
-      public protocol NamespaceA_ServiceA_ServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {}
-
-      /// Partial conformance to `NamespaceA_ServiceA_StreamingServiceProtocol`.
       extension NamespaceA_ServiceA.ServiceProtocol {
       }
       """

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
@@ -47,13 +47,24 @@ final class ServerCodeTranslatorSnippetBasedTests {
     )
 
     let expectedSwift = """
-      /// Documentation for ServiceA
-      public protocol NamespaceA_ServiceA_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {
-          /// Documentation for unaryMethod
-          func unary(
-              request: GRPCCore.StreamingServerRequest<NamespaceA_ServiceARequest>,
-              context: GRPCCore.ServerContext
-          ) async throws -> GRPCCore.StreamingServerResponse<NamespaceA_ServiceAResponse>
+      extension NamespaceA_ServiceA {
+          /// Documentation for ServiceA
+          public protocol StreamingServiceProtocol: GRPCCore.RegistrableRPCService {
+              /// Documentation for unaryMethod
+              func unary(
+                  request: GRPCCore.StreamingServerRequest<NamespaceA_ServiceARequest>,
+                  context: GRPCCore.ServerContext
+              ) async throws -> GRPCCore.StreamingServerResponse<NamespaceA_ServiceAResponse>
+          }
+
+          /// Documentation for ServiceA
+          public protocol ServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
+              /// Documentation for unaryMethod
+              func unary(
+                  request: GRPCCore.ServerRequest<NamespaceA_ServiceARequest>,
+                  context: GRPCCore.ServerContext
+              ) async throws -> GRPCCore.ServerResponse<NamespaceA_ServiceAResponse>
+          }
       }
       /// Conformance to `GRPCCore.RegistrableRPCService`.
       extension NamespaceA_ServiceA.StreamingServiceProtocol {
@@ -71,15 +82,6 @@ final class ServerCodeTranslatorSnippetBasedTests {
               )
           }
       }
-      /// Documentation for ServiceA
-      public protocol NamespaceA_ServiceA_ServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {
-          /// Documentation for unaryMethod
-          func unary(
-              request: GRPCCore.ServerRequest<NamespaceA_ServiceARequest>,
-              context: GRPCCore.ServerContext
-          ) async throws -> GRPCCore.ServerResponse<NamespaceA_ServiceAResponse>
-      }
-      /// Partial conformance to `NamespaceA_ServiceA_StreamingServiceProtocol`.
       extension NamespaceA_ServiceA.ServiceProtocol {
           public func unary(
               request: GRPCCore.StreamingServerRequest<NamespaceA_ServiceARequest>,


### PR DESCRIPTION
Motivation:

The minimum Swift version we require supports protocols being declared within another type. This means that all protocols and types we generate for a service can be declared within the enum namespace for that service and we can remove the typealiases.

Modifications:

- Declare generated protocols within their enum namespace
- Inline generated service descriptors

Result:

Simpler generated code