### PR TITLE
Add RPCErrorConvertible

### DIFF
--- a/Sources/GRPCCore/Call/Server/Internal/ServerRPCExecutor.swift
+++ b/Sources/GRPCCore/Call/Server/Internal/ServerRPCExecutor.swift
@@ -188,7 +188,15 @@ struct ServerRPCExecutor {
         try await handler(request, context)
       }
     }.castError(to: RPCError.self) { error in
-      RPCError(code: .unknown, message: "Service method threw an unknown error.", cause: error)
+      if let convertible = error as? (any RPCErrorConvertible) {
+        return RPCError(convertible)
+      } else {
+        return RPCError(
+          code: .unknown,
+          message: "Service method threw an unknown error.",
+          cause: error
+        )
+      }
     }.flatMap { response in
       response.accepted
     }

--- a/Tests/GRPCCoreTests/RPCErrorTests.swift
+++ b/Tests/GRPCCoreTests/RPCErrorTests.swift
@@ -189,4 +189,49 @@ struct RPCErrorTests {
     #expect(wrappedError1.message == "Error 1.")
     #expect(wrappedError1.cause == nil)
   }
+
+  @Test("Convert type to RPCError")
+  func convertTypeUsingRPCErrorConvertible() {
+    struct Cause: Error {}
+    struct ConvertibleError: RPCErrorConvertible {
+      var rpcErrorCode: RPCError.Code { .unknown }
+      var rpcErrorMessage: String { "uhoh" }
+      var rpcErrorMetadata: Metadata { ["k": "v"] }
+      var rpcErrorCause: (any Error)? { Cause() }
+    }
+
+    let error = RPCError(ConvertibleError())
+    #expect(error.code == .unknown)
+    #expect(error.message == "uhoh")
+    #expect(error.metadata == ["k": "v"])
+    #expect(error.cause is Cause)
+  }
+
+  @Test("Convert type to RPCError with defaults")
+  func convertTypeUsingRPCErrorConvertibleDefaults() {
+    struct ConvertibleType: RPCErrorConvertible {
+      var rpcErrorCode: RPCError.Code { .unknown }
+      var rpcErrorMessage: String { "uhoh" }
+    }
+
+    let error = RPCError(ConvertibleType())
+    #expect(error.code == .unknown)
+    #expect(error.message == "uhoh")
+    #expect(error.metadata == [:])
+    #expect(error.cause == nil)
+  }
+
+  @Test("Convert error to RPCError with defaults")
+  func convertErrorUsingRPCErrorConvertibleDefaults() {
+    struct ConvertibleType: RPCErrorConvertible, Error {
+      var rpcErrorCode: RPCError.Code { .unknown }
+      var rpcErrorMessage: String { "uhoh" }
+    }
+
+    let error = RPCError(ConvertibleType())
+    #expect(error.code == .unknown)
+    #expect(error.message == "uhoh")
+    #expect(error.metadata == [:])
+    #expect(error.cause is ConvertibleType)
+  }
 }


### PR DESCRIPTION
Motivation:

If an error is thrown from a server RPC then the status sent to the client will always have the unknown error code unless an `RPCError` is thrown.

Moreover, there are various extensions to gRPC which rely on additional information being stuffed into the metadata. This is difficult and a bit error prone for users to do directly.

We should provide a mechanism whereby errors can be converted to an `RPCError` such that the appropriate code, message and metadata are sent to the client.

Modifications:

- Add the `RPCErrorConvertible` protocol. Conforming types provide appropriate properties to populate an `RPCError`.
- Add handling for this in the server executor such that convertible errors are converted into an `RPCError`.

Result:

Easier for users to propagate an appropriate status