### PR TITLE
Update dependencies for rc

### DIFF
--- a/Examples/echo/Package.swift
+++ b/Examples/echo/Package.swift
@@ -21,9 +21,9 @@ let package = Package(
   name: "echo",
   platforms: [.macOS("15.0")],
   dependencies: [
-    .package(url: "https://github.com/grpc/grpc-swift.git", branch: "main"),
-    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", branch: "main"),
-    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", branch: "main"),
+    .package(url: "https://github.com/grpc/grpc-swift.git", exact: "2.0.0-rc.1"),
+    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", exact: "1.0.0-rc.1"),
+    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", exact: "1.0.0-rc.1"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
   ],
   targets: [

--- a/Examples/error-details/Package.swift
+++ b/Examples/error-details/Package.swift
@@ -21,8 +21,8 @@ let package = Package(
   name: "error-details",
   platforms: [.macOS(.v15)],
   dependencies: [
-    .package(url: "https://github.com/grpc/grpc-swift.git", branch: "main"),
-    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", branch: "main"),
+    .package(url: "https://github.com/grpc/grpc-swift.git", exact: "2.0.0-rc.1"),
+    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", exact: "1.0.0-rc.1"),
   ],
   targets: [
     .executableTarget(

--- a/Examples/hello-world/Package.swift
+++ b/Examples/hello-world/Package.swift
@@ -21,9 +21,9 @@ let package = Package(
   name: "hello-world",
   platforms: [.macOS("15.0")],
   dependencies: [
-    .package(url: "https://github.com/grpc/grpc-swift.git", branch: "main"),
-    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", branch: "main"),
-    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", branch: "main"),
+    .package(url: "https://github.com/grpc/grpc-swift.git", exact: "2.0.0-rc.1"),
+    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", exact: "2.0.0-rc.1"),
+    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", exact: "1.0.0-rc.1"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
   ],
   targets: [

--- a/Examples/reflection-server/Package.swift
+++ b/Examples/reflection-server/Package.swift
@@ -21,10 +21,10 @@ let package = Package(
   name: "reflection-server",
   platforms: [.macOS(.v15)],
   dependencies: [
-    .package(url: "https://github.com/grpc/grpc-swift.git", branch: "main"),
-    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", branch: "main"),
-    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", branch: "main"),
-    .package(url: "https://github.com/grpc/grpc-swift-extras.git", exact: "1.0.0-beta.3"),
+    .package(url: "https://github.com/grpc/grpc-swift.git", exact: "2.0.0-rc.1"),
+    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", exact: "1.0.0-rc.1"),
+    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", exact: "1.0.0-rc.1"),
+    .package(url: "https://github.com/grpc/grpc-swift-extras.git", exact: "1.0.0-rc.1"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
   ],
   targets: [

--- a/Examples/route-guide/Package.swift
+++ b/Examples/route-guide/Package.swift
@@ -21,9 +21,9 @@ let package = Package(
   name: "route-guide",
   platforms: [.macOS("15.0")],
   dependencies: [
-    .package(url: "https://github.com/grpc/grpc-swift.git", branch: "main"),
-    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", branch: "main"),
-    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", branch: "main"),
+    .package(url: "https://github.com/grpc/grpc-swift.git", exact: "2.0.0-rc.1"),
+    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", exact: "1.0.0-rc.1"),
+    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", exact: "1.0.0-rc.1"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
   ],
   targets: [

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ let package = Package(
     name: "foo-package",
     platforms: [.macOS("15.0")],
     dependencies: [
-        .package(url: "https://github.com/grpc/grpc-swift.git", from: "2.0.0-beta.3"),
-        .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "1.0.0-beta.3"),
-        .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "1.0.0-beta.3"),
+        .package(url: "https://github.com/grpc/grpc-swift.git", from: "2.0.0-rc.1"),
+        .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "1.0.0-rc.1"),
+        .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "1.0.0-rc.1"),
     ],
     targets: [
         .executableTarget(

--- a/Sources/GRPCCore/Documentation.docc/Tutorials/Hello-World/Hello-World.tutorial
+++ b/Sources/GRPCCore/Documentation.docc/Tutorials/Hello-World/Hello-World.tutorial
@@ -18,7 +18,7 @@
     repository by running the following command in a terminal:
 
     ```console
-    git clone --branch 2.0.0-beta.3 https://github.com/grpc/grpc-swift
+    git clone --branch 2.0.0-rc.1 https://github.com/grpc/grpc-swift
     ```
 
     You then need to change directory to the `Examples/hello-world` directory of the cloned

--- a/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec01-step07-description.swift
+++ b/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec01-step07-description.swift
@@ -5,9 +5,9 @@ let package = Package(
   name: "RouteGuide",
   platforms: [.macOS(.v15)],
   dependencies: [
-    .package(url: "https://github.com/grpc/grpc-swift.git", from: "2.0.0-beta.3"),
-    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "1.0.0-beta.3"),
-    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "1.0.0-beta.3"),
+    .package(url: "https://github.com/grpc/grpc-swift.git", from: "2.0.0-rc.1"),
+    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "1.0.0-rc.1"),
+    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "1.0.0-rc.1"),
   ],
   targets: []
 )

--- a/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec01-step08-description.swift
+++ b/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec01-step08-description.swift
@@ -5,9 +5,9 @@ let package = Package(
   name: "RouteGuide",
   platforms: [.macOS(.v15)],
   dependencies: [
-    .package(url: "https://github.com/grpc/grpc-swift.git", from: "2.0.0-beta.3"),
-    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "1.0.0-beta.3"),
-    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "1.0.0-beta.3"),
+    .package(url: "https://github.com/grpc/grpc-swift.git", from: "2.0.0-rc.1"),
+    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "1.0.0-rc.1"),
+    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "1.0.0-rc.1"),
   ],
   targets: [
     .executableTarget(

--- a/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec01-step09-plugin.swift
+++ b/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec01-step09-plugin.swift
@@ -5,9 +5,9 @@ let package = Package(
   name: "RouteGuide",
   platforms: [.macOS(.v15)],
   dependencies: [
-    .package(url: "https://github.com/grpc/grpc-swift.git", from: "2.0.0-beta.3"),
-    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "1.0.0-beta.3"),
-    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "1.0.0-beta.3"),
+    .package(url: "https://github.com/grpc/grpc-swift.git", from: "2.0.0-rc.1"),
+    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "1.0.0-rc.1"),
+    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "1.0.0-rc.1"),
   ],
   targets: [
     .executableTarget(

--- a/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec05-step00-package.swift
+++ b/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec05-step00-package.swift
@@ -5,9 +5,9 @@ let package = Package(
   name: "RouteGuide",
   platforms: [.macOS(.v15)],
   dependencies: [
-    .package(url: "https://github.com/grpc/grpc-swift.git", from: "2.0.0-beta.3"),
-    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "1.0.0-beta.3"),
-    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "1.0.0-beta.3"),
+    .package(url: "https://github.com/grpc/grpc-swift.git", from: "2.0.0-rc.1"),
+    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "1.0.0-rc.1"),
+    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "1.0.0-rc.1"),
   ],
   targets: [
     .executableTarget(

--- a/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec05-step01-package.swift
+++ b/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec05-step01-package.swift
@@ -5,9 +5,9 @@ let package = Package(
   name: "RouteGuide",
   platforms: [.macOS(.v15)],
   dependencies: [
-    .package(url: "https://github.com/grpc/grpc-swift.git", from: "2.0.0-beta.3"),
-    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "1.0.0-beta.3"),
-    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "1.0.0-beta.3"),
+    .package(url: "https://github.com/grpc/grpc-swift.git", from: "2.0.0-rc.1"),
+    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "1.0.0-rc.1"),
+    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "1.0.0-rc.1"),
   ],
   targets: [
     .executableTarget(

--- a/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec05-step02-package.swift
+++ b/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec05-step02-package.swift
@@ -5,9 +5,9 @@ let package = Package(
   name: "RouteGuide",
   platforms: [.macOS(.v15)],
   dependencies: [
-    .package(url: "https://github.com/grpc/grpc-swift.git", from: "2.0.0-beta.3"),
-    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "1.0.0-beta.3"),
-    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "1.0.0-beta.3"),
+    .package(url: "https://github.com/grpc/grpc-swift.git", from: "2.0.0-rc.1"),
+    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "1.0.0-rc.1"),
+    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "1.0.0-rc.1"),
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0"),
   ],
   targets: [


### PR DESCRIPTION
Motivation:

We're going to tag an RC soon so bump tutorial/example dependencies.

Modifications:

- Bump dependencies to `-rc.1`.

Result:

Docs will be correct for the tagged release.