### PR TITLE
fix generated method names

### DIFF
--- a/Sources/protoc-gen-grpc-swift/Generator-Client+AsyncAwait.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator-Client+AsyncAwait.swift
@@ -95,13 +95,13 @@ extension Generator {
         self.method = method
 
         let rpcType = streamingType(self.method)
-        printRpcFunctionImplementation(rpcType: rpcType)
-        printRpcFunctionWrapper(rpcType: rpcType)
+        printRPCFunctionImplementation(rpcType: rpcType)
+        printRPCFunctionWrapper(rpcType: rpcType)
       }
     }
   }
 
-  private func printRpcFunctionImplementation(rpcType: StreamingType) {
+  private func printRPCFunctionImplementation(rpcType: StreamingType) {
     let argumentsBuilder: (() -> Void)?
     switch rpcType {
     case .unary, .serverStreaming:
@@ -112,7 +112,7 @@ extension Generator {
       argumentsBuilder = nil
     }
     let callTypeWithoutPrefix = Types.call(for: rpcType, withGRPCPrefix: false)
-    printRpcFunction(rpcType: rpcType, name: self.methodMakeFunctionCallName) {
+    printRPCFunction(rpcType: rpcType, name: self.methodMakeFunctionCallName) {
       self.withIndentation("return self.make\(callTypeWithoutPrefix)", braces: .round) {
         self.println("path: \(self.methodPathUsingClientMetadata),")
         argumentsBuilder?()
@@ -124,7 +124,7 @@ extension Generator {
     }
   }
 
-  private func printRpcFunctionWrapper(rpcType: StreamingType) {
+  private func printRPCFunctionWrapper(rpcType: StreamingType) {
     let functionName = methodMakeFunctionCallName
     let functionWrapperName = methodMakeFunctionCallWrapperName
     guard functionName != functionWrapperName else { return }
@@ -139,7 +139,7 @@ extension Generator {
     default:
       argumentsBuilder = nil
     }
-    printRpcFunction(rpcType: rpcType, name: functionWrapperName) {
+    printRPCFunction(rpcType: rpcType, name: functionWrapperName) {
       self.withIndentation("return self.\(functionName)", braces: .round) {
         argumentsBuilder?()
         self.println("callOptions: callOptions")
@@ -147,7 +147,7 @@ extension Generator {
     }
   }
 
-  private func printRpcFunction(rpcType: StreamingType, name: String, bodyBuilder: (() -> Void)?) {
+  private func printRPCFunction(rpcType: StreamingType, name: String, bodyBuilder: (() -> Void)?) {
     let callType = Types.call(for: rpcType)
     self.printFunction(
       name: name,

--- a/Sources/protoc-gen-grpc-swift/Generator-Names.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator-Names.swift
@@ -128,16 +128,15 @@ extension Generator {
   }
 
   internal var methodMakeFunctionCallName: String {
-    let name: String
+    return "make\(methodComposableName)Call"
+  }
 
-    if self.options.keepMethodCasing {
-      name = self.method.name
-    } else {
-      name = NamingUtils.toUpperCamelCase(self.method.name)
+  internal var methodComposableName: String {
+    var name = method.name
+    if !options.keepMethodCasing {
+      name = name.prefix(1).uppercased() + name.dropFirst()
     }
-
-    let fnName = "make\(name)Call"
-    return self.sanitize(fieldName: fnName)
+    return name
   }
 
   internal func sanitize(fieldName string: String) -> String {
@@ -156,7 +155,7 @@ extension Generator {
   }
 
   internal var methodInterceptorFactoryName: String {
-    return "make\(self.method.name)Interceptors"
+    return "make\(methodComposableName)Interceptors"
   }
 
   internal var servicePath: String {

--- a/Sources/protoc-gen-grpc-swift/Generator-Names.swift
+++ b/Sources/protoc-gen-grpc-swift/Generator-Names.swift
@@ -128,6 +128,18 @@ extension Generator {
   }
 
   internal var methodMakeFunctionCallName: String {
+    let name: String
+    if self.options.keepMethodCasing {
+      name = self.method.name
+    } else {
+      name = NamingUtils.toUpperCamelCase(self.method.name)
+    }
+
+    let fnName = "make\(name)Call"
+    return self.sanitize(fieldName: fnName)
+  }
+
+  internal var methodMakeFunctionCallWrapperName: String {
     return "make\(methodComposableName)Call"
   }
 
@@ -155,7 +167,7 @@ extension Generator {
   }
 
   internal var methodInterceptorFactoryName: String {
-    return "make\(methodComposableName)Interceptors"
+    return "make\(self.method.name)Interceptors"
   }
 
   internal var servicePath: String {


### PR DESCRIPTION
This PR fixes incorrectly generated method names.

For example:
`rpc GRPCUnary(google.protobuf.Empty) returns (google.protobuf.Empty) {}`

The plugin correctly generates:
- `makeGRPCUnaryInterceptors`
- `Methods.gRPCUnary`
- `func gRPCUnary`

but incorrectly:
- `makeGrpcunaryCall`
This seems to be the only place with a different logic.

And when using lowercase letters, the interceptor method name is incorrect:
`rpc unary(google.protobuf.Empty) returns (FunctionName) {}`

The plugin correctly generates:
- `makeUnaryCall`
- `Methods.unary`
- `func unary`
but incorrectly:
- `makeunaryInterceptors`

The PR fixes these two issues by introducing a common logic for  `methodMakeFunctionCallName` and `methodInterceptorFactoryName`. The logic is similar to the one in `methodFunctionName`, just that it uppercases the first character instead of lowercasing.

Thus, for the given examples the result is:
`makeGRPCUnaryCall` and `makeUnaryInterceptors`