### PR TITLE
Fix grpc-swift-protobuf version in hello-world example

### DIFF
--- a/Examples/hello-world/Package.swift
+++ b/Examples/hello-world/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
   platforms: [.macOS("15.0")],
   dependencies: [
     .package(url: "https://github.com/grpc/grpc-swift.git", exact: "2.0.0-rc.1"),
-    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", exact: "2.0.0-rc.1"),
+    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", exact: "1.0.0-rc.1"),
     .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", exact: "1.0.0-rc.1"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
   ],


### PR DESCRIPTION
CI is currently failing to build because `grpc-swift-protobuf`'s dependency on the `hello-world` example points to no a non-existing tag.