### PR TITLE
Add Swift 6.1 CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ jobs:
       linux_5_9_enabled: false
       linux_5_10_enabled: false
       linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+      linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,6 +23,7 @@ jobs:
       linux_5_9_enabled: false
       linux_5_10_enabled: false
       linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+      linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
 

--- a/IntegrationTests/Benchmarks/Thresholds/6.1/GRPCSwiftBenchmark.Metadata_Add_binary.p90.json
+++ b/IntegrationTests/Benchmarks/Thresholds/6.1/GRPCSwiftBenchmark.Metadata_Add_binary.p90.json
@@ -1,0 +1,7 @@
+{
+  "mallocCountTotal" : 11,
+  "memoryLeaked" : 0,
+  "releaseCount" : 3012,
+  "retainCount" : 2000,
+  "syscalls" : 0
+}

--- a/IntegrationTests/Benchmarks/Thresholds/6.1/GRPCSwiftBenchmark.Metadata_Add_string.p90.json
+++ b/IntegrationTests/Benchmarks/Thresholds/6.1/GRPCSwiftBenchmark.Metadata_Add_string.p90.json
@@ -1,0 +1,7 @@
+{
+  "mallocCountTotal" : 11,
+  "memoryLeaked" : 0,
+  "releaseCount" : 4012,
+  "retainCount" : 2000,
+  "syscalls" : 0
+}

--- a/IntegrationTests/Benchmarks/Thresholds/6.1/GRPCSwiftBenchmark.Metadata_Iterate_all_values.p90.json
+++ b/IntegrationTests/Benchmarks/Thresholds/6.1/GRPCSwiftBenchmark.Metadata_Iterate_all_values.p90.json
@@ -1,0 +1,7 @@
+{
+  "mallocCountTotal" : 0,
+  "memoryLeaked" : 0,
+  "releaseCount" : 3001,
+  "retainCount" : 1000,
+  "syscalls" : 0
+}

--- a/IntegrationTests/Benchmarks/Thresholds/6.1/GRPCSwiftBenchmark.Metadata_Iterate_binary_values_when_only_binary_values_stored.p90.json
+++ b/IntegrationTests/Benchmarks/Thresholds/6.1/GRPCSwiftBenchmark.Metadata_Iterate_binary_values_when_only_binary_values_stored.p90.json
@@ -1,0 +1,7 @@
+{
+  "mallocCountTotal" : 0,
+  "memoryLeaked" : 0,
+  "releaseCount" : 3001,
+  "retainCount" : 1000,
+  "syscalls" : 0
+}

--- a/IntegrationTests/Benchmarks/Thresholds/6.1/GRPCSwiftBenchmark.Metadata_Iterate_binary_values_when_only_strings_stored.p90.json
+++ b/IntegrationTests/Benchmarks/Thresholds/6.1/GRPCSwiftBenchmark.Metadata_Iterate_binary_values_when_only_strings_stored.p90.json
@@ -1,0 +1,7 @@
+{
+  "mallocCountTotal" : 2000,
+  "memoryLeaked" : 0,
+  "releaseCount" : 6001,
+  "retainCount" : 2000,
+  "syscalls" : 0
+}

--- a/IntegrationTests/Benchmarks/Thresholds/6.1/GRPCSwiftBenchmark.Metadata_Iterate_string_values.p90.json
+++ b/IntegrationTests/Benchmarks/Thresholds/6.1/GRPCSwiftBenchmark.Metadata_Iterate_string_values.p90.json
@@ -1,0 +1,7 @@
+{
+  "mallocCountTotal" : 0,
+  "memoryLeaked" : 0,
+  "releaseCount" : 3001,
+  "retainCount" : 1000,
+  "syscalls" : 0
+}

--- a/IntegrationTests/Benchmarks/Thresholds/6.1/GRPCSwiftBenchmark.Metadata_Remove_values_for_key.p90.json
+++ b/IntegrationTests/Benchmarks/Thresholds/6.1/GRPCSwiftBenchmark.Metadata_Remove_values_for_key.p90.json
@@ -1,0 +1,7 @@
+{
+  "mallocCountTotal" : 0,
+  "memoryLeaked" : 0,
+  "releaseCount" : 2002001,
+  "retainCount" : 1999000,
+  "syscalls" : 0
+}

--- a/IntegrationTests/Benchmarks/Thresholds/nightly-6.1
+++ b/IntegrationTests/Benchmarks/Thresholds/nightly-6.1
@@ -1,1 +1,0 @@
-./nightly-next


### PR DESCRIPTION
Motivation:

Swift 6.1 has been released, we should add it to our CI coverage.

Modifications:

- Add additional Swift 6.1 jobs where appropriate in main.yml, pull_request.yml
- Add thresholds for Swift 6.1

Result:

Improved test coverage.