### PR TITLE
Expose APIs to customise NIOTS bootstraps

### DIFF
--- a/Sources/GRPC/ClientConnection.swift
+++ b/Sources/GRPC/ClientConnection.swift
@@ -469,6 +469,24 @@ extension ClientConnection {
     @preconcurrency
     public var debugChannelInitializer: (@Sendable (Channel) -> EventLoopFuture<Void>)?
 
+    #if canImport(Network)
+    @available(macOS 10.14, iOS 12.0, watchOS 6.0, tvOS 12.0, *)
+    public var clientBootstrapNWParametersConfigurator: (
+      @Sendable (NIOTSConnectionBootstrap) -> Void
+    )? {
+      get {
+        return self._clientBootstrapNWParametersConfigurator as! (
+          @Sendable (NIOTSConnectionBootstrap) -> Void
+        )?
+      }
+      set {
+        self._clientBootstrapNWParametersConfigurator = newValue
+      }
+    }
+
+    private var _clientBootstrapNWParametersConfigurator: (any Sendable)?
+    #endif
+
     #if canImport(NIOSSL)
     /// Create a `Configuration` with some pre-defined defaults. Prefer using
     /// `ClientConnection.secure(group:)` to build a connection secured with TLS or

--- a/Sources/GRPC/ConnectionPool/PooledChannel.swift
+++ b/Sources/GRPC/ConnectionPool/PooledChannel.swift
@@ -79,7 +79,36 @@ internal final class PooledChannel: GRPCChannel {
 
     self._scheme = scheme
 
-    let provider = DefaultChannelProvider(
+    let provider: DefaultChannelProvider
+    #if canImport(Network)
+    if #available(macOS 10.14, iOS 12.0, watchOS 6.0, tvOS 12.0, *) {
+      provider = DefaultChannelProvider(
+        connectionTarget: configuration.target,
+        connectionKeepalive: configuration.keepalive,
+        connectionIdleTimeout: configuration.idleTimeout,
+        tlsMode: tlsMode,
+        tlsConfiguration: configuration.transportSecurity.tlsConfiguration,
+        httpTargetWindowSize: configuration.http2.targetWindowSize,
+        httpMaxFrameSize: configuration.http2.maxFrameSize,
+        errorDelegate: configuration.errorDelegate,
+        debugChannelInitializer: configuration.debugChannelInitializer,
+        clientBootstrapNWParametersConfigurator: configuration.transportServices.clientBootstrapNWParametersConfigurator
+      )
+    } else {
+      provider = DefaultChannelProvider(
+        connectionTarget: configuration.target,
+        connectionKeepalive: configuration.keepalive,
+        connectionIdleTimeout: configuration.idleTimeout,
+        tlsMode: tlsMode,
+        tlsConfiguration: configuration.transportSecurity.tlsConfiguration,
+        httpTargetWindowSize: configuration.http2.targetWindowSize,
+        httpMaxFrameSize: configuration.http2.maxFrameSize,
+        errorDelegate: configuration.errorDelegate,
+        debugChannelInitializer: configuration.debugChannelInitializer
+      )
+    }
+    #else
+    provider = DefaultChannelProvider(
       connectionTarget: configuration.target,
       connectionKeepalive: configuration.keepalive,
       connectionIdleTimeout: configuration.idleTimeout,
@@ -90,6 +119,7 @@ internal final class PooledChannel: GRPCChannel {
       errorDelegate: configuration.errorDelegate,
       debugChannelInitializer: configuration.debugChannelInitializer
     )
+    #endif
 
     self._pool = PoolManager.makeInitializedPoolManager(
       using: configuration.eventLoopGroup,

--- a/Tests/GRPCTests/ServerTests.swift
+++ b/Tests/GRPCTests/ServerTests.swift
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import NIOTransportServices
+import XCTest
+import NIOConcurrencyHelpers
+import GRPC
+
+#if canImport(Network)
+import Network
+#endif
+
+class ServerTests: GRPCTestCase {
+  #if canImport(Network)
+  func testParametersConfigurator() throws {
+    let counter = NIOLockedValueBox(0)
+    let serverEventLoopGroup = NIOTSEventLoopGroup()
+    var serverConfiguration = Server.Configuration.default(
+      target: .hostAndPort("localhost", 0),
+      eventLoopGroup: serverEventLoopGroup,
+      serviceProviders: []
+    )
+    serverConfiguration.serverBootstrapNWParametersConfigurator = { _ in
+      counter.withLockedValue { $0 += 1 }
+    }
+
+    _ = try Server.start(configuration: serverConfiguration).wait()
+    XCTAssertEqual(1, counter.withLockedValue({ $0 }))
+  }
+  #endif
+}


### PR DESCRIPTION
`swift-nio-transport-services` added support for customising the `NWParameters` used in the underlying connections in https://github.com/apple/swift-nio-transport-services/pull/230.

This PR adds API in `grpc-swift` v1 to allow users to customise the bootstraps used when creating gRPC connections using NIOTS. This will allow them to, for example, customise their `NWParameters` using the new APIs in `swift-nio-transport-services`.