### PR TITLE
Add a new field, transportSpecific to ServerContext

### DIFF
--- a/Sources/GRPCCore/Call/Server/ServerContext.swift
+++ b/Sources/GRPCCore/Call/Server/ServerContext.swift
@@ -45,6 +45,15 @@ public struct ServerContext: Sendable {
   /// - "in-process:27182".
   public var localPeer: String
 
+  /// An optional field for transports to store specific data
+  ///
+  /// Refer to the transport documentation to understand what type of
+  /// value this field will contain, if any.
+  ///
+  /// An example of what this field can be used for, would be to store
+  /// things like a peerCertificate from a mTLS connection
+  public var transportSpecific: (any Sendable)?
+
   /// A handle for checking the cancellation status of an RPC.
   public var cancellation: RPCCancellationHandle
 

--- a/Sources/GRPCCore/Call/Server/ServerContext.swift
+++ b/Sources/GRPCCore/Call/Server/ServerContext.swift
@@ -51,7 +51,7 @@ public struct ServerContext: Sendable {
   /// value this field will contain, if any.
   ///
   /// An example of what this field can be used for, would be to store
-  /// things like a peerCertificate from a mTLS connection
+  /// things like a peer certificate from a mTLS connection
   public var transportSpecific: (any Sendable)?
 
   /// A handle for checking the cancellation status of an RPC.

--- a/Sources/GRPCCore/Call/Server/ServerContext.swift
+++ b/Sources/GRPCCore/Call/Server/ServerContext.swift
@@ -16,6 +16,10 @@
 
 /// Additional information about an RPC handled by a server.
 public struct ServerContext: Sendable {
+
+  /// Protocol used to help identify transport specific context fields
+  public protocol TransportSpecific: Sendable {}
+
   /// A description of the method being called.
   public var descriptor: MethodDescriptor
 
@@ -52,7 +56,7 @@ public struct ServerContext: Sendable {
   ///
   /// An example of what this field can be used for, would be to store
   /// things like a peer certificate from a mTLS connection
-  public var transportSpecific: (any Sendable)?
+  public var transportSpecific: (any TransportSpecific)?
 
   /// A handle for checking the cancellation status of an RPC.
   public var cancellation: RPCCancellationHandle


### PR DESCRIPTION
Motivation:

Currently there's no way to plumb through details from the transport level to a request handler. Adding this field allows transports, such as the nio transport, to add the peer certificate to the server context when using mTLS.

From there there it's easy for an interceptor to take this data and propogate it forward to a request handler.

Modifications:

This PR adds a single field to the ServerContext that transports can use

Result:

A new field will be accessible to transports and consumers of the API