### PR TITLE
Fix build issues with static Linux SDK

### DIFF
--- a/Sources/GRPCCore/Call/Client/Internal/RetryDelaySequence.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/RetryDelaySequence.swift
@@ -15,8 +15,12 @@
  */
 #if canImport(Darwin)
 public import Darwin  // should be @usableFromInline
-#else
+#elseif canImport(Glibc)
 public import Glibc  // should be @usableFromInline
+#elseif canImport(Musl)
+public import Musl  // should be @usableFromInline
+#else
+#error("Unsupported OS")
 #endif
 
 @usableFromInline

--- a/Sources/GRPCInProcessTransport/Syscalls.swift
+++ b/Sources/GRPCInProcessTransport/Syscalls.swift
@@ -17,9 +17,11 @@
 #if canImport(Darwin)
 private import Darwin
 #elseif canImport(Glibc)
-private import Glibc
+private import Glibc  // should be @usableFromInline
 #elseif canImport(Musl)
-private import Musl
+private import Musl  // should be @usableFromInline
+#else
+#error("Unsupported OS")
 #endif
 
 enum System {


### PR DESCRIPTION
This PR fixes some imports so that grpc-swift can be built using the static Linux SDK.