### PR TITLE
Add deprecation warnings

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,8 +22,8 @@ jobs:
     with:
       linux_5_9_enabled: false
       linux_5_10_enabled: false
-      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors -Xswiftc -require-explicit-availability"
-      linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors -Xswiftc -require-explicit-availability"
+      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-availability"
+      linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-availability"
       linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-availability"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-availability"
 

--- a/Sources/GRPCCore/Call/Server/RegistrableRPCService.swift
+++ b/Sources/GRPCCore/Call/Server/RegistrableRPCService.swift
@@ -23,6 +23,7 @@
 /// ``RPCRouter/registerHandler(forMethod:deserializer:serializer:handler:)`` for each method
 /// you want to register with the router.
 @available(gRPCSwift 2.0, *)
+@available(*, deprecated, message: "See https://forums.swift.org/t/80177")
 public protocol RegistrableRPCService: Sendable {
   /// Registers methods to server with the provided ``RPCRouter``.
   ///

--- a/Sources/GRPCCore/GRPCClient.swift
+++ b/Sources/GRPCCore/GRPCClient.swift
@@ -55,6 +55,7 @@ private import Synchronization
 /// additional resources that need their lifecycles managed you should consider using [Swift Service
 /// Lifecycle](https://github.com/swift-server/swift-service-lifecycle).
 @available(gRPCSwift 2.0, *)
+@available(*, deprecated, message: "See https://forums.swift.org/t/80177")
 public final class GRPCClient<Transport: ClientTransport>: Sendable {
   /// The transport which provides a bidirectional communication channel with the server.
   private let transport: Transport
@@ -399,6 +400,7 @@ public final class GRPCClient<Transport: ClientTransport>: Sendable {
 ///   - handleClient: A closure which is called with the client. When the closure returns, the
 ///       client is shutdown gracefully.
 @available(gRPCSwift 2.0, *)
+@available(*, deprecated, message: "See https://forums.swift.org/t/80177")
 public func withGRPCClient<Transport: ClientTransport, Result: Sendable>(
   transport: Transport,
   interceptors: [any ClientInterceptor] = [],
@@ -428,6 +430,7 @@ public func withGRPCClient<Transport: ClientTransport, Result: Sendable>(
 ///       client is shutdown gracefully.
 /// - Returns: The result of the `handleClient` closure.
 @available(gRPCSwift 2.0, *)
+@available(*, deprecated, message: "See https://forums.swift.org/t/80177")
 public func withGRPCClient<Transport: ClientTransport, Result: Sendable>(
   transport: Transport,
   interceptorPipeline: [ConditionalInterceptor<any ClientInterceptor>],

--- a/Sources/GRPCCore/GRPCServer.swift
+++ b/Sources/GRPCCore/GRPCServer.swift
@@ -76,6 +76,7 @@ private import Synchronization
 /// Lifecycle](https://github.com/swift-server/swift-service-lifecycle) and the
 /// `GRPCServiceLifecycle` module provided by [gRPC Swift Extras](https://github.com/grpc/grpc-swift-extras).
 @available(gRPCSwift 2.0, *)
+@available(*, deprecated, message: "See https://forums.swift.org/t/80177")
 public final class GRPCServer<Transport: ServerTransport>: Sendable {
   typealias Stream = RPCStream<Transport.Inbound, Transport.Outbound>
 
@@ -259,6 +260,7 @@ public final class GRPCServer<Transport: ServerTransport>: Sendable {
 ///       server is shutdown gracefully.
 /// - Returns: The result of the `handleServer` closure.
 @available(gRPCSwift 2.0, *)
+@available(*, deprecated, message: "See https://forums.swift.org/t/80177")
 public func withGRPCServer<Transport: ServerTransport, Result: Sendable>(
   transport: Transport,
   services: [any RegistrableRPCService],
@@ -291,6 +293,7 @@ public func withGRPCServer<Transport: ServerTransport, Result: Sendable>(
 ///       server is shutdown gracefully.
 /// - Returns: The result of the `handleServer` closure.
 @available(gRPCSwift 2.0, *)
+@available(*, deprecated, message: "See https://forums.swift.org/t/80177")
 public func withGRPCServer<Transport: ServerTransport, Result: Sendable>(
   transport: Transport,
   services: [any RegistrableRPCService],

--- a/Sources/GRPCCore/Metadata.swift
+++ b/Sources/GRPCCore/Metadata.swift
@@ -80,6 +80,7 @@
 /// the "-bin" suffix may have string values (rather than binary). These are deserialized automatically when
 /// using ``subscript(binaryValues:)``.
 @available(gRPCSwift 2.0, *)
+@available(*, deprecated, message: "See https://forums.swift.org/t/80177")
 public struct Metadata: Sendable, Hashable {
 
   /// A metadata value. It can either be a simple string, or binary data.

--- a/Sources/GRPCCore/Transport/ClientTransport.swift
+++ b/Sources/GRPCCore/Transport/ClientTransport.swift
@@ -26,6 +26,7 @@
 /// transport built on top of SwiftNIO in the https://github.com/grpc/grpc-swift-nio-transport
 /// package.
 @available(gRPCSwift 2.0, *)
+@available(*, deprecated, message: "See https://forums.swift.org/t/80177")
 public protocol ClientTransport<Bytes>: Sendable {
   /// The bag-of-bytes type used by the transport.
   associatedtype Bytes: GRPCContiguousBytes & Sendable

--- a/Sources/GRPCCore/Transport/ServerTransport.swift
+++ b/Sources/GRPCCore/Transport/ServerTransport.swift
@@ -23,6 +23,7 @@
 /// transport built on top of SwiftNIO in the https://github.com/grpc/grpc-swift-nio-transport
 /// package.
 @available(gRPCSwift 2.0, *)
+@available(*, deprecated, message: "See https://forums.swift.org/t/80177")
 public protocol ServerTransport<Bytes>: Sendable {
   /// The bag-of-bytes type used by the transport.
   associatedtype Bytes: GRPCContiguousBytes & Sendable

--- a/Sources/GRPCInProcessTransport/InProcessTransport.swift
+++ b/Sources/GRPCInProcessTransport/InProcessTransport.swift
@@ -17,6 +17,7 @@
 public import GRPCCore
 
 @available(gRPCSwift 2.0, *)
+@available(*, deprecated, message: "See https://forums.swift.org/t/80177")
 public struct InProcessTransport: Sendable {
   public let server: Self.Server
   public let client: Self.Client

--- a/Tests/GRPCCoreTests/Configuration/Generated/rls.pb.swift
+++ b/Tests/GRPCCoreTests/Configuration/Generated/rls.pb.swift
@@ -134,13 +134,16 @@ fileprivate let _protobuf_package = "grpc.lookup.v1"
 
 extension Grpc_Lookup_V1_RouteLookupRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RouteLookupRequest"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    3: .standard(proto: "target_type"),
-    5: .same(proto: "reason"),
-    6: .standard(proto: "stale_header_data"),
-    4: .standard(proto: "key_map"),
-    7: .same(proto: "extensions"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(
+      reservedNames: ["server", "path"],
+      reservedRanges: [1..<3],
+      numberNameMappings: [
+        3: .standard(proto: "target_type"),
+        5: .same(proto: "reason"),
+        6: .standard(proto: "stale_header_data"),
+        4: .standard(proto: "key_map"),
+        7: .same(proto: "extensions"),
+  ])
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -198,11 +201,14 @@ extension Grpc_Lookup_V1_RouteLookupRequest.Reason: SwiftProtobuf._ProtoNameProv
 
 extension Grpc_Lookup_V1_RouteLookupResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RouteLookupResponse"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    3: .same(proto: "targets"),
-    2: .standard(proto: "header_data"),
-    4: .same(proto: "extensions"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(
+      reservedNames: ["target"],
+      reservedRanges: [1..<2],
+      numberNameMappings: [
+        3: .same(proto: "targets"),
+        2: .standard(proto: "header_data"),
+        4: .same(proto: "extensions"),
+  ])
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {

--- a/Tests/GRPCCoreTests/Configuration/Generated/rls_config.pb.swift
+++ b/Tests/GRPCCoreTests/Configuration/Generated/rls_config.pb.swift
@@ -587,17 +587,20 @@ extension Grpc_Lookup_V1_HttpKeyBuilder: SwiftProtobuf.Message, SwiftProtobuf._M
 
 extension Grpc_Lookup_V1_RouteLookupConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RouteLookupConfig"
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "http_keybuilders"),
-    2: .standard(proto: "grpc_keybuilders"),
-    3: .standard(proto: "lookup_service"),
-    4: .standard(proto: "lookup_service_timeout"),
-    5: .standard(proto: "max_age"),
-    6: .standard(proto: "stale_age"),
-    7: .standard(proto: "cache_size_bytes"),
-    8: .standard(proto: "valid_targets"),
-    9: .standard(proto: "default_target"),
-  ]
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(
+      reservedNames: ["request_processing_strategy"],
+      reservedRanges: [10..<11],
+      numberNameMappings: [
+        1: .standard(proto: "http_keybuilders"),
+        2: .standard(proto: "grpc_keybuilders"),
+        3: .standard(proto: "lookup_service"),
+        4: .standard(proto: "lookup_service_timeout"),
+        5: .standard(proto: "max_age"),
+        6: .standard(proto: "stale_age"),
+        7: .standard(proto: "cache_size_bytes"),
+        8: .standard(proto: "valid_targets"),
+        9: .standard(proto: "default_target"),
+  ])
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {

--- a/Tests/GRPCCoreTests/Configuration/Generated/service_config.pb.swift
+++ b/Tests/GRPCCoreTests/Configuration/Generated/service_config.pb.swift
@@ -2549,15 +2549,11 @@ extension Grpc_ServiceConfig_RlsLoadBalancingPolicyConfig: SwiftProtobuf.Message
     var _childPolicy: [Grpc_ServiceConfig_LoadBalancingConfig] = []
     var _childPolicyConfigTargetFieldName: String = String()
 
-    #if swift(>=5.10)
       // This property is used as the initial default value for new instances of the type.
       // The type itself is protecting the reference to its storage via CoW semantics.
       // This will force a copy to be made of this reference when the first mutation occurs;
       // hence, it is safe to mark this as `nonisolated(unsafe)`.
       static nonisolated(unsafe) let defaultInstance = _StorageClass()
-    #else
-      static let defaultInstance = _StorageClass()
-    #endif
 
     private init() {}
 
@@ -3692,15 +3688,11 @@ extension Grpc_ServiceConfig_XdsClusterResolverLoadBalancingPolicyConfig.Discove
     var _overrideHostStatus: [Grpc_ServiceConfig_OverrideHostLoadBalancingPolicyConfig.HealthStatus] = []
     var _telemetryLabels: Dictionary<String,String> = [:]
 
-    #if swift(>=5.10)
       // This property is used as the initial default value for new instances of the type.
       // The type itself is protecting the reference to its storage via CoW semantics.
       // This will force a copy to be made of this reference when the first mutation occurs;
       // hence, it is safe to mark this as `nonisolated(unsafe)`.
       static nonisolated(unsafe) let defaultInstance = _StorageClass()
-    #else
-      static let defaultInstance = _StorageClass()
-    #endif
 
     private init() {}
 

--- a/dev/protos/generate.sh
+++ b/dev/protos/generate.sh
@@ -21,7 +21,8 @@ protoc=$(which protoc)
 
 # Checkout and build the plugins.
 build_dir=$(mktemp -d)
-git clone https://github.com/grpc/grpc-swift-protobuf --depth 1 "$build_dir"
+git clone -b 1.3.0 https://github.com/grpc/grpc-swift-protobuf --depth 1 "$build_dir"
+
 swift build --package-path "$build_dir" --product protoc-gen-swift
 swift build --package-path "$build_dir" --product protoc-gen-grpc-swift
 


### PR DESCRIPTION
Motivation:

v2 has moved to a new repo, grpc-swift-2. That's not all that discoverable.

Modifications:

- Deprecate commonly used high-level types with a link to a forums post explaining the move.

Result:

Users are notified about the move