### PR TITLE
Add note about minimum deployment versions for Apple platforms

### DIFF
--- a/Sources/GRPCCore/Documentation.docc/Articles/Compatibility.md
+++ b/Sources/GRPCCore/Documentation.docc/Articles/Compatibility.md
@@ -20,3 +20,14 @@ gRPC Swift aims to support the same platforms as Swift project. These are listed
 on [swift.org](https://www.swift.org/platform-support/).
 
 The only known unsupported platform from that list is currently Windows.
+
+Apple platforms have a minimum deployment version. These are as follows for gRPC
+Swift:
+
+| OS       | Minimum Deployment Version |
+|----------|----------------------------|
+| macOS    | 15.0                       |
+| iOS      | 18.0                       |
+| tvOS     | 18.0                       |
+| watchOS  | 11.0                       |
+| visionOS | 2.0                        |


### PR DESCRIPTION
Motivation:

The compatibility doc doesn't mention minimum deployment versions for Apple platforms. It should.

Modifications:

- Add minimum deployment versions.

Result:

Better docs.