### PR TITLE
Add explicit read permissions to workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,7 @@
 name: CI
+
+permissions:
+  contents: read
 on:
   push:
     branches: ["release/1.x"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Motivation:

* More secure GitHub Actions workflows

Modifications:

Add explicit 'contents: read' permissions to workflows that did not have
explicit permissions defined. This follows GitHub Actions security best
practices by limiting the default GITHUB_TOKEN permissions.

Result:

An extra layer of security.
