### PR TITLE
Add a 'simple' service protocol

### DIFF
--- a/Sources/GRPCCodeGen/Internal/Renderer/TextBasedRenderer.swift
+++ b/Sources/GRPCCodeGen/Internal/Renderer/TextBasedRenderer.swift
@@ -613,7 +613,14 @@ struct TextBasedRenderer: RendererProtocol {
       writer.nextLineAppendsToLastLine()
       writer.writeLine("<")
       writer.nextLineAppendsToLastLine()
-      renderExistingTypeDescription(wrapped)
+      for (wrap, isLast) in wrapped.enumeratedWithLastMarker() {
+        renderExistingTypeDescription(wrap)
+        writer.nextLineAppendsToLastLine()
+        if !isLast {
+          writer.writeLine(", ")
+          writer.nextLineAppendsToLastLine()
+        }
+      }
       writer.nextLineAppendsToLastLine()
       writer.writeLine(">")
     case .optional(let existingTypeDescription):

--- a/Sources/GRPCCodeGen/Internal/StructuredSwift+Types.swift
+++ b/Sources/GRPCCodeGen/Internal/StructuredSwift+Types.swift
@@ -70,6 +70,14 @@ extension ExistingTypeDescription {
     .generic(wrapper: .grpcCore("RPCWriter"), wrapped: .member(type))
   }
 
+  package static func rpcAsyncSequence(forType type: String) -> Self {
+    .generic(
+      wrapper: .grpcCore("RPCAsyncSequence"),
+      wrapped: .member(type),
+      .any(.member(["Swift", "Error"]))
+    )
+  }
+
   package static let callOptions: Self = .grpcCore("CallOptions")
   package static let metadata: Self = .grpcCore("Metadata")
   package static let grpcClient: Self = .grpcCore("GRPCClient")

--- a/Sources/GRPCCodeGen/Internal/StructuredSwiftRepresentation.swift
+++ b/Sources/GRPCCodeGen/Internal/StructuredSwiftRepresentation.swift
@@ -453,10 +453,10 @@ indirect enum ExistingTypeDescription: Equatable, Codable, Sendable {
   /// For example, `Foo?`.
   case optional(ExistingTypeDescription)
 
-  /// A wrapper type generic over a wrapped type.
+  /// A wrapper type generic over a list of wrapped types.
   ///
   /// For example, `Wrapper<Wrapped>`.
-  case generic(wrapper: ExistingTypeDescription, wrapped: ExistingTypeDescription)
+  case generic(wrapper: ExistingTypeDescription, wrapped: [ExistingTypeDescription])
 
   /// A type reference represented by the components.
   ///
@@ -483,6 +483,16 @@ indirect enum ExistingTypeDescription: Equatable, Codable, Sendable {
   ///
   /// For example: `(String) async throws -> Int`.
   case closure(ClosureSignatureDescription)
+
+  /// A wrapper type generic over a list of wrapped types.
+  ///
+  /// For example, `Wrapper<Wrapped>`.
+  static func generic(
+    wrapper: ExistingTypeDescription,
+    wrapped: ExistingTypeDescription...
+  ) -> Self {
+    return .generic(wrapper: wrapper, wrapped: Array(wrapped))
+  }
 }
 
 /// A description of a typealias declaration.

--- a/Sources/GRPCCodeGen/Internal/Translator/Docs.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/Docs.swift
@@ -56,7 +56,7 @@ package enum Docs {
       """
 
     let body = docs.split(separator: "\n").map { line in
-      "/// > " + line.dropFirst(4)
+      "/// > " + line.dropFirst(4).trimmingCharacters(in: .whitespaces)
     }.joined(separator: "\n")
 
     return header + "\n" + body

--- a/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
@@ -105,6 +105,24 @@ struct ServerCodeTranslator {
             )
           )
         ),
+
+        // protocol SimpleServiceProtocol { ... }
+        .commentable(
+          .preFormatted(
+            Docs.suffix(
+              self.simpleServiceDocs(serviceName: service.fullyQualifiedName),
+              withDocs: service.documentation
+            )
+          ),
+          .protocol(
+            .simpleServiceProtocol(
+              accessModifier: accessModifier,
+              name: "SimpleServiceProtocol",
+              serviceProtocol: "\(service.namespacedGeneratedName).ServiceProtocol",
+              methods: service.methods
+            )
+          )
+        ),
       ]
     )
     blocks.append(.declaration(.extension(`extension`)))
@@ -141,6 +159,19 @@ struct ServerCodeTranslator {
       )
     )
 
+    // extension <Service>_SimpleServiceProtocol { ... }
+    let serviceDefaultImplExtension: ExtensionDescription = .serviceProtocolDefaultImplementation(
+      accessModifier: accessModifier,
+      on: "\(service.namespacedGeneratedName).SimpleServiceProtocol",
+      methods: service.methods
+    )
+    blocks.append(
+      CodeBlock(
+        comment: .inline("Default implementation of methods from 'ServiceProtocol'."),
+        item: .declaration(.extension(serviceDefaultImplExtension))
+      )
+    )
+
     return blocks
   }
 
@@ -168,6 +199,16 @@ struct ServerCodeTranslator {
       /// trailing response metadata. If you don't need these then consider using
       /// the ``SimpleServiceProtocol``. If you need fine grained control over your RPCs then
       /// use ``StreamingServiceProtocol``.
+      """
+  }
+
+  private func simpleServiceDocs(serviceName: String) -> String {
+    return """
+      /// Simple service protocol for the "\(serviceName)" service.
+      ///
+      /// This is the highest level protocol for the service. The API is the easiest to use but
+      /// doesn't provide access to request or response metadata. If you need access to these
+      /// then use ``ServiceProtocol`` instead.
       """
   }
 }

--- a/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
@@ -261,6 +261,17 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
           /// >
           /// > Documentation for AService
           public protocol ServiceProtocol: NamespaceA_ServiceA.StreamingServiceProtocol {}
+
+          /// Simple service protocol for the "namespaceA.ServiceA" service.
+          ///
+          /// This is the highest level protocol for the service. The API is the easiest to use but
+          /// doesn't provide access to request or response metadata. If you need access to these
+          /// then use ``ServiceProtocol`` instead.
+          ///
+          /// > Source IDL Documentation:
+          /// >
+          /// > Documentation for AService
+          public protocol SimpleServiceProtocol: NamespaceA_ServiceA.ServiceProtocol {}
       }
 
       // Default implementation of 'registerMethods(with:)'.
@@ -270,6 +281,10 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
 
       // Default implementation of streaming methods from 'StreamingServiceProtocol'.
       extension NamespaceA_ServiceA.ServiceProtocol {
+      }
+
+      // Default implementation of methods from 'ServiceProtocol'.
+      extension NamespaceA_ServiceA.SimpleServiceProtocol {
       }
       """
     try self.assertIDLToStructuredSwiftTranslation(

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
@@ -112,6 +112,35 @@ final class ServerCodeTranslatorSnippetBasedTests {
                   context: GRPCCore.ServerContext
               ) async throws -> GRPCCore.ServerResponse<NamespaceA_ServiceAResponse>
           }
+
+          /// Simple service protocol for the "namespaceA.AlongNameForServiceA" service.
+          ///
+          /// This is the highest level protocol for the service. The API is the easiest to use but
+          /// doesn't provide access to request or response metadata. If you need access to these
+          /// then use ``ServiceProtocol`` instead.
+          ///
+          /// > Source IDL Documentation:
+          /// >
+          /// > Documentation for ServiceA
+          public protocol SimpleServiceProtocol: NamespaceA_ServiceA.ServiceProtocol {
+              /// Handle the "UnaryMethod" method.
+              ///
+              /// > Source IDL Documentation:
+              /// >
+              /// > Documentation for unaryMethod
+              ///
+              /// - Parameters:
+              ///   - request: A `NamespaceA_ServiceARequest` message.
+              ///   - context: Context providing information about the RPC.
+              /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+              ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+              ///     to an internal error.
+              /// - Returns: A `NamespaceA_ServiceAResponse` to respond with.
+              func unary(
+                  request: NamespaceA_ServiceARequest,
+                  context: GRPCCore.ServerContext
+              ) async throws -> NamespaceA_ServiceAResponse
+          }
       }
       // Default implementation of 'registerMethods(with:)'.
       extension NamespaceA_ServiceA.StreamingServiceProtocol {
@@ -140,6 +169,21 @@ final class ServerCodeTranslatorSnippetBasedTests {
                   context: context
               )
               return GRPCCore.StreamingServerResponse(single: response)
+          }
+      }
+      // Default implementation of methods from 'ServiceProtocol'.
+      extension NamespaceA_ServiceA.SimpleServiceProtocol {
+          public func unary(
+              request: GRPCCore.ServerRequest<NamespaceA_ServiceARequest>,
+              context: GRPCCore.ServerContext
+          ) async throws -> GRPCCore.ServerResponse<NamespaceA_ServiceAResponse> {
+              return GRPCCore.ServerResponse<NamespaceA_ServiceAResponse>(
+                  message: try await self.unary(
+                      request: request.message,
+                      context: context
+                  ),
+                  metadata: [:]
+              )
           }
       }
       """


### PR DESCRIPTION
Motivation:

The generated service protocol requires users to deal with request/response objects. Many users won't care about metadata so can benefit from an easier-to-use API.

Modifications:

- Add a "simple" server protocol which doesn't make user of request/response objects

Result:

Easier to implement a service