### PR TITLE
Fix Metadata's description for prettier printing

### DIFF
--- a/Sources/GRPCCore/Metadata.swift
+++ b/Sources/GRPCCore/Metadata.swift
@@ -494,7 +494,15 @@ extension Metadata.Value: ExpressibleByArrayLiteral {
 
 extension Metadata: CustomStringConvertible {
   public var description: String {
-    String(describing: self.map({ ($0.key.description, $0.value.description) }))
+    var description = "["
+    description = self.dropLast().reduce(into: description) { partialResult, nextPair in
+      partialResult += "\"\(nextPair.key)\": \(nextPair.value), "
+    }
+    if let lastElement = self.last {
+      description += "\"\(lastElement.key)\": \(lastElement.value)"
+    }
+    description += "]"
+    return description
   }
 }
 
@@ -502,7 +510,7 @@ extension Metadata.Value: CustomStringConvertible {
   public var description: String {
     switch self {
     case .string(let stringValue):
-      return stringValue
+      return "\"\(stringValue)\""
     case .binary(let binaryValue):
       return String(describing: binaryValue)
     }

--- a/Sources/GRPCCore/Metadata.swift
+++ b/Sources/GRPCCore/Metadata.swift
@@ -494,7 +494,7 @@ extension Metadata.Value: ExpressibleByArrayLiteral {
 
 extension Metadata: CustomStringConvertible {
   public var description: String {
-    String(describing: self.map({ ($0.key, $0.value) }))
+    String(describing: self.map({ ($0.key.description, $0.value.description) }))
   }
 }
 
@@ -502,7 +502,7 @@ extension Metadata.Value: CustomStringConvertible {
   public var description: String {
     switch self {
     case .string(let stringValue):
-      return String(describing: stringValue)
+      return stringValue
     case .binary(let binaryValue):
       return String(describing: binaryValue)
     }

--- a/Sources/GRPCCore/Metadata.swift
+++ b/Sources/GRPCCore/Metadata.swift
@@ -497,7 +497,7 @@ extension Metadata: CustomStringConvertible {
     if self.isEmpty {
       return "[:]"
     } else {
-      let elements = self.map { "\(String(reflecting: $0.key)): \(String(reflecting: $0.value))"}
+      let elements = self.map { "\(String(reflecting: $0.key)): \(String(reflecting: $0.value))" }
         .joined(separator: ", ")
       return "[\(elements)]"
     }

--- a/Sources/GRPCCore/Metadata.swift
+++ b/Sources/GRPCCore/Metadata.swift
@@ -494,20 +494,29 @@ extension Metadata.Value: ExpressibleByArrayLiteral {
 
 extension Metadata: CustomStringConvertible {
   public var description: String {
-    var description = "["
-    description = self.dropLast().reduce(into: description) { partialResult, nextPair in
-      partialResult += "\"\(nextPair.key)\": \(nextPair.value), "
+    if self.isEmpty {
+      return "[:]"
+    } else {
+      let elements = self.map { "\(String(reflecting: $0.key)): \(String(reflecting: $0.value))"}
+        .joined(separator: ", ")
+      return "[\(elements)]"
     }
-    if let lastElement = self.last {
-      description += "\"\(lastElement.key)\": \(lastElement.value)"
-    }
-    description += "]"
-    return description
   }
 }
 
 extension Metadata.Value: CustomStringConvertible {
   public var description: String {
+    switch self {
+    case .string(let stringValue):
+      return stringValue
+    case .binary(let binaryValue):
+      return String(describing: binaryValue)
+    }
+  }
+}
+
+extension Metadata.Value: CustomDebugStringConvertible {
+  public var debugDescription: String {
     switch self {
     case .string(let stringValue):
       return "\"\(stringValue)\""

--- a/Sources/GRPCCore/Metadata.swift
+++ b/Sources/GRPCCore/Metadata.swift
@@ -508,7 +508,7 @@ extension Metadata.Value: CustomStringConvertible {
   public var description: String {
     switch self {
     case .string(let stringValue):
-      return stringValue
+      return String(describing: stringValue)
     case .binary(let binaryValue):
       return String(describing: binaryValue)
     }
@@ -519,9 +519,9 @@ extension Metadata.Value: CustomDebugStringConvertible {
   public var debugDescription: String {
     switch self {
     case .string(let stringValue):
-      return "\"\(stringValue)\""
+      return String(reflecting: stringValue)
     case .binary(let binaryValue):
-      return String(describing: binaryValue)
+      return String(reflecting: binaryValue)
     }
   }
 }

--- a/Tests/GRPCCoreTests/MetadataTests.swift
+++ b/Tests/GRPCCoreTests/MetadataTests.swift
@@ -324,7 +324,21 @@ struct MetadataTests {
         "key2": "value2",
         "key-bin": .binary([1, 2, 3]),
       ]
+
       #expect("\(metadata)" == #"["key1": "value1", "key2": "value2", "key-bin": [1, 2, 3]]"#)
+
+      for (key, value) in metadata {
+        switch key {
+        case "key1":
+          #expect("\(value)" == "value1")
+        case "key2":
+          #expect("\(value)" == "value2")
+        case "key-bin":
+          #expect("\(value)" == "[1, 2, 3]")
+        default:
+          Issue.record("Should not have reached this point")
+        }
+      }
     }
   }
 }

--- a/Tests/GRPCCoreTests/MetadataTests.swift
+++ b/Tests/GRPCCoreTests/MetadataTests.swift
@@ -314,4 +314,17 @@ struct MetadataTests {
       )
     }
   }
+
+  @Suite("Description")
+  struct Description {
+    @Test("Metadata")
+    func describeMetadata() async throws {
+      let metadata: Metadata = [
+        "key1": "value1",
+        "key2": "value2",
+        "key-bin": .binary([1,2,3]),
+      ]
+      #expect("\(metadata)" == #"["key1": "value1", "key2": "value2", "key-bin": [1, 2, 3]]"#)
+    }
+  }
 }

--- a/Tests/GRPCCoreTests/MetadataTests.swift
+++ b/Tests/GRPCCoreTests/MetadataTests.swift
@@ -322,7 +322,7 @@ struct MetadataTests {
       let metadata: Metadata = [
         "key1": "value1",
         "key2": "value2",
-        "key-bin": .binary([1,2,3]),
+        "key-bin": .binary([1, 2, 3]),
       ]
       #expect("\(metadata)" == #"["key1": "value1", "key2": "value2", "key-bin": [1, 2, 3]]"#)
     }

--- a/Tests/GRPCCoreTests/MetadataTests.swift
+++ b/Tests/GRPCCoreTests/MetadataTests.swift
@@ -317,11 +317,11 @@ struct MetadataTests {
 
   @Suite("Description")
   struct Description {
-    let metadata = Metadata([
+    let metadata: Metadata = [
       "key1": "value1",
       "key2": "value2",
       "key-bin": .binary([1, 2, 3]),
-    ])
+    ]
 
     @Test("Metadata")
     func describeMetadata() async throws {

--- a/Tests/GRPCCoreTests/MetadataTests.swift
+++ b/Tests/GRPCCoreTests/MetadataTests.swift
@@ -317,17 +317,20 @@ struct MetadataTests {
 
   @Suite("Description")
   struct Description {
+    let metadata = Metadata([
+      "key1": "value1",
+      "key2": "value2",
+      "key-bin": .binary([1, 2, 3]),
+    ])
+
     @Test("Metadata")
     func describeMetadata() async throws {
-      let metadata: Metadata = [
-        "key1": "value1",
-        "key2": "value2",
-        "key-bin": .binary([1, 2, 3]),
-      ]
+      #expect("\(self.metadata)" == #"["key1": "value1", "key2": "value2", "key-bin": [1, 2, 3]]"#)
+    }
 
-      #expect("\(metadata)" == #"["key1": "value1", "key2": "value2", "key-bin": [1, 2, 3]]"#)
-
-      for (key, value) in metadata {
+    @Test("Metadata.Value")
+    func describeMetadataValue() async throws {
+      for (key, value) in self.metadata {
         switch key {
         case "key1":
           #expect("\(value)" == "value1")


### PR DESCRIPTION
This PR changes `Metadata`'s description to include quotes around string values.

From this:

```
[("some-key", some-value)]
```

to this:

```
[("some-key", "some-value")]
```