### PR TITLE
Expose max reset streams HTTP2 configuration

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let packageDependencies: [Package.Dependency] = [
   ),
   .package(
     url: "https://github.com/apple/swift-nio-http2.git",
-    from: "1.32.0"
+    from: "1.36.0"
   ),
   .package(
     url: "https://github.com/apple/swift-nio-transport-services.git",

--- a/Sources/GRPC/ConnectionManagerChannelProvider.swift
+++ b/Sources/GRPC/ConnectionManagerChannelProvider.swift
@@ -70,6 +70,8 @@ internal struct DefaultChannelProvider: ConnectionManagerChannelProvider {
   internal var httpTargetWindowSize: Int
   @usableFromInline
   internal var httpMaxFrameSize: Int
+  @usableFromInline
+  internal var httpMaxResetStreams: Int
 
   @usableFromInline
   internal var errorDelegate: Optional<ClientErrorDelegate>
@@ -102,6 +104,7 @@ internal struct DefaultChannelProvider: ConnectionManagerChannelProvider {
     tlsConfiguration: GRPCTLSConfiguration?,
     httpTargetWindowSize: Int,
     httpMaxFrameSize: Int,
+    httpMaxResetStreams: Int,
     errorDelegate: ClientErrorDelegate?,
     debugChannelInitializer: ((Channel) -> EventLoopFuture<Void>)?,
     nwParametersConfigurator: (@Sendable (NWParameters) -> Void)?
@@ -114,6 +117,7 @@ internal struct DefaultChannelProvider: ConnectionManagerChannelProvider {
       tlsConfiguration: tlsConfiguration,
       httpTargetWindowSize: httpTargetWindowSize,
       httpMaxFrameSize: httpMaxFrameSize,
+      httpMaxResetStreams: httpMaxResetStreams,
       errorDelegate: errorDelegate,
       debugChannelInitializer: debugChannelInitializer
     )
@@ -131,6 +135,7 @@ internal struct DefaultChannelProvider: ConnectionManagerChannelProvider {
     tlsConfiguration: GRPCTLSConfiguration?,
     httpTargetWindowSize: Int,
     httpMaxFrameSize: Int,
+    httpMaxResetStreams: Int,
     errorDelegate: ClientErrorDelegate?,
     debugChannelInitializer: ((Channel) -> EventLoopFuture<Void>)?
   ) {
@@ -143,6 +148,7 @@ internal struct DefaultChannelProvider: ConnectionManagerChannelProvider {
 
     self.httpTargetWindowSize = httpTargetWindowSize
     self.httpMaxFrameSize = httpMaxFrameSize
+    self.httpMaxResetStreams = httpMaxResetStreams
 
     self.errorDelegate = errorDelegate
     self.debugChannelInitializer = debugChannelInitializer
@@ -180,6 +186,7 @@ internal struct DefaultChannelProvider: ConnectionManagerChannelProvider {
       tlsConfiguration: configuration.tlsConfiguration,
       httpTargetWindowSize: configuration.httpTargetWindowSize,
       httpMaxFrameSize: configuration.httpMaxFrameSize,
+      httpMaxResetStreams: configuration.httpMaxResetStreams,
       errorDelegate: configuration.errorDelegate,
       debugChannelInitializer: configuration.debugChannelInitializer
     )
@@ -259,6 +266,7 @@ internal struct DefaultChannelProvider: ConnectionManagerChannelProvider {
             connectionIdleTimeout: self.connectionIdleTimeout,
             httpTargetWindowSize: self.httpTargetWindowSize,
             httpMaxFrameSize: self.httpMaxFrameSize,
+            httpMaxResetStreams: self.httpMaxResetStreams,
             errorDelegate: self.errorDelegate,
             logger: logger
           )

--- a/Sources/GRPC/ConnectionPool/GRPCChannelPool.swift
+++ b/Sources/GRPC/ConnectionPool/GRPCChannelPool.swift
@@ -261,6 +261,13 @@ extension GRPCChannelPool.Configuration {
         self.maxFrameSize = self.maxFrameSize.clamped(to: Self.allowedMaxFrameSizes)
       }
     }
+
+    /// The HTTP/2 max number of reset streams. Defaults to 32. Must be non-negative.
+    public var maxResetStreams: Int = 32 {
+      willSet {
+        precondition(newValue >= 0, "maxResetStreams must be non-negative")
+      }
+    }
   }
 }
 

--- a/Sources/GRPC/ConnectionPool/PooledChannel.swift
+++ b/Sources/GRPC/ConnectionPool/PooledChannel.swift
@@ -90,6 +90,7 @@ internal final class PooledChannel: GRPCChannel {
         tlsConfiguration: configuration.transportSecurity.tlsConfiguration,
         httpTargetWindowSize: configuration.http2.targetWindowSize,
         httpMaxFrameSize: configuration.http2.maxFrameSize,
+        httpMaxResetStreams: configuration.http2.maxResetStreams,
         errorDelegate: configuration.errorDelegate,
         debugChannelInitializer: configuration.debugChannelInitializer,
         nwParametersConfigurator: configuration.transportServices.nwParametersConfigurator
@@ -103,6 +104,7 @@ internal final class PooledChannel: GRPCChannel {
         tlsConfiguration: configuration.transportSecurity.tlsConfiguration,
         httpTargetWindowSize: configuration.http2.targetWindowSize,
         httpMaxFrameSize: configuration.http2.maxFrameSize,
+        httpMaxResetStreams: configuration.http2.maxResetStreams,
         errorDelegate: configuration.errorDelegate,
         debugChannelInitializer: configuration.debugChannelInitializer
       )
@@ -116,6 +118,7 @@ internal final class PooledChannel: GRPCChannel {
       tlsConfiguration: configuration.transportSecurity.tlsConfiguration,
       httpTargetWindowSize: configuration.http2.targetWindowSize,
       httpMaxFrameSize: configuration.http2.maxFrameSize,
+      httpMaxResetStreams: configuration.http2.maxResetStreams,
       errorDelegate: configuration.errorDelegate,
       debugChannelInitializer: configuration.debugChannelInitializer
     )

--- a/Sources/GRPC/GRPCServerPipelineConfigurator.swift
+++ b/Sources/GRPC/GRPCServerPipelineConfigurator.swift
@@ -79,27 +79,27 @@ final class GRPCServerPipelineConfigurator: ChannelInboundHandler, RemovableChan
 
   /// Makes an HTTP/2 handler.
   private func makeHTTP2Handler() -> NIOHTTP2Handler {
-    return .init(
-      mode: .server,
-      initialSettings: [
-        HTTP2Setting(
-          parameter: .maxConcurrentStreams,
-          value: self.configuration.httpMaxConcurrentStreams
-        ),
-        HTTP2Setting(
-          parameter: .maxHeaderListSize,
-          value: HPACKDecoder.defaultMaxHeaderListSize
-        ),
-        HTTP2Setting(
-          parameter: .maxFrameSize,
-          value: self.configuration.httpMaxFrameSize
-        ),
-        HTTP2Setting(
-          parameter: .initialWindowSize,
-          value: self.configuration.httpTargetWindowSize
-        ),
-      ]
-    )
+    var configuration = NIOHTTP2Handler.ConnectionConfiguration()
+    configuration.initialSettings = [
+      HTTP2Setting(
+        parameter: .maxConcurrentStreams,
+        value: self.configuration.httpMaxConcurrentStreams
+      ),
+      HTTP2Setting(
+        parameter: .maxHeaderListSize,
+        value: HPACKDecoder.defaultMaxHeaderListSize
+      ),
+      HTTP2Setting(
+        parameter: .maxFrameSize,
+        value: self.configuration.httpMaxFrameSize
+      ),
+      HTTP2Setting(
+        parameter: .initialWindowSize,
+        value: self.configuration.httpTargetWindowSize
+      ),
+    ]
+    configuration.maximumRecentlyResetStreams = self.configuration.httpMaxResetStreams
+    return NIOHTTP2Handler(mode: .server, connectionConfiguration: configuration)
   }
 
   /// Makes an HTTP/2 multiplexer suitable handling gRPC requests.

--- a/Sources/GRPC/Server.swift
+++ b/Sources/GRPC/Server.swift
@@ -379,6 +379,13 @@ extension Server {
       }
     }
 
+    /// The HTTP/2 max number of reset streams. Defaults to 32. Must be non-negative.
+    public var httpMaxResetStreams: Int = 32 {
+      willSet {
+        precondition(newValue >= 0, "httpMaxResetStreams must be non-negative")
+      }
+    }
+
     /// The root server logger. Accepted connections will branch from this logger and RPCs on
     /// each connection will use a logger branched from the connections logger. This logger is made
     /// available to service providers via `context`. Defaults to a no-op logger.


### PR DESCRIPTION
We have exposed the max reset stream frames config in NIO H2 (https://github.com/apple/swift-nio-http2/pull/494/) - we need to add configuration to expose it in gRPC v1 as well.