### PR TITLE
Add LocalizedError conformance to GRPCStatus

### DIFF
--- a/Sources/GRPC/GRPCStatus.swift
+++ b/Sources/GRPC/GRPCStatus.swift
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import Foundation
 import NIOCore
 import NIOHTTP1
 import NIOHTTP2
@@ -133,6 +134,12 @@ extension GRPCStatus: CustomStringConvertible {
     case (.none, .none):
       return "\(self.code)"
     }
+  }
+}
+
+extension GRPCStatus: LocalizedError {
+  public var errorDescription: String? {
+    return self.description
   }
 }
 


### PR DESCRIPTION
`GRPCStatus` conforms to `Error` and `CustomStringConvertible`, but not `LocalizedError`. This means `localizedDescription` returns a generic message like `"The operation couldn't be completed. (GRPC.GRPCStatus error 1.)"` instead of the status description. This is a problem for applications that display errors in a UI using `errorDescription`, which is the standard pattern in Swift.

This adds `LocalizedError` conformance so that `errorDescription` returns the same string as `description`, e.g. `"unavailable (14): server not reachable"`.