### PR TITLE
Close server interceptor pipeline before nil-ing out

### DIFF
--- a/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncServerHandler.swift
+++ b/Sources/GRPC/AsyncAwaitSupport/GRPCAsyncServerHandler.swift
@@ -399,6 +399,7 @@ internal final class AsyncServerHandler<
       self.responseWriter?.sendEnd(status: .processingError, trailers: [:], promise: nil)
       fallthrough
     case .nilOutInterceptorPipeline:
+      self.interceptors?.close()
       self.interceptors = nil
       self.responseWriter = nil
     case .none:

--- a/Sources/GRPCReflectionService/v1/reflection-v1.pb.swift
+++ b/Sources/GRPCReflectionService/v1/reflection-v1.pb.swift
@@ -29,7 +29,11 @@
 // The canonical version of this proto can be found at
 // https://github.com/grpc/grpc-proto/blob/master/grpc/reflection/v1/reflection.proto
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import SwiftProtobuf
 
 // If the compiler emits an error on this type, it is because this file

--- a/Sources/GRPCReflectionService/v1Alpha/reflection-v1alpha.pb.swift
+++ b/Sources/GRPCReflectionService/v1Alpha/reflection-v1alpha.pb.swift
@@ -26,7 +26,11 @@
 // Warning: this entire file is deprecated. Use this instead:
 // https://github.com/grpc/grpc-proto/blob/master/grpc/reflection/v1/reflection.proto
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import SwiftProtobuf
 
 // If the compiler emits an error on this type, it is because this file

--- a/Tests/GRPCTests/GRPCAsyncServerHandlerTests.swift
+++ b/Tests/GRPCTests/GRPCAsyncServerHandlerTests.swift
@@ -62,6 +62,7 @@ class AsyncServerHandlerTests: GRPCTestCase {
   private func makeHandler(
     encoding: ServerMessageEncoding = .disabled,
     callType: GRPCCallType = .bidirectionalStreaming,
+    interceptors: [ServerInterceptor<String, String>] = [],
     observer:
       @escaping @Sendable (
         GRPCAsyncRequestStream<String>,
@@ -74,7 +75,7 @@ class AsyncServerHandlerTests: GRPCTestCase {
       requestDeserializer: StringDeserializer(),
       responseSerializer: StringSerializer(),
       callType: callType,
-      interceptors: [],
+      interceptors: interceptors,
       userHandler: observer
     )
   }
@@ -520,6 +521,79 @@ class AsyncServerHandlerTests: GRPCTestCase {
     await responseStream.next().assertStatus { status, _ in
       XCTAssertEqual(status.code, .internalError)
     }
+  }
+
+  func testInterceptorPipelineClosedOnFinishBeforeMetadata() async throws {
+    // Cancel path: finish() called before any metadata is received (idle handler state).
+    let handler = self.makeHandler(
+      interceptors: [ServerInterceptor<String, String>()],
+      observer: Self.neverCalled(requests:responseStreamWriter:context:)
+    )
+    let pipeline = handler.interceptors!
+
+    self.loop.execute {
+      handler.finish()
+    }
+
+    let responseStream = self.recorder.responseSequence.makeAsyncIterator()
+    await responseStream.next().assertStatus()
+    await responseStream.next().assertNil()
+
+    let isOpen = try self.loop.submit { pipeline._isOpen }.wait()
+    XCTAssertFalse(isOpen)
+  }
+
+  func testInterceptorPipelineClosedOnErrorAfterMetadata() async throws {
+    // Cancel path: receiveError() after metadata has been received and the handler is running.
+    let handler = self.makeHandler(
+      interceptors: [ServerInterceptor<String, String>()],
+      observer: Self.neverReceivesMessage(requests:responseStreamWriter:context:)
+    )
+    let pipeline = handler.interceptors!
+
+    self.loop.execute {
+      handler.receiveMetadata([:])
+      handler.receiveError(CancellationError())
+    }
+
+    let responseStream = self.recorder.responseSequence.makeAsyncIterator()
+    await responseStream.next().assertStatus { status, _ in
+      XCTAssertEqual(status.code, .unavailable)
+    }
+    await responseStream.next().assertNil()
+
+    let isOpen = try self.loop.submit { pipeline._isOpen }.wait()
+    XCTAssertFalse(isOpen)
+  }
+
+  func testInterceptorPipelineClosedOnFinishAfterMessage() async throws {
+    // Cancel path: finish() after messages have been exchanged (response stream is writing).
+    let handler = self.makeHandler(
+      interceptors: [ServerInterceptor<String, String>()],
+      observer: Self.echo(requests:responseStreamWriter:context:)
+    )
+    let pipeline = handler.interceptors!
+
+    self.loop.execute {
+      handler.receiveMetadata([:])
+      handler.receiveMessage(ByteBuffer(string: "hello"))
+    }
+
+    let responseStream = self.recorder.responseSequence.makeAsyncIterator()
+    await responseStream.next().assertMetadata()
+    await responseStream.next().assertMessage()
+
+    self.loop.execute {
+      handler.finish()
+    }
+
+    await responseStream.next().assertStatus { status, _ in
+      XCTAssertEqual(status.code, .internalError)
+    }
+    await responseStream.next().assertNil()
+
+    let isOpen = try self.loop.submit { pipeline._isOpen }.wait()
+    XCTAssertFalse(isOpen)
   }
 }
 

--- a/Tests/GRPCTests/GRPCReflectionServiceTests/Generated/v1/reflection-v1.pb.swift
+++ b/Tests/GRPCTests/GRPCReflectionServiceTests/Generated/v1/reflection-v1.pb.swift
@@ -29,7 +29,11 @@
 // The canonical version of this proto can be found at
 // https://github.com/grpc/grpc-proto/blob/master/grpc/reflection/v1/reflection.proto
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import SwiftProtobuf
 
 // If the compiler emits an error on this type, it is because this file

--- a/Tests/GRPCTests/GRPCReflectionServiceTests/Generated/v1Alpha/reflection-v1alpha.pb.swift
+++ b/Tests/GRPCTests/GRPCReflectionServiceTests/Generated/v1Alpha/reflection-v1alpha.pb.swift
@@ -26,7 +26,11 @@
 // Warning: this entire file is deprecated. Use this instead:
 // https://github.com/grpc/grpc-proto/blob/master/grpc/reflection/v1/reflection.proto
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import SwiftProtobuf
 
 // If the compiler emits an error on this type, it is because this file


### PR DESCRIPTION
Motivation:

The server interceptor pipeline and context create a retain cycle which is broken when the RPC is finished. However there's a path through the async server handler where the interceptor pipeline is nil'd out but not closed, meaning the retain cycle isn't broken.

Modifications:

- close the pipeline before niling it out

Result:

Fewer leaks