### PR TITLE
Don't build examples twice

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -42,7 +42,7 @@ jobs:
           MATRIX_LINUX_5_9_ENABLED: false
           MATRIX_LINUX_5_10_ENABLED: false
           MATRIX_LINUX_COMMAND: "./dev/build-examples.sh"
-          MATRIX_LINUX_SETUP_COMMAND: "apt update && apt install -y protobuf-compiler && ./dev/build-examples.sh"
+          MATRIX_LINUX_SETUP_COMMAND: "apt update && apt install -y protobuf-compiler"
 
   examples-matrix:
     name: Examples


### PR DESCRIPTION
Motivation:

The CI for examples builds them in the setup stage and the actual run stages. That's just a silly oversight.

Modifications:

- Don't build them during set.

Result:

Examples don't build twice in CI