### PR TITLE
chore: Bump deps to compatible minimums

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let includeNIOSSL = ProcessInfo.processInfo.environment["GRPC_NO_NIO_SSL"] == ni
 let packageDependencies: [Package.Dependency] = [
   .package(
     url: "https://github.com/apple/swift-nio.git",
-    from: "2.65.0"
+    from: "2.82.0"
   ),
   .package(
     url: "https://github.com/apple/swift-nio-http2.git",
@@ -48,7 +48,7 @@ let packageDependencies: [Package.Dependency] = [
   ),
   .package(
     url: "https://github.com/apple/swift-collections.git",
-    from: "1.0.5"
+    from: "1.1.0"
   ),
   .package(
     url: "https://github.com/apple/swift-atomics.git",


### PR DESCRIPTION
Good to have updates on Package dependencies (for reference when built outside SPM)

Both recent bumps of `swift-nio-transport-services` and `swift-nio-http2` require  lastest`swift-nio`:
* `swift-nio-transport-services` 1.24.0  -> `swift-nio` `2.81.0`
* `swift-nio-http2` 1.36.0 -> `swift-nio` `2.82.0`

And latest `swift-nio` require bump of `swift-collections`:
* `swift-nio` `2.82.0` -> `swift-collections` `1.1.0`

