### PR TITLE
Drop Swift 5.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     name: License Header and Formatting Checks
     runs-on: ubuntu-latest
     container:
-      image: swift:6.0-jammy
+      image: swift:6.1
     steps:
     - name: "Checkout repository"
       uses: actions/checkout@v4
@@ -25,18 +25,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: swiftlang/swift:nightly-jammy
-            # No TSAN because of: https://github.com/apple/swift/issues/59068
-            # swift-test-flags: "--sanitize=thread"
+          - image: swift:6.1
           - image: swift:6.0-jammy
-            # No TSAN because of: https://github.com/apple/swift/issues/59068
-            # swift-test-flags: "--sanitize=thread"
           - image: swift:5.10.1-noble
-            # No TSAN because of: https://github.com/apple/swift/issues/59068
-            # swift-test-flags: "--sanitize=thread"
-          - image: swift:5.9-jammy
-            # No TSAN because of: https://github.com/apple/swift/issues/59068
-            # swift-test-flags: "--sanitize=thread"
     name: Build and Test on ${{ matrix.image }}
     runs-on: ubuntu-latest
     container:
@@ -54,8 +45,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: swiftlang/swift:nightly-jammy
-            swift-version: 'main'
+          - image: swift:6.1
+            swift-version: '6.1'
             env:
               MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 323000
               MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 161000
@@ -87,17 +78,6 @@ jobs:
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 163000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 170000
               MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 170000
-          - image: swift:5.9-jammy
-            swift-version: 5.9
-            env:
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_10_requests: 323000
-              MAX_ALLOCS_ALLOWED_bidi_1k_rpcs_1_request: 161000
-              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_10_small_requests: 110000
-              MAX_ALLOCS_ALLOWED_embedded_server_bidi_1k_rpcs_1_small_request: 65000
-              MAX_ALLOCS_ALLOWED_embedded_server_unary_1k_rpcs_1_small_request: 61000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong: 163000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_client: 170000
-              MAX_ALLOCS_ALLOWED_unary_1k_ping_pong_interceptors_server: 170000
     name: Performance Tests on ${{ matrix.image }}
     runs-on: ubuntu-latest
     container:
@@ -113,14 +93,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: swiftlang/swift:nightly-jammy
-            swift-tools-version: '6.0'
+          - image: swift:6.1
+            swift-tools-version: '6.1'
           - image: swift:6.0-jammy
             swift-tools-version: '6.0'
           - image: swift:5.10.1-noble
             swift-tools-version: '5.10'
-          - image: swift:5.9-jammy
-            swift-tools-version: '5.9'
     name: Integration Tests on ${{ matrix.image }}
     runs-on: ubuntu-latest
     container:

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 /*
  * Copyright 2017, gRPC Authors All rights reserved.
  *


### PR DESCRIPTION
Swift 6.1 has been released so we can drop 5.9 support per our policy.