### PR TITLE
Enable MemberImportVisibility check on all targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -117,3 +117,14 @@ let package = Package(
   dependencies: dependencies,
   targets: targets
 )
+
+// ---    STANDARD CROSS-REPO SETTINGS DO NOT EDIT   --- //
+for target in package.targets {
+  if target.type != .plugin {
+    var settings = target.swiftSettings ?? []
+    // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0444-member-import-visibility.md
+    settings.append(.enableUpcomingFeature("MemberImportVisibility"))
+    target.swiftSettings = settings
+  }
+}
+// --- END: STANDARD CROSS-REPO SETTINGS DO NOT EDIT --- //

--- a/Package.swift
+++ b/Package.swift
@@ -49,6 +49,7 @@ let defaultSwiftSettings: [SwiftSetting] = [
   .swiftLanguageMode(.v6),
   .enableUpcomingFeature("ExistentialAny"),
   .enableUpcomingFeature("InternalImportsByDefault"),
+  .enableUpcomingFeature("MemberImportVisibility"),
 ]
 
 let targets: [Target] = [
@@ -117,14 +118,3 @@ let package = Package(
   dependencies: dependencies,
   targets: targets
 )
-
-// ---    STANDARD CROSS-REPO SETTINGS DO NOT EDIT   --- //
-for target in package.targets {
-  if target.type != .plugin {
-    var settings = target.swiftSettings ?? []
-    // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0444-member-import-visibility.md
-    settings.append(.enableUpcomingFeature("MemberImportVisibility"))
-    target.swiftSettings = settings
-  }
-}
-// --- END: STANDARD CROSS-REPO SETTINGS DO NOT EDIT --- //

--- a/Sources/GRPCCodeGen/CodeGenerationRequest.swift
+++ b/Sources/GRPCCodeGen/CodeGenerationRequest.swift
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import Foundation
+
 /// Describes the services, dependencies and trivia from an IDL file,
 /// and the IDL itself through its specific serializer and deserializer.
 public struct CodeGenerationRequest {

--- a/Sources/GRPCCodeGen/Internal/Translator/Docs.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/Docs.swift
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import Foundation
+
 package enum Docs {
   package static func suffix(_ header: String, withDocs footer: String) -> String {
     if footer.isEmpty {

--- a/Tests/GRPCCoreTests/Configuration/ServiceConfigCodingTests.swift
+++ b/Tests/GRPCCoreTests/Configuration/ServiceConfigCodingTests.swift
@@ -16,6 +16,7 @@
 
 import Foundation
 import GRPCCore
+import SwiftProtobuf
 import XCTest
 
 final class ServiceConfigCodingTests: XCTestCase {

--- a/Tests/GRPCCoreTests/Test Utilities/Services/HelloWorld.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/Services/HelloWorld.swift
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import Foundation
 import GRPCCore
 
 struct HelloWorld: RegistrableRPCService {


### PR DESCRIPTION
Enable MemberImportVisibility check on all targets. Use a standard string header and footer to bracket the new block for ease of updating in the future with scripts.