### PR TITLE
Use a nil Descriptor list for empty proto files

### DIFF
--- a/Sources/GRPCCodeGen/Internal/Translator/IDLToStructuredSwiftTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/IDLToStructuredSwiftTranslator.swift
@@ -74,9 +74,9 @@ package struct IDLToStructuredSwiftTranslator: Translator {
       }
     }
 
-    let imports: [ImportDescription]
+    let imports: [ImportDescription]?
     if codeGenerationRequest.services.isEmpty {
-      imports = []
+      imports = nil
       codeBlocks.append(
         CodeBlock(comment: .inline("This file contained no services."))
       )

--- a/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
@@ -145,7 +145,6 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
       """
       /// Some really exciting license header 2023.
 
-
       // This file contained no services.
       """
     try self.assertIDLToStructuredSwiftTranslation(


### PR DESCRIPTION
### Motivation:

If a proto file contains no services we include a comment indicating this is expected. At the moment this has two empty lines above it.

### Modifications:

Store `nil` instead of an empty array of `Descriptor`s into the `FileDescription`.

### Result:

Only one empty line above the comment.