### PR TITLE
Remove guarded declarations case in generated code

### DIFF
--- a/Sources/GRPCCodeGen/Internal/Renderer/TextBasedRenderer.swift
+++ b/Sources/GRPCCodeGen/Internal/Renderer/TextBasedRenderer.swift
@@ -857,8 +857,6 @@ struct TextBasedRenderer: RendererProtocol {
       renderCommentableDeclaration(comment: comment, declaration: nestedDeclaration)
     case let .deprecated(deprecation, nestedDeclaration):
       renderDeprecatedDeclaration(deprecation: deprecation, declaration: nestedDeclaration)
-    case let .guarded(availability, nestedDeclaration):
-      renderGuardedDeclaration(availability: availability, declaration: nestedDeclaration)
     case .variable(let variableDescription): renderVariable(variableDescription)
     case .extension(let extensionDescription): renderExtension(extensionDescription)
     case .struct(let structDescription): renderStruct(structDescription)

--- a/Sources/GRPCCodeGen/Internal/StructuredSwiftRepresentation.swift
+++ b/Sources/GRPCCodeGen/Internal/StructuredSwiftRepresentation.swift
@@ -791,9 +791,6 @@ indirect enum Declaration: Equatable, Codable, Sendable {
   /// A declaration that adds a comment on top of the provided declaration.
   case deprecated(DeprecationDescription, Declaration)
 
-  /// A declaration that adds an availability guard on top of the provided declaration.
-  case guarded(AvailabilityDescription, Declaration)
-
   /// A variable declaration.
   case variable(VariableDescription)
 
@@ -1870,7 +1867,6 @@ extension Declaration {
       switch self {
       case .commentable(_, let declaration): return declaration.accessModifier
       case .deprecated(_, let declaration): return declaration.accessModifier
-      case .guarded(_, let declaration): return declaration.accessModifier
       case .variable(let variableDescription): return variableDescription.accessModifier
       case .extension(let extensionDescription): return extensionDescription.accessModifier
       case .struct(let structDescription): return structDescription.accessModifier
@@ -1889,9 +1885,6 @@ extension Declaration {
       case .deprecated(let deprecationDescription, var declaration):
         declaration.accessModifier = newValue
         self = .deprecated(deprecationDescription, declaration)
-      case .guarded(let availability, var declaration):
-        declaration.accessModifier = newValue
-        self = .guarded(availability, declaration)
       case .variable(var variableDescription):
         variableDescription.accessModifier = newValue
         self = .variable(variableDescription)


### PR DESCRIPTION
## Motivation
https://github.com/grpc/grpc-swift/pull/2131 removed all usages of availability guards. However, the `guarded` Declaration case was not removed even though it's unused.

## Modifications
This PR removes the `guarded` case since it's not used anywhere anymore.

## Result
Cleaner codebase.