### PR TITLE
Update parameter labels for GRPCClient

### DIFF
--- a/Sources/GRPCCore/Documentation.docc/Development/Design.md
+++ b/Sources/GRPCCore/Documentation.docc/Development/Design.md
@@ -159,10 +159,10 @@ can either be applied to all RPCs or to specific services.
 The call layer includes  a concrete ``GRPCClient`` which provides API to execute all
 four types of RPC against a ``ClientTransport``. These methods are:
 
-- ``GRPCClient/unary(request:descriptor:serializer:deserializer:options:handler:)``,
-- ``GRPCClient/clientStreaming(request:descriptor:serializer:deserializer:options:handler:)``,
-- ``GRPCClient/serverStreaming(request:descriptor:serializer:deserializer:options:handler:)``, and
-- ``GRPCClient/bidirectionalStreaming(request:descriptor:serializer:deserializer:options:handler:)``.
+- ``GRPCClient/unary(request:descriptor:serializer:deserializer:options:onResponse:)``,
+- ``GRPCClient/clientStreaming(request:descriptor:serializer:deserializer:options:onResponse:)``,
+- ``GRPCClient/serverStreaming(request:descriptor:serializer:deserializer:options:onResponse:)``, and
+- ``GRPCClient/bidirectionalStreaming(request:descriptor:serializer:deserializer:options:onResponse:)``.
 
 As lower level methods they require you to pass in a serializer and
 deserializer, as well as the descriptor of the method being called. Each method

--- a/Sources/GRPCCore/GRPCClient.swift
+++ b/Sources/GRPCCore/GRPCClient.swift
@@ -247,9 +247,9 @@ public final class GRPCClient: Sendable {
   ///   - serializer: A request serializer.
   ///   - deserializer: A response deserializer.
   ///   - options: Call specific options.
-  ///   - onResponse: A unary response handler.
+  ///   - handleResponse: A unary response handler.
   ///
-  /// - Returns: The return value from the `onResponse`.
+  /// - Returns: The return value from the `handleResponse`.
   public func unary<Request, Response, ReturnValue: Sendable>(
     request: ClientRequest<Request>,
     descriptor: MethodDescriptor,
@@ -280,9 +280,9 @@ public final class GRPCClient: Sendable {
   ///   - serializer: A request serializer.
   ///   - deserializer: A response deserializer.
   ///   - options: Call specific options.
-  ///   - onResponse: A unary response handler.
+  ///   - handleResponse: A unary response handler.
   ///
-  /// - Returns: The return value from the `onResponse`.
+  /// - Returns: The return value from the `handleResponse`.
   public func clientStreaming<Request, Response, ReturnValue: Sendable>(
     request: StreamingClientRequest<Request>,
     descriptor: MethodDescriptor,
@@ -313,9 +313,9 @@ public final class GRPCClient: Sendable {
   ///   - serializer: A request serializer.
   ///   - deserializer: A response deserializer.
   ///   - options: Call specific options.
-  ///   - onResponse: A response stream handler.
+  ///   - handleResponse: A response stream handler.
   ///
-  /// - Returns: The return value from the `onResponse`.
+  /// - Returns: The return value from the `handleResponse`.
   public func serverStreaming<Request, Response, ReturnValue: Sendable>(
     request: ClientRequest<Request>,
     descriptor: MethodDescriptor,
@@ -347,9 +347,9 @@ public final class GRPCClient: Sendable {
   ///   - serializer: A request serializer.
   ///   - deserializer: A response deserializer.
   ///   - options: Call specific options.
-  ///   - onResponse: A response stream handler.
+  ///   - handleResponse: A response stream handler.
   ///
-  /// - Returns: The return value from the `onResponse`.
+  /// - Returns: The return value from the `handleResponse`.
   public func bidirectionalStreaming<Request, Response, ReturnValue: Sendable>(
     request: StreamingClientRequest<Request>,
     descriptor: MethodDescriptor,

--- a/Sources/GRPCCore/GRPCClient.swift
+++ b/Sources/GRPCCore/GRPCClient.swift
@@ -21,10 +21,10 @@ private import Synchronization
 /// A ``GRPCClient`` communicates to a server via a ``ClientTransport``.
 ///
 /// You can start RPCs to the server by calling the corresponding method:
-/// - ``unary(request:descriptor:serializer:deserializer:options:handler:)``
-/// - ``clientStreaming(request:descriptor:serializer:deserializer:options:handler:)``
-/// - ``serverStreaming(request:descriptor:serializer:deserializer:options:handler:)``
-/// - ``bidirectionalStreaming(request:descriptor:serializer:deserializer:options:handler:)``
+/// - ``unary(request:descriptor:serializer:deserializer:options:onResponse:)``
+/// - ``clientStreaming(request:descriptor:serializer:deserializer:options:onResponse:)``
+/// - ``serverStreaming(request:descriptor:serializer:deserializer:options:onResponse:)``
+/// - ``bidirectionalStreaming(request:descriptor:serializer:deserializer:options:onResponse:)``
 ///
 /// However, in most cases you should prefer wrapping the ``GRPCClient`` with a generated stub.
 ///
@@ -247,9 +247,9 @@ public final class GRPCClient: Sendable {
   ///   - serializer: A request serializer.
   ///   - deserializer: A response deserializer.
   ///   - options: Call specific options.
-  ///   - handler: A unary response handler.
+  ///   - onResponse: A unary response handler.
   ///
-  /// - Returns: The return value from the `handler`.
+  /// - Returns: The return value from the `onResponse`.
   public func unary<Request, Response, ReturnValue: Sendable>(
     request: ClientRequest<Request>,
     descriptor: MethodDescriptor,
@@ -280,9 +280,9 @@ public final class GRPCClient: Sendable {
   ///   - serializer: A request serializer.
   ///   - deserializer: A response deserializer.
   ///   - options: Call specific options.
-  ///   - handler: A unary response handler.
+  ///   - onResponse: A unary response handler.
   ///
-  /// - Returns: The return value from the `handler`.
+  /// - Returns: The return value from the `onResponse`.
   public func clientStreaming<Request, Response, ReturnValue: Sendable>(
     request: StreamingClientRequest<Request>,
     descriptor: MethodDescriptor,
@@ -313,9 +313,9 @@ public final class GRPCClient: Sendable {
   ///   - serializer: A request serializer.
   ///   - deserializer: A response deserializer.
   ///   - options: Call specific options.
-  ///   - handler: A response stream handler.
+  ///   - onResponse: A response stream handler.
   ///
-  /// - Returns: The return value from the `handler`.
+  /// - Returns: The return value from the `onResponse`.
   public func serverStreaming<Request, Response, ReturnValue: Sendable>(
     request: ClientRequest<Request>,
     descriptor: MethodDescriptor,
@@ -347,9 +347,9 @@ public final class GRPCClient: Sendable {
   ///   - serializer: A request serializer.
   ///   - deserializer: A response deserializer.
   ///   - options: Call specific options.
-  ///   - handler: A response stream handler.
+  ///   - onResponse: A response stream handler.
   ///
-  /// - Returns: The return value from the `handler`.
+  /// - Returns: The return value from the `onResponse`.
   public func bidirectionalStreaming<Request, Response, ReturnValue: Sendable>(
     request: StreamingClientRequest<Request>,
     descriptor: MethodDescriptor,

--- a/Sources/GRPCCore/GRPCClient.swift
+++ b/Sources/GRPCCore/GRPCClient.swift
@@ -256,7 +256,9 @@ public final class GRPCClient: Sendable {
     serializer: some MessageSerializer<Request>,
     deserializer: some MessageDeserializer<Response>,
     options: CallOptions,
-    handler: @Sendable @escaping (ClientResponse<Response>) async throws -> ReturnValue
+    onResponse handleResponse: @Sendable @escaping (
+      _ response: ClientResponse<Response>
+    ) async throws -> ReturnValue
   ) async throws -> ReturnValue {
     try await self.bidirectionalStreaming(
       request: StreamingClientRequest(single: request),
@@ -266,7 +268,7 @@ public final class GRPCClient: Sendable {
       options: options
     ) { stream in
       let singleResponse = await ClientResponse(stream: stream)
-      return try await handler(singleResponse)
+      return try await handleResponse(singleResponse)
     }
   }
 
@@ -287,7 +289,9 @@ public final class GRPCClient: Sendable {
     serializer: some MessageSerializer<Request>,
     deserializer: some MessageDeserializer<Response>,
     options: CallOptions,
-    handler: @Sendable @escaping (ClientResponse<Response>) async throws -> ReturnValue
+    onResponse handleResponse: @Sendable @escaping (
+      _ response: ClientResponse<Response>
+    ) async throws -> ReturnValue
   ) async throws -> ReturnValue {
     try await self.bidirectionalStreaming(
       request: request,
@@ -297,7 +301,7 @@ public final class GRPCClient: Sendable {
       options: options
     ) { stream in
       let singleResponse = await ClientResponse(stream: stream)
-      return try await handler(singleResponse)
+      return try await handleResponse(singleResponse)
     }
   }
 
@@ -318,7 +322,9 @@ public final class GRPCClient: Sendable {
     serializer: some MessageSerializer<Request>,
     deserializer: some MessageDeserializer<Response>,
     options: CallOptions,
-    handler: @Sendable @escaping (StreamingClientResponse<Response>) async throws -> ReturnValue
+    onResponse handleResponse: @Sendable @escaping (
+      _ response: StreamingClientResponse<Response>
+    ) async throws -> ReturnValue
   ) async throws -> ReturnValue {
     try await self.bidirectionalStreaming(
       request: StreamingClientRequest(single: request),
@@ -326,7 +332,7 @@ public final class GRPCClient: Sendable {
       serializer: serializer,
       deserializer: deserializer,
       options: options,
-      handler: handler
+      onResponse: handleResponse
     )
   }
 
@@ -350,7 +356,9 @@ public final class GRPCClient: Sendable {
     serializer: some MessageSerializer<Request>,
     deserializer: some MessageDeserializer<Response>,
     options: CallOptions,
-    handler: @Sendable @escaping (StreamingClientResponse<Response>) async throws -> ReturnValue
+    onResponse handleResponse: @Sendable @escaping (
+      _ response: StreamingClientResponse<Response>
+    ) async throws -> ReturnValue
   ) async throws -> ReturnValue {
     let applicableInterceptors = try self.stateMachine.withLock {
       try $0.checkExecutableAndGetApplicableInterceptors(for: descriptor)
@@ -367,7 +375,7 @@ public final class GRPCClient: Sendable {
       deserializer: deserializer,
       transport: self.transport,
       interceptors: applicableInterceptors,
-      handler: handler
+      handler: handleResponse
     )
   }
 }


### PR DESCRIPTION
Motivation:

The updated generated code added parameter labels to the handler passed to each method of the GRPCClient. This was done purposefully to improve readability. We haven't as yet actually updated the client to use the new labels.

Modifications:

- Update param labels in GRPCClient

Result:

New generated code compiles