### PR TITLE
Fix typos/punctuation

### DIFF
--- a/Sources/GRPCCore/Documentation.docc/Articles/Public-API.md
+++ b/Sources/GRPCCore/Documentation.docc/Articles/Public-API.md
@@ -7,10 +7,10 @@ made by the maintainers.
 
 The gRPC Swift project uses [Semantic Versioning 2.0.0][0] which requires
 projects to declare their public API. This document describes what is and isn't
-part of the public API; commitments the maintainers make relating to the API;
+part of the public API; commitments the maintainers make relating to the API,
 and guidelines for users.
 
-For clarity the project is comprised of the following Swift packages:
+For clarity, the project is comprised of the following Swift packages:
 
 - [grpc/grpc-swift][1],
 - [grpc/grpc-swift-nio-transport][2],
@@ -21,7 +21,7 @@ For clarity the project is comprised of the following Swift packages:
 
 ### Library targets
 
-All library targets made available as package products as considered to be
+All library targets made available as package products are considered to be
 public API. Examples of these include `GRPCCore` and `GRPCProtobuf`.
 
 > Exceptions:


### PR DESCRIPTION
Motivation:

Some comments on #2175 were missed becuase automerge was enabled and the PR got approved.

Modification:

Fix typos/punctuation.

Result:

Better docs.