### PR TITLE
Fix a few warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,8 +13,8 @@ jobs:
     with:
       linux_5_9_enabled: false
       linux_5_10_enabled: false
-      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-      linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
+      linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
       linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,8 +22,8 @@ jobs:
     with:
       linux_5_9_enabled: false
       linux_5_10_enabled: false
-      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-      linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
+      linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
       linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
 

--- a/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor.swift
@@ -186,7 +186,7 @@ extension ClientRPCExecutor {
         }
       } catch let error as RPCError {
         return StreamingClientResponse(error: error)
-      } catch let error as RPCErrorConvertible {
+      } catch let error as any RPCErrorConvertible {
         return StreamingClientResponse(error: RPCError(error))
       } catch let other {
         let error = RPCError(code: .unknown, message: "", cause: other)

--- a/Sources/GRPCCore/Call/Server/Internal/ServerRPCExecutor.swift
+++ b/Sources/GRPCCore/Call/Server/Internal/ServerRPCExecutor.swift
@@ -330,7 +330,7 @@ extension ServerRPCExecutor {
         }
       } catch let error as RPCError {
         return StreamingServerResponse(error: error)
-      } catch let error as RPCErrorConvertible {
+      } catch let error as any RPCErrorConvertible {
         return StreamingServerResponse(error: RPCError(error))
       } catch let other {
         let error = RPCError(code: .unknown, message: "", cause: other)

--- a/Tests/GRPCCoreTests/Call/Server/ServerResponseTests.swift
+++ b/Tests/GRPCCoreTests/Call/Server/ServerResponseTests.swift
@@ -27,7 +27,7 @@ struct ServerResponseTests {
       trailingMetadata: ["metadata": "trailing"]
     )
 
-    let contents = try #require(try response.accepted.get())
+    let contents = try response.accepted.get()
     #expect(contents.message == "message")
     #expect(contents.metadata == ["metadata": "initial"])
     #expect(contents.trailingMetadata == ["metadata": "trailing"])
@@ -55,7 +55,7 @@ struct ServerResponseTests {
       return ["metadata": "trailing"]
     }
 
-    let contents = try #require(try response.accepted.get())
+    let contents = try response.accepted.get()
     #expect(contents.metadata == ["metadata": "initial"])
     let trailingMetadata = try await contents.producer(.failTestOnWrite())
     #expect(trailingMetadata == ["metadata": "trailing"])

--- a/Tests/GRPCCoreTests/GRPCClientTests.swift
+++ b/Tests/GRPCCoreTests/GRPCClientTests.swift
@@ -431,7 +431,7 @@ struct ClientTests {
         deserializer: IdentityDeserializer(),
         options: .defaults
       ) { response in
-        let message = try #require(try response.message)
+        let message = try response.message
         #expect(message == Array("hello".utf8))
       }
 
@@ -449,7 +449,7 @@ struct ClientTests {
         deserializer: IdentityDeserializer(),
         options: .defaults
       ) { response in
-        let message = try #require(try response.message)
+        let message = try response.message
         #expect(message == Array("Hello, Swift!".utf8))
       }
 
@@ -494,7 +494,7 @@ struct ClientTests {
         deserializer: IdentityDeserializer(),
         options: .defaults
       ) { response in
-        let message = try #require(try response.message)
+        let message = try response.message
         #expect(message == Array("hello".utf8))
       }
 
@@ -512,7 +512,7 @@ struct ClientTests {
         deserializer: IdentityDeserializer(),
         options: .defaults
       ) { response in
-        let message = try #require(try response.message)
+        let message = try response.message
         #expect(message == Array("hello".utf8))
       }
 


### PR DESCRIPTION
Motivation:

We should aim to keep warnings at zero. There were a few littered around as a result of Swift 6.1.

Modifications:

- Fix the warnings
- Enabled warnings-as-errors in CI to avoid regressions

Result:

No warnings