### PR TITLE
Add remote peer info to the server context

### DIFF
--- a/Sources/GRPCCore/Call/Server/ServerContext.swift
+++ b/Sources/GRPCCore/Call/Server/ServerContext.swift
@@ -19,6 +19,19 @@ public struct ServerContext: Sendable {
   /// A description of the method being called.
   public var descriptor: MethodDescriptor
 
+  /// A description of the remote peer.
+  ///
+  /// The format of the description should follow the pattern "<transport>:<address>" where
+  /// "<transport>" indicates the underlying network transport (such as "ipv4", "unix", or
+  /// "in-process"). This is a guideline for how descriptions should be formatted; different
+  /// implementations may not follow this format so you shouldn't make assumptions based on it.
+  ///
+  /// Some examples include:
+  /// - "ipv4:127.0.0.1:31415",
+  /// - "ipv6:[::1]:443",
+  /// - "in-process:27182".
+  public var peer: String
+
   /// A handle for checking the cancellation status of an RPC.
   public var cancellation: RPCCancellationHandle
 
@@ -26,10 +39,16 @@ public struct ServerContext: Sendable {
   ///
   /// - Parameters:
   ///   - descriptor: A description of the method being called.
+  ///   - peer: A description of the remote peer.
   ///   - cancellation: A cancellation handle. You can create a cancellation handle
   ///     using ``withServerContextRPCCancellationHandle(_:)``.
-  public init(descriptor: MethodDescriptor, cancellation: RPCCancellationHandle) {
+  public init(
+    descriptor: MethodDescriptor,
+    peer: String,
+    cancellation: RPCCancellationHandle
+  ) {
     self.descriptor = descriptor
+    self.peer = peer
     self.cancellation = cancellation
   }
 }

--- a/Sources/GRPCInProcessTransport/InProcessTransport+Client.swift
+++ b/Sources/GRPCInProcessTransport/InProcessTransport+Client.swift
@@ -109,7 +109,7 @@ extension InProcessTransport {
     /// - Parameters:
     ///   - server: The in-process server transport to connect to.
     ///   - serviceConfig: Service configuration.
-    public init(
+    package init(
       server: InProcessTransport.Server,
       serviceConfig: ServiceConfig = ServiceConfig()
     ) {

--- a/Sources/GRPCInProcessTransport/InProcessTransport.swift
+++ b/Sources/GRPCInProcessTransport/InProcessTransport.swift
@@ -25,7 +25,8 @@ public struct InProcessTransport: Sendable {
   /// - Parameters:
   ///   - serviceConfig: Configuration describing how methods should be executed.
   public init(serviceConfig: ServiceConfig = ServiceConfig()) {
-    self.server = Self.Server()
+    let peer = "in-process:\(System.pid())"
+    self.server = Self.Server(peer: peer)
     self.client = Self.Client(server: self.server, serviceConfig: serviceConfig)
   }
 }

--- a/Sources/GRPCInProcessTransport/Syscalls.swift
+++ b/Sources/GRPCInProcessTransport/Syscalls.swift
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
+
+enum System {
+  static func pid() -> Int {
+    #if canImport(Darwin)
+    let pid = Darwin.getpid()
+    return Int(pid)
+    #elseif canImport(Glibc)
+    let pid = Glibc.getpid()
+    return Int(pid)
+    #elseif canImport(Musl)
+    let pid = Musl.getpid()
+    return Int(pid)
+    #endif
+  }
+}

--- a/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTestSupport/ClientRPCExecutorTestHarness.swift
+++ b/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTestSupport/ClientRPCExecutorTestHarness.swift
@@ -47,13 +47,13 @@ struct ClientRPCExecutorTestHarness {
 
     switch transport {
     case .inProcess:
-      let server = InProcessTransport.Server()
+      let server = InProcessTransport.Server(peer: "in-process")
       let client = server.spawnClientTransport()
       self.serverTransport = StreamCountingServerTransport(wrapping: server)
       self.clientTransport = StreamCountingClientTransport(wrapping: client)
 
     case .throwsOnStreamCreation(let code):
-      let server = InProcessTransport.Server()  // Will never be called.
+      let server = InProcessTransport.Server(peer: "in-process")  // Will never be called.
       let client = ThrowOnStreamCreationTransport(code: code)
       self.serverTransport = StreamCountingServerTransport(wrapping: server)
       self.clientTransport = StreamCountingClientTransport(wrapping: client)

--- a/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTestSupport/ClientRPCExecutorTestHarness.swift
+++ b/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTestSupport/ClientRPCExecutorTestHarness.swift
@@ -47,13 +47,13 @@ struct ClientRPCExecutorTestHarness {
 
     switch transport {
     case .inProcess:
-      let server = InProcessTransport.Server(peer: "in-process")
+      let server = InProcessTransport.Server(peer: "in-process:1234")
       let client = server.spawnClientTransport()
       self.serverTransport = StreamCountingServerTransport(wrapping: server)
       self.clientTransport = StreamCountingClientTransport(wrapping: client)
 
     case .throwsOnStreamCreation(let code):
-      let server = InProcessTransport.Server(peer: "in-process")  // Will never be called.
+      let server = InProcessTransport.Server(peer: "in-process:1234")  // Will never be called.
       let client = ThrowOnStreamCreationTransport(code: code)
       self.serverTransport = StreamCountingServerTransport(wrapping: server)
       self.clientTransport = StreamCountingClientTransport(wrapping: client)

--- a/Tests/GRPCCoreTests/Call/Server/Internal/ServerRPCExecutorTestSupport/ServerRPCExecutorTestHarness.swift
+++ b/Tests/GRPCCoreTests/Call/Server/Internal/ServerRPCExecutorTestSupport/ServerRPCExecutorTestHarness.swift
@@ -102,6 +102,7 @@ struct ServerRPCExecutorTestHarness {
         await withServerContextRPCCancellationHandle { cancellation in
           let context = ServerContext(
             descriptor: MethodDescriptor(fullyQualifiedService: "foo", method: "bar"),
+            peer: "tests",
             cancellation: cancellation
           )
 

--- a/Tests/GRPCCoreTests/GRPCServerTests.swift
+++ b/Tests/GRPCCoreTests/GRPCServerTests.swift
@@ -334,7 +334,10 @@ final class GRPCServerTests: XCTestCase {
   }
 
   func testTestRunStoppedServer() async throws {
-    let server = GRPCServer(transport: InProcessTransport.Server(peer: "in-process"), services: [])
+    let server = GRPCServer(
+      transport: InProcessTransport.Server(peer: "in-process:1234"),
+      services: []
+    )
     // Run the server.
     let task = Task { try await server.serve() }
     task.cancel()

--- a/Tests/GRPCCoreTests/GRPCServerTests.swift
+++ b/Tests/GRPCCoreTests/GRPCServerTests.swift
@@ -334,7 +334,7 @@ final class GRPCServerTests: XCTestCase {
   }
 
   func testTestRunStoppedServer() async throws {
-    let server = GRPCServer(transport: InProcessTransport.Server(), services: [])
+    let server = GRPCServer(transport: InProcessTransport.Server(peer: "in-process"), services: [])
     // Run the server.
     let task = Task { try await server.serve() }
     task.cancel()

--- a/Tests/GRPCInProcessTransportTests/InProcessClientTransportTests.swift
+++ b/Tests/GRPCInProcessTransportTests/InProcessClientTransportTests.swift
@@ -142,7 +142,7 @@ final class InProcessClientTransportTests: XCTestCase {
   }
 
   func testOpenStreamSuccessfullyAndThenClose() async throws {
-    let server = InProcessTransport.Server(peer: "in-process")
+    let server = InProcessTransport.Server(peer: "in-process:1234")
     let client = makeClient(server: server)
 
     try await withThrowingTaskGroup(of: Void.self) { group in
@@ -199,7 +199,7 @@ final class InProcessClientTransportTests: XCTestCase {
     )
 
     var client = InProcessTransport.Client(
-      server: InProcessTransport.Server(peer: "in-process"),
+      server: InProcessTransport.Server(peer: "in-process:1234"),
       serviceConfig: serviceConfig
     )
 
@@ -223,7 +223,7 @@ final class InProcessClientTransportTests: XCTestCase {
     )
     serviceConfig.methodConfig.append(overrideConfiguration)
     client = InProcessTransport.Client(
-      server: InProcessTransport.Server(peer: "in-process"),
+      server: InProcessTransport.Server(peer: "in-process:1234"),
       serviceConfig: serviceConfig
     )
 
@@ -239,7 +239,7 @@ final class InProcessClientTransportTests: XCTestCase {
   }
 
   func testOpenMultipleStreamsThenClose() async throws {
-    let server = InProcessTransport.Server(peer: "in-process")
+    let server = InProcessTransport.Server(peer: "in-process:1234")
     let client = makeClient(server: server)
 
     try await withThrowingTaskGroup(of: Void.self) { group in
@@ -269,7 +269,7 @@ final class InProcessClientTransportTests: XCTestCase {
   }
 
   func makeClient(
-    server: InProcessTransport.Server = InProcessTransport.Server(peer: "in-process")
+    server: InProcessTransport.Server = InProcessTransport.Server(peer: "in-process:1234")
   ) -> InProcessTransport.Client {
     let defaultPolicy = RetryPolicy(
       maxAttempts: 10,

--- a/Tests/GRPCInProcessTransportTests/InProcessClientTransportTests.swift
+++ b/Tests/GRPCInProcessTransportTests/InProcessClientTransportTests.swift
@@ -142,7 +142,7 @@ final class InProcessClientTransportTests: XCTestCase {
   }
 
   func testOpenStreamSuccessfullyAndThenClose() async throws {
-    let server = InProcessTransport.Server()
+    let server = InProcessTransport.Server(peer: "in-process")
     let client = makeClient(server: server)
 
     try await withThrowingTaskGroup(of: Void.self) { group in
@@ -199,7 +199,7 @@ final class InProcessClientTransportTests: XCTestCase {
     )
 
     var client = InProcessTransport.Client(
-      server: InProcessTransport.Server(),
+      server: InProcessTransport.Server(peer: "in-process"),
       serviceConfig: serviceConfig
     )
 
@@ -223,7 +223,7 @@ final class InProcessClientTransportTests: XCTestCase {
     )
     serviceConfig.methodConfig.append(overrideConfiguration)
     client = InProcessTransport.Client(
-      server: InProcessTransport.Server(),
+      server: InProcessTransport.Server(peer: "in-process"),
       serviceConfig: serviceConfig
     )
 
@@ -239,7 +239,7 @@ final class InProcessClientTransportTests: XCTestCase {
   }
 
   func testOpenMultipleStreamsThenClose() async throws {
-    let server = InProcessTransport.Server()
+    let server = InProcessTransport.Server(peer: "in-process")
     let client = makeClient(server: server)
 
     try await withThrowingTaskGroup(of: Void.self) { group in
@@ -269,7 +269,7 @@ final class InProcessClientTransportTests: XCTestCase {
   }
 
   func makeClient(
-    server: InProcessTransport.Server = InProcessTransport.Server()
+    server: InProcessTransport.Server = InProcessTransport.Server(peer: "in-process")
   ) -> InProcessTransport.Client {
     let defaultPolicy = RetryPolicy(
       maxAttempts: 10,

--- a/Tests/GRPCInProcessTransportTests/InProcessServerTransportTests.swift
+++ b/Tests/GRPCInProcessTransportTests/InProcessServerTransportTests.swift
@@ -21,7 +21,7 @@ import XCTest
 
 final class InProcessServerTransportTests: XCTestCase {
   func testStartListening() async throws {
-    let transport = InProcessTransport.Server()
+    let transport = InProcessTransport.Server(peer: "in-process")
 
     let outbound = GRPCAsyncThrowingStream.makeStream(of: RPCResponsePart.self)
     let stream = RPCStream<
@@ -53,7 +53,7 @@ final class InProcessServerTransportTests: XCTestCase {
   }
 
   func testStopListening() async throws {
-    let transport = InProcessTransport.Server()
+    let transport = InProcessTransport.Server(peer: "in-process")
 
     let firstStreamOutbound = GRPCAsyncThrowingStream.makeStream(of: RPCResponsePart.self)
     let firstStream = RPCStream<

--- a/Tests/GRPCInProcessTransportTests/InProcessServerTransportTests.swift
+++ b/Tests/GRPCInProcessTransportTests/InProcessServerTransportTests.swift
@@ -21,7 +21,7 @@ import XCTest
 
 final class InProcessServerTransportTests: XCTestCase {
   func testStartListening() async throws {
-    let transport = InProcessTransport.Server(peer: "in-process")
+    let transport = InProcessTransport.Server(peer: "in-process:1234")
 
     let outbound = GRPCAsyncThrowingStream.makeStream(of: RPCResponsePart.self)
     let stream = RPCStream<
@@ -53,7 +53,7 @@ final class InProcessServerTransportTests: XCTestCase {
   }
 
   func testStopListening() async throws {
-    let transport = InProcessTransport.Server(peer: "in-process")
+    let transport = InProcessTransport.Server(peer: "in-process:1234")
 
     let firstStreamOutbound = GRPCAsyncThrowingStream.makeStream(of: RPCResponsePart.self)
     let firstStream = RPCStream<


### PR DESCRIPTION
Motivation:

It's often useful to know the identity of the remote peer when handling RPCs.

Modifications:

- Add a 'peer' to the server context
- Implement this for the in-process transport
- Make some in-process inits `package`, these should never have been `public`

Result:

Server RPCs have some idea what the address of remote peer is