### PR TITLE
Improve error message when client is run when shutdown

### DIFF
--- a/Sources/GRPCCore/GRPCClient.swift
+++ b/Sources/GRPCCore/GRPCClient.swift
@@ -89,7 +89,11 @@ public final class GRPCClient<Transport: ClientTransport>: Sendable {
       case .stopping, .stopped:
         throw RuntimeError(
           code: .clientIsStopped,
-          message: "The client has stopped and can only be started once."
+          message: """
+            Can't call 'runConnections()' as the client is stopped (or is stopping). \
+            This can happen if the you call 'runConnections()' after shutting the \
+            client down or if you used 'withGRPCClient' with an empty body.
+            """
         )
       }
     }


### PR DESCRIPTION
Motivation:

GRPCClient can throw an error when run is called more than once or if run is called after it has been shutdown. Normally this would happen if a user caller 'run()' more than once, but can also happen if 'withGRPCClient' is called and the client is never used and the body returns quickly.

Modifications:

- Improve the error message

Result:

Better error message.